### PR TITLE
fix: recognize Unicode em-dash as blank page placeholder

### DIFF
--- a/.changeset/unicode-dash-blank-page.md
+++ b/.changeset/unicode-dash-blank-page.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix Unicode em-dash (U+2014) not recognized as blank page placeholder in citations like `500 F.4th — (2024)`. The `normalizeDashes` cleaner now converts em-dash to `---` (matching the existing blank page pattern) and en-dash to `-` (for page ranges). Closes #54.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -63,21 +63,22 @@ export function removeOcrArtifacts(text: string): string {
 }
 
 /**
- * Normalize Unicode dashes to ASCII hyphens.
+ * Normalize Unicode dashes to ASCII equivalents.
  *
- * Converts en-dash (U+2013) and em-dash (U+2014) to ASCII hyphen-minus (U+002D).
- * This ensures extraction regexes that expect ASCII hyphens work correctly.
- *
- * @example
- * normalizeDashes("Smith v. Doe, 500 F.2d 123–125")  // en-dash
- * // => "Smith v. Doe, 500 F.2d 123-125"
+ * En-dash (U+2013) → single hyphen (used in page ranges like 105–107).
+ * Em-dash (U+2014) → triple hyphen (used as blank page placeholder in citations
+ * like "500 F.4th — (2024)", matching the existing `-{3,}` blank page pattern).
  *
  * @example
- * normalizeDashes("Smith v. Doe—500 F.2d 123")  // em-dash
- * // => "Smith v. Doe-500 F.2d 123"
+ * normalizeDashes("500 F.2d 123, 125–130")  // en-dash in range
+ * // => "500 F.2d 123, 125-130"
+ *
+ * @example
+ * normalizeDashes("500 F.4th — (2024)")  // em-dash blank page
+ * // => "500 F.4th --- (2024)"
  */
 export function normalizeDashes(text: string): string {
-  return text.replace(/[\u2013\u2014]/g, "-")
+  return text.replace(/\u2014/g, "---").replace(/\u2013/g, "-")
 }
 
 /**

--- a/tests/clean/cleanText.test.ts
+++ b/tests/clean/cleanText.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { cleanText, fixSmartQuotes, normalizeWhitespace, stripHtmlTags } from "../../src/clean"
+import {
+  cleanText,
+  fixSmartQuotes,
+  normalizeDashes,
+  normalizeWhitespace,
+  stripHtmlTags,
+} from "../../src/clean"
 
 describe("cleanText position tracking", () => {
   it("should maintain identity transformation when no changes occur", () => {
@@ -159,5 +165,23 @@ describe("cleanText position tracking", () => {
 
     // First character 't' is at position 0 in cleaned, position 11 in original (after "<div><span>")
     expect(result.transformationMap.cleanToOriginal.get(0)).toBe(11)
+  })
+})
+
+describe("normalizeDashes (issue #54)", () => {
+  it("converts en-dash to single hyphen", () => {
+    expect(normalizeDashes("105\u2013107")).toBe("105-107")
+  })
+
+  it("converts em-dash to triple hyphen for blank page matching", () => {
+    expect(normalizeDashes("500 F.4th \u2014 (2024)")).toBe("500 F.4th --- (2024)")
+  })
+
+  it("handles mixed dashes", () => {
+    expect(normalizeDashes("100\u2013200 and \u2014")).toBe("100-200 and ---")
+  })
+
+  it("leaves regular hyphens unchanged", () => {
+    expect(normalizeDashes("105-107")).toBe("105-107")
   })
 })

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -1272,6 +1272,54 @@ describe("blank page placeholders (BLANK-01 through BLANK-04)", () => {
       }
     })
   })
+
+  describe("Unicode dash handling (issue #54)", () => {
+    it("should parse en-dash pincite range correctly", () => {
+      const citations = extractCitations("500 F.3d 100, 105\u2013107 (2020)")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "case") {
+        expect(citations[0].year).toBe(2020)
+        expect(citations[0].pincite).toBe(105)
+        expect(citations[0].pinciteInfo?.endPage).toBe(107)
+        expect(citations[0].pinciteInfo?.isRange).toBe(true)
+      }
+    })
+
+    it("should recognize em-dash as blank page placeholder", () => {
+      const citations = extractCitations("500 F.4th \u2014 (2024)")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "case") {
+        expect(citations[0].volume).toBe(500)
+        expect(citations[0].reporter).toBe("F.4th")
+        expect(citations[0].page).toBeUndefined()
+        expect(citations[0].hasBlankPage).toBe(true)
+        expect(citations[0].year).toBe(2024)
+        expect(citations[0].confidence).toBe(0.8)
+      }
+    })
+
+    it("should recognize em-dash blank page in Supreme Court citation", () => {
+      const citations = extractCitations("600 U.S. \u2014 (2024)")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "case") {
+        expect(citations[0].volume).toBe(600)
+        expect(citations[0].reporter).toBe("U.S.")
+        expect(citations[0].page).toBeUndefined()
+        expect(citations[0].hasBlankPage).toBe(true)
+        expect(citations[0].year).toBe(2024)
+      }
+    })
+
+    it("should recognize em-dash blank page with court and year", () => {
+      const citations = extractCitations("500 F.4th \u2014 (9th Cir. 2024)")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "case") {
+        expect(citations[0].hasBlankPage).toBe(true)
+        expect(citations[0].court).toBe("9th Cir.")
+        expect(citations[0].year).toBe(2024)
+      }
+    })
+  })
 })
 
 describe("party name extraction (Phase 7)", () => {


### PR DESCRIPTION
## Summary

- Fixes em-dash (`—`, U+2014) not being recognized as a blank page placeholder in citations like `500 F.4th — (2024)`
- `normalizeDashes` cleaner now converts em-dash → `---` (matches existing `-{3,}` blank page pattern) and en-dash → `-` (for page ranges)
- En-dash pincite ranges (e.g., `105–107`) already worked correctly; added regression test

Closes #54

## Test plan

- [x] 4 new cleaner unit tests (`tests/clean/cleanText.test.ts`)
- [x] 4 new extraction integration tests (`tests/extract/extractCase.test.ts`) — en-dash pincite, em-dash blank page (federal, SCOTUS, with court+year)
- [x] All 1318 existing tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)