### PR TITLE
fix: support comma-before-at in short-form case citations (#127)

### DIFF
--- a/.changeset/fix-shortform-comma-at.md
+++ b/.changeset/fix-shortform-comma-at.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix short-form case citation recall for comma-before-at patterns (#127). The regex now accepts an optional comma between the reporter and `at` keyword (`\s*,?\s+at`), matching SCOTUS style (`597 U.S., at 721`), federal circuit style (`116 F.4th, at 1193`), nominative reporters (`9 Wheat., at 201`), and law review short forms (`133 Harv. L. Rev., at 580`). Expected recall improvement from ~47.6% to ~75%+.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -237,10 +237,11 @@ export function extractShortFormCase(
 ): ShortFormCaseCitation {
   const { text, span } = token
 
-  // Parse volume-reporter-at-page
-  // Pattern: number space abbreviation space "at" space number
+  // Parse volume-reporter-[,]-at-page
+  // Pattern: number space abbreviation [, ] at space number
   // Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th)
-  const shortFormRegex = /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s+at\s+(\d+)/
+  // Handles comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193"
+  const shortFormRegex = /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\d+)/
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -38,13 +38,14 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
   /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\d+))?|\s+at\s+(\d+)|\s+(?:§+|Part|p\.)\s*\S+)/g
 
 /**
- * Short-form case: volume reporter at page
- * Pattern: number space abbreviation space "at" space number
+ * Short-form case: volume reporter [,] at page
+ * Pattern: number space abbreviation [, ] at space number
  * Simplified detection; full parsing in extraction layer.
  * Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
+ * Handles SCOTUS/federal comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s+at\s+(\d+)\b/g
+  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\d+)\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [


### PR DESCRIPTION
## Summary

- Short-form case recall was 47.6% (527 FNs / 1,005 ground truth) — the single highest-impact extraction issue
- Root cause: regex required `reporter at page` but SCOTUS/federal opinions use `reporter, at page`
- Fix: `\s+at\s+` → `\s*,?\s+at\s+` in both tokenizer pattern and extraction regex

Closes #127

## Patterns now matched

| Pattern | Example | Reporter |
|---------|---------|----------|
| SCOTUS spacing | `597 U. S., at 721` | U.S. |
| Federal circuit | `116 F. 4th, at 1193` | F.4th |
| Nominative | `9 Wheat., at 201` | Wheat. |
| Law review | `133 Harv. L. Rev., at 580` | Harv. L. Rev. |

## Test plan

- [x] 1543 tests pass (0 regressions)
- [x] All 6 issue examples now found
- [x] Existing comma-free patterns (`500 F.2d at 123`) still work
- [x] Build + size check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)