### PR TITLE
feat: binary search for paragraph boundary assignment (ALG-05)

### DIFF
--- a/.changeset/binary-search-paragraph-boundaries.md
+++ b/.changeset/binary-search-paragraph-boundaries.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+internal: binary search for paragraph boundary assignment

--- a/docs/algorithms/05-binary-search-paragraph-boundaries.md
+++ b/docs/algorithms/05-binary-search-paragraph-boundaries.md
@@ -1,6 +1,6 @@
 # ALG-05: Binary Search for Paragraph Boundaries
 
-**Status:** Ready
+**Status:** Complete
 **Priority:** 2 (implement second)
 **Textbook References:** CLRS Ch.2.3 (binary search), Sedgewick Ch.1.1 (binary search)
 **Target Files:** `src/resolve/scopeBoundary.ts` lines 38-52

--- a/src/resolve/scopeBoundary.ts
+++ b/src/resolve/scopeBoundary.ts
@@ -10,6 +10,21 @@ import type { Citation } from "../types/citation"
 import type { ScopeStrategy } from "./types"
 
 /**
+ * Binary search returning the insertion point for `value` in sorted `arr`.
+ * Returns the smallest index i such that arr[i] > value (or arr.length if none).
+ */
+function bisectRight(arr: number[], value: number): number {
+  let lo = 0
+  let hi = arr.length
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1
+    if (arr[mid] <= value) lo = mid + 1
+    else hi = mid
+  }
+  return lo
+}
+
+/**
  * Detects paragraph boundaries from text and assigns each citation to a paragraph.
  *
  * @param text - Original document text
@@ -40,16 +55,7 @@ export function detectParagraphBoundaries(
     const citation = citations[i]
     const citationStart = citation.span.originalStart
 
-    // Find which paragraph this citation belongs to
-    let paragraphNum = 0
-    for (let j = 0; j < boundaries.length - 1; j++) {
-      if (citationStart >= boundaries[j] && citationStart < boundaries[j + 1]) {
-        paragraphNum = j
-        break
-      }
-    }
-
-    paragraphMap.set(i, paragraphNum)
+    paragraphMap.set(i, bisectRight(boundaries, citationStart) - 1)
   }
 
   return paragraphMap

--- a/tests/unit/resolve/scopeBoundary.test.ts
+++ b/tests/unit/resolve/scopeBoundary.test.ts
@@ -125,6 +125,49 @@ describe("detectParagraphBoundaries", () => {
   })
 })
 
+describe("detectParagraphBoundaries — binary search edge cases", () => {
+  function makeCitation(originalStart: number): Citation {
+    return {
+      type: "case",
+      text: "cite",
+      span: { originalStart, originalEnd: originalStart + 4, cleanStart: originalStart, cleanEnd: originalStart + 4 },
+      matchedText: "cite",
+      confidence: 1.0,
+      processTimeMs: 0,
+      patternsChecked: 0,
+      volume: 100,
+      reporter: "F.2d",
+      page: 100,
+    }
+  }
+
+  it("assigns citation at position 0 to paragraph 0", () => {
+    const text = "Start.\n\nEnd."
+    const map = detectParagraphBoundaries(text, [makeCitation(0)])
+    expect(map.get(0)).toBe(0)
+  })
+
+  it("assigns citation at exact boundary start to that paragraph", () => {
+    // "Hello.\n\nWorld." — boundary at position 8
+    const text = "Hello.\n\nWorld."
+    const map = detectParagraphBoundaries(text, [makeCitation(8)])
+    expect(map.get(0)).toBe(1) // paragraph 1 starts at position 8
+  })
+
+  it("assigns citation near end of document to last paragraph", () => {
+    const text = "A.\n\nB.\n\nC."
+    const map = detectParagraphBoundaries(text, [makeCitation(8)])
+    expect(map.get(0)).toBe(2) // last paragraph
+  })
+
+  it("handles two citations in the same paragraph", () => {
+    const text = "First citation and second citation.\n\nOther."
+    const map = detectParagraphBoundaries(text, [makeCitation(0), makeCitation(20)])
+    expect(map.get(0)).toBe(0)
+    expect(map.get(1)).toBe(0)
+  })
+})
+
 describe("isWithinBoundary", () => {
   it("returns true for citations in same paragraph", () => {
     const map = new Map<number, number>([


### PR DESCRIPTION
## Summary

- Replace linear scan in `detectParagraphBoundaries()` with `bisectRight()` — O(N log B) instead of O(N*B)
- Eliminates load-bearing `break` statement that was one refactor away from silently assigning wrong paragraphs
- Fixes edge case: citations after all boundaries now correctly assigned to the last paragraph

## Test plan

- [x] 4 new edge case tests (position 0, exact boundary, last paragraph, same paragraph)
- [x] 1446/1446 tests pass (no regressions)
- [x] Typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)