### PR TITLE
fix: use conditional types in exports map for correct declaration resolution

### DIFF
--- a/.changeset/fix-type-declarations.md
+++ b/.changeset/fix-type-declarations.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix missing type declarations (#149). The package.json exports map pointed to `.d.ts` files that don't exist — the build emits `.d.mts` (ESM) and `.d.cts` (CJS). Updated exports to use conditional types per format so TypeScript consumers get proper type information for all entry points.

--- a/package.json
+++ b/package.json
@@ -5,29 +5,49 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./data": {
-      "types": "./dist/data/index.d.ts",
-      "import": "./dist/data/index.mjs",
-      "require": "./dist/data/index.cjs"
+      "import": {
+        "types": "./dist/data/index.d.mts",
+        "default": "./dist/data/index.mjs"
+      },
+      "require": {
+        "types": "./dist/data/index.d.cts",
+        "default": "./dist/data/index.cjs"
+      }
     },
     "./annotate": {
-      "types": "./dist/annotate/index.d.ts",
-      "import": "./dist/annotate/index.mjs",
-      "require": "./dist/annotate/index.cjs"
+      "import": {
+        "types": "./dist/annotate/index.d.mts",
+        "default": "./dist/annotate/index.mjs"
+      },
+      "require": {
+        "types": "./dist/annotate/index.d.cts",
+        "default": "./dist/annotate/index.cjs"
+      }
     },
     "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "import": "./dist/utils/index.mjs",
-      "require": "./dist/utils/index.cjs"
+      "import": {
+        "types": "./dist/utils/index.d.mts",
+        "default": "./dist/utils/index.mjs"
+      },
+      "require": {
+        "types": "./dist/utils/index.d.cts",
+        "default": "./dist/utils/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Fixes #149 — TypeScript consumers get no type information because `package.json` pointed to `.d.ts` files that don't exist (build emits `.d.mts` / `.d.cts`).

- Updated all four entry points (`.`, `./data`, `./annotate`, `./utils`) to use per-format conditional `types` in the exports map
- Updated top-level `types` field to point to `./dist/index.d.mts`

## Test plan

- [x] All 8 type declaration files (4 ESM + 4 CJS) verified to exist
- [x] Full test suite passes (1565 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)