### PR TITLE
fix: handle double section symbol (§§) in statute citations

### DIFF
--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -54,8 +54,8 @@ export function extractStatute(
 	const { text, span } = token
 
 	// Parse title-code-section using regex
-	// Pattern: optional title (digits) + code (letters/periods/spaces) + § + section
-	const statuteRegex = /^(?:(\d+)\s+)?([A-Za-z.\s]+?)\s*§\s*(\d+[A-Za-z0-9-]*)/
+	// Pattern: optional title (digits) + code (letters/periods/spaces) + §+ (one or more) + section
+	const statuteRegex = /^(?:(\d+)\s+)?([A-Za-z.\s]+?)\s*§+\s*(\d+[A-Za-z0-9-]*)/
 	const match = statuteRegex.exec(text)
 
 	if (!match) {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -89,6 +89,23 @@ describe('extractStatute', () => {
 
 			expect(citation.section).toBe('1983-1')
 		})
+
+		it('should handle double section symbol (§§)', () => {
+			const token: Token = {
+				text: '42 U.S.C. §§ 1983',
+				span: { cleanStart: 0, cleanEnd: 17 },
+				type: 'statute',
+				patternId: 'usc',
+			}
+			const transformationMap = createIdentityMap()
+
+			const citation = extractStatute(token, transformationMap)
+
+			expect(citation.title).toBe(42)
+			expect(citation.code).toBe('U.S.C.')
+			expect(citation.section).toBe('1983')
+			expect(citation.text).toBe('42 U.S.C. §§ 1983')
+		})
 	})
 
 	describe('different statutory codes', () => {
@@ -212,6 +229,17 @@ describe('extractStatute', () => {
 			expect(citations).toHaveLength(1)
 			if (citations[0].type === 'statute') {
 				expect(citations[0].section).toBe('2339B')
+			}
+		})
+
+		it('should extract citation with double section symbol (§§)', () => {
+			const citations = extractCitations('42 U.S.C. §§ 1983')
+			expect(citations).toHaveLength(1)
+			expect(citations[0].type).toBe('statute')
+			if (citations[0].type === 'statute') {
+				expect(citations[0].title).toBe(42)
+				expect(citations[0].code).toBe('U.S.C.')
+				expect(citations[0].section).toBe('1983')
 			}
 		})
 	})


### PR DESCRIPTION
## Summary

Fixes #43 by updating the statute extractor regex to handle double section symbols (§§).

## Changes

- Updated regex in `src/extract/extractStatute.ts` from `§\s*` to `§+\s*`
- Added unit test for double section symbol token parsing
- Added integration test via full pipeline

The tokenizer already matched `§§` correctly with its `§+` pattern, but the extractor regex only expected a single `§`. This simple fix aligns them and allows parsing citations like `42 U.S.C. §§ 1983`.

## Test Plan

- [ ] Run `pnpm test` to verify new tests pass
- [ ] Run `pnpm typecheck` to verify no type errors
- [ ] Run `pnpm lint` to verify code style
- [ ] Verify `extractCitations('42 U.S.C. §§ 1983')` no longer throws

----

Generated with [Claude Code](https://claude.ai/code)