### PR TITLE
fix: Lookahead bugs #52, #53 — pincite ranges & footnote refs

### DIFF
--- a/.changeset/lookahead-bug-fixes.md
+++ b/.changeset/lookahead-bug-fixes.md
@@ -1,0 +1,10 @@
+---
+"eyecite-ts": patch
+---
+
+Fix lookahead pattern bugs #52 and #53 that prevented year extraction:
+
+- **Bug #52**: Fixed footnote reference (n.3) preventing year extraction - updated lookahead pattern to skip optional footnote markers like "n.3" or "note 7"
+- **Bug #53**: Fixed pincite ranges (152-53, 163-64) preventing year extraction - updated lookahead pattern to handle hyphenated ranges and multiple comma-separated pincites
+
+These fixes improve year extraction accuracy for citations with complex pincite formats, promoting 2 test cases from known limitations to passing tests.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -45,10 +45,10 @@ const PINCITE_REGEX = /,\s*(\d+)/
 const PAREN_REGEX = /\(([^)]+)\)/
 
 /** Look-ahead pattern for parenthetical after token */
-const LOOKAHEAD_PAREN_REGEX = /^(?:,\s*\d+)*\s*\(([^)]+)\)/
+const LOOKAHEAD_PAREN_REGEX = /^(?:,\s*\d+(?:-\d+)?)*(?:\s+(?:n|note)\s*\.?\s*\d+)?\s*\(([^)]+)\)/
 
 /** Extracts pincite from look-ahead text */
-const LOOKAHEAD_PINCITE_REGEX = /^,\s*(\d+)/
+const LOOKAHEAD_PINCITE_REGEX = /^,\s*(\d+(?:-\d+)?)/
 
 /** Matches chained parentheticals with disposition */
 const CHAINED_DISPOSITION_REGEX = /\([^)]+\)\s*\((en banc|per curiam)\)/i

--- a/tests/fixtures/thorny-corpus.json
+++ b/tests/fixtures/thorny-corpus.json
@@ -439,7 +439,6 @@
       "id": "pincite-footnote-n",
       "category": "thorny-pincites",
       "description": "Pincite with footnote reference (n.3)",
-      "knownLimitation": "Footnote ref (n.3) prevents year extraction (#52)",
       "text": "Miranda v. Arizona, 384 U.S. 436, 444 n.3 (1966)",
       "expected": [
         {
@@ -469,7 +468,6 @@
       "id": "pincite-multiple",
       "category": "thorny-pincites",
       "description": "Multiple pincites (passim)",
-      "knownLimitation": "Multiple pincite ranges prevent year extraction (#53)",
       "text": "Roe v. Wade, 410 U.S. 113, 152-53, 163-64 (1973)",
       "expected": [
         {


### PR DESCRIPTION
## Summary
Fixes two lookahead pattern bugs (#52, #53) that prevented year extraction from parentheticals when complex pincite formats appeared between the citation and the year. Both bugs were in the `LOOKAHEAD_PAREN_REGEX` pattern that scans ahead to find parentheticals after the main citation token.

## Bug Fixes

### Bug #52 — Footnote reference prevents year extraction ✅
**Example**: `"Miranda v. Arizona, 384 U.S. 436, 444 n.3 (1966)"`

**Root cause**: The lookahead pattern `(?:,\s*\d+)*\s*\(` expected an immediate parenthetical after pincite(s), but footnote references like `n.3` or `note 7` appeared in between, causing the pattern to fail and miss the year.

**Fix**: Added optional footnote pattern to `LOOKAHEAD_PAREN_REGEX`:
```typescript
(?:\s+(?:n|note)\s*\.?\s*\d+)?  // matches: " n.3", " n.4", " note 7", etc.
```

**Test promoted**: `pincite-footnote-n` (thorny corpus)

### Bug #53 — Pincite ranges prevent year extraction ✅  
**Examples**: 
- `"500 F.3d 100, 152-53 (2020)"` - single range
- `"Roe v. Wade, 410 U.S. 113, 152-53, 163-64 (1973)"` - multiple ranges

**Root cause**: The pattern `(?:,\s*\d+)*` only matched single digit sequences like `, 152`, not ranges like `, 152-53`. When it encountered the hyphen after `152`, it failed to continue scanning for the parenthetical.

**Fix**: Changed pincite pattern from `\d+` to `\d+(?:-\d+)?` to handle optional hyphenated ranges:
```typescript
(?:,\s*\d+(?:-\d+)?)*  // matches: ", 152" or ", 152-53" or ", 105-107"
```

Also updated `LOOKAHEAD_PINCITE_REGEX` to extract ranges correctly.

**Tests affected**:
- Promoted: `pincite-multiple` (thorny corpus)
- Now passing: `en-dash-range` (expanded corpus) - was compound bug with #54, now fully fixed

## Updated Patterns

**File**: `src/extract/extractCase.ts`

```typescript
// Before:
const LOOKAHEAD_PAREN_REGEX = /^(?:,\s*\d+)*\s*\(([^)]+)\)/
const LOOKAHEAD_PINCITE_REGEX = /^,\s*(\d+)/

// After:
const LOOKAHEAD_PAREN_REGEX = /^(?:,\s*\d+(?:-\d+)?)*(?:\s+(?:n|note)\s*\.?\s*\d+)?\s*\(([^)]+)\)/
const LOOKAHEAD_PINCITE_REGEX = /^,\s*(\d+(?:-\d+)?)/
```

**Pattern breakdown**:
- `^` - start of lookahead text
- `(?:,\s*\d+(?:-\d+)?)*` - zero or more comma-prefixed pincites with optional ranges
- `(?:\s+(?:n|note)\s*\.?\s*\d+)?` - optional footnote reference
- `\s*\(([^)]+)\)` - whitespace and parenthetical (capture group 1)

## Test Results
- ✅ **771 tests passing** (up from 769)
- ⏭️ **24 skipped** (down from 26 - 2 bugs fixed)
- ✅ All typecheck, lint, and bundle size checks pass
- 📦 Bundle size: **6.55KB gzipped** (unchanged, 87% under 50KB limit)

## Impact
Improves year extraction accuracy for:
- Citations with footnote references (common in academic legal writing)
- Citations with pincite ranges (common in appellate briefs citing specific passages)
- Multiple pincite ranges in a single citation

🤖 Generated with [Claude Code](https://claude.com/claude-code)