### PR TITLE
chore: release v0.3.0

### DIFF
--- a/.changeset/add-4th-5th-series.md
+++ b/.changeset/add-4th-5th-series.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Add support for 4th and 5th series reporters in case citation patterns

--- a/.changeset/compact-journal-fix.md
+++ b/.changeset/compact-journal-fix.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix compact journal citations (e.g., "93 Harv.L.Rev. 752") being misclassified as case citations. Added a specific pattern for compact law review abbreviations containing L.Rev., L.J., or L.Q. that runs before the broad state-reporter case pattern.

--- a/.changeset/fix-annotation-html-tags.md
+++ b/.changeset/fix-annotation-html-tags.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix annotation markers being inserted inside HTML tags when mapping back to original text

--- a/.changeset/fix-court-date-parenthetical.md
+++ b/.changeset/fix-court-date-parenthetical.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix court extraction when parenthetical contains month/day date (e.g., "(2d Cir. Jan. 15, 2020)")

--- a/.changeset/fix-hyphenated-volume.md
+++ b/.changeset/fix-hyphenated-volume.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": minor
----
-
-Support hyphenated volume numbers (e.g., "1984-1 Trade Cas. 66"). Volume type changed from `number` to `number | string` across all citation types — numeric volumes remain numbers, hyphenated volumes are strings.

--- a/.changeset/fix-parenthetical-year-court.md
+++ b/.changeset/fix-parenthetical-year-court.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix year and court not extracted from parentheticals on full case citations. The extractor now looks ahead in the cleaned text for trailing parentheticals like `(1989)` or `(9th Cir. 2020)`. Also strips year from court field and infers `scotus` for Supreme Court reporters.

--- a/.changeset/fix-supra-signal-words.md
+++ b/.changeset/fix-supra-signal-words.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix supra resolution failing when antecedent citation is preceded by signal words (In, See, Compare, etc.)

--- a/.changeset/reporter-internal-spaces.md
+++ b/.changeset/reporter-internal-spaces.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix "U. S." (with internal space) not being recognized as a Supreme Court reporter. Added optional whitespace between "U." and "S." in the supreme-court tokenization pattern.

--- a/.changeset/statute-trailing-letters.md
+++ b/.changeset/statute-trailing-letters.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix statute sections with trailing letters (e.g., "18 U.S.C. § 1028A") not being recognized. Updated tokenization patterns for both USC and state code statutes to allow alphanumeric section suffixes.

--- a/.changeset/statutes-at-large.md
+++ b/.changeset/statutes-at-large.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": minor
----
-
-Add `statutesAtLarge` citation type for Statutes at Large references (e.g., "124 Stat. 119"). Previously these were misclassified as case citations via the broad state-reporter pattern.

