### PR TITLE
fix: improve short-form citation recall — id, supra, shortFormCase

### DIFF
--- a/.changeset/fix-short-form-recall.md
+++ b/.changeset/fix-short-form-recall.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+Improve short-form citation recall for Id., supra, and shortFormCase patterns.
+
+- Id: handle comma before pincite (`Id., at 105`) and page range pincites (`Id. at 5-6`)
+- Supra: support hyphenated names, apostrophes, period-ending names, and `supra note N` with pincite
+- ShortFormCase: fix two-letter ordinal suffixes in reporters (`F.4th`, `Cal.4th`)

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -45,8 +45,8 @@ export function extractId(token: Token, transformationMap: TransformationMap): I
   const { text, span } = token
 
   // Parse Id. with optional pincite
-  // Pattern: Id. or Ibid. with optional "at [page]"
-  const idRegex = /[Ii](?:d|bid)\.(?:\s+at\s+(\d+))?/
+  // Pattern: Id. or Ibid. with optional comma + "at [page]" (handles "Id., at 5")
+  const idRegex = /[Ii](?:d|bid)\.(?:,?\s+at\s+(\d+(?:\s*[-–]\s*\d+)?))?/
   const match = idRegex.exec(text)
 
   if (!match) {
@@ -114,11 +114,11 @@ export function extractId(token: Token, transformationMap: TransformationMap): I
 export function extractSupra(token: Token, transformationMap: TransformationMap): SupraCitation {
   const { text, span } = token
 
-  // Parse party name and optional pincite
-  // Pattern: word(s), supra [, at page]
-  // Note: Matches party names including "v." (e.g., "Smith v. Jones")
+  // Parse party name, optional note number, and optional pincite
+  // Pattern: word(s), supra [note N] [, at page]
+  // Note: Matches party names including hyphens, apostrophes, periods, and "v."
   const supraRegex =
-    /\b([A-Z][a-zA-Z]+(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z]+)*)\s*,?\s+supra(?:,?\s+at\s+(\d+))?/
+    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\d+))?/
   const match = supraRegex.exec(text)
 
   if (!match) {
@@ -126,7 +126,7 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   }
 
   const partyName = match[1]
-  const pincite = match[2] ? Number.parseInt(match[2], 10) : undefined
+  const pincite = match[3] ? Number.parseInt(match[3], 10) : undefined
 
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
@@ -194,7 +194,8 @@ export function extractShortFormCase(
 
   // Parse volume-reporter-at-page
   // Pattern: number space abbreviation space "at" space number
-  const shortFormRegex = /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.\s]+?(?:\d[a-z])?)\s+at\s+(\d+)/
+  // Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th)
+  const shortFormRegex = /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s+at\s+(\d+)/
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -12,28 +12,29 @@
 
 import type { Pattern } from "./casePatterns"
 
-/** Id. with optional pincite: "Id." or "Id. at 253" */
-export const ID_PATTERN: RegExp = /\b[Ii]d\.(?:\s+at\s+(\d+))?/g
+/** Id. with optional pincite: "Id." or "Id. at 253" or "Id., at 253" */
+export const ID_PATTERN: RegExp = /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d\.(?:,?\s+at\s+(\d+(?:\s*[-–]\s*\d+)?))?/g
 
 /** Ibid. with optional pincite (less common variant) */
-export const IBID_PATTERN: RegExp = /\b[Ii]bid\.(?:\s+at\s+(\d+))?/g
+export const IBID_PATTERN: RegExp = /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\.(?:,?\s+at\s+(\d+(?:\s*[-–]\s*\d+)?))?/g
 
 /**
  * Supra with party name and optional pincite.
- * Pattern: word(s), supra [, at page]
- * Captures: (1) party name, (2) pincite
- * Note: Matches party names including "v." (e.g., "Smith v. Jones, supra")
+ * Pattern: word(s), supra [note N] [, at page]
+ * Captures: (1) party name, (2) note number (if any), (3) pincite
+ * Note: Matches party names including hyphens, apostrophes, periods, and "v."
  */
 export const SUPRA_PATTERN: RegExp =
