### PR TITLE
feat: add standalone supra extraction (#132)

### DIFF
--- a/.changeset/fix-standalone-supra.md
+++ b/.changeset/fix-standalone-supra.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": minor
+---
+
+Add standalone supra citation extraction (#132). Previously, supra required a preceding party name, missing common footnote patterns like `supra note 12`, `supra at 15`, and `supra § 3`. New STANDALONE_SUPRA_PATTERN matches these with confidence 0.8. The `partyName` field on `SupraCitation` is now optional to support standalone references.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -140,25 +140,44 @@ export function extractId(
 export function extractSupra(token: Token, transformationMap: TransformationMap): SupraCitation {
   const { text, span } = token
 
-  // Parse party name, optional note number, and optional pincite
-  // Pattern: word(s), supra [note N] [, at page]
-  // Note: Matches party names including hyphens, apostrophes, periods, and "v."
-  const supraRegex =
+  // Try party-name pattern first: "Smith, supra [note N] [, at page]"
+  const partySupraRegex =
     /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\d+))?/
-  const match = supraRegex.exec(text)
+  const partyMatch = partySupraRegex.exec(text)
+
+  // Fallback: standalone supra — "supra note N", "supra at N", "supra § N"
+  const standaloneRegex =
+    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\d+))?|\s+at\s+(\d+))?/
+  const match = partyMatch || standaloneRegex.exec(text)
 
   if (!match) {
     throw new Error(`Failed to parse supra citation: ${text}`)
   }
 
-  const partyName = match[1]
-  const pincite = match[3] ? Number.parseInt(match[3], 10) : undefined
+  let partyName: string | undefined
+  let pincite: number | undefined
+  let confidence: number
+
+  if (partyMatch) {
+    partyName = partyMatch[1]
+    pincite = partyMatch[3] ? Number.parseInt(partyMatch[3], 10) : undefined
+    confidence = 0.9
+  } else {
+    // Standalone supra — no party name
+    partyName = undefined
+    const noteNum = match[1]
+    const noteAtPage = match[2]
+    const atPage = match[3]
+    pincite = noteAtPage
+      ? Number.parseInt(noteAtPage, 10)
+      : atPage
+        ? Number.parseInt(atPage, 10)
+        : undefined
+    confidence = 0.8 // Slightly lower — standalone supra is less specific
+  }
 
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
-
-  // Confidence: 0.9 (supra format is fairly standard)
-  const confidence = 0.9
 
   return {
     type: "supra",

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -28,6 +28,16 @@ export const SUPRA_PATTERN: RegExp =
   /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\d+))?/g
 
 /**
+ * Standalone supra without party name (common in footnotes).
+ * Matches: "supra note 12", "supra at 15", "supra § 3", "supra Part II"
+ * Requires "note", "at", "§", "Part", or "p." after supra to avoid matching
+ * the word "supra" in prose. Preceded by whitespace, start, or signal words.
+ * Captures: (1) note number (if any), (2) pincite
+ */
+export const STANDALONE_SUPRA_PATTERN: RegExp =
+  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\d+))?|\s+at\s+(\d+)|\s+(?:§+|Part|p\.)\s*\S+)/g
+
+/**
  * Short-form case: volume reporter at page
  * Pattern: number space abbreviation space "at" space number
  * Simplified detection; full parsing in extraction layer.
@@ -41,6 +51,7 @@ export const SHORT_FORM_PATTERNS: readonly RegExp[] = [
   ID_PATTERN,
   IBID_PATTERN,
   SUPRA_PATTERN,
+  STANDALONE_SUPRA_PATTERN,
   SHORT_FORM_CASE_PATTERN,
 ] as const
 
@@ -62,6 +73,12 @@ export const shortFormPatterns: Pattern[] = [
     id: "supra",
     regex: SUPRA_PATTERN,
     description: 'Supra citations (e.g., "Smith, supra" or "Smith, supra, at 460")',
+    type: "case", // Will be typed as 'supra' in extraction layer
+  },
+  {
+    id: "supra",
+    regex: STANDALONE_SUPRA_PATTERN,
+    description: 'Standalone supra (e.g., "supra note 12" or "supra at 15")',
     type: "case", // Will be typed as 'supra' in extraction layer
   },
   {

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -171,6 +171,7 @@ export class DocumentResolver {
    * Resolves supra citation by matching party name.
    */
   private resolveSupra(citation: SupraCitation): ResolutionResult | undefined {
+    if (!citation.partyName) return undefined // Standalone supra — cannot resolve by party name
     const currentIndex = this.context.citationIndex
     const targetPartyName = this.normalizePartyName(citation.partyName)
 

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -515,8 +515,8 @@ export interface IdCitation extends CitationBase {
  */
 export interface SupraCitation extends CitationBase {
   type: "supra"
-  /** Party name extracted from citation text */
-  partyName: string
+  /** Party name extracted from citation text (undefined for standalone supra references) */
+  partyName?: string
   /** Specific page reference */
   pincite?: number
 }

--- a/tests/branch-coverage/branchCoverage.test.ts
+++ b/tests/branch-coverage/branchCoverage.test.ts
@@ -256,8 +256,8 @@ describe("extractShortForms.ts — throw branches and position fallbacks", () =>
 
   it("extractSupra should throw on text that does not match supra regex", () => {
     const token: Token = {
-      text: "not a supra citation",
-      span: { cleanStart: 0, cleanEnd: 20 },
+      text: "not a citation at all",
+      span: { cleanStart: 0, cleanEnd: 21 },
       type: "case",
       patternId: "supra",
     }

--- a/tests/patterns/shortForm.test.ts
+++ b/tests/patterns/shortForm.test.ts
@@ -248,8 +248,8 @@ describe("SHORT_FORM_CASE_PATTERN", () => {
 })
 
 describe("SHORT_FORM_PATTERNS array", () => {
-  it("should export all four patterns", () => {
-    expect(SHORT_FORM_PATTERNS).toHaveLength(4)
+  it("should export all five patterns", () => {
+    expect(SHORT_FORM_PATTERNS).toHaveLength(5)
     expect(SHORT_FORM_PATTERNS).toContain(ID_PATTERN)
     expect(SHORT_FORM_PATTERNS).toContain(IBID_PATTERN)
     expect(SHORT_FORM_PATTERNS).toContain(SUPRA_PATTERN)


### PR DESCRIPTION
## Summary

- Supra recall was 68.4% (24 FNs / 76 ground truth) because the pattern required a preceding party name
- Adds `STANDALONE_SUPRA_PATTERN` for footnote-style references: `supra note 12`, `supra at 15`, `supra § 3`, `supra Part II`
- Makes `SupraCitation.partyName` optional (breaking type change → minor version bump)

Closes #132

## Details

The standalone pattern requires `supra` followed by `note N`, `at N`, `§`, `Part`, or `p.` to avoid false-matching the word "supra" in prose. Standalone supras get confidence 0.8 (vs 0.9 for party-name form) since they're less specific.

`DocumentResolver.resolveSupra()` returns `undefined` for standalone supra since there's no party name to match against.

## Test plan

- [x] 1543 tests pass (0 regressions)
- [x] `supra note 12` — now found (was missed)
- [x] `see supra at 15` — now found (was missed)
- [x] `see supra § 3` — now found (was missed)
- [x] Party-name supra still works: `Smith, supra, at 135`
- [x] Build + size check pass
- [x] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)