### PR TITLE
feat: support nominative reporter citations (#49, #16)

### DIFF
--- a/.changeset/nominative-reporters.md
+++ b/.changeset/nominative-reporters.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": minor
+---
+
+Support nominative reporter citations in early SCOTUS cases (#49, #16)
+
+- Fix extraction of citations with nominative parentheticals like `5 U.S. (1 Cranch) 137` (previously produced 0 results)
+- Capture nominative reporter metadata as `nominativeVolume` and `nominativeReporter` fields on `FullCaseCitation`
+- Supports all early SCOTUS nominative reporters: Black, Cranch, How., Wall., Wheat., Pet., Dall.

--- a/docs/superpowers/specs/2026-04-02-nominative-reporter-design.md
+++ b/docs/superpowers/specs/2026-04-02-nominative-reporter-design.md
@@ -1,0 +1,87 @@
+# Nominative Reporter Support
+
+**Issues:** #49 (extraction blocked), #16 (capture nominative metadata)
+**Date:** 2026-04-02
+
+## Problem
+
+Citations like `5 U.S. (1 Cranch) 137 (1803)` — where a historical (nominative) reporter appears in parentheses between the modern reporter and page number — produce 0 extractions. The parenthetical breaks the tokenizer's `volume reporter page` pattern.
+
+When extraction does work (via fix), the nominative reporter data (`1 Cranch`) should be captured as structured metadata, not silently discarded.
+
+## Affected Citation Format
+
+Early SCOTUS cases use dual-reporter citations:
+
+```
+67 U.S. (2 Black) 635 (1862)
+5 U.S. (1 Cranch) 137 (1803)
+60 U.S. (19 How.) 393 (1856)
+74 U.S. (7 Wall.) 506 (1868)
+```
+
+Structure: `volume U.S. (nominativeVolume nominativeReporter) page (year)`
+
+Known nominative reporters: Dallas (Dall.), Cranch, Wheaton (Wheat.), Peters (Pet.), Howard (How.), Black, Wallace (Wall.). All present in `data/reporters.json` with `cite_type: "scotus_early"`.
+
+## Design
+
+Three changes, all backward-compatible:
+
+### 1. Tokenizer Pattern (`src/patterns/casePatterns.ts`)
+
+Add optional non-capturing group to the supreme-court regex between reporter and page:
+
+```
+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?
+```
+
+This lets the tokenizer span the full citation including the parenthetical so the page number is captured in the token text. Non-capturing because the tokenizer only needs the token text — parsing happens in extraction.
+
+### 2. Extraction Regex + Logic (`src/extract/extractCase.ts`)
+
+Update `VOLUME_REPORTER_PAGE_REGEX` to capture nominative content:
+
+```
+/^(\d+(?:-\d+)?)\s+([A-Za-z0-9.\s]+?)\s+(?:\((\d+)\s+([A-Z][A-Za-z.]+)\)\s+)?(\d+|_{3,}|-{3,})/
+```
+
+- Group 1: volume
+- Group 2: reporter (now non-greedy `+?` to stop before parenthetical)
+- Group 3: nominative volume (new, optional)
+- Group 4: nominative reporter (new, optional)
+- Group 5: page (shifted from group 3)
+
+When groups 3 and 4 are present, populate `nominativeVolume` (parsed as number) and `nominativeReporter` on the citation.
+
+### 3. Type Definition (`src/types/citation.ts`)
+
+Add two optional fields to `FullCaseCitation`:
+
+```typescript
+nominativeVolume?: number
+nominativeReporter?: string
+```
+
+### Validation Approach
+
+Pattern-only — trust the positional constraint (must appear between reporter and page in `(number word)` shape). No validation against the reporter database. The position is unambiguous: year parentheticals contain only digits, nominative parentheticals contain digits + a word.
+
+### What Doesn't Change
+
+- No new citation type
+- No new pipeline stage
+- No changes to resolve, annotate, or clean layers
+- Existing citations without nominative parentheticals are unaffected (optional group)
+- `S.Ct.` and `L.Ed.` patterns are included in the tokenizer change for consistency, though nominative parentheticals only appear with `U.S.`
+
+## Test Cases
+
+```
+"67 U.S. (2 Black) 635 (1862)"           → volume: 67, reporter: "U.S.", page: 635, nominativeVolume: 2, nominativeReporter: "Black"
+"5 U.S. (1 Cranch) 137 (1803)"           → with case name "Marbury v. Madison"
+"60 U.S. (19 How.) 393 (1856)"           → multi-digit nominative volume
+"74 U.S. (7 Wall.) 506 (1868)"           → Wallace reporter with period
+"500 U.S. 123 (1991)"                    → no nominative fields (backward compat)
+"Marbury v. Madison, 5 U.S. (1 Cranch) 137, 180 (1803)" → with pincite
+```

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -56,8 +56,9 @@ const MONTH_PATTERN =
 // Compiled regex patterns for performance (hoisted to module level)
 // ============================================================================
 
-/** Matches volume-reporter-page format in citation core */
-const VOLUME_REPORTER_PAGE_REGEX = /^(\d+(?:-\d+)?)\s+([A-Za-z0-9.\s']+)\s+(\d+|_{3,}|-{3,})/
+/** Matches volume-reporter-page format in citation core, with optional nominative reporter parenthetical */
+const VOLUME_REPORTER_PAGE_REGEX =
+  /^(\d+(?:-\d+)?)\s+([A-Za-z0-9.\s']+)\s+(?:\((\d+)\s+([A-Z][A-Za-z.]+)\)\s+)?(\d+|_{3,}|-{3,})/
 
 /** Detects blank page placeholders (3+ underscores or dashes) */
 const BLANK_PAGE_REGEX = /^[_-]{3,}$/
@@ -711,8 +712,12 @@ export function extractCase(
   const volume = parseVolume(match[1])
   const reporter = match[2].trim()
 
-  // Check if page is a blank placeholder
-  const pageStr = match[3]
+  // Extract nominative reporter if present (e.g., "1 Cranch" from "5 U.S. (1 Cranch) 137")
+  const nominativeVolume = match[3] ? Number.parseInt(match[3], 10) : undefined
+  const nominativeReporter = match[4] || undefined
+
+  // Check if page is a blank placeholder (group 5 after nominative groups)
+  const pageStr = match[5]
   const isBlankPage = BLANK_PAGE_REGEX.test(pageStr)
   const page = isBlankPage ? undefined : Number.parseInt(pageStr, 10)
   const hasBlankPage = isBlankPage ? true : undefined
@@ -736,8 +741,10 @@ export function extractCase(
   // Extract parenthetical from token text
   let parentheticalContent: string | undefined
   // Match any parenthetical (with or without letters)
+  // When a nominative reporter is present, the first paren in token text is the
+  // nominative (e.g., "(2 Black)") — skip it so the year/court look-ahead runs.
   const parenMatch = PAREN_REGEX.exec(text)
-  if (parenMatch) {
+  if (parenMatch && !nominativeVolume) {
     parentheticalContent = parenMatch[1]
     // Parse parenthetical using unified parser
     const parenResult = parseParenthetical(parentheticalContent)
@@ -957,6 +964,8 @@ export function extractCase(
     volume,
     reporter,
     page,
+    nominativeVolume,
+    nominativeReporter,
     pincite,
     pinciteInfo,
     court,

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -32,8 +32,9 @@ export const casePatterns: Pattern[] = [
   {
     id: "supreme-court",
     regex:
-      /\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?2d)?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
-    description: "U.S. Supreme Court reporters",
+      /\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?2d)?)\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+    description:
+      "U.S. Supreme Court reporters (with optional nominative reporter parenthetical)",
     type: "case",
   },
   {

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -315,6 +315,20 @@ export interface FullCaseCitation extends CitationBase {
   proceduralPrefix?: string
 
   /**
+   * Nominative (historical) reporter volume for early SCOTUS citations.
+   * Present only when citation includes a nominative parenthetical, e.g.,
+   * `67 U.S. (2 Black) 635` → nominativeVolume: 2
+   */
+  nominativeVolume?: number
+
+  /**
+   * Nominative (historical) reporter abbreviation for early SCOTUS citations.
+   * Present only when citation includes a nominative parenthetical, e.g.,
+   * `67 U.S. (2 Black) 635` → nominativeReporter: "Black"
+   */
+  nominativeReporter?: string
+
+  /**
    * True when page position contains a blank placeholder ("___" or "---").
    * Populated by Phase 5 (Blank Page support).
    * When true, page field will be undefined and confidence reduced to 0.8.

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -1732,3 +1732,75 @@ describe("signal word extraction", () => {
     expect(caseCite?.signal).toBe("see")
   })
 })
+
+describe("nominative reporter support (#49, #16)", () => {
+  describe("extraction — citations with nominative parenthetical", () => {
+    it("extracts 67 U.S. (2 Black) 635 (1862)", () => {
+      const citations = extractCitations("67 U.S. (2 Black) 635 (1862)")
+      expect(citations.length).toBeGreaterThanOrEqual(1)
+      const cite = citations[0] as FullCaseCitation
+      expect(cite.type).toBe("case")
+      expect(cite.volume).toBe(67)
+      expect(cite.reporter).toBe("U.S.")
+      expect(cite.page).toBe(635)
+      expect(cite.year).toBe(1862)
+      expect(cite.nominativeVolume).toBe(2)
+      expect(cite.nominativeReporter).toBe("Black")
+    })
+
+    it("extracts Marbury v. Madison, 5 U.S. (1 Cranch) 137 (1803)", () => {
+      const citations = extractCitations(
+        "Marbury v. Madison, 5 U.S. (1 Cranch) 137 (1803)",
+      )
+      expect(citations.length).toBeGreaterThanOrEqual(1)
+      const cite = citations[0] as FullCaseCitation
+      expect(cite.volume).toBe(5)
+      expect(cite.reporter).toBe("U.S.")
+      expect(cite.page).toBe(137)
+      expect(cite.nominativeVolume).toBe(1)
+      expect(cite.nominativeReporter).toBe("Cranch")
+      expect(cite.caseName).toContain("Marbury")
+    })
+
+    it("extracts multi-digit nominative volume: 60 U.S. (19 How.) 393", () => {
+      const citations = extractCitations("60 U.S. (19 How.) 393 (1856)")
+      expect(citations.length).toBeGreaterThanOrEqual(1)
+      const cite = citations[0] as FullCaseCitation
+      expect(cite.volume).toBe(60)
+      expect(cite.reporter).toBe("U.S.")
+      expect(cite.page).toBe(393)
+      expect(cite.nominativeVolume).toBe(19)
+      expect(cite.nominativeReporter).toBe("How.")
+    })
+
+    it("extracts Wallace reporter: 74 U.S. (7 Wall.) 506 (1868)", () => {
+      const citations = extractCitations("74 U.S. (7 Wall.) 506 (1868)")
+      expect(citations.length).toBeGreaterThanOrEqual(1)
+      const cite = citations[0] as FullCaseCitation
+      expect(cite.volume).toBe(74)
+      expect(cite.reporter).toBe("U.S.")
+      expect(cite.page).toBe(506)
+      expect(cite.nominativeVolume).toBe(7)
+      expect(cite.nominativeReporter).toBe("Wall.")
+    })
+  })
+
+  describe("backward compatibility — no nominative fields when absent", () => {
+    it("500 U.S. 123 has no nominative fields", () => {
+      const citations = extractCitations("500 U.S. 123 (1991)")
+      const cite = citations[0] as FullCaseCitation
+      expect(cite.volume).toBe(500)
+      expect(cite.reporter).toBe("U.S.")
+      expect(cite.page).toBe(123)
+      expect(cite.nominativeVolume).toBeUndefined()
+      expect(cite.nominativeReporter).toBeUndefined()
+    })
+
+    it("410 F.2d 999 has no nominative fields", () => {
+      const citations = extractCitations("410 F.2d 999 (1969)")
+      const cite = citations[0] as FullCaseCitation
+      expect(cite.nominativeVolume).toBeUndefined()
+      expect(cite.nominativeReporter).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Fix extraction of early SCOTUS citations with nominative parentheticals like `5 U.S. (1 Cranch) 137` — previously produced 0 results
- Capture `nominativeVolume` and `nominativeReporter` as optional fields on `FullCaseCitation`
- Three surgical changes: tokenizer pattern, extraction regex + logic, type definition

Closes #49, closes #16

## Changes
- **`src/patterns/casePatterns.ts`** — add optional `(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?` group to supreme-court tokenizer
- **`src/extract/extractCase.ts`** — add capturing groups for nominative volume/reporter, skip nominative paren for year extraction
- **`src/types/citation.ts`** — add `nominativeVolume?: number` and `nominativeReporter?: string` to `FullCaseCitation`

## Test plan
- [x] 4 new extraction tests: Black, Cranch, Howard, Wallace nominative reporters
- [x] 2 backward-compat tests: standard citations have no nominative fields
- [x] All 1352 existing tests pass (zero regressions)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)