### PR TITLE
feat: add F. App'x (Federal Appendix) to federal-reporter pattern

### DIFF
--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -24,8 +24,8 @@ export interface Pattern {
 export const casePatterns: Pattern[] = [
   {
     id: 'federal-reporter',
-    regex: /\b(\d+(?:-\d+)?)\s+(F\.|F\.2d|F\.3d|F\.4th|F\.\s?Supp\.|F\.\s?Supp\.\s?2d|F\.\s?Supp\.\s?3d|F\.\s?Supp\.\s?4th)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
-    description: 'Federal Reporter (F., F.2d, F.3d, F.4th, F.Supp., etc.)',
+    regex: /\b(\d+(?:-\d+)?)\s+(F\.|F\.2d|F\.3d|F\.4th|F\.\s?App'x|F\.\s?Supp\.|F\.\s?Supp\.\s?2d|F\.\s?Supp\.\s?3d|F\.\s?Supp\.\s?4th)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+    description: 'Federal Reporter (F., F.2d, F.3d, F.4th, F. App\'x, F.Supp., etc.)',
     type: 'case',
   },
   {

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -96,6 +96,22 @@ describe('extractCase', () => {
 			expect(citation.page).toBe(100)
 		})
 
+		it('should extract F. App\'x citations (Federal Appendix)', () => {
+			const token: Token = {
+				text: '500 F. App\'x 100',
+				span: { cleanStart: 0, cleanEnd: 16 },
+				type: 'case',
+				patternId: 'federal-reporter',
+			}
+			const transformationMap = createIdentityMap()
+
+			const citation = extractCase(token, transformationMap)
+
+			expect(citation.volume).toBe(500)
+			expect(citation.reporter).toBe('F. App\'x')
+			expect(citation.page).toBe(100)
+		})
+
 		it('should extract Cal.App.4th citations', () => {
 			const token: Token = {
 				text: '173 Cal.App.4th 655',

--- a/tests/integration/fullPipeline.test.ts
+++ b/tests/integration/fullPipeline.test.ts
@@ -315,6 +315,21 @@ describe('Full Pipeline Integration Tests', () => {
 			}
 		})
 
+		it('extracts F. App\'x citations (Federal Appendix)', () => {
+			const text = 'See Doe v. Smith, 500 F. App\'x 100 (11th Cir. 2012), for discussion.'
+			const citations = extractCitations(text)
+
+			const fAppx = citations.find(
+				(c) => c.type === 'case' && c.volume === 500 && c.reporter === 'F. App\'x',
+			)
+			expect(fAppx).toBeDefined()
+			if (fAppx && fAppx.type === 'case') {
+				expect(fAppx.volume).toBe(500)
+				expect(fAppx.reporter).toBe('F. App\'x')
+				expect(fAppx.page).toBe(100)
+			}
+		})
+
 		it('extracts Cal.App.4th citations', () => {
 			const text = 'See People v. Smith, 173 Cal.App.4th 655, for precedent.'
 			const citations = extractCitations(text)


### PR DESCRIPTION
## Summary

Adds support for `F. App'x` (Federal Appendix) citations, used for unpublished federal opinions.

## Changes
- Added `F.\s?App'x` to the federal-reporter regex pattern in `src/patterns/casePatterns.ts`
- Added unit test in `tests/extract/extractCase.test.ts`
- Added integration test in `tests/integration/fullPipeline.test.ts`

## Test Coverage
Now correctly extracts:
- `500 F. App'x 100` → volume=500, reporter="F. App'x", page=100
- `500 F. App'x 100 (11th Cir. 2012)` → full citation with court and year

Closes #44

Generated with [Claude Code](https://claude.ai/code)