### PR TITLE
fix: change default resolution scope to improve accuracy from 13% to 97% (#131)

### DIFF
--- a/.changeset/fix-resolution-scope.md
+++ b/.changeset/fix-resolution-scope.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": minor
+---
+
+Change default resolution scope strategy from `"paragraph"` to `"none"` (#131). The paragraph scope (`\n\n+` boundaries) was too restrictive for real court opinions where HTML stripping produces frequent double-newlines, blocking 87% of Id. and short-form resolutions. Resolution accuracy improves from 13% to ~97%. Users can still opt into paragraph scope via `resolutionOptions: { scopeStrategy: "paragraph" }`.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -54,7 +54,7 @@ export class DocumentResolver {
 
     // Apply defaults to options
     this.options = {
-      scopeStrategy: options.scopeStrategy ?? "paragraph",
+      scopeStrategy: options.scopeStrategy ?? "none",
       autoDetectParagraphs: options.autoDetectParagraphs ?? true,
       paragraphBoundaryPattern: options.paragraphBoundaryPattern ?? /\n\n+/g,
       fuzzyPartyMatching: options.fuzzyPartyMatching ?? true,

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -19,11 +19,11 @@ export type ScopeStrategy = "paragraph" | "section" | "footnote" | "none"
  */
 export interface ResolutionOptions {
   /**
-   * Scope boundary strategy (default: 'paragraph')
-   * - paragraph: Only resolve within same paragraph
+   * Scope boundary strategy (default: 'none')
+   * - none: Resolve across entire document (recommended for HTML-stripped text)
+   * - paragraph: Only resolve within same paragraph (too restrictive for most inputs)
    * - section: Only resolve within same section
    * - footnote: Only resolve within same footnote
-   * - none: Resolve across entire document
    */
   scopeStrategy?: ScopeStrategy
 

--- a/tests/integration/resolution.test.ts
+++ b/tests/integration/resolution.test.ts
@@ -59,7 +59,7 @@ describe("Resolution Integration Tests", () => {
   })
 
   describe("Paragraph Scope Boundaries", () => {
-    it("Id. does not resolve across paragraph boundaries (default)", () => {
+    it("Id. resolves across paragraph boundaries with default scope (none)", () => {
       const text = `First paragraph: Smith v. Jones, 500 F.2d 123 (2020).
 
 Second paragraph: Id. at 125.`
@@ -68,7 +68,22 @@ Second paragraph: Id. at 125.`
 
       expect(citations).toHaveLength(2)
 
-      // Id. in second paragraph fails to resolve
+      // Default scope is "none" — Id. resolves across paragraphs
+      expect(citations[1].type).toBe("id")
+      expect(citations[1].resolution?.resolvedTo).toBe(0)
+    })
+
+    it("Id. does not resolve across paragraph boundaries with paragraph scope", () => {
+      const text = `First paragraph: Smith v. Jones, 500 F.2d 123 (2020).
+
+Second paragraph: Id. at 125.`
+
+      const citations = extractCitations(text, {
+        resolve: true,
+        resolutionOptions: { scopeStrategy: "paragraph" },
+      }) as ResolvedCitation[]
+
+      expect(citations).toHaveLength(2)
       expect(citations[1].type).toBe("id")
       expect(citations[1].resolution?.resolvedTo).toBeUndefined()
       expect(citations[1].resolution?.failureReason).toContain("scope boundary")


### PR DESCRIPTION
## Summary

- Short-form resolution accuracy was 13.2% (146/1,102 correct) because paragraph scope blocked 87% of resolutions
- Root cause: HTML-stripped opinions have `\n\n` after every `<p>` tag, creating hundreds of scope boundaries. The resolver couldn't find antecedents across these artificial paragraphs.
- Fix: change default `scopeStrategy` from `"paragraph"` to `"none"` (resolve across entire document), matching Python eyecite's behavior
- Resolution accuracy: **13.2% → 96.9%** on 5-document sample

Closes #131

## Breaking Change (minor)

Default `scopeStrategy` changed from `"paragraph"` to `"none"`. Users relying on paragraph-scoped resolution can opt back in:

```typescript
extractCitations(text, {
  resolve: true,
  resolutionOptions: { scopeStrategy: "paragraph" }
})
```

## Test plan

- [x] 1544 tests pass (0 regressions, +1 new test)
- [x] Existing paragraph-scope test preserved with explicit `scopeStrategy: "paragraph"`
- [x] New test: Id. resolves across paragraphs with default scope
- [x] Build + size check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)