### PR TITLE
fix: support hyphenated volume numbers (1984-1 Trade Cas.)

### DIFF
--- a/.changeset/fix-hyphenated-volume.md
+++ b/.changeset/fix-hyphenated-volume.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": minor
+---
+
+Support hyphenated volume numbers (e.g., "1984-1 Trade Cas. 66"). Volume type changed from `number` to `number | string` across all citation types — numeric volumes remain numbers, hyphenated volumes are strings.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -18,6 +18,12 @@ import type { Token } from '@/tokenize'
 import type { FullCaseCitation } from '@/types/citation'
 import type { TransformationMap } from '@/types/span'
 
+/** Parse a volume string as number when purely numeric, string when hyphenated */
+function parseVolume(raw: string): number | string {
+	const num = Number.parseInt(raw, 10)
+	return String(num) === raw ? num : raw
+}
+
 /**
  * Extracts case citation metadata from a tokenized citation.
  *
@@ -79,7 +85,7 @@ export function extractCase(
 	// Parse volume-reporter-page using regex
 	// Pattern: volume (digits) + reporter (letters/periods/spaces/numbers) + page (digits)
 	// Use greedy matching for reporter to capture full abbreviation including spaces
-	const volumeReporterPageRegex = /^(\d+)\s+([A-Za-z0-9.\s]+)\s+(\d+)/
+	const volumeReporterPageRegex = /^(\d+(?:-\d+)?)\s+([A-Za-z0-9.\s]+)\s+(\d+)/
 	const match = volumeReporterPageRegex.exec(text)
 
 	if (!match) {
@@ -87,7 +93,7 @@ export function extractCase(
 		throw new Error(`Failed to parse case citation: ${text}`)
 	}
 
-	const volume = Number.parseInt(match[1], 10)
+	const volume = parseVolume(match[1])
 	const reporter = match[2].trim()
 	const page = Number.parseInt(match[3], 10)
 

--- a/src/extract/extractFederalRegister.ts
+++ b/src/extract/extractFederalRegister.ts
@@ -52,14 +52,15 @@ export function extractFederalRegister(
 
 	// Parse volume-page using regex
 	// Pattern: volume (digits) + "Fed. Reg." + page (digits)
-	const federalRegisterRegex = /^(\d+)\s+Fed\.\s?Reg\.\s+(\d+)/
+	const federalRegisterRegex = /^(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d+)/
 	const match = federalRegisterRegex.exec(text)
 
 	if (!match) {
 		throw new Error(`Failed to parse Federal Register citation: ${text}`)
 	}
 
-	const volume = Number.parseInt(match[1], 10)
+	const rawVolume = match[1]
+	const volume = /^\d+$/.test(rawVolume) ? Number.parseInt(rawVolume, 10) : rawVolume
 	const page = Number.parseInt(match[2], 10)
 
 	// Extract optional year in parentheses

--- a/src/extract/extractJournal.ts
+++ b/src/extract/extractJournal.ts
@@ -57,14 +57,15 @@ export function extractJournal(
 
 	// Parse volume-journal-page using regex
 	// Pattern: volume (digits) + journal (letters/periods/spaces) + page (digits)
-	const journalRegex = /^(\d+)\s+([A-Za-z.\s]+?)\s+(\d+)/
+	const journalRegex = /^(\d+(?:-\d+)?)\s+([A-Za-z.\s]+?)\s+(\d+)/
 	const match = journalRegex.exec(text)
 
 	if (!match) {
 		throw new Error(`Failed to parse journal citation: ${text}`)
 	}
 
-	const volume = Number.parseInt(match[1], 10)
+	const rawVolume = match[1]
+	const volume = /^\d+$/.test(rawVolume) ? Number.parseInt(rawVolume, 10) : rawVolume
 	const journal = match[2].trim()
 	const page = Number.parseInt(match[3], 10)
 

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -205,14 +205,15 @@ export function extractShortFormCase(
 
 	// Parse volume-reporter-at-page
 	// Pattern: number space abbreviation space "at" space number
-	const shortFormRegex = /(\d+)\s+([A-Z][A-Za-z.\s]+?(?:\d[a-z])?)\s+at\s+(\d+)/
+	const shortFormRegex = /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.\s]+?(?:\d[a-z])?)\s+at\s+(\d+)/
 	const match = shortFormRegex.exec(text)
 
 	if (!match) {
 		throw new Error(`Failed to parse short-form case citation: ${text}`)
 	}
 
-	const volume = Number.parseInt(match[1], 10)
+	const rawVolume = match[1]
+	const volume = /^\d+$/.test(rawVolume) ? Number.parseInt(rawVolume, 10) : rawVolume
 	const reporter = match[2].trim() // Remove trailing spaces
 	const pincite = Number.parseInt(match[3], 10)
 

--- a/src/extract/extractStatutesAtLarge.ts
+++ b/src/extract/extractStatutesAtLarge.ts
@@ -21,14 +21,15 @@ export function extractStatutesAtLarge(
 	const { text, span } = token
 
 	// Parse volume-Stat.-page
-	const statRegex = /^(\d+)\s+Stat\.\s+(\d+)/
+	const statRegex = /^(\d+(?:-\d+)?)\s+Stat\.\s+(\d+)/
 	const match = statRegex.exec(text)
 
 	if (!match) {
 		throw new Error(`Failed to parse Statutes at Large citation: ${text}`)
 	}
 
-	const volume = Number.parseInt(match[1], 10)
+	const rawVolume = match[1]
+	const volume = /^\d+$/.test(rawVolume) ? Number.parseInt(rawVolume, 10) : rawVolume
 	const page = Number.parseInt(match[2], 10)
 
 	// Extract optional year in parentheses

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -24,19 +24,19 @@ export interface Pattern {
 export const casePatterns: Pattern[] = [
   {
     id: 'federal-reporter',
-    regex: /\b(\d+)\s+(F\.|F\.2d|F\.3d|F\.4th|F\.\s?Supp\.|F\.\s?Supp\.\s?2d|F\.\s?Supp\.\s?3d|F\.\s?Supp\.\s?4th)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+(F\.|F\.2d|F\.3d|F\.4th|F\.\s?Supp\.|F\.\s?Supp\.\s?2d|F\.\s?Supp\.\s?3d|F\.\s?Supp\.\s?4th)\s+(\d+)\b/g,
     description: 'Federal Reporter (F., F.2d, F.3d, F.4th, F.Supp., etc.)',
     type: 'case',
   },
   {
     id: 'supreme-court',
-    regex: /\b(\d+)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?2d)?)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?2d)?)\s+(\d+)\b/g,
     description: 'U.S. Supreme Court reporters',
     type: 'case',
   },
   {
     id: 'state-reporter',
-    regex: /\b(\d+)\s+([A-Z][A-Za-z.]+(?:\s?2d|\s?3d|\s?4th|\s?5th)?)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.]+(?:\s?2d|\s?3d|\s?4th|\s?5th)?)\s+(\d+)\b/g,
     description: 'State reporters (broad pattern, validated against reporters-db in Phase 3)',
     type: 'case',
   },

--- a/src/patterns/journalPatterns.ts
+++ b/src/patterns/journalPatterns.ts
@@ -16,7 +16,7 @@ import type { Pattern } from './casePatterns'
 export const journalPatterns: Pattern[] = [
   {
     id: 'law-review',
-    regex: /\b(\d+)\s+([A-Z][A-Za-z.\s]+)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.\s]+)\s+(\d+)\b/g,
     description: 'Law review citations (e.g., "120 Harv. L. Rev. 500"), validated against journals-db in Phase 3',
     type: 'journal',
   },

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -34,19 +34,19 @@ export const neutralPatterns: Pattern[] = [
   },
   {
     id: 'federal-register',
-    regex: /\b(\d+)\s+Fed\.\s?Reg\.\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d+)\b/g,
     description: 'Federal Register citations (e.g., "86 Fed. Reg. 12345")',
     type: 'federalRegister',
   },
   {
     id: 'statutes-at-large',
-    regex: /\b(\d+)\s+Stat\.\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+Stat\.\s+(\d+)\b/g,
     description: 'Statutes at Large citations (e.g., "124 Stat. 119")',
     type: 'statutesAtLarge',
   },
   {
     id: 'compact-law-review',
-    regex: /\b(\d+)\s+([A-Z][A-Za-z.]+L\.(?:Rev|J|Q)\.)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.]+L\.(?:Rev|J|Q)\.)\s+(\d+)\b/g,
     description: 'Compact law review citations without spaces (e.g., "93 Harv.L.Rev. 752")',
     type: 'journal',
   },

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -31,7 +31,7 @@ export const SUPRA_PATTERN: RegExp = /\b([A-Z][a-zA-Z]+(?:(?:\s+v\.?\s+|\s+)[A-Z
  * Pattern: number space abbreviation space "at" space number
  * Simplified detection; full parsing in extraction layer
  */
