### PR TITLE
fix: improve Id. citation precision with confidence differentiation (#129)

### DIFF
--- a/.changeset/fix-id-confidence.md
+++ b/.changeset/fix-id-confidence.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Improve Id. citation precision with confidence differentiation and context validation (#129). Standard `Id. at N` gets confidence 1.0, comma variant `Id., at N` gets 0.9, lowercase `id.` gets 0.85. Mid-sentence non-citation uses (e.g., "The Id. card") are penalized to 0.4 via preceding-context validation.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -273,7 +273,7 @@ export function extractCitations(
       case "case":
         // Check pattern ID to distinguish short-form from full citations
         if (token.patternId === "id" || token.patternId === "ibid") {
-          citation = extractId(token, transformationMap)
+          citation = extractId(token, transformationMap, cleaned)
         } else if (token.patternId === "supra") {
           citation = extractSupra(token, transformationMap)
         } else if (token.patternId === "shortFormCase") {

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -41,26 +41,52 @@ import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
  * // }
  * ```
  */
-export function extractId(token: Token, transformationMap: TransformationMap): IdCitation {
+export function extractId(
+  token: Token,
+  transformationMap: TransformationMap,
+  cleanedText?: string,
+): IdCitation {
   const { text, span } = token
 
   // Parse Id. with optional pincite
   // Pattern: Id. or Ibid. with optional comma + "at [page]" (handles "Id., at 5")
-  const idRegex = /[Ii](?:d|bid)\.(?:,?\s+at\s+(\d+(?:\s*[-–]\s*\d+)?))?/
+  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(\d+(?:\s*[-–]\s*\d+)?))?/
   const match = idRegex.exec(text)
 
   if (!match) {
     throw new Error(`Failed to parse Id. citation: ${text}`)
   }
 
-  // Extract pincite if present
-  const pincite = match[1] ? Number.parseInt(match[1], 10) : undefined
+  const firstChar = match[1]
+  const hasComma = match[3] === ","
+  const pincite = match[4] ? Number.parseInt(match[4], 10) : undefined
+
+  // Confidence scoring based on variant
+  let confidence = 1.0
+  const isLowercase = firstChar === "i"
+  if (isLowercase) confidence = 0.85 // Lowercase id. is non-standard
+  if (hasComma) confidence = Math.min(confidence, 0.9) // Comma variant (Id., at N)
+
+  // Context validation: check whether Id. appears in a citation context.
+  // Real Id. citations follow sentence-ending punctuation, semicolons,
+  // or paragraph breaks — not mid-sentence prose like "The Id. card".
+  if (cleanedText && span.cleanStart > 0) {
+    const preceding = cleanedText.slice(Math.max(0, span.cleanStart - 20), span.cleanStart)
+    // Look for the last non-whitespace character before Id.
+    const trimmed = preceding.trimEnd()
+    if (trimmed.length > 0) {
+      const lastChar = trimmed[trimmed.length - 1]
+      // Citation contexts end with: . ; ) ] — or follow certain patterns
+      const isCitationContext = /[.;)\]—:]$/.test(trimmed)
+      if (!isCitationContext) {
+        // Mid-sentence Id. (e.g., "The Id. card") — likely not a citation
+        confidence = Math.min(confidence, 0.4)
+      }
+    }
+  }
 
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
-
-  // Confidence: 1.0 (Id. format is unambiguous)
-  const confidence = 1.0
 
   return {
     type: "id",

--- a/tests/extract/idConfidence.test.ts
+++ b/tests/extract/idConfidence.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+
+describe("Id. citation confidence scoring (issue #129)", () => {
+  function getIdConfidence(text: string): number | undefined {
+    const cits = extractCitations(text)
+    const id = cits.find((c) => c.type === "id")
+    return id?.confidence
+  }
+
+  describe("standard form — confidence 1.0", () => {
+    it("bare Id.", () => {
+      expect(getIdConfidence("See 500 F.2d 100 (1974). Id.")).toBe(1.0)
+    })
+
+    it("Id. at pincite", () => {
+      expect(getIdConfidence("See 500 F.2d 100 (1974). Id. at 253")).toBe(1.0)
+    })
+
+    it("after semicolon (string citation)", () => {
+      expect(getIdConfidence("500 F.2d 100; Id. at 105")).toBe(1.0)
+    })
+
+    it("after close parenthetical", () => {
+      expect(getIdConfidence("(2d Cir. 1974) Id. at 5")).toBe(1.0)
+    })
+  })
+
+  describe("comma variant — confidence 0.9", () => {
+    it("Id., at pincite", () => {
+      expect(getIdConfidence("See 500 F.2d 100 (1974). Id., at 28")).toBe(0.9)
+    })
+
+    it("Id., at range", () => {
+      expect(getIdConfidence("See 500 F.2d 100 (1974). Id., at 108-109")).toBe(0.9)
+    })
+  })
+
+  describe("lowercase — confidence 0.85", () => {
+    it("bare id.", () => {
+      expect(getIdConfidence("See 500 F.2d 100 (1974). id.")).toBe(0.85)
+    })
+
+    it("id. at pincite", () => {
+      expect(getIdConfidence("See 500 F.2d 100 (1974). id. at 5")).toBe(0.85)
+    })
+
+    it("id., at pincite (lowercase + comma)", () => {
+      expect(getIdConfidence("See 500 F.2d 100 (1974). id., at 10")).toBe(0.85)
+    })
+  })
+
+  describe("context validation — non-citation contexts penalized", () => {
+    it("mid-sentence 'The Id. card' gets low confidence", () => {
+      const conf = getIdConfidence("The Id. card was invalid.")
+      expect(conf).toBeLessThanOrEqual(0.4)
+    })
+
+    it("mid-sentence 'His Id.' gets low confidence", () => {
+      const conf = getIdConfidence("His Id. showed his age.")
+      expect(conf).toBeLessThanOrEqual(0.4)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Id. citations previously all received confidence 1.0, contributing to 52.8% precision (928 FPs vs 1,039 TPs)
- Adds variant-aware confidence scoring: standard `Id.` (1.0), comma variant `Id., at N` (0.9), lowercase `id.` (0.85)
- Adds preceding-context validation: mid-sentence non-citation uses like "The Id. card" penalized to 0.4

Closes #129

## Details

The comma-after-Id variant (`Id., at 28`) is valid SCOTUS house style but causes benchmark disagreements since other adapters don't recognize it. Lower confidence (0.9) lets consumers filter by threshold while still extracting them.

Context validation checks the character preceding Id. for citation-ending punctuation (`. ; ) ] — :`). Text like "The Id. card" has a preceding "e" (from "The"), which isn't citation context, so it gets penalized.

## Test plan

- [x] 1542 tests pass (0 regressions, +11 new)
- [x] Standard form: confidence 1.0 preserved
- [x] Comma variant: confidence 0.9
- [x] Lowercase: confidence 0.85
- [x] After semicolons and close-parens: confidence 1.0 (citation context)
- [x] Mid-sentence non-citation: confidence ≤ 0.4
- [x] Build + size check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)