### PR TITLE
fix: recognize statute sections with trailing letters (§ 1028A)

### DIFF
--- a/.changeset/statute-trailing-letters.md
+++ b/.changeset/statute-trailing-letters.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix statute sections with trailing letters (e.g., "18 U.S.C. § 1028A") not being recognized. Updated tokenization patterns for both USC and state code statutes to allow alphanumeric section suffixes.

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -16,13 +16,13 @@ import type { Pattern } from './casePatterns'
 export const statutePatterns: Pattern[] = [
   {
     id: 'usc',
-    regex: /\b(\d+)\s+U\.S\.C\.?\s+§+\s*(\d+)\b/g,
+    regex: /\b(\d+)\s+U\.S\.C\.?\s+§+\s*(\d+[A-Za-z]*)\b/g,
     description: 'U.S. Code citations (e.g., "42 U.S.C. § 1983")',
     type: 'statute',
   },
   {
     id: 'state-code',
-    regex: /\b([A-Z][a-z]+\.?\s+[A-Za-z.]+\s+Code)\s+§\s*(\d+)\b/g,
+    regex: /\b([A-Z][a-z]+\.?\s+[A-Za-z.]+\s+Code)\s+§\s*(\d+[A-Za-z]*)\b/g,
     description: 'State code citations (broad pattern, e.g., "Cal. Penal Code § 187")',
     type: 'statute',
   },

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractStatute } from '@/extract'
+import { extractStatute, extractCitations } from '@/extract'
 import type { Token } from '@/tokenize'
 import type { TransformationMap } from '@/types/span'
 
@@ -194,6 +194,25 @@ describe('extractStatute', () => {
 			const citation = extractStatute(token, transformationMap)
 
 			expect(citation.confidence).toBe(0.5)
+		})
+	})
+
+	describe('trailing letters via full pipeline', () => {
+		it('should extract section with trailing uppercase letter', () => {
+			const citations = extractCitations('18 U.S.C. § 1028A')
+			expect(citations).toHaveLength(1)
+			expect(citations[0].type).toBe('statute')
+			if (citations[0].type === 'statute') {
+				expect(citations[0].section).toBe('1028A')
+			}
+		})
+
+		it('should extract section with trailing lowercase letter', () => {
+			const citations = extractCitations('18 U.S.C. § 2339B')
+			expect(citations).toHaveLength(1)
+			if (citations[0].type === 'statute') {
+				expect(citations[0].section).toBe('2339B')
+			}
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Updated USC and state code tokenization patterns to allow trailing letters in section numbers
- Changed section capture from `(\d+)` to `(\d+[A-Za-z]*)` in both patterns
- The extractor regex already handled alphanumeric sections — only the tokenizer was rejecting them

## Test plan

- [x] 325 tests pass (2 new integration tests)
- [x] `18 U.S.C. § 1028A` → `statute §1028A` (was: no match)
- [x] `18 U.S.C. § 2339B` → `statute §2339B` (was: no match)
- [x] Existing numeric sections unaffected

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)