### PR TITLE
fix: correct span mapping when input contains newlines (#134)

### DIFF
--- a/.changeset/fix-span-mapping-newlines.md
+++ b/.changeset/fix-span-mapping-newlines.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix span mapping when input text contains newlines (#134). The `rebuildPositionMaps` algorithm's deletion lookahead misinterpreted same-length character replacements (e.g., `\n` → ` `) as multi-character deletions, causing `originalStart`/`originalEnd` to point to wrong positions. Added a fast-path: when remaining text lengths are equal, all mismatches are treated as 1:1 replacements without lookahead.

--- a/src/clean/cleanText.ts
+++ b/src/clean/cleanText.ts
@@ -163,6 +163,20 @@ function rebuildPositionMaps(
       afterIdx++
     } else {
       // Characters differ - need to determine if this is insertion/deletion/replacement
+
+      // If remaining lengths are equal, every mismatch is a pure character
+      // replacement (no insertions or deletions from this point on).
+      // This prevents the lookahead from misinterpreting replacements like \n→' '
+      // as multi-char deletions when the replacement char appears later in the text.
+      if (beforeText.length - beforeIdx === afterText.length - afterIdx) {
+        const originalPos = oldCleanToOriginal.get(beforeIdx) ?? beforeIdx
+        newCleanToOriginal.set(afterIdx, originalPos)
+        newOriginalToClean.set(originalPos, afterIdx)
+        beforeIdx++
+        afterIdx++
+        continue
+      }
+
       // Look ahead to find next match
       let foundMatch = false
       const maxLookAhead = 20 // Limit lookahead to avoid performance issues


### PR DESCRIPTION
## Summary

- `span.originalStart`/`originalEnd` were wrong when input text contained newlines — `text.slice(originalStart, originalEnd)` did not equal `matchedText`
- Root cause: `rebuildPositionMaps`' deletion lookahead found a space at position 62 when the `\n`→` ` replacement was at position 58, treating 4 characters as "deleted"
- Fix: when remaining before/after text lengths are equal, skip lookahead entirely — every mismatch is a 1:1 replacement

Closes #134

## Root Cause

```
before: ...Goldsmith,\n598 U.S. 508...
after:  ...Goldsmith, 598 U.S. 508...
                     ^
                     position 58: \n → ' '
```

The lookahead scanned forward in `beforeText` looking for `' '`, found it at position 62 (`" U.S."`), and treated positions 58-61 (`\n598`) as deleted. This corrupted all subsequent span mappings.

## Fix

```typescript
// If remaining lengths are equal → pure replacement, no ins/del possible
if (beforeText.length - beforeIdx === afterText.length - afterIdx) {
  // Map 1:1 and advance both — no lookahead needed
}
```

This is mathematically correct: equal remaining lengths means zero net insertions/deletions from that point on, so every character mismatch must be a replacement.

## Test plan

- [x] 1543 tests pass (0 regressions)
- [x] `text.slice(originalStart, originalEnd) === matchedText` verified for text with newlines
- [x] Multi-newline text (`\n` in case name, between citations, before Id.) all correct
- [x] Build + size check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)