-export const SHORT_FORM_CASE_PATTERN: RegExp = /\b(\d+)\s+([A-Z][A-Za-z.\s]+?(?:\d[a-z])?)\s+at\s+(\d+)\b/g
+export const SHORT_FORM_CASE_PATTERN: RegExp = /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.\s]+?(?:\d[a-z])?)\s+at\s+(\d+)\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -59,7 +59,7 @@ export interface CitationBase {
  */
 export interface FullCaseCitation extends CitationBase {
   type: "case"
-  volume: number
+  volume: number | string
   reporter: string
   page: number
   pincite?: number
@@ -71,7 +71,7 @@ export interface FullCaseCitation extends CitationBase {
 
   /** Parallel citations for same case in different reporters */
   parallelCitations?: Array<{
-    volume: number
+    volume: number | string
     reporter: string
     page: number
   }>
@@ -100,7 +100,7 @@ export interface FullCaseCitation extends CitationBase {
    * Used when reporter abbreviation matches multiple reporters or format is unclear.
    */
   possibleInterpretations?: Array<{
-    volume: number
+    volume: number | string
     reporter: string
     page: number
     confidence: number
@@ -134,8 +134,8 @@ export interface JournalCitation extends CitationBase {
   author?: string
   /** Article title (if extracted) */
   title?: string
-  /** Volume number */
-  volume?: number
+  /** Volume number (string for hyphenated volumes like "1984-1") */
+  volume?: number | string
   /** Full journal name */
   journal: string
   /** Standard journal abbreviation (e.g., "Harv. L. Rev.") */
@@ -195,7 +195,7 @@ export interface PublicLawCitation extends CitationBase {
 export interface FederalRegisterCitation extends CitationBase {
   type: 'federalRegister'
   /** Federal Register volume */
-  volume: number
+  volume: number | string
   /** Page number */
   page: number
   /** Publication year (if extracted) */
@@ -206,7 +206,7 @@ export interface FederalRegisterCitation extends CitationBase {
 export interface StatutesAtLargeCitation extends CitationBase {
   type: 'statutesAtLarge'
   /** Statutes at Large volume */
-  volume: number
+  volume: number | string
   /** Page number */
   page: number
   /** Publication year (if extracted) */
@@ -246,7 +246,7 @@ export interface SupraCitation extends CitationBase {
  */
 export interface ShortFormCaseCitation extends CitationBase {
   type: "shortFormCase"
-  volume: number
+  volume: number | string
   reporter: string
   page?: number
   pincite?: number

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -416,6 +416,40 @@ describe('reporter with internal spaces (integration)', () => {
 	})
 })
 
+describe('hyphenated volume (integration)', () => {
+	it('should extract full hyphenated volume from Trade Cases', () => {
+		const citations = extractCitations('1984-1 Trade Cas. 66')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case' || citations[0].type === 'journal') {
+			expect(citations[0].volume).toBe('1984-1')
+		}
+	})
+
+	it('should still extract numeric volumes as numbers', () => {
+		const citations = extractCitations('500 F.2d 123')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case') {
+			expect(citations[0].volume).toBe(500)
+			expect(typeof citations[0].volume).toBe('number')
+		}
+	})
+
+	it('should handle multiple hyphenated volume examples', () => {
+		const examples = [
+			{ text: '1998-2 Trade Cas. 72', volume: '1998-2' },
+			{ text: '2020-1 Trade Cas. 81', volume: '2020-1' },
+		]
+		for (const { text, volume } of examples) {
+			const citations = extractCitations(text)
+			expect(citations).toHaveLength(1)
+			const c = citations[0]
+			if (c.type === 'case' || c.type === 'journal') {
+				expect(c.volume).toBe(volume)
+			}
+		}
+	})
+})
+
 describe('parenthetical year and court extraction (integration)', () => {
 	it('should extract year from parenthetical', () => {
 		const citations = extractCitations('491 U.S. 397 (1989)')


### PR DESCRIPTION
## Summary
- Tokenization patterns now capture `\d+(?:-\d+)?` for volumes, matching hyphenated forms like `1984-1`
- Extractors use smart parsing: purely numeric → `number`, hyphenated → `string`
- **Breaking**: `volume` type changed from `number` to `number | string` across all citation interfaces (minor semver since alpha)

## Test plan
- [x] 3 new integration tests for hyphenated volumes
- [x] All 346 tests passing (343 existing + 3 new)
- [x] Verified `1984-1 Trade Cas. 66` → `volume: "1984-1"` (was `volume: 1`)
- [x] Verified `500 F.2d 123` → `volume: 500` (still number)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)