### PR TITLE
fix: strip date components from court in parentheticals

### DIFF
--- a/.changeset/fix-court-date-parenthetical.md
+++ b/.changeset/fix-court-date-parenthetical.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix court extraction when parenthetical contains month/day date (e.g., "(2d Cir. Jan. 15, 2020)")

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -532,3 +532,59 @@ describe('parenthetical year and court extraction (integration)', () => {
 		}
 	})
 })
+
+describe('court extraction with date in parenthetical (#5)', () => {
+	it('extracts court when parenthetical contains month and day', () => {
+		const citations = extractCitations('500 F.3d 100 (2d Cir. Jan. 15, 2020)')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case') {
+			expect(citations[0].court).toBe('2d Cir.')
+			expect(citations[0].year).toBe(2020)
+		}
+	})
+
+	it('extracts court with different month abbreviation', () => {
+		const citations = extractCitations('347 U.S. 483 (C.D. Cal. Feb. 9, 2015)')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case') {
+			expect(citations[0].court).toBe('C.D. Cal.')
+			expect(citations[0].year).toBe(2015)
+		}
+	})
+
+	it('extracts court when parenthetical has month without day', () => {
+		const citations = extractCitations('500 F.3d 100 (D. Mass. Mar. 2020)')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case') {
+			expect(citations[0].court).toBe('D. Mass.')
+			expect(citations[0].year).toBe(2020)
+		}
+	})
+
+	it('still extracts court with simple year-only parenthetical', () => {
+		const citations = extractCitations('500 F.3d 100 (2d Cir. 2020)')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case') {
+			expect(citations[0].court).toBe('2d Cir.')
+			expect(citations[0].year).toBe(2020)
+		}
+	})
+
+	it('handles Sept. abbreviation', () => {
+		const citations = extractCitations('100 F.2d 50 (5th Cir. Sept. 30, 2019)')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case') {
+			expect(citations[0].court).toBe('5th Cir.')
+			expect(citations[0].year).toBe(2019)
+		}
+	})
+
+	it('handles district court with full date', () => {
+		const citations = extractCitations('200 F. Supp. 2d 300 (S.D.N.Y. Dec. 1, 2018)')
+		expect(citations).toHaveLength(1)
+		if (citations[0].type === 'case') {
+			expect(citations[0].court).toBe('S.D.N.Y.')
+			expect(citations[0].year).toBe(2018)
+		}
+	})
+})


### PR DESCRIPTION
## Summary
- Fixes #5 — court extraction included month/day fragments when parenthetical contained a full date
- `"500 F.3d 100 (2d Cir. Jan. 15, 2020)"` was returning court `"2d Cir. Jan. 15,"` instead of `"2d Cir."`
- Added `stripDateFromCourt()` helper that strips month abbreviations (Jan–Dec/Sept), day numbers, and trailing year
- Applied to both in-token and look-ahead court extraction paths

## Test plan
- [x] 6 new tests: month+day, month-only, Sept. abbreviation, district court, simple year-only, different months
- [x] All 358 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)