--- a/.changeset/supra-space-comma.md
+++ b/.changeset/supra-space-comma.md
@@ -1,5 +1,0 @@
----
-"eyecite-ts": patch
----
-
-Fix supra pattern failing when a space precedes the comma (e.g., "Twombly , supra"), which occurs when HTML tags are cleaned from text like `<em>Twombly</em>, supra`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# eyecite-ts
+
+## 0.3.0
+
+### Minor Changes
+
+- [#32](https://github.com/medelman17/eyecite-ts/pull/32) [`a070d35`](https://github.com/medelman17/eyecite-ts/commit/a070d352adb8c76ec2f313c0ddd0911342012fa9) Thanks [@medelman17](https://github.com/medelman17)! - Support hyphenated volume numbers (e.g., "1984-1 Trade Cas. 66"). Volume type changed from `number` to `number | string` across all citation types — numeric volumes remain numbers, hyphenated volumes are strings.
+
+- [#26](https://github.com/medelman17/eyecite-ts/pull/26) [`18ae4c2`](https://github.com/medelman17/eyecite-ts/commit/18ae4c2f19af46ce9b89a72f9061b5133d4816f3) Thanks [@medelman17](https://github.com/medelman17)! - Add `statutesAtLarge` citation type for Statutes at Large references (e.g., "124 Stat. 119"). Previously these were misclassified as case citations via the broad state-reporter pattern.
+
+### Patch Changes
+
+- [#24](https://github.com/medelman17/eyecite-ts/pull/24) [`0a064ed`](https://github.com/medelman17/eyecite-ts/commit/0a064edcc132df16f7a1a8a8440915660f64ee3d) Thanks [@medelman17](https://github.com/medelman17)! - Add support for 4th and 5th series reporters in case citation patterns
+
+- [#29](https://github.com/medelman17/eyecite-ts/pull/29) [`fb1e58f`](https://github.com/medelman17/eyecite-ts/commit/fb1e58f674e3a443c6b1f594fd258f3ab33b572c) Thanks [@medelman17](https://github.com/medelman17)! - Fix compact journal citations (e.g., "93 Harv.L.Rev. 752") being misclassified as case citations. Added a specific pattern for compact law review abbreviations containing L.Rev., L.J., or L.Q. that runs before the broad state-reporter case pattern.
+
+- [#35](https://github.com/medelman17/eyecite-ts/pull/35) [`14320ad`](https://github.com/medelman17/eyecite-ts/commit/14320ad56e9b639ec6ea33e6babc2dcf48776b8a) Thanks [@medelman17](https://github.com/medelman17)! - Fix annotation markers being inserted inside HTML tags when mapping back to original text
+
+- [#34](https://github.com/medelman17/eyecite-ts/pull/34) [`195403e`](https://github.com/medelman17/eyecite-ts/commit/195403e737e820ae89cc0d38805719806b10d022) Thanks [@medelman17](https://github.com/medelman17)! - Fix court extraction when parenthetical contains month/day date (e.g., "(2d Cir. Jan. 15, 2020)")
+
+- [#31](https://github.com/medelman17/eyecite-ts/pull/31) [`77f30ce`](https://github.com/medelman17/eyecite-ts/commit/77f30ce22ad6a81398cb6e59e9f6ac593e5cc972) Thanks [@medelman17](https://github.com/medelman17)! - Fix year and court not extracted from parentheticals on full case citations. The extractor now looks ahead in the cleaned text for trailing parentheticals like `(1989)` or `(9th Cir. 2020)`. Also strips year from court field and infers `scotus` for Supreme Court reporters.
+
+- [#33](https://github.com/medelman17/eyecite-ts/pull/33) [`c05948b`](https://github.com/medelman17/eyecite-ts/commit/c05948b9833c0bdb564abdcba412928b6711e46e) Thanks [@medelman17](https://github.com/medelman17)! - Fix supra resolution failing when antecedent citation is preceded by signal words (In, See, Compare, etc.)
+
+- [#30](https://github.com/medelman17/eyecite-ts/pull/30) [`70d70a7`](https://github.com/medelman17/eyecite-ts/commit/70d70a76866964be98871cd98ae69074da63fb57) Thanks [@medelman17](https://github.com/medelman17)! - Fix "U. S." (with internal space) not being recognized as a Supreme Court reporter. Added optional whitespace between "U." and "S." in the supreme-court tokenization pattern.
+
+- [#27](https://github.com/medelman17/eyecite-ts/pull/27) [`6fa73a8`](https://github.com/medelman17/eyecite-ts/commit/6fa73a816e3cdc20d91ab56f9bcf6a4b7d1d80bf) Thanks [@medelman17](https://github.com/medelman17)! - Fix statute sections with trailing letters (e.g., "18 U.S.C. § 1028A") not being recognized. Updated tokenization patterns for both USC and state code statutes to allow alphanumeric section suffixes.
+
+- [#28](https://github.com/medelman17/eyecite-ts/pull/28) [`dba6092`](https://github.com/medelman17/eyecite-ts/commit/dba609256eec9a0007223de88b8bd8504bd64dc4) Thanks [@medelman17](https://github.com/medelman17)! - Fix supra pattern failing when a space precedes the comma (e.g., "Twombly , supra"), which occurs when HTML tags are cleaned from text like `<em>Twombly</em>, supra`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eyecite-ts",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "TypeScript port of eyecite - extract, resolve, and annotate legal citations",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Version Packages (v0.3.0)

### Minor Changes
- **Hyphenated volume support** — `volume` type changed from `number` to `number | string` (#32)
- **New `statutesAtLarge` citation type** — e.g., "124 Stat. 119" (#26)

### Patch Changes (9 bug fixes)
- 4th/5th series reporters (#24)
- Compact journal misclassification (#29)
- Annotation markers inside HTML tags (#35)
- Court extraction with dates in parentheticals (#34)
- Parenthetical year/court extraction (#31)
- Supra resolution with signal words (#33)
- Reporter internal spaces — `U. S.` (#30)
- Statute trailing letters — `§ 1028A` (#27)
- Supra space-comma pattern (#28)

🤖 Generated with [Claude Code](https://claude.com/claude-code)