### PR TITLE
feat: expand Unicode normalization for OCR'd legal documents (#11)

### DIFF
--- a/.changeset/unicode-normalization.md
+++ b/.changeset/unicode-normalization.md
@@ -1,0 +1,10 @@
+---
+"eyecite-ts": minor
+---
+
+Expand Unicode normalization for OCR'd legal documents (#11)
+
+- Expand `normalizeWhitespace` to handle non-breaking space (U+00A0), thin/hair/en/em spaces, and other Unicode whitespace
+- Expand `normalizeDashes` to handle horizontal bar (U+2015), Unicode hyphen (U+2010), and figure dash (U+2012)
+- Add `normalizeTypography` cleaner (default pipeline): converts prime marks to apostrophes and strips zero-width characters
+- Add `stripDiacritics` opt-in cleaner: removes diacritical marks from OCR artifacts using NFD decomposition

--- a/src/clean/cleanText.ts
+++ b/src/clean/cleanText.ts
@@ -5,6 +5,7 @@ import {
   fixSmartQuotes,
   normalizeDashes,
   normalizeReporterSpacing,
+  normalizeTypography,
   normalizeUnicode,
   normalizeWhitespace,
   stripHtmlTags,
@@ -32,7 +33,7 @@ export interface CleanTextResult {
  * cleaned text while reporting positions in the original text.
  *
  * @param original - Original input text
- * @param cleaners - Array of cleaner functions to apply (default: stripHtmlTags, decodeHtmlEntities, normalizeWhitespace, normalizeUnicode, normalizeDashes, fixSmartQuotes, normalizeReporterSpacing)
+ * @param cleaners - Array of cleaner functions to apply (default: stripHtmlTags, decodeHtmlEntities, normalizeWhitespace, normalizeUnicode, normalizeDashes, fixSmartQuotes, normalizeTypography, normalizeReporterSpacing)
  * @returns Cleaned text with position mappings and warnings
  *
  * @example
@@ -49,6 +50,7 @@ export function cleanText(
     normalizeUnicode,
     normalizeDashes,
     fixSmartQuotes,
+    normalizeTypography,
     normalizeReporterSpacing,
   ],
 ): CleanTextResult {

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -24,7 +24,9 @@ export function stripHtmlTags(text: string): string {
  * // => "Smith v. Doe, 500 F.2d 123"
  */
 export function normalizeWhitespace(text: string): string {
-  return text.replace(/[\t\n\r]+/g, " ").replace(/ {2,}/g, " ")
+  return text
+    .replace(/[\t\n\r\u00A0\u2000-\u200A\u202F\u205F\u3000]+/g, " ")
+    .replace(/ {2,}/g, " ")
 }
 
 /**
@@ -78,7 +80,9 @@ export function removeOcrArtifacts(text: string): string {
  * // => "500 F.4th --- (2024)"
  */
 export function normalizeDashes(text: string): string {
-  return text.replace(/\u2014/g, "---").replace(/\u2013/g, "-")
+  return text
+    .replace(/[\u2014\u2015]/g, "---") // em-dash, horizontal bar → triple hyphen
+    .replace(/[\u2010\u2012\u2013]/g, "-") // hyphen, figure dash, en-dash → hyphen
 }
 
 /**
@@ -150,4 +154,41 @@ export function normalizeReporterSpacing(text: string): string {
   result = result.replace(/([A-Za-z])\.\s+(\d+[a-z]+)/g, "$1.$2")
 
   return result
+}
+
+/**
+ * Normalize typographical symbols and strip zero-width characters.
+ *
+ * Handles prime marks (common OCR substitution for apostrophes) and invisible
+ * Unicode characters that can silently break regex pattern matching.
+ *
+ * @example
+ * normalizeTypography("Doe\u2032s case")  // prime mark
+ * // => "Doe's case"
+ *
+ * @example
+ * normalizeTypography("500\u200BF.2d")  // zero-width space
+ * // => "500F.2d"
+ */
+export function normalizeTypography(text: string): string {
+  return text
+    .replace(/[\u2032\u2035]/g, "'") // prime, reversed prime → apostrophe
+    .replace(/\u200B|\u200C|\u200D|\u2060|\uFEFF/g, "") // zero-width chars
+}
+
+/**
+ * Strip diacritical marks from text (opt-in OCR cleaner).
+ *
+ * Uses Unicode NFD decomposition to separate base characters from combining
+ * marks, then strips the marks. Useful for OCR'd legal documents where
+ * accented characters are artifacts of misrecognition.
+ *
+ * NOT included in the default pipeline — call explicitly or pass in cleaners array.
+ *
+ * @example
+ * stripDiacritics("Hernández v. García")
+ * // => "Hernandez v. Garcia"
+ */
+export function stripDiacritics(text: string): string {
+  return text.normalize("NFD").replace(/[\u0300-\u036F]/g, "")
 }

--- a/tests/clean/cleanText.test.ts
+++ b/tests/clean/cleanText.test.ts
@@ -3,7 +3,9 @@ import {
   cleanText,
   fixSmartQuotes,
   normalizeDashes,
+  normalizeTypography,
   normalizeWhitespace,
+  stripDiacritics,
   stripHtmlTags,
 } from "../../src/clean"
 
@@ -183,5 +185,144 @@ describe("normalizeDashes (issue #54)", () => {
 
   it("leaves regular hyphens unchanged", () => {
     expect(normalizeDashes("105-107")).toBe("105-107")
+  })
+
+  it("converts horizontal bar (U+2015) to triple hyphen", () => {
+    expect(normalizeDashes("500 F.4th \u2015 (2024)")).toBe("500 F.4th --- (2024)")
+  })
+
+  it("converts Unicode hyphen (U+2010) to ASCII hyphen", () => {
+    expect(normalizeDashes("105\u2010107")).toBe("105-107")
+  })
+
+  it("converts figure dash (U+2012) to ASCII hyphen", () => {
+    expect(normalizeDashes("105\u2012107")).toBe("105-107")
+  })
+})
+
+describe("normalizeWhitespace — Unicode whitespace (issue #11)", () => {
+  it("converts non-breaking space (U+00A0) to regular space", () => {
+    expect(normalizeWhitespace("42\u00A0U.S.C.")).toBe("42 U.S.C.")
+  })
+
+  it("collapses consecutive non-breaking spaces", () => {
+    expect(normalizeWhitespace("42\u00A0\u00A0U.S.C.")).toBe("42 U.S.C.")
+  })
+
+  it("converts thin space (U+2009) to regular space", () => {
+    expect(normalizeWhitespace("500\u2009F.2d")).toBe("500 F.2d")
+  })
+
+  it("converts en space (U+2002) and em space (U+2003) to regular space", () => {
+    expect(normalizeWhitespace("500\u2002F.2d\u2003123")).toBe("500 F.2d 123")
+  })
+
+  it("converts narrow no-break space (U+202F) to regular space", () => {
+    expect(normalizeWhitespace("§\u202F1983")).toBe("§ 1983")
+  })
+
+  it("converts ideographic space (U+3000) to regular space", () => {
+    expect(normalizeWhitespace("500\u3000F.2d")).toBe("500 F.2d")
+  })
+})
+
+describe("normalizeTypography (issue #11)", () => {
+  it("converts prime mark (U+2032) to apostrophe", () => {
+    expect(normalizeTypography("Doe\u2032s")).toBe("Doe's")
+  })
+
+  it("converts reversed prime (U+2035) to apostrophe", () => {
+    expect(normalizeTypography("Doe\u2035s")).toBe("Doe's")
+  })
+
+  it("strips zero-width space (U+200B)", () => {
+    expect(normalizeTypography("500\u200BF.2d")).toBe("500F.2d")
+  })
+
+  it("strips word joiner (U+2060)", () => {
+    expect(normalizeTypography("42\u2060 U.S.C.")).toBe("42 U.S.C.")
+  })
+
+  it("strips BOM/ZWNBSP (U+FEFF) inline", () => {
+    expect(normalizeTypography("\uFEFF500 F.2d 123")).toBe("500 F.2d 123")
+  })
+
+  it("strips zero-width non-joiner (U+200C) and joiner (U+200D)", () => {
+    expect(normalizeTypography("F.\u200C2d")).toBe("F.2d")
+    expect(normalizeTypography("F.\u200D2d")).toBe("F.2d")
+  })
+
+  it("leaves normal text unchanged", () => {
+    expect(normalizeTypography("Smith v. Doe, 500 F.2d 123")).toBe("Smith v. Doe, 500 F.2d 123")
+  })
+})
+
+describe("stripDiacritics — opt-in OCR cleaner (issue #11)", () => {
+  it("strips acute accents (é → e)", () => {
+    expect(stripDiacritics("Hernández")).toBe("Hernandez")
+  })
+
+  it("strips umlauts (ü → u)", () => {
+    expect(stripDiacritics("Müller")).toBe("Muller")
+  })
+
+  it("strips cedilla (ç → c)", () => {
+    expect(stripDiacritics("François")).toBe("Francois")
+  })
+
+  it("strips tilde (ñ → n)", () => {
+    expect(stripDiacritics("Muñoz")).toBe("Munoz")
+  })
+
+  it("handles multiple diacritics in one string", () => {
+    expect(stripDiacritics("Hérnandéz v. García")).toBe("Hernandez v. Garcia")
+  })
+
+  it("leaves ASCII text unchanged", () => {
+    expect(stripDiacritics("Smith v. Doe, 500 F.2d 123")).toBe("Smith v. Doe, 500 F.2d 123")
+  })
+
+  it("preserves section symbols and other non-diacritic Unicode", () => {
+    expect(stripDiacritics("42 U.S.C. § 1983")).toBe("42 U.S.C. § 1983")
+  })
+})
+
+describe("full pipeline — OCR-like legal text (issue #11)", () => {
+  it("normalizes Unicode whitespace and dashes in default pipeline", () => {
+    // Simulates OCR text with NBSP, em-dash placeholder, and en-dash range
+    const input = "See Smith v. Doe, 500\u00A0F.4th\u00A0\u2014 (2024), 105\u2013107"
+    const result = cleanText(input)
+    expect(result.cleaned).toContain("500 F.4th --- (2024)")
+    expect(result.cleaned).toContain("105-107")
+  })
+
+  it("strips zero-width characters that would break patterns", () => {
+    const input = "500\u200B F.2d 123"
+    const result = cleanText(input)
+    expect(result.cleaned).toBe("500 F.2d 123")
+  })
+
+  it("handles horizontal bar as blank page placeholder", () => {
+    const input = "500 F.4th \u2015 (2024)"
+    const result = cleanText(input)
+    expect(result.cleaned).toContain("500 F.4th --- (2024)")
+  })
+
+  it("supports opt-in stripDiacritics in custom pipeline", () => {
+    const input = "Hernández v. García, 500 F.2d 123"
+    const result = cleanText(input, [stripDiacritics])
+    expect(result.cleaned).toBe("Hernandez v. Garcia, 500 F.2d 123")
+  })
+
+  it("tracks positions correctly through typography normalization", () => {
+    // Prime mark (1 char) → apostrophe (1 char) = same-length replacement
+    const input = "Doe\u2032s case, 500 F.2d 123"
+    const result = cleanText(input, [normalizeTypography])
+    expect(result.cleaned).toBe("Doe's case, 500 F.2d 123")
+
+    // Position of "5" in "500" should be preserved
+    const cleanPos = result.cleaned.indexOf("500")
+    const originalPos = result.transformationMap.cleanToOriginal.get(cleanPos)
+    expect(originalPos).toBe(input.indexOf("500"))
   })
 })


### PR DESCRIPTION
## Summary
- Expands `normalizeWhitespace` to handle NBSP (U+00A0), thin/hair/em spaces, and other Unicode whitespace characters
- Expands `normalizeDashes` to handle horizontal bar (U+2015), Unicode hyphen (U+2010), and figure dash (U+2012)
- Adds `normalizeTypography` cleaner to default pipeline — converts prime marks to apostrophes and strips zero-width characters that silently break regex matching
- Adds opt-in `stripDiacritics` cleaner using NFD decomposition for OCR diacritical artifacts (e.g., é→e, ü→u)

Closes #11

## Test plan
- [x] 28 new unit tests covering each cleaner function individually
- [x] 5 integration tests with OCR-like legal text through full pipeline
- [x] Position tracking verified through typography normalization
- [x] All 1346 existing tests pass (zero regressions)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)