### PR TITLE
fix: rejoin hyphenated line breaks in cleaning pipeline (#130)

### DIFF
--- a/.changeset/fix-hyphenated-line-breaks.md
+++ b/.changeset/fix-hyphenated-line-breaks.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Add `rejoinHyphenatedWords` cleaner to restore words split across line breaks (#130). Court opinions wrap long words with hyphens at line breaks (e.g., `F. Sup-\np. 3d`), which prevented reporter recognition. The new cleaner runs before whitespace normalization, removing `hyphen + newline` sequences while preserving accurate span mappings to the original text.

--- a/src/clean/cleanText.ts
+++ b/src/clean/cleanText.ts
@@ -9,6 +9,7 @@ import {
   normalizeTypography,
   normalizeUnicode,
   normalizeWhitespace,
+  rejoinHyphenatedWords,
   stripHtmlTags,
 } from "./cleaners"
 
@@ -47,6 +48,7 @@ export function cleanText(
   cleaners: Array<(text: string) => string> = [
     stripHtmlTags,
     decodeHtmlEntities,
+    rejoinHyphenatedWords,
     normalizeWhitespace,
     normalizeUnicode,
     normalizeDashes,

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -17,6 +17,28 @@ export function stripHtmlTags(text: string): string {
 }
 
 /**
+ * Rejoin words split across line breaks by a hyphen.
+ *
+ * Court opinions often wrap long words (party names, reporter abbreviations)
+ * with a hyphen at the line break: "Dil-\nlinger" or "F. Sup-\np. 3d".
+ * This cleaner removes the hyphen + line break to restore the original word.
+ *
+ * Must run before normalizeWhitespace (which converts \n to spaces, leaving
+ * "Dil- linger" instead of "Dillinger").
+ *
+ * @example
+ * rejoinHyphenatedWords("Dil-\nlinger V, 672 F. Supp. 3d")
+ * // => "Dillinger V, 672 F. Supp. 3d"
+ *
+ * @example
+ * rejoinHyphenatedWords("F. Sup-\np. 3d 100")
+ * // => "F. Supp. 3d 100"
+ */
+export function rejoinHyphenatedWords(text: string): string {
+  return text.replace(/(\w)-\s*[\n\r]+\s*(\w)/g, "$1$2")
+}
+
+/**
  * Normalize whitespace: convert tabs/newlines to spaces, collapse multiple spaces.
  *
  * @example


### PR DESCRIPTION
## Summary

- Court opinions wrap words at line breaks with hyphens (e.g., `F. Sup-\np. 3d`), breaking reporter recognition after cleaning left `F. Sup- p.3d`
- Adds `rejoinHyphenatedWords` cleaner: `(\w)-\s*[\n\r]+\s*(\w)` → `$1$2`
- Runs before `normalizeWhitespace` in the default pipeline so the rejoined text is properly normalized

Closes #130

## Before/After

| Input | Before | After |
|-------|--------|-------|
| `F. Sup-\np. 3d` | `F. Sup- p.3d` (MISS) | `F.Supp.3d` (FOUND) |
| `Dil-\nlinger` | `Dil- linger` | `Dillinger` |
| `Gon-\nzales` | `Gon- zales` | `Gonzales` |

## Test plan

- [x] 1543 tests pass (0 regressions)
- [x] Previously missed `F. Sup-\np. 3d` now found as `F.Supp.3d`
- [x] Span mapping verified: originalStart/originalEnd point to correct positions in original text
- [x] Build + size check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)