-  /\b([A-Z][a-zA-Z]+(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z]+)*)\s*,?\s+supra(?:,?\s+at\s+(\d+))?/g
+  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\d+))?/g
 
 /**
  * Short-form case: volume reporter at page
  * Pattern: number space abbreviation space "at" space number
- * Simplified detection; full parsing in extraction layer
+ * Simplified detection; full parsing in extraction layer.
+ * Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.\s]+?(?:\d[a-z])?)\s+at\s+(\d+)\b/g
+  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s+at\s+(\d+)\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -367,6 +367,121 @@ describe("extractShortForms", () => {
     })
   })
 
+  describe("Id. with comma before pincite", () => {
+    it("should extract pincite from 'Id., at 105'", () => {
+      const token: Token = {
+        text: "Id., at 105",
+        span: { cleanStart: 0, cleanEnd: 11 },
+        type: "case",
+        patternId: "id",
+      }
+      const citation = extractId(token, createIdentityMap())
+
+      expect(citation.type).toBe("id")
+      expect(citation.pincite).toBe(105)
+      expect(citation.text).toBe("Id., at 105")
+    })
+
+    it("should extract pincite from 'id., at 200'", () => {
+      const token: Token = {
+        text: "id., at 200",
+        span: { cleanStart: 5, cleanEnd: 16 },
+        type: "case",
+        patternId: "id",
+      }
+      const citation = extractId(token, createIdentityMap())
+
+      expect(citation.type).toBe("id")
+      expect(citation.pincite).toBe(200)
+    })
+  })
+
+  describe("supra with note number and pincite", () => {
+    it("should extract pincite from 'Smith, supra note 5, at 130'", () => {
+      const token: Token = {
+        text: "Smith, supra note 5, at 130",
+        span: { cleanStart: 0, cleanEnd: 27 },
+        type: "case",
+        patternId: "supra",
+      }
+      const citation = extractSupra(token, createIdentityMap())
+
+      expect(citation.type).toBe("supra")
+      expect(citation.partyName).toBe("Smith")
+      expect(citation.pincite).toBe(130)
+    })
+
+    it("should extract hyphenated party name", () => {
+      const token: Token = {
+        text: "Martinez-Fernandez, supra, at 100",
+        span: { cleanStart: 0, cleanEnd: 33 },
+        type: "case",
+        patternId: "supra",
+      }
+      const citation = extractSupra(token, createIdentityMap())
+
+      expect(citation.partyName).toBe("Martinez-Fernandez")
+      expect(citation.pincite).toBe(100)
+    })
+
+    it("should extract party name with apostrophe", () => {
+      const token: Token = {
+        text: "O'Brien, supra, at 100",
+        span: { cleanStart: 0, cleanEnd: 22 },
+        type: "case",
+        patternId: "supra",
+      }
+      const citation = extractSupra(token, createIdentityMap())
+
+      expect(citation.partyName).toBe("O'Brien")
+      expect(citation.pincite).toBe(100)
+    })
+
+    it("should extract party name ending with period", () => {
+      const token: Token = {
+        text: "Bros., supra, at 100",
+        span: { cleanStart: 0, cleanEnd: 20 },
+        type: "case",
+        patternId: "supra",
+      }
+      const citation = extractSupra(token, createIdentityMap())
+
+      expect(citation.partyName).toBe("Bros.")
+      expect(citation.pincite).toBe(100)
+    })
+  })
+
+  describe("shortFormCase with 4th-series reporters", () => {
+    it("should extract F.4th short-form", () => {
+      const token: Token = {
+        text: "74 F.4th at 30",
+        span: { cleanStart: 0, cleanEnd: 14 },
+        type: "case",
+        patternId: "shortFormCase",
+      }
+      const citation = extractShortFormCase(token, createIdentityMap())
+
+      expect(citation.type).toBe("shortFormCase")
+      expect(citation.volume).toBe(74)
+      expect(citation.reporter).toBe("F.4th")
+      expect(citation.pincite).toBe(30)
+    })
+
+    it("should extract Cal.4th short-form", () => {
+      const token: Token = {
+        text: "500 Cal.4th at 120",
+        span: { cleanStart: 0, cleanEnd: 18 },
+        type: "case",
+        patternId: "shortFormCase",
+      }
+      const citation = extractShortFormCase(token, createIdentityMap())
+
+      expect(citation.volume).toBe(500)
+      expect(citation.reporter).toBe("Cal.4th")
+      expect(citation.pincite).toBe(120)
+    })
+  })
+
   describe("confidence scoring", () => {
     it("should assign confidence 1.0 to Id. citations", () => {
       const token: Token = {
@@ -460,5 +575,137 @@ describe("supra with HTML cleaning artifacts (integration)", () => {
       expect(supra.partyName).toBe("Twombly")
       expect(supra.pincite).toBe(553)
     }
+  })
+})
+
+describe("short-form recall improvements (integration)", () => {
+  describe("Id. with comma before pincite", () => {
+    it("should capture pincite from 'Id., at 105' in full text", () => {
+      const text = "Smith v. Jones, 500 F.2d 100 (2d Cir. 1974). Id., at 105."
+      const citations = extractCitations(text)
+      const id = citations.find((c) => c.type === "id")
+
+      expect(id).toBeDefined()
+      if (id?.type === "id") {
+        expect(id.pincite).toBe(105)
+      }
+    })
+
+    it("should capture pincite from 'Id., at 105' across newline", () => {
+      const text = "Smith v. Jones, 500 F.2d 100 (2d Cir. 1974).\nId., at 105."
+      const citations = extractCitations(text)
+      const id = citations.find((c) => c.type === "id")
+
+      expect(id).toBeDefined()
+      if (id?.type === "id") {
+        expect(id.pincite).toBe(105)
+      }
+    })
+  })
+
+  describe("supra with newlines and note numbers", () => {
+    it("should extract supra with newline before pincite", () => {
+      const text = "Smith, supra,\nat 130"
+      const citations = extractCitations(text)
+      const supra = citations.find((c) => c.type === "supra")
+
+      expect(supra).toBeDefined()
+      if (supra?.type === "supra") {
+        expect(supra.partyName).toBe("Smith")
+        expect(supra.pincite).toBe(130)
+        // Verify span points to correct location in original text
+        expect(text.substring(supra.span.originalStart, supra.span.originalEnd)).toBe(text)
+      }
+    })
+
+    it("should extract supra with note number and pincite", () => {
+      const text = "Smith, supra note 5, at 130"
+      const citations = extractCitations(text)
+      const supra = citations.find((c) => c.type === "supra")
+
+      expect(supra).toBeDefined()
+      if (supra?.type === "supra") {
+        expect(supra.partyName).toBe("Smith")
+        expect(supra.pincite).toBe(130)
+      }
+    })
+
+    it("should extract supra with hyphenated party name", () => {
+      const text = "Martinez-Fernandez, supra, at 100"
+      const citations = extractCitations(text)
+      const supra = citations.find((c) => c.type === "supra")
+
+      expect(supra).toBeDefined()
+      if (supra?.type === "supra") {
+        expect(supra.partyName).toBe("Martinez-Fernandez")
+        expect(supra.pincite).toBe(100)
+      }
+    })
+
+    it("should extract supra with apostrophe in party name", () => {
+      const text = "O'Brien, supra, at 100"
+      const citations = extractCitations(text)
+      const supra = citations.find((c) => c.type === "supra")
+
+      expect(supra).toBeDefined()
+      if (supra?.type === "supra") {
+        expect(supra.partyName).toBe("O'Brien")
+        expect(supra.pincite).toBe(100)
+      }
+    })
+  })
+
+  describe("shortFormCase with 4th-series reporters", () => {
+    it("should detect '74 F.4th at 30' as shortFormCase", () => {
+      const text = "74 F.4th at 30"
+      const citations = extractCitations(text)
+      const shortForm = citations.find((c) => c.type === "shortFormCase")
+
+      expect(shortForm).toBeDefined()
+      if (shortForm?.type === "shortFormCase") {
+        expect(shortForm.volume).toBe(74)
+        expect(shortForm.reporter).toBe("F.4th")
+        expect(shortForm.pincite).toBe(30)
+      }
+    })
+
+    it("should detect '500 Cal.4th at 120' as shortFormCase", () => {
+      const text = "500 Cal.4th at 120"
+      const citations = extractCitations(text)
+      const shortForm = citations.find((c) => c.type === "shortFormCase")
+
+      expect(shortForm).toBeDefined()
+      if (shortForm?.type === "shortFormCase") {
+        expect(shortForm.volume).toBe(500)
+        expect(shortForm.reporter).toBe("Cal.4th")
+        expect(shortForm.pincite).toBe(120)
+      }
+    })
+
+    it("should detect '563 U.S. at 735' as shortFormCase", () => {
+      const text = "563 U.S. at 735"
+      const citations = extractCitations(text)
+      const shortForm = citations.find((c) => c.type === "shortFormCase")
+
+      expect(shortForm).toBeDefined()
+      if (shortForm?.type === "shortFormCase") {
+        expect(shortForm.volume).toBe(563)
+        expect(shortForm.reporter).toBe("U.S.")
+        expect(shortForm.pincite).toBe(735)
+      }
+    })
+
+    it("should detect '942 F.3d at 146' as shortFormCase", () => {
+      const text = "942 F.3d at 146"
+      const citations = extractCitations(text)
+      const shortForm = citations.find((c) => c.type === "shortFormCase")
+
+      expect(shortForm).toBeDefined()
+      if (shortForm?.type === "shortFormCase") {
+        expect(shortForm.volume).toBe(942)
+        expect(shortForm.reporter).toBe("F.3d")
+        expect(shortForm.pincite).toBe(146)
+      }
+    })
   })
 })

--- a/tests/patterns/shortForm.test.ts
+++ b/tests/patterns/shortForm.test.ts
@@ -59,6 +59,24 @@ describe("ID_PATTERN", () => {
     const match = ID_PATTERN.exec(text)
     expect(match).toBeNull()
   })
+
+  it("should match Id. with comma before pincite", () => {
+    ID_PATTERN.lastIndex = 0
+    const text = "Id., at 105"
+    const match = ID_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[0]).toBe("Id., at 105")
+    expect(match?.[1]).toBe("105")
+  })
+
+  it("should match Id. with page range pincite", () => {
+    ID_PATTERN.lastIndex = 0
+    const text = "Id. at 5-6"
+    const match = ID_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[0]).toBe("Id. at 5-6")
+    expect(match?.[1]).toBe("5-6")
+  })
 })
 
 describe("IBID_PATTERN", () => {
@@ -102,7 +120,7 @@ describe("SUPRA_PATTERN", () => {
     expect(match).not.toBeNull()
     expect(match?.[0]).toBe("Smith, supra, at 460")
     expect(match?.[1]).toBe("Smith")
-    expect(match?.[2]).toBe("460") // Capture group for pincite
+    expect(match?.[3]).toBe("460") // Capture group 3 for pincite (group 2 is note number)
   })
 
   it("should match supra without comma before at", () => {
@@ -111,7 +129,7 @@ describe("SUPRA_PATTERN", () => {
     const match = SUPRA_PATTERN.exec(text)
     expect(match).not.toBeNull()
     expect(match?.[1]).toBe("Jones")
-    expect(match?.[2]).toBe("125")
+    expect(match?.[3]).toBe("125")
   })
 
   it("should match multi-word party name", () => {
@@ -120,7 +138,7 @@ describe("SUPRA_PATTERN", () => {
     const match = SUPRA_PATTERN.exec(text)
     expect(match).not.toBeNull()
     expect(match?.[1]).toBe("United States")
-    expect(match?.[2]).toBe("200")
+    expect(match?.[3]).toBe("200")
   })
 
   it("should match supra without comma after party name", () => {
@@ -129,7 +147,7 @@ describe("SUPRA_PATTERN", () => {
     const match = SUPRA_PATTERN.exec(text)
     expect(match).not.toBeNull()
     expect(match?.[1]).toBe("Brown")
-    expect(match?.[2]).toBe("50")
+    expect(match?.[3]).toBe("50")
   })
 
   it("should NOT match lowercase party name (requires capitalization)", () => {
@@ -137,6 +155,43 @@ describe("SUPRA_PATTERN", () => {
     const text = "smith, supra"
     const match = SUPRA_PATTERN.exec(text)
     expect(match).toBeNull()
+  })
+
+  it("should match supra with note number and pincite", () => {
+    SUPRA_PATTERN.lastIndex = 0
+    const text = "Smith, supra note 5, at 130"
+    const match = SUPRA_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[1]).toBe("Smith")
+    expect(match?.[2]).toBe("5") // note number
+    expect(match?.[3]).toBe("130") // pincite
+  })
+
+  it("should match supra with hyphenated party name", () => {
+    SUPRA_PATTERN.lastIndex = 0
+    const text = "Martinez-Fernandez, supra, at 100"
+    const match = SUPRA_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[1]).toBe("Martinez-Fernandez")
+    expect(match?.[3]).toBe("100")
+  })
+
+  it("should match supra with apostrophe in party name", () => {
+    SUPRA_PATTERN.lastIndex = 0
+    const text = "O'Brien, supra, at 100"
+    const match = SUPRA_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[1]).toBe("O'Brien")
+    expect(match?.[3]).toBe("100")
+  })
+
+  it("should match supra with period-ending party name", () => {
+    SUPRA_PATTERN.lastIndex = 0
+    const text = "Bros., supra, at 100"
+    const match = SUPRA_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[1]).toBe("Bros.")
+    expect(match?.[3]).toBe("100")
   })
 })
 
@@ -169,6 +224,26 @@ describe("SHORT_FORM_CASE_PATTERN", () => {
     expect(match?.[1]).toBe("123")
     expect(match?.[2]).toBe("Cal.Rptr.")
     expect(match?.[3]).toBe("456")
+  })
+
+  it("should match F.4th reporter (two-letter ordinal suffix)", () => {
+    SHORT_FORM_CASE_PATTERN.lastIndex = 0
+    const text = "74 F.4th at 30"
+    const match = SHORT_FORM_CASE_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[1]).toBe("74")
+    expect(match?.[2]).toBe("F.4th")
+    expect(match?.[3]).toBe("30")
+  })
+
+  it("should match Cal.4th reporter", () => {
+    SHORT_FORM_CASE_PATTERN.lastIndex = 0
+    const text = "500 Cal.4th at 120"
+    const match = SHORT_FORM_CASE_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[1]).toBe("500")
+    expect(match?.[2]).toBe("Cal.4th")
+    expect(match?.[3]).toBe("120")
   })
 })
 


### PR DESCRIPTION
## Summary
- **Id**: Handle `Id., at 105` (comma before pincite), page ranges `Id. at 5-6`
- **Supra**: Extended party name chars (hyphens, apostrophes, periods), `supra note N` support
- **ShortFormCase**: Fix reporter ordinal suffix matching (`F.4th`, `Cal.4th` — two-letter suffixes)
- 26 new tests, 0 regressions (1500 total)

## Benchmark context
eyecite-ts recall on 85 real court opinions vs Python eyecite:
| Type | Before | Python eyecite | Gap |
|---|---|---|---|
| id | 65.1% | 88.4% | -23pp |
| shortFormCase | 36.0% | 94.7% | -59pp |
| supra | 35.8% | 90.6% | -55pp |

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)