### PR TITLE
feat: expand state statute coverage to all 50 US states + DC

### DIFF
--- a/.changeset/state-statute-coverage.md
+++ b/.changeset/state-statute-coverage.md
@@ -1,0 +1,12 @@
+---
+"eyecite-ts": minor
+---
+
+Add statute citation patterns for 31 additional US state jurisdictions
+
+Expands the `abbreviated-code` pattern family from 12 to 43 states using a data-driven
+regex generation approach. Each new state was verified against real citation formats from
+court opinions and legislative text.
+
+New jurisdictions: AK, AZ, AR, CT, DC, HI, IA, ID, KS, KY, LA, ME, MN, MO, MS, MT,
+ND, NE, NH, NM, NV, OK, OR, RI, SC, SD, TN, VT, WI, WV, WY.

--- a/docs/superpowers/plans/2026-04-06-state-statute-coverage.md
+++ b/docs/superpowers/plans/2026-04-06-state-statute-coverage.md
@@ -1,0 +1,1084 @@
+# State Statute Coverage Expansion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ~30 missing US state jurisdictions to the abbreviated-code statute pattern, using a data-driven regex generation approach.
+
+**Architecture:** New `src/data/stateStatutes.ts` file holds a state abbreviation table. The `abbreviated-code` regex in `statutePatterns.ts` is generated from this table at import time. `knownCodes.ts` derives its `abbreviatedCodes[]` from the same table. Single source of truth — no manual sync.
+
+**Tech Stack:** TypeScript, Vitest, Biome
+
+**Spec:** `docs/superpowers/specs/2026-04-06-state-statute-coverage-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/data/stateStatutes.ts` | Create | State abbreviation table, `escapeForRegex`, `buildAbbreviatedCodeRegex` |
+| `src/data/knownCodes.ts` | Modify | Derive `abbreviatedCodes[]` from `stateStatuteEntries` |
+| `src/patterns/statutePatterns.ts` | Modify | Replace hardcoded regex with `buildAbbreviatedCodeRegex()` |
+| `src/data/index.ts` | Modify | Export `stateStatutes` |
+| `tests/data/stateStatutes.test.ts` | Create | Unit tests for escapeForRegex and regex builder |
+| `tests/extract/extractStatute.test.ts` | Modify | Add per-state smoke tests |
+| `tests/fixtures/statute-corpus.json` | Modify | Add corpus entries for new states |
+
+---
+
+### Task 1: Create stateStatutes.ts with types and escapeForRegex
+
+**Files:**
+- Create: `src/data/stateStatutes.ts`
+- Create: `tests/data/stateStatutes.test.ts`
+
+- [ ] **Step 1: Write failing tests for escapeForRegex**
+
+```ts
+// tests/data/stateStatutes.test.ts
+import { describe, expect, it } from "vitest"
+import { escapeForRegex } from "@/data/stateStatutes"
+
+describe("escapeForRegex", () => {
+  it("should handle dotted abbreviations like T.C.A.", () => {
+    const result = escapeForRegex("T.C.A.")
+    expect("T.C.A.").toMatch(new RegExp(result))
+    expect("TCA").toMatch(new RegExp(result))
+    expect("T C A").toMatch(new RegExp(result))
+  })
+
+  it("should handle word.space patterns like Conn. Gen. Stat.", () => {
+    const result = escapeForRegex("Conn. Gen. Stat.")
+    expect("Conn. Gen. Stat.").toMatch(new RegExp(result))
+    expect("Conn Gen Stat").toMatch(new RegExp(result))
+    expect("Conn.  Gen.  Stat.").toMatch(new RegExp(result))
+  })
+
+  it("should handle plain words like Alaska Stat.", () => {
+    const result = escapeForRegex("Alaska Stat.")
+    expect("Alaska Stat.").toMatch(new RegExp(result))
+    expect("Alaska Stat").toMatch(new RegExp(result))
+    expect("Alaska  Stat.").toMatch(new RegExp(result))
+  })
+
+  it("should handle abbreviations without periods like MCL", () => {
+    const result = escapeForRegex("MCL")
+    expect("MCL").toMatch(new RegExp(result))
+  })
+
+  it("should handle mixed patterns like N.H. Rev. Stat. Ann.", () => {
+    const result = escapeForRegex("N.H. Rev. Stat. Ann.")
+    expect("N.H. Rev. Stat. Ann.").toMatch(new RegExp(result))
+    expect("NH Rev Stat Ann").toMatch(new RegExp(result))
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run tests/data/stateStatutes.test.ts -v`
+Expected: FAIL — module `@/data/stateStatutes` not found
+
+- [ ] **Step 3: Implement the types and escapeForRegex**
+
+```ts
+// src/data/stateStatutes.ts
+
+/**
+ * State statute abbreviation table — single source of truth for the
+ * abbreviated-code tokenizer pattern and the knownCodes lookup registry.
+ */
+
+export interface StateStatuteEntry {
+  /** Two-letter jurisdiction code (e.g., "AK", "AZ") */
+  jurisdiction: string
+  /** All recognized abbreviation forms — used for lookup by findAbbreviatedCode */
+  abbreviations: string[]
+  /**
+   * Regex fragment for tokenizer alternation. If omitted, auto-generated
+   * from abbreviations via escapeForRegex. Provide explicitly when the
+   * pattern needs optional components (e.g., "Stat(?:utes)?").
+   */
+  regexFragment?: string
+}
+
+/**
+ * Convert a plain abbreviation string into a regex fragment.
+ *
+ * Rules:
+ * - Periods followed by a letter (e.g., "T.C.") → optional period + optional space
+ * - Periods followed by a space (e.g., "Stat. Ann.") → optional period + flexible space
+ * - Trailing periods → optional period
+ * - Spaces → flexible whitespace (\s+)
+ * - Regex-special characters are escaped
+ */
+export function escapeForRegex(abbreviation: string): string {
+  return (
+    abbreviation
+      // Escape regex-special chars (except period and space, handled below)
+      .replace(/[\\^$*+?{}[\]|()]/g, "\\$&")
+      // Period followed by letter: "T.C" → "T\.?\s*C"
+      .replace(/\.(?=[A-Za-z])/g, "\\.?\\s*")
+      // Period followed by space: "Stat. Ann" → "Stat\.?\s+Ann"
+      .replace(/\.\s+/g, "\\.?\\s+")
+      // Trailing period: "Ann." → "Ann\.?"
+      .replace(/\.$/g, "\\.?")
+      // Remaining spaces → flexible whitespace
+      .replace(/ +/g, "\\s+")
+  )
+}
+
+/** Placeholder — entries added in Tasks 2-7 */
+export const stateStatuteEntries: StateStatuteEntry[] = []
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run tests/data/stateStatutes.test.ts -v`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/data/stateStatutes.ts tests/data/stateStatutes.test.ts
+git commit -m "feat(data): add stateStatutes types and escapeForRegex helper"
+```
+
+---
+
+### Task 2: Add buildAbbreviatedCodeRegex
+
+**Files:**
+- Modify: `src/data/stateStatutes.ts`
+- Modify: `tests/data/stateStatutes.test.ts`
+
+- [ ] **Step 1: Write failing test for regex builder**
+
+Add to `tests/data/stateStatutes.test.ts`:
+
+```ts
+import { escapeForRegex, buildAbbreviatedCodeRegex, stateStatuteEntries } from "@/data/stateStatutes"
+import type { StateStatuteEntry } from "@/data/stateStatutes"
+
+describe("buildAbbreviatedCodeRegex", () => {
+  it("should build regex that matches abbreviations from entries", () => {
+    // Temporarily push a test entry
+    const original = [...stateStatuteEntries]
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push({
+      jurisdiction: "XX",
+      abbreviations: ["X.X. Code", "XX Code"],
+    })
+
+    const regex = buildAbbreviatedCodeRegex()
+    const text = "X.X. Code § 123"
+    const match = regex.exec(text)
+    expect(match).not.toBeNull()
+    expect(match![2]).toContain("X.X. Code")
+    expect(match![3]).toBe("123")
+
+    // Restore
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push(...original)
+  })
+
+  it("should capture optional leading title number", () => {
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push({
+      jurisdiction: "XX",
+      abbreviations: ["XX Code"],
+    })
+
+    const regex = buildAbbreviatedCodeRegex()
+    const text = "42 XX Code § 5524"
+    const match = regex.exec(text)
+    expect(match).not.toBeNull()
+    expect(match![1]).toBe("42")
+    expect(match![3]).toBe("5524")
+
+    stateStatuteEntries.length = 0
+  })
+
+  it("should use regexFragment when provided", () => {
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push({
+      jurisdiction: "XX",
+      abbreviations: ["X. Stat."],
+      regexFragment: "X\\.?\\s*Stat(?:utes)?\\.?(?:\\s+Ann\\.?)?",
+    })
+
+    const regex = buildAbbreviatedCodeRegex()
+    expect("X. Statutes Ann. § 99".match(regex)).not.toBeNull()
+    expect("X Stat § 99".match(regex)).not.toBeNull()
+
+    stateStatuteEntries.length = 0
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run tests/data/stateStatutes.test.ts -v`
+Expected: FAIL — `buildAbbreviatedCodeRegex` not exported
+
+- [ ] **Step 3: Implement buildAbbreviatedCodeRegex**
+
+Add to `src/data/stateStatutes.ts`:
+
+```ts
+/**
+ * Build the abbreviated-code tokenizer regex from stateStatuteEntries.
+ *
+ * Produces the same capture group structure as the original hardcoded regex:
+ *   (1) optional leading title number
+ *   (2) abbreviation text
+ *   (3) section + subsections + et seq.
+ *
+ * Fragments are sorted longest-first for PEG-style ordered choice —
+ * "Alaska Stat. Ann." matches before "AS" can grab a false positive.
+ */
+export function buildAbbreviatedCodeRegex(): RegExp {
+  const allFragments: string[] = []
+
+  for (const entry of stateStatuteEntries) {
+    if (entry.regexFragment) {
+      allFragments.push(entry.regexFragment)
+    } else {
+      for (const abbrev of entry.abbreviations) {
+        allFragments.push(escapeForRegex(abbrev))
+      }
+    }
+  }
+
+  // Sort longest-first so more specific patterns match before shorter ones
+  allFragments.sort((a, b) => b.length - a.length)
+
+  const alternation = allFragments.join("|")
+
+  return new RegExp(
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*§?\\s*(\\d+[A-Za-z0-9.:/-]*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
+    "g",
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm exec vitest run tests/data/stateStatutes.test.ts -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/data/stateStatutes.ts tests/data/stateStatutes.test.ts
+git commit -m "feat(data): add buildAbbreviatedCodeRegex function"
+```
+
+---
+
+### Task 3: Migrate existing 12 states into stateStatuteEntries
+
+**Files:**
+- Modify: `src/data/stateStatutes.ts`
+- Modify: `tests/data/stateStatutes.test.ts`
+
+- [ ] **Step 1: Write regression test**
+
+Add to `tests/data/stateStatutes.test.ts`:
+
+```ts
+describe("stateStatuteEntries — existing 12 states", () => {
+  // These are the exact strings the current hardcoded regex matches.
+  // The generated regex must match all of them.
+  const existingCitations = [
+    { text: "Fla. Stat. § 768.81", jurisdiction: "FL" },
+    { text: "F.S. 768.81", jurisdiction: "FL" },
+    { text: "R.C. 2305.01", jurisdiction: "OH" },
+    { text: "Ohio Rev. Code § 2305.01", jurisdiction: "OH" },
+    { text: "MCL 750.81", jurisdiction: "MI" },
+    { text: "M.C.L. § 750.81", jurisdiction: "MI" },
+    { text: "Utah Code § 76-5-302", jurisdiction: "UT" },
+    { text: "U.C.A. § 63G-2-103", jurisdiction: "UT" },
+    { text: "C.R.S. § 13-1-101", jurisdiction: "CO" },
+    { text: "Colo. Rev. Stat. § 6-1-1301", jurisdiction: "CO" },
+    { text: "RCW 26.09.191", jurisdiction: "WA" },
+    { text: "Wash. Rev. Code § 26.09.191", jurisdiction: "WA" },
+    { text: "G.S. 20-138.1", jurisdiction: "NC" },
+    { text: "N.C. Gen. Stat. § 15A-302", jurisdiction: "NC" },
+    { text: "O.C.G.A. § 16-5-1", jurisdiction: "GA" },
+    { text: "Ga. Code Ann. § 16-5-1", jurisdiction: "GA" },
+    { text: "42 Pa.C.S. § 5524", jurisdiction: "PA" },
+    { text: "43 P.S. § 951", jurisdiction: "PA" },
+    { text: "Ind. Code § 35-42-1-1", jurisdiction: "IN" },
+    { text: "IC 35-42-1-1", jurisdiction: "IN" },
+    { text: "N.J.S.A. 2A:10-1", jurisdiction: "NJ" },
+    { text: "8 Del. C. § 141", jurisdiction: "DE" },
+    { text: "Del. Code Ann. § 141", jurisdiction: "DE" },
+  ]
+
+  const regex = buildAbbreviatedCodeRegex()
+
+  for (const { text } of existingCitations) {
+    it(`should match: "${text}"`, () => {
+      regex.lastIndex = 0
+      expect(text.match(regex)).not.toBeNull()
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/data/stateStatutes.test.ts -t "existing 12" -v`
+Expected: FAIL — `stateStatuteEntries` is empty, regex matches nothing
+
+- [ ] **Step 3: Populate the 12 existing states**
+
+Replace the empty `stateStatuteEntries` array in `src/data/stateStatutes.ts` with:
+
+```ts
+export const stateStatuteEntries: StateStatuteEntry[] = [
+  // ── Florida ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "FL",
+    abbreviations: ["Fla. Stat. Ann.", "Fla. Stat.", "Fla Stat", "F.S.", "FS"],
+    regexFragment:
+      "Fla\\.?\\s*Stat(?:utes)?\\.?(?:\\s*Ann\\.?)?|F\\.?S\\.?",
+  },
+  // ── Ohio ───────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "OH",
+    abbreviations: ["Ohio Rev. Code Ann.", "Ohio Rev. Code", "O.R.C.", "ORC", "R.C.", "RC"],
+    regexFragment:
+      "Ohio\\s+Rev\\.?\\s+Code(?:\\s+Ann\\.?)?|O\\.?R\\.?C\\.?|R\\.?C\\.?",
+  },
+  // ── Michigan ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MI",
+    abbreviations: [
+      "Mich. Comp. Laws Ann.",
+      "Mich. Comp. Laws Serv.",
+      "Mich. Comp. Laws",
+      "M.C.L.",
+      "MCLA",
+      "MCLS",
+      "MCL",
+    ],
+    regexFragment:
+      "Mich\\.?\\s+Comp\\.?\\s+Laws(?:\\s+(?:Ann|Serv)\\.?)?|M\\.?C\\.?L\\.?|MCL[AS]?",
+  },
+  // ── Utah ───────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "UT",
+    abbreviations: ["Utah Code Ann.", "Utah Code", "U.C.A.", "UCA"],
+    regexFragment: "Utah\\s+Code(?:\\s+Ann\\.?)?|U\\.?C\\.?A\\.?",
+  },
+  // ── Colorado ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "CO",
+    abbreviations: ["Colo. Rev. Stat. Ann.", "Colo. Rev. Stat.", "C.R.S.", "CRS"],
+    regexFragment:
+      "Colo\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|C\\.?R\\.?S\\.?",
+  },
+  // ── Washington ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WA",
+    abbreviations: ["Wash. Rev. Code Ann.", "Wash. Rev. Code", "RCW"],
+    regexFragment: "Wash\\.?\\s+Rev\\.?\\s+Code(?:\\s+Ann\\.?)?|RCW",
+  },
+  // ── North Carolina ─────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NC",
+    abbreviations: ["N.C. Gen. Stat. Ann.", "N.C. Gen. Stat.", "N.C.G.S.", "NCGS", "G.S.", "GS"],
+    regexFragment:
+      "N\\.?C\\.?\\s*Gen\\.?\\s*Stat\\.?(?:\\s+Ann\\.?)?|N\\.?C\\.?G\\.?S\\.?|G\\.?S\\.?",
+  },
+  // ── Georgia ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "GA",
+    abbreviations: ["Ga. Code Ann.", "Ga. Code", "O.C.G.A.", "OCGA"],
+    regexFragment: "Ga\\.?\\s+Code(?:\\s+Ann\\.?)?|O\\.?C\\.?G\\.?A\\.?",
+  },
+  // ── Pennsylvania (consolidated) ────────────────────────────────────────────
+  {
+    jurisdiction: "PA",
+    abbreviations: ["Pa. Cons. Stat.", "Pa.C.S.A.", "Pa.C.S.", "Pa. C.S.A.", "Pa. C.S."],
+    regexFragment: "Pa\\.?\\s*C\\.?S\\.?A?\\.?|Pa\\.?\\s+Cons\\.?\\s+Stat\\.?",
+  },
+  // ── Pennsylvania (unconsolidated) ──────────────────────────────────────────
+  {
+    jurisdiction: "PA",
+    abbreviations: ["P.S.", "PS"],
+    regexFragment: "P\\.?S\\.?",
+  },
+  // ── Indiana ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "IN",
+    abbreviations: [
+      "Burns Ind. Code Ann.",
+      "Burns Ind. Code",
+      "Indiana Code Ann.",
+      "Indiana Code",
+      "Ind. Code Ann.",
+      "Ind. Code",
+      "I.C.",
+      "IC",
+    ],
+    regexFragment:
+      "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?",
+  },
+  // ── New Jersey ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NJ",
+    abbreviations: ["N.J.S.A.", "NJSA", "N.J.S.", "NJS"],
+    regexFragment: "N\\.?J\\.?\\s*S(?:tat)?\\.?\\s*A?\\.?",
+  },
+  // ── Delaware ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "DE",
+    abbreviations: ["Del. Code Ann.", "Del. Code", "Del. C.", "Del C"],
+    regexFragment: "Del\\.?\\s*(?:Code(?:\\s+Ann\\.?)?|C\\.?)",
+  },
+]
+```
+
+- [ ] **Step 4: Run regression test to verify existing citations still match**
+
+Run: `pnpm exec vitest run tests/data/stateStatutes.test.ts -t "existing 12" -v`
+Expected: All 23 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/data/stateStatutes.ts tests/data/stateStatutes.test.ts
+git commit -m "feat(data): populate stateStatuteEntries with existing 12 states"
+```
+
+---
+
+### Task 4: Wire up statutePatterns.ts and knownCodes.ts
+
+**Files:**
+- Modify: `src/patterns/statutePatterns.ts`
+- Modify: `src/data/knownCodes.ts`
+
+- [ ] **Step 1: Run full test suite to establish baseline**
+
+Run: `pnpm exec vitest run -v 2>&1 | tail -5`
+Expected: All tests PASS (note the count for comparison)
+
+- [ ] **Step 2: Replace hardcoded regex in statutePatterns.ts**
+
+In `src/patterns/statutePatterns.ts`, replace the `abbreviated-code` entry:
+
+Replace this:
+```ts
+  {
+    id: "abbreviated-code",
+    // Alternation order: longer/more-specific patterns first within each state to avoid partial matches.
+    // The \b anchor prevents cross-boundary matches (e.g., "N.C.G.S." won't match "G.S." at position 4).
+    regex:
+      /\b(?:(\d+)\s+)?(Fla\.?\s*Stat(?:utes)?\.?(?:\s*Ann\.?)?|F\.?S\.?|R\.?C\.?|O\.?R\.?C\.?|Ohio\s+Rev\.?\s+Code(?:\s+Ann\.?)?|MCL[AS]?|M\.?C\.?L\.?|Mich\.?\s+Comp\.?\s+Laws(?:\s+(?:Ann|Serv)\.?)?|Utah\s+Code(?:\s+Ann\.?)?|U\.?C\.?A\.?|C\.?R\.?S\.?|Colo\.?\s+Rev\.?\s+Stat\.?(?:\s+Ann\.?)?|RCW|Wash\.?\s+Rev\.?\s+Code(?:\s+Ann\.?)?|G\.?S\.?|N\.?C\.?\s*Gen\.?\s*Stat\.?(?:\s+Ann\.?)?|N\.?C\.?G\.?S\.?|O\.?C\.?G\.?A\.?|Ga\.?\s+Code(?:\s+Ann\.?)?|Pa\.?\s*C\.?S\.?A?\.?|Pa\.?\s+Cons\.?\s+Stat\.?|P\.?S\.?|Ind(?:iana)?\.?\s+Code(?:\s+Ann\.?)?|Burns\s+Ind\.?\s+Code(?:\s+Ann\.?)?|I\.?C\.?|N\.?J\.?\s*S(?:tat)?\.?\s*A?\.?|Del\.?\s*(?:Code(?:\s+Ann\.?)?|C\.?))\s*§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+    description:
+      "Abbreviated state code citations for 12 jurisdictions (FL, OH, MI, UT, CO, WA, NC, GA, PA, IN, NJ, DE)",
+    type: "statute",
+  },
+```
+
+With:
+```ts
+  {
+    id: "abbreviated-code",
+    regex: buildAbbreviatedCodeRegex(),
+    description: "Abbreviated state code citations for all US jurisdictions",
+    type: "statute",
+  },
+```
+
+Add the import at the top:
+```ts
+import { buildAbbreviatedCodeRegex } from "@/data/stateStatutes"
+```
+
+- [ ] **Step 3: Update knownCodes.ts to derive abbreviatedCodes**
+
+In `src/data/knownCodes.ts`, replace the hardcoded `abbreviatedCodes` array with a derivation from `stateStatuteEntries`.
+
+Replace this (the entire `export const abbreviatedCodes: CodeEntry[] = [...]` block, lines 37–133):
+```ts
+export const abbreviatedCodes: CodeEntry[] = [
+  { jurisdiction: "FL", abbreviation: "STAT", family: "abbreviated", patterns: [...] },
+  // ... all 13 entries through DE
+]
+```
+
+With:
+```ts
+import { stateStatuteEntries } from "./stateStatutes"
+
+/**
+ * Registry of state statutory codes that use abbreviated citation forms.
+ * Derived from stateStatuteEntries — the single source of truth.
+ */
+export const abbreviatedCodes: CodeEntry[] = stateStatuteEntries.map((entry) => ({
+  jurisdiction: entry.jurisdiction,
+  abbreviation: entry.abbreviations[entry.abbreviations.length - 1],
+  family: "abbreviated" as const,
+  patterns: entry.abbreviations,
+}))
+```
+
+- [ ] **Step 4: Run full test suite to verify no regression**
+
+Run: `pnpm exec vitest run -v 2>&1 | tail -5`
+Expected: Same test count, all PASS
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/patterns/statutePatterns.ts src/data/knownCodes.ts
+git commit -m "refactor: generate abbreviated-code regex from stateStatuteEntries"
+```
+
+---
+
+### Task 5: Add new states batch 1 — AK, AZ, AR, CT, DC, HI, IA, ID
+
+**Files:**
+- Modify: `src/data/stateStatutes.ts`
+- Modify: `tests/extract/extractStatute.test.ts`
+
+- [ ] **Step 1: Write failing smoke tests**
+
+Add to `tests/extract/extractStatute.test.ts`, inside a new describe block:
+
+```ts
+import { extractCitations } from "@/index"
+
+describe("new state jurisdictions — batch 1", () => {
+  const cases = [
+    { text: "Alaska Stat. § 11.41.100", jurisdiction: "AK", section: "11.41.100" },
+    { text: "AS 11.41.100", jurisdiction: "AK", section: "11.41.100" },
+    { text: "Ariz. Rev. Stat. § 13-1105", jurisdiction: "AZ", section: "13-1105" },
+    { text: "A.R.S. § 13-1105", jurisdiction: "AZ", section: "13-1105" },
+    { text: "Ark. Code Ann. § 5-10-101", jurisdiction: "AR", section: "5-10-101" },
+    { text: "A.C.A. § 5-10-101", jurisdiction: "AR", section: "5-10-101" },
+    { text: "Conn. Gen. Stat. § 52-555", jurisdiction: "CT", section: "52-555" },
+    { text: "C.G.S. § 14-227a", jurisdiction: "CT", section: "14-227a" },
+    { text: "D.C. Code § 22-3211", jurisdiction: "DC", section: "22-3211" },
+    { text: "Haw. Rev. Stat. § 707-711", jurisdiction: "HI", section: "707-711" },
+    { text: "HRS § 707-711", jurisdiction: "HI", section: "707-711" },
+    { text: "Iowa Code § 714.1", jurisdiction: "IA", section: "714.1" },
+    { text: "Idaho Code § 18-4001", jurisdiction: "ID", section: "18-4001" },
+  ]
+
+  for (const { text, jurisdiction, section } of cases) {
+    it(`should extract "${text}"`, () => {
+      const citations = extractCitations(text)
+      const statutes = citations.filter((c) => c.type === "statute")
+      expect(statutes).toHaveLength(1)
+      expect(statutes[0].jurisdiction).toBe(jurisdiction)
+      expect(statutes[0].section).toBe(section)
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 1" -v`
+Expected: All 13 tests FAIL — new abbreviations not in the regex
+
+- [ ] **Step 3: Add 8 state entries to stateStatuteEntries**
+
+Append to the `stateStatuteEntries` array in `src/data/stateStatutes.ts`:
+
+```ts
+  // ── Alaska ─────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "AK",
+    abbreviations: ["Alaska Stat. Ann.", "Alaska Stat.", "AS"],
+    regexFragment: "Alaska\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?S\\.?",
+  },
+  // ── Arizona ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "AZ",
+    abbreviations: ["Ariz. Rev. Stat. Ann.", "Ariz. Rev. Stat.", "A.R.S."],
+    regexFragment: "Ariz\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?R\\.?S\\.?",
+  },
+  // ── Arkansas ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "AR",
+    abbreviations: ["Ark. Code Ann.", "Arkansas Code", "A.C.A."],
+    regexFragment: "Ark(?:ansas)?\\.?\\s+Code(?:\\s+Ann\\.?)?|A\\.?C\\.?A\\.?",
+  },
+  // ── Connecticut ────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "CT",
+    abbreviations: ["Conn. Gen. Stat. Ann.", "Conn. Gen. Stat.", "C.G.S."],
+    regexFragment: "Conn\\.?\\s+Gen\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|C\\.?G\\.?S\\.?",
+  },
+  // ── District of Columbia ───────────────────────────────────────────────────
+  {
+    jurisdiction: "DC",
+    abbreviations: ["D.C. Official Code", "D.C. Code Ann.", "D.C. Code"],
+    regexFragment: "D\\.?C\\.?\\s+(?:Official\\s+)?Code(?:\\s+Ann\\.?)?",
+  },
+  // ── Hawaii ─────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "HI",
+    abbreviations: ["Haw. Rev. Stat. Ann.", "Haw. Rev. Stat.", "HRS"],
+    regexFragment: "Haw\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|HRS",
+  },
+  // ── Iowa ───────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "IA",
+    abbreviations: ["Iowa Code Ann.", "Iowa Code", "I.C.A."],
+    regexFragment: "Iowa\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?A\\.?",
+  },
+  // ── Idaho ──────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "ID",
+    abbreviations: ["Idaho Code Ann.", "Idaho Code"],
+    regexFragment: "Idaho\\s+Code(?:\\s+Ann\\.?)?",
+  },
+```
+
+- [ ] **Step 4: Run smoke tests to verify they pass**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 1" -v`
+Expected: All 13 tests PASS
+
+- [ ] **Step 5: Run full suite for regression**
+
+Run: `pnpm exec vitest run -v 2>&1 | tail -5`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/data/stateStatutes.ts tests/extract/extractStatute.test.ts
+git commit -m "feat: add statute patterns for AK, AZ, AR, CT, DC, HI, IA, ID"
+```
+
+---
+
+### Task 6: Add new states batch 2 — KS, KY, LA, ME, MN, MO, MS, MT
+
+**Files:**
+- Modify: `src/data/stateStatutes.ts`
+- Modify: `tests/extract/extractStatute.test.ts`
+
+- [ ] **Step 1: Write failing smoke tests**
+
+Add to `tests/extract/extractStatute.test.ts`:
+
+```ts
+describe("new state jurisdictions — batch 2", () => {
+  const cases = [
+    { text: "Kan. Stat. Ann. § 21-5401", jurisdiction: "KS", section: "21-5401" },
+    { text: "K.S.A. § 21-5401", jurisdiction: "KS", section: "21-5401" },
+    { text: "Ky. Rev. Stat. Ann. § 507.020", jurisdiction: "KY", section: "507.020" },
+    { text: "KRS § 507.020", jurisdiction: "KY", section: "507.020" },
+    { text: "La. Rev. Stat. Ann. § 14:30", jurisdiction: "LA", section: "14:30" },
+    { text: "La. R.S. 14:30", jurisdiction: "LA", section: "14:30" },
+    { text: "Me. Rev. Stat. Ann. § 208", jurisdiction: "ME", section: "208" },
+    { text: "M.R.S.A. § 208", jurisdiction: "ME", section: "208" },
+    { text: "Minn. Stat. § 609.02", jurisdiction: "MN", section: "609.02" },
+    { text: "Miss. Code Ann. § 97-3-19", jurisdiction: "MS", section: "97-3-19" },
+    { text: "Mo. Rev. Stat. § 565.021", jurisdiction: "MO", section: "565.021" },
+    { text: "RSMo § 565.021", jurisdiction: "MO", section: "565.021" },
+    { text: "Mont. Code Ann. § 45-5-502", jurisdiction: "MT", section: "45-5-502" },
+    { text: "MCA § 45-5-502", jurisdiction: "MT", section: "45-5-502" },
+  ]
+
+  for (const { text, jurisdiction, section } of cases) {
+    it(`should extract "${text}"`, () => {
+      const citations = extractCitations(text)
+      const statutes = citations.filter((c) => c.type === "statute")
+      expect(statutes).toHaveLength(1)
+      expect(statutes[0].jurisdiction).toBe(jurisdiction)
+      expect(statutes[0].section).toBe(section)
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 2" -v`
+Expected: All 14 tests FAIL
+
+- [ ] **Step 3: Add 8 state entries**
+
+Append to `stateStatuteEntries` in `src/data/stateStatutes.ts`:
+
+```ts
+  // ── Kansas ─────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "KS",
+    abbreviations: ["Kan. Stat. Ann.", "K.S.A."],
+    regexFragment: "Kan\\.?\\s+Stat\\.?\\s+Ann\\.?|K\\.?S\\.?A\\.?",
+  },
+  // ── Kentucky ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "KY",
+    abbreviations: ["Ky. Rev. Stat. Ann.", "Ky. Rev. Stat.", "KRS"],
+    regexFragment: "Ky\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|KRS",
+  },
+  // ── Louisiana ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "LA",
+    abbreviations: ["La. Rev. Stat. Ann.", "La. R.S.", "LSA-R.S."],
+    regexFragment: "La\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|La\\.?\\s+R\\.?S\\.?|LSA-R\\.?S\\.?",
+  },
+  // ── Maine ──────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "ME",
+    abbreviations: ["Me. Rev. Stat. Ann.", "Me. Rev. Stat.", "M.R.S.A.", "M.R.S."],
+    regexFragment: "Me\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.?R\\.?S\\.?A?\\.?",
+  },
+  // ── Minnesota ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MN",
+    abbreviations: ["Minn. Stat. Ann.", "Minn. Stat.", "M.S.A."],
+    regexFragment: "Minn\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.?S\\.?A\\.?",
+  },
+  // ── Mississippi ────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MS",
+    abbreviations: ["Miss. Code Ann.", "Mississippi Code", "MS Code"],
+    regexFragment: "Miss(?:issippi)?\\.?\\s+Code(?:\\s+Ann\\.?)?|MS\\s+Code",
+  },
+  // ── Missouri ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MO",
+    abbreviations: ["Mo. Ann. Stat.", "Mo. Rev. Stat.", "V.A.M.S.", "RSMo"],
+    regexFragment:
+      "Mo\\.?\\s+(?:Ann\\.?\\s+|Rev\\.?\\s+)Stat\\.?|V\\.?A\\.?M\\.?S\\.?|RSMo",
+  },
+  // ── Montana ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MT",
+    abbreviations: ["Mont. Code Ann.", "MCA"],
+    regexFragment: "Mont\\.?\\s+Code(?:\\s+Ann\\.?)?|MCA",
+  },
+```
+
+- [ ] **Step 4: Run smoke tests to verify they pass**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 2" -v`
+Expected: All 14 tests PASS
+
+- [ ] **Step 5: Run full suite for regression**
+
+Run: `pnpm exec vitest run -v 2>&1 | tail -5`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/data/stateStatutes.ts tests/extract/extractStatute.test.ts
+git commit -m "feat: add statute patterns for KS, KY, LA, ME, MN, MO, MS, MT"
+```
+
+---
+
+### Task 7: Add new states batch 3 — ND, NE, NH, NM, NV, OK, OR, RI
+
+**Files:**
+- Modify: `src/data/stateStatutes.ts`
+- Modify: `tests/extract/extractStatute.test.ts`
+
+- [ ] **Step 1: Write failing smoke tests**
+
+Add to `tests/extract/extractStatute.test.ts`:
+
+```ts
+describe("new state jurisdictions — batch 3", () => {
+  const cases = [
+    { text: "N.D. Cent. Code § 12.1-02-01", jurisdiction: "ND", section: "12.1-02-01" },
+    { text: "N.D.C.C. § 12.1-02-01", jurisdiction: "ND", section: "12.1-02-01" },
+    { text: "Neb. Rev. Stat. § 28-303", jurisdiction: "NE", section: "28-303" },
+    { text: "N.H. Rev. Stat. Ann. § 625:9", jurisdiction: "NH", section: "625:9" },
+    { text: "RSA § 625:9", jurisdiction: "NH", section: "625:9" },
+    { text: "N.M. Stat. Ann. § 30-16-1", jurisdiction: "NM", section: "30-16-1" },
+    { text: "NMSA § 30-16-1", jurisdiction: "NM", section: "30-16-1" },
+    { text: "Nev. Rev. Stat. § 200.030", jurisdiction: "NV", section: "200.030" },
+    { text: "NRS § 200.030", jurisdiction: "NV", section: "200.030" },
+    { text: "Okla. Stat. § 496", jurisdiction: "OK", section: "496" },
+    { text: "Or. Rev. Stat. § 161.085", jurisdiction: "OR", section: "161.085" },
+    { text: "ORS § 161.085", jurisdiction: "OR", section: "161.085" },
+    { text: "R.I. Gen. Laws § 11-1-2", jurisdiction: "RI", section: "11-1-2" },
+    { text: "R.I.G.L. § 11-1-2", jurisdiction: "RI", section: "11-1-2" },
+  ]
+
+  for (const { text, jurisdiction, section } of cases) {
+    it(`should extract "${text}"`, () => {
+      const citations = extractCitations(text)
+      const statutes = citations.filter((c) => c.type === "statute")
+      expect(statutes).toHaveLength(1)
+      expect(statutes[0].jurisdiction).toBe(jurisdiction)
+      expect(statutes[0].section).toBe(section)
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 3" -v`
+Expected: All 14 tests FAIL
+
+- [ ] **Step 3: Add 8 state entries**
+
+Append to `stateStatuteEntries` in `src/data/stateStatutes.ts`:
+
+```ts
+  // ── North Dakota ───────────────────────────────────────────────────────────
+  {
+    jurisdiction: "ND",
+    abbreviations: ["N.D. Cent. Code", "N.D.C.C."],
+    regexFragment: "N\\.?D\\.?\\s+Cent\\.?\\s+Code|N\\.?D\\.?C\\.?C\\.?",
+  },
+  // ── Nebraska ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NE",
+    abbreviations: ["Neb. Rev. Stat.", "R.R.S. Neb.", "R.R.S."],
+    regexFragment: "Neb\\.?\\s+Rev\\.?\\s+Stat\\.?|R\\.?R\\.?S\\.?(?:\\s+Neb\\.?)?",
+  },
+  // ── New Hampshire ──────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NH",
+    abbreviations: ["N.H. Rev. Stat. Ann.", "N.H. RSA", "RSA"],
+    regexFragment: "N\\.?H\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|N\\.?H\\.?\\s+RSA|RSA",
+  },
+  // ── New Mexico ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NM",
+    abbreviations: ["N.M. Stat. Ann.", "NMSA 1978", "NMSA"],
+    regexFragment: "N\\.?M\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|NMSA(?:\\s+1978)?",
+  },
+  // ── Nevada ─────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NV",
+    abbreviations: ["Nev. Rev. Stat. Ann.", "Nev. Rev. Stat.", "NRS"],
+    regexFragment: "Nev\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|NRS",
+  },
+  // ── Oklahoma ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "OK",
+    abbreviations: ["Okla. Stat. Ann.", "Okla. Stat.", "O.S."],
+    regexFragment: "Okla\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|O\\.?S\\.?",
+  },
+  // ── Oregon ─────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "OR",
+    abbreviations: ["Or. Rev. Stat. Ann.", "Or. Rev. Stat.", "ORS"],
+    regexFragment: "Or\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|ORS",
+  },
+  // ── Rhode Island ───────────────────────────────────────────────────────────
+  {
+    jurisdiction: "RI",
+    abbreviations: ["R.I. Gen. Laws", "R.I.G.L."],
+    regexFragment: "R\\.?I\\.?\\s+Gen\\.?\\s+Laws|R\\.?I\\.?G\\.?L\\.?",
+  },
+```
+
+- [ ] **Step 4: Run smoke tests to verify they pass**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 3" -v`
+Expected: All 14 tests PASS
+
+- [ ] **Step 5: Run full suite for regression**
+
+Run: `pnpm exec vitest run -v 2>&1 | tail -5`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/data/stateStatutes.ts tests/extract/extractStatute.test.ts
+git commit -m "feat: add statute patterns for ND, NE, NH, NM, NV, OK, OR, RI"
+```
+
+---
+
+### Task 8: Add new states batch 4 — SC, SD, TN, VT, WI, WV, WY
+
+**Files:**
+- Modify: `src/data/stateStatutes.ts`
+- Modify: `tests/extract/extractStatute.test.ts`
+
+- [ ] **Step 1: Write failing smoke tests**
+
+Add to `tests/extract/extractStatute.test.ts`:
+
+```ts
+describe("new state jurisdictions — batch 4", () => {
+  const cases = [
+    { text: "S.C. Code Ann. § 16-3-10", jurisdiction: "SC", section: "16-3-10" },
+    { text: "S.D. Codified Laws § 22-1-2", jurisdiction: "SD", section: "22-1-2" },
+    { text: "SDCL § 22-1-2", jurisdiction: "SD", section: "22-1-2" },
+    { text: "Tenn. Code Ann. § 39-13-101", jurisdiction: "TN", section: "39-13-101" },
+    { text: "T.C.A. § 39-13-101", jurisdiction: "TN", section: "39-13-101" },
+    { text: "Vt. Stat. Ann. § 2301", jurisdiction: "VT", section: "2301" },
+    { text: "V.S.A. § 2301", jurisdiction: "VT", section: "2301" },
+    { text: "Wis. Stat. § 940.01", jurisdiction: "WI", section: "940.01" },
+    { text: "W. Va. Code § 61-2-9", jurisdiction: "WV", section: "61-2-9" },
+    { text: "Wyo. Stat. Ann. § 6-2-101", jurisdiction: "WY", section: "6-2-101" },
+    { text: "W.S. § 6-2-101", jurisdiction: "WY", section: "6-2-101" },
+  ]
+
+  for (const { text, jurisdiction, section } of cases) {
+    it(`should extract "${text}"`, () => {
+      const citations = extractCitations(text)
+      const statutes = citations.filter((c) => c.type === "statute")
+      expect(statutes).toHaveLength(1)
+      expect(statutes[0].jurisdiction).toBe(jurisdiction)
+      expect(statutes[0].section).toBe(section)
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 4" -v`
+Expected: All 11 tests FAIL
+
+- [ ] **Step 3: Add 7 state entries**
+
+Append to `stateStatuteEntries` in `src/data/stateStatutes.ts`:
+
+```ts
+  // ── South Carolina ─────────────────────────────────────────────────────────
+  {
+    jurisdiction: "SC",
+    abbreviations: ["S.C. Code Ann.", "S.C. Code"],
+    regexFragment: "S\\.?C\\.?\\s+Code(?:\\s+Ann\\.?)?",
+  },
+  // ── South Dakota ───────────────────────────────────────────────────────────
+  {
+    jurisdiction: "SD",
+    abbreviations: ["S.D. Codified Laws", "S.D.C.L.", "SDCL"],
+    regexFragment: "S\\.?D\\.?\\s+Codified\\s+Laws|S\\.?D\\.?C\\.?L\\.?|SDCL",
+  },
+  // ── Tennessee ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "TN",
+    abbreviations: ["Tenn. Code Ann.", "Tennessee Code", "T.C.A.", "TN Code"],
+    regexFragment: "Tenn(?:essee)?\\.?\\s+Code(?:\\s+Ann\\.?)?|T\\.?C\\.?A\\.?|TN\\s+Code",
+  },
+  // ── Vermont ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "VT",
+    abbreviations: ["Vt. Stat. Ann.", "V.S.A."],
+    regexFragment: "Vt\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|V\\.?S\\.?A\\.?",
+  },
+  // ── Wisconsin ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WI",
+    abbreviations: ["Wis. Stat. Ann.", "Wis. Stat.", "W.S.A."],
+    regexFragment: "Wis\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|W\\.?S\\.?A\\.?",
+  },
+  // ── West Virginia ──────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WV",
+    abbreviations: ["W. Va. Code Ann.", "W. Va. Code", "WV Code"],
+    regexFragment: "W\\.?\\s*Va\\.?\\s+Code(?:\\s+Ann\\.?)?|WV\\s+Code",
+  },
+  // ── Wyoming ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WY",
+    abbreviations: ["Wyo. Stat. Ann.", "Wyo. Stat.", "W.S."],
+    regexFragment: "Wyo\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|W\\.?S\\.?",
+  },
+```
+
+- [ ] **Step 4: Run smoke tests to verify they pass**
+
+Run: `pnpm exec vitest run tests/extract/extractStatute.test.ts -t "batch 4" -v`
+Expected: All 11 tests PASS
+
+- [ ] **Step 5: Run full suite for regression**
+
+Run: `pnpm exec vitest run -v 2>&1 | tail -5`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/data/stateStatutes.ts tests/extract/extractStatute.test.ts
+git commit -m "feat: add statute patterns for SC, SD, TN, VT, WI, WV, WY"
+```
+
+---
+
+### Task 9: Update exports, lint, and final validation
+
+**Files:**
+- Modify: `src/data/index.ts`
+
+- [ ] **Step 1: Update data entry point exports**
+
+In `src/data/index.ts`, add the export:
+
+```ts
+export { stateStatuteEntries, type StateStatuteEntry } from "./stateStatutes"
+```
+
+- [ ] **Step 2: Run lint and format**
+
+Run: `pnpm lint && pnpm format`
+Expected: No errors (or auto-fixed)
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `pnpm exec vitest run -v`
+Expected: All tests PASS including all new state smoke tests
+
+- [ ] **Step 5: Run build and size check**
+
+Run: `pnpm build && pnpm size`
+Expected: Build succeeds, size within limits
+
+- [ ] **Step 6: Verify the original issue example**
+
+Run this as a quick inline test to confirm the issue's Alaska example now works:
+
+```bash
+node -e "
+const { extractCitations } = require('./dist/index.cjs');
+const c = extractCitations('Alaska Stat. §08.29.400 (4)');
+const s = c.filter(x => x.type === 'statute');
+console.log(s.length ? '✓ Alaska found: ' + s[0].section : '✗ Alaska not found');
+"
+```
+
+Expected: `✓ Alaska found: 08.29.400`
+
+- [ ] **Step 7: Commit and create changeset**
+
+```bash
+git add src/data/index.ts
+git commit -m "chore: export stateStatuteEntries from data entry point"
+pnpm changeset
+```
+
+Select: `minor` (new feature — 31 new jurisdictions). Summary: "Add statute citation patterns for 31 additional US state jurisdictions"
+
+```bash
+git add .changeset/
+git commit -m "chore: add changeset for state statute coverage expansion"
+```

--- a/docs/superpowers/specs/2026-04-06-state-statute-coverage-design.md
+++ b/docs/superpowers/specs/2026-04-06-state-statute-coverage-design.md
@@ -1,0 +1,145 @@
+# State Statute Coverage Expansion
+
+**Issue:** #155 — Coverage gap: state statutes, CFR, and state-specific codes
+**Scope:** Add the ~30 missing US state jurisdictions to the `abbreviated-code` statute pattern family
+**Date:** 2026-04-06
+
+## Problem
+
+eyecite-ts supports statute citations from 20 US states. The remaining ~30 states are completely unrecognized. For example, `Alaska Stat. § 08.29.400` produces zero results because Alaska is not in the `abbreviated-code` pattern's regex alternation or the `abbreviatedCodes[]` lookup table.
+
+The root cause is architectural: the `abbreviated-code` pattern in `statutePatterns.ts` uses a hardcoded regex alternation listing every supported abbreviation, and `knownCodes.ts` maintains a separate-but-must-match data array. Adding a state requires editing both in sync — a duplication that discourages expansion.
+
+## Out of Scope
+
+- State constitution citations (`Cal. Const. art. I, § 7`)
+- Federal Rules of Procedure (`Federal Rule of Civil Procedure Rule 54(b)`)
+- Bare section references (`§1158(a)`, `Section 207(c)`)
+- Expanding the `named-code` pattern (multi-code states like NY, CA, TX)
+- CFR/USC patterns (already working)
+
+These are separate gap categories identified in the issue investigation and can be addressed in follow-up PRs.
+
+## Design
+
+### 1. Data Model
+
+New file: `src/data/stateStatutes.ts`
+
+```ts
+export interface StateStatuteEntry {
+  /** Two-letter jurisdiction code (e.g., "AK", "AZ") */
+  jurisdiction: string
+  /** All recognized abbreviation forms, longest first */
+  abbreviations: string[]
+  /**
+   * Regex fragment for the abbreviation alternation.
+   * Auto-generated from abbreviations if omitted (periods become optional,
+   * whitespace becomes \s+). Provide explicitly when the abbreviation
+   * requires special regex (e.g., optional components, word boundaries).
+   */
+  regexFragment?: string
+}
+```
+
+This file contains:
+- A `stateStatuteEntries` array with entries for all ~50 states (the existing 12 + ~30 new)
+- An `escapeForRegex(abbreviations: string[]): string` helper that converts plain abbreviation strings into regex fragments (e.g., `"T.C.A."` becomes `T\.?\s*C\.?\s*A\.?`)
+- Entries are ordered longest-abbreviation-first within each state to prevent partial matches
+
+### 2. Regex Generation
+
+In `statutePatterns.ts`, the `abbreviated-code` entry changes from a hardcoded regex literal to a dynamically built one:
+
+```ts
+import { buildAbbreviatedAlternation } from "@/data/stateStatutes"
+
+// In the statutePatterns array:
+{
+  id: "abbreviated-code",
+  regex: buildAbbreviatedCodeRegex(),
+  description: "Abbreviated state code citations for all US jurisdictions",
+  type: "statute",
+}
+```
+
+The `buildAbbreviatedCodeRegex()` function:
+1. Collects all regex fragments from `stateStatuteEntries`
+2. Sorts fragments longest-first (PEG ordered choice — more specific beats less specific)
+3. Joins with `|` into a single alternation
+4. Wraps in the existing capture group structure: `(?:(title)\s+)?(alternation)\s*§?\s*(section)`
+5. Returns a compiled `RegExp` with the `g` flag
+
+This runs once at module load time. The resulting regex is functionally identical to today's — same capture groups, same extraction path — just built from data instead of a literal.
+
+### 3. knownCodes.ts Migration
+
+The existing `abbreviatedCodes[]` array in `knownCodes.ts` migrates to derive from `stateStatuteEntries`:
+
+- `stateStatuteEntries` is the single source of truth for abbreviation data
+- `abbreviatedCodes` is computed from it (mapping `StateStatuteEntry` to `CodeEntry[]`)
+- `findAbbreviatedCode()` and `findNamedCode()` remain unchanged in interface
+- The `namedCodes[]` array is untouched
+
+### 4. Data Population
+
+Source: the OurFirm.ai statute repo's research docs (`docs/srcs/*.md`) and `citation-normalizer.ts`.
+
+For each of the ~30 missing states:
+1. Read the state's research doc for citation format variants and abbreviations
+2. Cross-reference against `citation-normalizer.ts` patterns
+3. Create a `StateStatuteEntry` with all recognized forms
+4. For states without statute repo research, derive from standard Bluebook conventions
+
+Example entries:
+
+```ts
+{ jurisdiction: "AK", abbreviations: ["Alaska Stat. Ann.", "Alaska Stat.", "AS"] },
+{ jurisdiction: "AZ", abbreviations: ["Ariz. Rev. Stat. Ann.", "Ariz. Rev. Stat.", "A.R.S."] },
+{ jurisdiction: "CT", abbreviations: ["Conn. Gen. Stat. Ann.", "Conn. Gen. Stat.", "C.G.S."] },
+{ jurisdiction: "KS", abbreviations: ["Kan. Stat. Ann.", "K.S.A."] },
+{ jurisdiction: "SC", abbreviations: ["S.C. Code Ann.", "S.C. Code"] },
+{ jurisdiction: "TN", abbreviations: ["Tenn. Code Ann.", "T.C.A."] },
+```
+
+### 5. Verification Strategy
+
+Each new state is verified against real-world citations before being committed:
+
+1. **Per-state smoke test**: For each new state, write a test with 2-3 real citations sourced from court opinions (CourtListener) or legislative text (statute repo fixtures). Assert:
+   - Citation is extracted (not missed)
+   - `jurisdiction` field is correct
+   - `section` is parsed correctly
+   - No false positives on surrounding non-citation text
+
+2. **Add-then-test ordering**: Add a state's data entry, write its smoke test with real examples, confirm it passes, then move to the next state. Not batch-add-then-test.
+
+3. **Regression**: Run the full existing test suite after each batch of additions to ensure the expanded regex doesn't break the 12 currently-supported states.
+
+4. **Cross-validation**: For the 22 states supported by both eyecite-ts and the statute repo, run sample citations through both systems — jurisdiction and section should agree.
+
+### 6. Files Changed
+
+| File | Change |
+|------|--------|
+| `src/data/stateStatutes.ts` | **New.** ~50-state abbreviation table, `escapeForRegex` helper, `buildAbbreviatedCodeRegex` function |
+| `src/data/knownCodes.ts` | Migrate `abbreviatedCodes[]` to derive from `stateStatuteEntries`. Lookup functions unchanged. |
+| `src/patterns/statutePatterns.ts` | Replace hardcoded `abbreviated-code` regex with call to `buildAbbreviatedCodeRegex()` |
+| `src/data/index.ts` | Export `stateStatutes` entry point |
+| `tests/extract/extractStatute.test.ts` | Add per-state smoke tests with real citation examples |
+
+### 7. What Doesn't Change
+
+- `named-code` pattern and its 6 jurisdictions (NY, CA, TX, MD, VA, AL)
+- `mass-chapter`, `chapter-act`, `usc`, `cfr`, `prose` patterns
+- All extraction logic (`extractAbbreviated.ts`, `extractNamedCode.ts`, etc.)
+- The `CodeEntry` interface and `findAbbreviatedCode()` / `findNamedCode()` function signatures
+- Types, pipeline, resolve, annotate — nothing outside the data + pattern layer
+
+## Architecture Rationale
+
+- **Data-driven over regex-driven** (Raymond: "fold knowledge into data so program logic can be stupid and robust")
+- **Single source of truth** eliminates the sync bug class between regex alternation and lookup table
+- **Deep module** (Ousterhout): one pattern entry serves all ~50 states rather than N shallow patterns
+- **Island grammar tolerance** (Moonen): the tokenizer captures broadly; `extractAbbreviated.ts` validates and assigns confidence. Existing confidence model (0.95 with §, 0.85 without) applies to new states unchanged.
+- **PEG ordered choice** (Ford): longest fragments sort first in the alternation, so `Alaska Stat. Ann.` matches before `AS` could grab a false positive.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -7,3 +7,4 @@
 
 export * from "./knownCodes"
 export * from "./reporters"
+export { stateStatuteEntries, type StateStatuteEntry } from "./stateStatutes"

--- a/src/data/knownCodes.ts
+++ b/src/data/knownCodes.ts
@@ -6,6 +6,8 @@
  * citation extractor to identify and normalize state statute citations.
  */
 
+import { stateStatuteEntries } from "./stateStatutes"
+
 /**
  * A single entry in the known codes registry.
  *
@@ -25,112 +27,14 @@ export interface CodeEntry {
 
 /**
  * Registry of state statutory codes that use abbreviated citation forms.
- *
- * Covers 12 jurisdictions. Pennsylvania has two entries because it
- * maintains two distinct code families (Pa.C.S. and P.S.).
- *
- * Note: Short 2-letter patterns (GS, IC, PS, RC, FS) may produce false positives
- * in non-legal text (e.g., "GS 5" for government service grade). The extraction
- * layer mitigates this via confidence scoring — citations without a § symbol receive
- * lower confidence (0.85 vs 0.95). Consumers should filter by confidence threshold.
+ * Derived from stateStatuteEntries — the single source of truth.
  */
-export const abbreviatedCodes: CodeEntry[] = [
-  {
-    jurisdiction: "FL",
-    abbreviation: "STAT",
-    family: "abbreviated",
-    patterns: ["Fla. Stat.", "Fla Stat", "Fla. Stat. Ann.", "F.S.", "FS"],
-  },
-  {
-    jurisdiction: "OH",
-    abbreviation: "RC",
-    family: "abbreviated",
-    patterns: ["R.C.", "RC", "O.R.C.", "ORC", "Ohio Rev. Code", "Ohio Rev. Code Ann."],
-  },
-  {
-    jurisdiction: "MI",
-    abbreviation: "MCL",
-    family: "abbreviated",
-    patterns: [
-      "MCL",
-      "M.C.L.",
-      "Mich. Comp. Laws",
-      "Mich. Comp. Laws Ann.",
-      "Mich. Comp. Laws Serv.",
-      "MCLA",
-      "MCLS",
-    ],
-  },
-  {
-    jurisdiction: "UT",
-    abbreviation: "UC",
-    family: "abbreviated",
-    patterns: ["Utah Code", "Utah Code Ann.", "U.C.A.", "UCA"],
-  },
-  {
-    jurisdiction: "CO",
-    abbreviation: "CRS",
-    family: "abbreviated",
-    patterns: ["C.R.S.", "CRS", "Colo. Rev. Stat.", "Colo. Rev. Stat. Ann."],
-  },
-  {
-    jurisdiction: "WA",
-    abbreviation: "RCW",
-    family: "abbreviated",
-    patterns: ["RCW", "Wash. Rev. Code", "Wash. Rev. Code Ann."],
-  },
-  {
-    jurisdiction: "NC",
-    abbreviation: "GS",
-    family: "abbreviated",
-    patterns: ["G.S.", "GS", "N.C. Gen. Stat.", "N.C. Gen. Stat. Ann.", "N.C.G.S.", "NCGS"],
-  },
-  {
-    jurisdiction: "GA",
-    abbreviation: "OCGA",
-    family: "abbreviated",
-    patterns: ["O.C.G.A.", "OCGA", "Ga. Code", "Ga. Code Ann."],
-  },
-  {
-    jurisdiction: "PA",
-    abbreviation: "PaCS",
-    family: "abbreviated",
-    patterns: ["Pa.C.S.", "Pa.C.S.A.", "Pa. C.S.", "Pa. C.S.A.", "Pa. Cons. Stat."],
-  },
-  {
-    jurisdiction: "PA",
-    abbreviation: "PS",
-    family: "abbreviated",
-    patterns: ["P.S.", "PS"],
-  },
-  {
-    jurisdiction: "IN",
-    abbreviation: "IC",
-    family: "abbreviated",
-    patterns: [
-      "Ind. Code",
-      "Ind. Code Ann.",
-      "Indiana Code",
-      "Indiana Code Ann.",
-      "I.C.",
-      "IC",
-      "Burns Ind. Code",
-      "Burns Ind. Code Ann.",
-    ],
-  },
-  {
-    jurisdiction: "NJ",
-    abbreviation: "NJSA",
-    family: "abbreviated",
-    patterns: ["N.J.S.A.", "NJSA", "N.J.S.", "NJS"],
-  },
-  {
-    jurisdiction: "DE",
-    abbreviation: "DelC",
-    family: "abbreviated",
-    patterns: ["Del. C.", "Del C", "Del. Code", "Del. Code Ann."],
-  },
-]
+export const abbreviatedCodes: CodeEntry[] = stateStatuteEntries.map((entry) => ({
+  jurisdiction: entry.jurisdiction,
+  abbreviation: entry.abbreviations[entry.abbreviations.length - 1],
+  family: "abbreviated" as const,
+  patterns: entry.abbreviations,
+}))
 
 /**
  * Registry of state statutory codes that use named-code citation forms.

--- a/src/data/knownCodes.ts
+++ b/src/data/knownCodes.ts
@@ -28,6 +28,11 @@ export interface CodeEntry {
 /**
  * Registry of state statutory codes that use abbreviated citation forms.
  * Derived from stateStatuteEntries — the single source of truth.
+ *
+ * Note: Short 2-letter patterns (AS, GS, IC, OS, PS, RC, FS, WS) may produce
+ * false positives in non-legal text. The extraction layer mitigates this via
+ * confidence scoring — citations without a § symbol receive lower confidence
+ * (0.85 vs 0.95). Consumers should filter by confidence threshold.
  */
 export const abbreviatedCodes: CodeEntry[] = stateStatuteEntries.map((entry) => ({
   jurisdiction: entry.jurisdiction,

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -42,5 +42,39 @@ export function escapeForRegex(abbreviation: string): string {
   );
 }
 
+/**
+ * Build the abbreviated-code tokenizer regex from stateStatuteEntries.
+ *
+ * Produces the same capture group structure as the original hardcoded regex:
+ *   (1) optional leading title number
+ *   (2) abbreviation text
+ *   (3) section + subsections + et seq.
+ *
+ * Fragments are sorted longest-first for PEG-style ordered choice.
+ */
+export function buildAbbreviatedCodeRegex(): RegExp {
+  const allFragments: string[] = [];
+
+  for (const entry of stateStatuteEntries) {
+    if (entry.regexFragment) {
+      allFragments.push(entry.regexFragment);
+    } else {
+      for (const abbrev of entry.abbreviations) {
+        allFragments.push(escapeForRegex(abbrev));
+      }
+    }
+  }
+
+  // Sort longest-first so more specific patterns match before shorter ones
+  allFragments.sort((a, b) => b.length - a.length);
+
+  const alternation = allFragments.join("|");
+
+  return new RegExp(
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*§?\\s*(\\d+[A-Za-z0-9.:/-]*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
+    "g",
+  );
+}
+
 /** Placeholder — entries added in subsequent tasks */
 export const stateStatuteEntries: StateStatuteEntry[] = [];

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -220,4 +220,52 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     abbreviations: ["Idaho Code Ann.", "Idaho Code"],
     regexFragment: "Idaho\\s+Code(?:\\s+Ann\\.?)?",
   },
+  // ── Kansas ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "KS",
+    abbreviations: ["Kan. Stat. Ann.", "K.S.A."],
+    regexFragment: "Kan\\.?\\s+Stat\\.?\\s+Ann\\.?|K\\.?S\\.?A\\.?",
+  },
+  // ── Kentucky ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "KY",
+    abbreviations: ["Ky. Rev. Stat. Ann.", "Ky. Rev. Stat.", "KRS"],
+    regexFragment: "Ky\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|KRS",
+  },
+  // ── Louisiana ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "LA",
+    abbreviations: ["La. Rev. Stat. Ann.", "La. R.S.", "LSA-R.S."],
+    regexFragment: "La\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|La\\.?\\s+R\\.?S\\.?|LSA-R\\.?S\\.?",
+  },
+  // ── Maine ─────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "ME",
+    abbreviations: ["Me. Rev. Stat. Ann.", "Me. Rev. Stat.", "M.R.S.A.", "M.R.S."],
+    regexFragment: "Me\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.?R\\.?S\\.?A?\\.?",
+  },
+  // ── Minnesota ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MN",
+    abbreviations: ["Minn. Stat. Ann.", "Minn. Stat.", "M.S.A."],
+    regexFragment: "Minn\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.?S\\.?A\\.?",
+  },
+  // ── Mississippi ───────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MS",
+    abbreviations: ["Miss. Code Ann.", "Mississippi Code", "MS Code"],
+    regexFragment: "Miss(?:issippi)?\\.?\\s+Code(?:\\s+Ann\\.?)?|MS\\s+Code",
+  },
+  // ── Missouri ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MO",
+    abbreviations: ["Mo. Ann. Stat.", "Mo. Rev. Stat.", "V.A.M.S.", "RSMo"],
+    regexFragment: "Mo\\.?\\s+(?:Ann\\.?\\s+|Rev\\.?\\s+)Stat\\.?|V\\.?A\\.?M\\.?S\\.?|RSMo",
+  },
+  // ── Montana ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MT",
+    abbreviations: ["Mont. Code Ann.", "MCA"],
+    regexFragment: "Mont\\.?\\s+Code(?:\\s+Ann\\.?)?|MCA",
+  },
 ];

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -76,6 +76,10 @@ export function buildAbbreviatedCodeRegex(): RegExp {
   );
 }
 
+/**
+ * Abbreviations are ordered longest-first within each entry. The last element
+ * is used as the canonical short abbreviation in knownCodes.ts.
+ */
 export const stateStatuteEntries: StateStatuteEntry[] = [
   // ── Florida ────────────────────────────────────────────────────────────────
   {

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -172,4 +172,52 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     abbreviations: ["Del. Code Ann.", "Del. Code", "Del. C.", "Del C"],
     regexFragment: "Del\\.?\\s*(?:Code(?:\\s+Ann\\.?)?|C\\.?)",
   },
+  // ── Alaska ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "AK",
+    abbreviations: ["Alaska Stat. Ann.", "Alaska Stat.", "AS"],
+    regexFragment: "Alaska\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?S\\.?",
+  },
+  // ── Arizona ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "AZ",
+    abbreviations: ["Ariz. Rev. Stat. Ann.", "Ariz. Rev. Stat.", "A.R.S."],
+    regexFragment: "Ariz\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?R\\.?S\\.?",
+  },
+  // ── Arkansas ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "AR",
+    abbreviations: ["Ark. Code Ann.", "Arkansas Code", "A.C.A."],
+    regexFragment: "Ark(?:ansas)?\\.?\\s+Code(?:\\s+Ann\\.?)?|A\\.?C\\.?A\\.?",
+  },
+  // ── Connecticut ───────────────────────────────────────────────────────────
+  {
+    jurisdiction: "CT",
+    abbreviations: ["Conn. Gen. Stat. Ann.", "Conn. Gen. Stat.", "C.G.S."],
+    regexFragment: "Conn\\.?\\s+Gen\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|C\\.?G\\.?S\\.?",
+  },
+  // ── District of Columbia ──────────────────────────────────────────────────
+  {
+    jurisdiction: "DC",
+    abbreviations: ["D.C. Official Code", "D.C. Code Ann.", "D.C. Code"],
+    regexFragment: "D\\.?C\\.?\\s+(?:Official\\s+)?Code(?:\\s+Ann\\.?)?",
+  },
+  // ── Hawaii ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "HI",
+    abbreviations: ["Haw. Rev. Stat. Ann.", "Haw. Rev. Stat.", "HRS"],
+    regexFragment: "Haw\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|HRS",
+  },
+  // ── Iowa ──────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "IA",
+    abbreviations: ["Iowa Code Ann.", "Iowa Code", "I.C.A."],
+    regexFragment: "Iowa\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?A\\.?",
+  },
+  // ── Idaho ─────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "ID",
+    abbreviations: ["Idaho Code Ann.", "Idaho Code"],
+    regexFragment: "Idaho\\s+Code(?:\\s+Ann\\.?)?",
+  },
 ];

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -268,4 +268,52 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     abbreviations: ["Mont. Code Ann.", "MCA"],
     regexFragment: "Mont\\.?\\s+Code(?:\\s+Ann\\.?)?|MCA",
   },
+  // ── North Dakota ──────────────────────────────────────────────────────────
+  {
+    jurisdiction: "ND",
+    abbreviations: ["N.D. Cent. Code", "N.D.C.C."],
+    regexFragment: "N\\.?D\\.?\\s+Cent\\.?\\s+Code|N\\.?D\\.?C\\.?C\\.?",
+  },
+  // ── Nebraska ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NE",
+    abbreviations: ["Neb. Rev. Stat.", "R.R.S. Neb.", "R.R.S."],
+    regexFragment: "Neb\\.?\\s+Rev\\.?\\s+Stat\\.?|R\\.?R\\.?S\\.?(?:\\s+Neb\\.?)?",
+  },
+  // ── New Hampshire ─────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NH",
+    abbreviations: ["N.H. Rev. Stat. Ann.", "N.H. RSA", "RSA"],
+    regexFragment: "N\\.?H\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|N\\.?H\\.?\\s+RSA|RSA",
+  },
+  // ── New Mexico ────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NM",
+    abbreviations: ["N.M. Stat. Ann.", "NMSA 1978", "NMSA"],
+    regexFragment: "N\\.?M\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|NMSA(?:\\s+1978)?",
+  },
+  // ── Nevada ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NV",
+    abbreviations: ["Nev. Rev. Stat. Ann.", "Nev. Rev. Stat.", "NRS"],
+    regexFragment: "Nev\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|NRS",
+  },
+  // ── Oklahoma ──────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "OK",
+    abbreviations: ["Okla. Stat. Ann.", "Okla. Stat.", "O.S."],
+    regexFragment: "Okla\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|O\\.?S\\.?",
+  },
+  // ── Oregon ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "OR",
+    abbreviations: ["Or. Rev. Stat. Ann.", "Or. Rev. Stat.", "ORS"],
+    regexFragment: "Or\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|ORS",
+  },
+  // ── Rhode Island ──────────────────────────────────────────────────────────
+  {
+    jurisdiction: "RI",
+    abbreviations: ["R.I. Gen. Laws", "R.I.G.L."],
+    regexFragment: "R\\.?I\\.?\\s+Gen\\.?\\s+Laws|R\\.?I\\.?G\\.?L\\.?",
+  },
 ];

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -76,5 +76,100 @@ export function buildAbbreviatedCodeRegex(): RegExp {
   );
 }
 
-/** Placeholder — entries added in subsequent tasks */
-export const stateStatuteEntries: StateStatuteEntry[] = [];
+export const stateStatuteEntries: StateStatuteEntry[] = [
+  // ── Florida ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "FL",
+    abbreviations: ["Fla. Stat. Ann.", "Fla. Stat.", "Fla Stat", "F.S.", "FS"],
+    regexFragment: "Fla\\.?\\s*Stat(?:utes)?\\.?(?:\\s*Ann\\.?)?|F\\.?S\\.?",
+  },
+  // ── Ohio ───────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "OH",
+    abbreviations: ["Ohio Rev. Code Ann.", "Ohio Rev. Code", "O.R.C.", "ORC", "R.C.", "RC"],
+    regexFragment: "Ohio\\s+Rev\\.?\\s+Code(?:\\s+Ann\\.?)?|O\\.?R\\.?C\\.?|R\\.?C\\.?",
+  },
+  // ── Michigan ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "MI",
+    abbreviations: [
+      "Mich. Comp. Laws Ann.",
+      "Mich. Comp. Laws Serv.",
+      "Mich. Comp. Laws",
+      "M.C.L.",
+      "MCLA",
+      "MCLS",
+      "MCL",
+    ],
+    regexFragment: "Mich\\.?\\s+Comp\\.?\\s+Laws(?:\\s+(?:Ann|Serv)\\.?)?|M\\.?C\\.?L\\.?|MCL[AS]?",
+  },
+  // ── Utah ───────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "UT",
+    abbreviations: ["Utah Code Ann.", "Utah Code", "U.C.A.", "UCA"],
+    regexFragment: "Utah\\s+Code(?:\\s+Ann\\.?)?|U\\.?C\\.?A\\.?",
+  },
+  // ── Colorado ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "CO",
+    abbreviations: ["Colo. Rev. Stat. Ann.", "Colo. Rev. Stat.", "C.R.S.", "CRS"],
+    regexFragment: "Colo\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|C\\.?R\\.?S\\.?",
+  },
+  // ── Washington ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WA",
+    abbreviations: ["Wash. Rev. Code Ann.", "Wash. Rev. Code", "RCW"],
+    regexFragment: "Wash\\.?\\s+Rev\\.?\\s+Code(?:\\s+Ann\\.?)?|RCW",
+  },
+  // ── North Carolina ─────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NC",
+    abbreviations: ["N.C. Gen. Stat. Ann.", "N.C. Gen. Stat.", "N.C.G.S.", "NCGS", "G.S.", "GS"],
+    regexFragment: "N\\.?C\\.?\\s*Gen\\.?\\s*Stat\\.?(?:\\s+Ann\\.?)?|N\\.?C\\.?G\\.?S\\.?|G\\.?S\\.?",
+  },
+  // ── Georgia ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "GA",
+    abbreviations: ["Ga. Code Ann.", "Ga. Code", "O.C.G.A.", "OCGA"],
+    regexFragment: "Ga\\.?\\s+Code(?:\\s+Ann\\.?)?|O\\.?C\\.?G\\.?A\\.?",
+  },
+  // ── Pennsylvania (consolidated) ────────────────────────────────────────────
+  {
+    jurisdiction: "PA",
+    abbreviations: ["Pa. Cons. Stat.", "Pa.C.S.A.", "Pa.C.S.", "Pa. C.S.A.", "Pa. C.S."],
+    regexFragment: "Pa\\.?\\s*C\\.?S\\.?A?\\.?|Pa\\.?\\s+Cons\\.?\\s+Stat\\.?",
+  },
+  // ── Pennsylvania (unconsolidated) ──────────────────────────────────────────
+  {
+    jurisdiction: "PA",
+    abbreviations: ["P.S.", "PS"],
+    regexFragment: "P\\.?S\\.?",
+  },
+  // ── Indiana ────────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "IN",
+    abbreviations: [
+      "Burns Ind. Code Ann.",
+      "Burns Ind. Code",
+      "Indiana Code Ann.",
+      "Indiana Code",
+      "Ind. Code Ann.",
+      "Ind. Code",
+      "I.C.",
+      "IC",
+    ],
+    regexFragment: "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?",
+  },
+  // ── New Jersey ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "NJ",
+    abbreviations: ["N.J.S.A.", "NJSA", "N.J.S.", "NJS"],
+    regexFragment: "N\\.?J\\.?\\s*S(?:tat)?\\.?\\s*A?\\.?",
+  },
+  // ── Delaware ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "DE",
+    abbreviations: ["Del. Code Ann.", "Del. Code", "Del. C.", "Del C"],
+    regexFragment: "Del\\.?\\s*(?:Code(?:\\s+Ann\\.?)?|C\\.?)",
+  },
+];

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -1,0 +1,46 @@
+/**
+ * State statute abbreviation table — single source of truth for the
+ * abbreviated-code tokenizer pattern and the knownCodes lookup registry.
+ */
+
+export interface StateStatuteEntry {
+  /** Two-letter jurisdiction code (e.g., "AK", "AZ") */
+  jurisdiction: string;
+  /** All recognized abbreviation forms — used for lookup by findAbbreviatedCode */
+  abbreviations: string[];
+  /**
+   * Regex fragment for tokenizer alternation. If omitted, auto-generated
+   * from abbreviations via escapeForRegex. Provide explicitly when the
+   * pattern needs optional components (e.g., "Stat(?:utes)?").
+   */
+  regexFragment?: string;
+}
+
+/**
+ * Convert a plain abbreviation string into a regex fragment.
+ *
+ * Rules:
+ * - Periods followed by a letter (e.g., "T.C.") → optional period + optional space
+ * - Periods followed by a space (e.g., "Stat. Ann.") → optional period + flexible space
+ * - Trailing periods → optional period
+ * - Spaces → flexible whitespace (\s+)
+ * - Regex-special characters are escaped
+ */
+export function escapeForRegex(abbreviation: string): string {
+  return (
+    abbreviation
+      // Escape regex-special chars (except period and space, handled below)
+      .replace(/[\\^$*+?{}[\]|()]/g, "\\$&")
+      // Period followed by letter: "T.C" → "T\.?\s*C"
+      .replace(/\.(?=[A-Za-z])/g, "\\.?\\s*")
+      // Period followed by space: "Stat. Ann" → "Stat\.?\s+Ann"
+      .replace(/\.\s+/g, "\\.?\\s+")
+      // Trailing period: "Ann." → "Ann\.?"
+      .replace(/\.$/g, "\\.?")
+      // Remaining spaces → flexible whitespace
+      .replace(/ +/g, "\\s+")
+  );
+}
+
+/** Placeholder — entries added in subsequent tasks */
+export const stateStatuteEntries: StateStatuteEntry[] = [];

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -316,4 +316,46 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     abbreviations: ["R.I. Gen. Laws", "R.I.G.L."],
     regexFragment: "R\\.?I\\.?\\s+Gen\\.?\\s+Laws|R\\.?I\\.?G\\.?L\\.?",
   },
+  // ── South Carolina ────────────────────────────────────────────────────────
+  {
+    jurisdiction: "SC",
+    abbreviations: ["S.C. Code Ann.", "S.C. Code"],
+    regexFragment: "S\\.?C\\.?\\s+Code(?:\\s+Ann\\.?)?",
+  },
+  // ── South Dakota ──────────────────────────────────────────────────────────
+  {
+    jurisdiction: "SD",
+    abbreviations: ["S.D. Codified Laws", "S.D.C.L.", "SDCL"],
+    regexFragment: "S\\.?D\\.?\\s+Codified\\s+Laws|S\\.?D\\.?C\\.?L\\.?|SDCL",
+  },
+  // ── Tennessee ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "TN",
+    abbreviations: ["Tenn. Code Ann.", "Tennessee Code", "T.C.A.", "TN Code"],
+    regexFragment: "Tenn(?:essee)?\\.?\\s+Code(?:\\s+Ann\\.?)?|T\\.?C\\.?A\\.?|TN\\s+Code",
+  },
+  // ── Vermont ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "VT",
+    abbreviations: ["Vt. Stat. Ann.", "V.S.A."],
+    regexFragment: "Vt\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|V\\.?S\\.?A\\.?",
+  },
+  // ── Wisconsin ─────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WI",
+    abbreviations: ["Wis. Stat. Ann.", "Wis. Stat.", "W.S.A."],
+    regexFragment: "Wis\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|W\\.?S\\.?A\\.?",
+  },
+  // ── West Virginia ─────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WV",
+    abbreviations: ["W. Va. Code Ann.", "W. Va. Code", "WV Code"],
+    regexFragment: "W\\.?\\s*Va\\.?\\s+Code(?:\\s+Ann\\.?)?|WV\\s+Code",
+  },
+  // ── Wyoming ───────────────────────────────────────────────────────────────
+  {
+    jurisdiction: "WY",
+    abbreviations: ["Wyo. Stat. Ann.", "Wyo. Stat.", "W.S."],
+    regexFragment: "Wyo\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|W\\.?S\\.?",
+  },
 ];

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -11,6 +11,7 @@
  * - Illinois: chapter-act (ILCS chapter/act/section format)
  */
 
+import { buildAbbreviatedCodeRegex } from "@/data/stateStatutes"
 import type { Pattern } from "./casePatterns"
 
 export const statutePatterns: Pattern[] = [
@@ -66,12 +67,8 @@ export const statutePatterns: Pattern[] = [
   },
   {
     id: "abbreviated-code",
-    // Alternation order: longer/more-specific patterns first within each state to avoid partial matches.
-    // The \b anchor prevents cross-boundary matches (e.g., "N.C.G.S." won't match "G.S." at position 4).
-    regex:
-      /\b(?:(\d+)\s+)?(Fla\.?\s*Stat(?:utes)?\.?(?:\s*Ann\.?)?|F\.?S\.?|R\.?C\.?|O\.?R\.?C\.?|Ohio\s+Rev\.?\s+Code(?:\s+Ann\.?)?|MCL[AS]?|M\.?C\.?L\.?|Mich\.?\s+Comp\.?\s+Laws(?:\s+(?:Ann|Serv)\.?)?|Utah\s+Code(?:\s+Ann\.?)?|U\.?C\.?A\.?|C\.?R\.?S\.?|Colo\.?\s+Rev\.?\s+Stat\.?(?:\s+Ann\.?)?|RCW|Wash\.?\s+Rev\.?\s+Code(?:\s+Ann\.?)?|G\.?S\.?|N\.?C\.?\s*Gen\.?\s*Stat\.?(?:\s+Ann\.?)?|N\.?C\.?G\.?S\.?|O\.?C\.?G\.?A\.?|Ga\.?\s+Code(?:\s+Ann\.?)?|Pa\.?\s*C\.?S\.?A?\.?|Pa\.?\s+Cons\.?\s+Stat\.?|P\.?S\.?|Ind(?:iana)?\.?\s+Code(?:\s+Ann\.?)?|Burns\s+Ind\.?\s+Code(?:\s+Ann\.?)?|I\.?C\.?|N\.?J\.?\s*S(?:tat)?\.?\s*A?\.?|Del\.?\s*(?:Code(?:\s+Ann\.?)?|C\.?))\s*§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
-    description:
-      "Abbreviated state code citations for 12 jurisdictions (FL, OH, MI, UT, CO, WA, NC, GA, PA, IN, NJ, DE)",
+    regex: buildAbbreviatedCodeRegex(),
+    description: "Abbreviated state code citations for all US jurisdictions",
     type: "statute",
   },
 ]

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -43,7 +43,7 @@ export const statutePatterns: Pattern[] = [
     // Matches: [State abbrev]. [Code/Law Name] § [section]
     // Captures: (1) jurisdiction prefix, (2) code name text, (3) section+subsections+et seq
     regex:
-      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s)Va\.?|Ala(?:bama)?\.?)\s+((?:[A-Za-z.&',\s]+?))\s*§§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s?)Va\.?|Ala(?:bama)?\.?)\s+((?:[A-Za-z.&',\s]+?))\s*§§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
     description:
       "Named-code state citations (NY, CA, TX, MD, VA, AL) with jurisdiction prefix + code name + §",
     type: "statute",

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -43,7 +43,7 @@ export const statutePatterns: Pattern[] = [
     // Matches: [State abbrev]. [Code/Law Name] § [section]
     // Captures: (1) jurisdiction prefix, (2) code name text, (3) section+subsections+et seq
     regex:
-      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|Va\.?|Ala(?:bama)?\.?)\s+((?:[A-Za-z.&',\s]+?))\s*§§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s)Va\.?|Ala(?:bama)?\.?)\s+((?:[A-Za-z.&',\s]+?))\s*§§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
     description:
       "Named-code state citations (NY, CA, TX, MD, VA, AL) with jurisdiction prefix + code name + §",
     type: "statute",

--- a/tests/data/knownCodes.test.ts
+++ b/tests/data/knownCodes.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe("knownCodes registry", () => {
   describe("abbreviatedCodes", () => {
-    it("should have entries for all 12 jurisdictions", () => {
+    it("should have entries for all 43 jurisdictions", () => {
       const jurisdictions = new Set(abbreviatedCodes.map((c) => c.jurisdiction))
       expect(jurisdictions).toContain("FL")
       expect(jurisdictions).toContain("OH")
@@ -23,7 +23,7 @@ describe("knownCodes registry", () => {
       expect(jurisdictions).toContain("IN")
       expect(jurisdictions).toContain("NJ")
       expect(jurisdictions).toContain("DE")
-      expect(jurisdictions.size).toBe(12)
+      expect(jurisdictions.size).toBe(43)
     })
 
     it("should have no duplicate abbreviation strings across jurisdictions", () => {

--- a/tests/data/stateStatutes.test.ts
+++ b/tests/data/stateStatutes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { escapeForRegex } from "@/data/stateStatutes"
+
+describe("escapeForRegex", () => {
+  it("should handle dotted abbreviations like T.C.A.", () => {
+    const result = escapeForRegex("T.C.A.")
+    expect("T.C.A.").toMatch(new RegExp(result))
+    expect("TCA").toMatch(new RegExp(result))
+    expect("T C A").toMatch(new RegExp(result))
+  })
+
+  it("should handle word.space patterns like Conn. Gen. Stat.", () => {
+    const result = escapeForRegex("Conn. Gen. Stat.")
+    expect("Conn. Gen. Stat.").toMatch(new RegExp(result))
+    expect("Conn Gen Stat").toMatch(new RegExp(result))
+    expect("Conn.  Gen.  Stat.").toMatch(new RegExp(result))
+  })
+
+  it("should handle plain words like Alaska Stat.", () => {
+    const result = escapeForRegex("Alaska Stat.")
+    expect("Alaska Stat.").toMatch(new RegExp(result))
+    expect("Alaska Stat").toMatch(new RegExp(result))
+    expect("Alaska  Stat.").toMatch(new RegExp(result))
+  })
+
+  it("should handle abbreviations without periods like MCL", () => {
+    const result = escapeForRegex("MCL")
+    expect("MCL").toMatch(new RegExp(result))
+  })
+
+  it("should handle mixed patterns like N.H. Rev. Stat. Ann.", () => {
+    const result = escapeForRegex("N.H. Rev. Stat. Ann.")
+    expect("N.H. Rev. Stat. Ann.").toMatch(new RegExp(result))
+    expect("NH Rev Stat Ann").toMatch(new RegExp(result))
+  })
+})

--- a/tests/data/stateStatutes.test.ts
+++ b/tests/data/stateStatutes.test.ts
@@ -92,3 +92,40 @@ describe("buildAbbreviatedCodeRegex", () => {
     stateStatuteEntries.push(...original)
   })
 })
+
+describe("stateStatuteEntries — existing 12 states", () => {
+  const existingCitations = [
+    { text: "Fla. Stat. § 768.81", jurisdiction: "FL" },
+    { text: "F.S. 768.81", jurisdiction: "FL" },
+    { text: "R.C. 2305.01", jurisdiction: "OH" },
+    { text: "Ohio Rev. Code § 2305.01", jurisdiction: "OH" },
+    { text: "MCL 750.81", jurisdiction: "MI" },
+    { text: "M.C.L. § 750.81", jurisdiction: "MI" },
+    { text: "Utah Code § 76-5-302", jurisdiction: "UT" },
+    { text: "U.C.A. § 63G-2-103", jurisdiction: "UT" },
+    { text: "C.R.S. § 13-1-101", jurisdiction: "CO" },
+    { text: "Colo. Rev. Stat. § 6-1-1301", jurisdiction: "CO" },
+    { text: "RCW 26.09.191", jurisdiction: "WA" },
+    { text: "Wash. Rev. Code § 26.09.191", jurisdiction: "WA" },
+    { text: "G.S. 20-138.1", jurisdiction: "NC" },
+    { text: "N.C. Gen. Stat. § 15A-302", jurisdiction: "NC" },
+    { text: "O.C.G.A. § 16-5-1", jurisdiction: "GA" },
+    { text: "Ga. Code Ann. § 16-5-1", jurisdiction: "GA" },
+    { text: "42 Pa.C.S. § 5524", jurisdiction: "PA" },
+    { text: "43 P.S. § 951", jurisdiction: "PA" },
+    { text: "Ind. Code § 35-42-1-1", jurisdiction: "IN" },
+    { text: "IC 35-42-1-1", jurisdiction: "IN" },
+    { text: "N.J.S.A. 2A:10-1", jurisdiction: "NJ" },
+    { text: "8 Del. C. § 141", jurisdiction: "DE" },
+    { text: "Del. Code Ann. § 141", jurisdiction: "DE" },
+  ]
+
+  const regex = buildAbbreviatedCodeRegex()
+
+  for (const { text } of existingCitations) {
+    it(`should match: "${text}"`, () => {
+      regex.lastIndex = 0
+      expect(text.match(regex)).not.toBeNull()
+    })
+  }
+})

--- a/tests/data/stateStatutes.test.ts
+++ b/tests/data/stateStatutes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { escapeForRegex } from "@/data/stateStatutes"
+import { escapeForRegex, buildAbbreviatedCodeRegex, stateStatuteEntries } from "@/data/stateStatutes"
+import type { StateStatuteEntry } from "@/data/stateStatutes"
 
 describe("escapeForRegex", () => {
   it("should handle dotted abbreviations like T.C.A.", () => {
@@ -32,5 +33,62 @@ describe("escapeForRegex", () => {
     const result = escapeForRegex("N.H. Rev. Stat. Ann.")
     expect("N.H. Rev. Stat. Ann.").toMatch(new RegExp(result))
     expect("NH Rev Stat Ann").toMatch(new RegExp(result))
+  })
+})
+
+describe("buildAbbreviatedCodeRegex", () => {
+  it("should build regex that matches abbreviations from entries", () => {
+    const original = [...stateStatuteEntries]
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push({
+      jurisdiction: "XX",
+      abbreviations: ["X.X. Code", "XX Code"],
+    })
+
+    const regex = buildAbbreviatedCodeRegex()
+    const text = "X.X. Code § 123"
+    const match = regex.exec(text)
+    expect(match).not.toBeNull()
+    expect(match![2]).toContain("X.X. Code")
+    expect(match![3]).toBe("123")
+
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push(...original)
+  })
+
+  it("should capture optional leading title number", () => {
+    const original = [...stateStatuteEntries]
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push({
+      jurisdiction: "XX",
+      abbreviations: ["XX Code"],
+    })
+
+    const regex = buildAbbreviatedCodeRegex()
+    const text = "42 XX Code § 5524"
+    const match = regex.exec(text)
+    expect(match).not.toBeNull()
+    expect(match![1]).toBe("42")
+    expect(match![3]).toBe("5524")
+
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push(...original)
+  })
+
+  it("should use regexFragment when provided", () => {
+    const original = [...stateStatuteEntries]
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push({
+      jurisdiction: "XX",
+      abbreviations: ["X. Stat."],
+      regexFragment: "X\\.?\\s*Stat(?:utes)?\\.?(?:\\s+Ann\\.?)?",
+    })
+
+    const regex = buildAbbreviatedCodeRegex()
+    expect("X. Statutes Ann. § 99".match(regex)).not.toBeNull()
+    expect("X Stat § 99".match(regex)).not.toBeNull()
+
+    stateStatuteEntries.length = 0
+    stateStatuteEntries.push(...original)
   })
 })

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -354,6 +354,34 @@ describe("extractStatute", () => {
     }
   })
 
+  describe("new state jurisdictions — batch 7", () => {
+    const cases = [
+      { text: "N.D. Cent. Code § 12.1-02-01", jurisdiction: "ND", section: "12.1-02-01" },
+      { text: "N.D.C.C. § 12.1-02-01", jurisdiction: "ND", section: "12.1-02-01" },
+      { text: "Neb. Rev. Stat. § 28-303", jurisdiction: "NE", section: "28-303" },
+      { text: "N.H. Rev. Stat. Ann. § 625:9", jurisdiction: "NH", section: "625:9" },
+      { text: "RSA § 625:9", jurisdiction: "NH", section: "625:9" },
+      { text: "N.M. Stat. Ann. § 30-16-1", jurisdiction: "NM", section: "30-16-1" },
+      { text: "NMSA § 30-16-1", jurisdiction: "NM", section: "30-16-1" },
+      { text: "Nev. Rev. Stat. § 200.030", jurisdiction: "NV", section: "200.030" },
+      { text: "NRS § 200.030", jurisdiction: "NV", section: "200.030" },
+      { text: "Okla. Stat. § 496", jurisdiction: "OK", section: "496" },
+      { text: "Or. Rev. Stat. § 161.085", jurisdiction: "OR", section: "161.085" },
+      { text: "ORS § 161.085", jurisdiction: "OR", section: "161.085" },
+      { text: "R.I. Gen. Laws § 11-1-2", jurisdiction: "RI", section: "11-1-2" },
+      { text: "R.I.G.L. § 11-1-2", jurisdiction: "RI", section: "11-1-2" },
+    ]
+    for (const { text, jurisdiction, section } of cases) {
+      it(`should extract "${text}"`, () => {
+        const citations = extractCitations(text)
+        const statutes = citations.filter((c) => c.type === "statute")
+        expect(statutes).toHaveLength(1)
+        expect(statutes[0].jurisdiction).toBe(jurisdiction)
+        expect(statutes[0].section).toBe(section)
+      })
+    }
+  })
+
   describe("new fields via full pipeline", () => {
     it("should extract subsection through full pipeline", () => {
       const citations = extractCitations("42 U.S.C. § 1983(a)(1)")

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -382,6 +382,31 @@ describe("extractStatute", () => {
     }
   })
 
+  describe("new state jurisdictions — batch 8", () => {
+    const cases = [
+      { text: "S.C. Code Ann. § 16-3-10", jurisdiction: "SC", section: "16-3-10" },
+      { text: "S.D. Codified Laws § 22-1-2", jurisdiction: "SD", section: "22-1-2" },
+      { text: "SDCL § 22-1-2", jurisdiction: "SD", section: "22-1-2" },
+      { text: "Tenn. Code Ann. § 39-13-101", jurisdiction: "TN", section: "39-13-101" },
+      { text: "T.C.A. § 39-13-101", jurisdiction: "TN", section: "39-13-101" },
+      { text: "Vt. Stat. Ann. § 2301", jurisdiction: "VT", section: "2301" },
+      { text: "V.S.A. § 2301", jurisdiction: "VT", section: "2301" },
+      { text: "Wis. Stat. § 940.01", jurisdiction: "WI", section: "940.01" },
+      { text: "W. Va. Code § 61-2-9", jurisdiction: "WV", section: "61-2-9" },
+      { text: "Wyo. Stat. Ann. § 6-2-101", jurisdiction: "WY", section: "6-2-101" },
+      { text: "W.S. § 6-2-101", jurisdiction: "WY", section: "6-2-101" },
+    ]
+    for (const { text, jurisdiction, section } of cases) {
+      it(`should extract "${text}"`, () => {
+        const citations = extractCitations(text)
+        const statutes = citations.filter((c) => c.type === "statute")
+        expect(statutes).toHaveLength(1)
+        expect(statutes[0].jurisdiction).toBe(jurisdiction)
+        expect(statutes[0].section).toBe(section)
+      })
+    }
+  })
+
   describe("new fields via full pipeline", () => {
     it("should extract subsection through full pipeline", () => {
       const citations = extractCitations("42 U.S.C. § 1983(a)(1)")

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -326,6 +326,34 @@ describe("extractStatute", () => {
     }
   })
 
+  describe("new state jurisdictions — batch 6", () => {
+    const cases = [
+      { text: "Kan. Stat. Ann. § 21-5401", jurisdiction: "KS", section: "21-5401" },
+      { text: "K.S.A. § 21-5401", jurisdiction: "KS", section: "21-5401" },
+      { text: "Ky. Rev. Stat. Ann. § 507.020", jurisdiction: "KY", section: "507.020" },
+      { text: "KRS § 507.020", jurisdiction: "KY", section: "507.020" },
+      { text: "La. Rev. Stat. Ann. § 14:30", jurisdiction: "LA", section: "14:30" },
+      { text: "La. R.S. 14:30", jurisdiction: "LA", section: "14:30" },
+      { text: "Me. Rev. Stat. Ann. § 208", jurisdiction: "ME", section: "208" },
+      { text: "M.R.S.A. § 208", jurisdiction: "ME", section: "208" },
+      { text: "Minn. Stat. § 609.02", jurisdiction: "MN", section: "609.02" },
+      { text: "Miss. Code Ann. § 97-3-19", jurisdiction: "MS", section: "97-3-19" },
+      { text: "Mo. Rev. Stat. § 565.021", jurisdiction: "MO", section: "565.021" },
+      { text: "RSMo § 565.021", jurisdiction: "MO", section: "565.021" },
+      { text: "Mont. Code Ann. § 45-5-502", jurisdiction: "MT", section: "45-5-502" },
+      { text: "MCA § 45-5-502", jurisdiction: "MT", section: "45-5-502" },
+    ]
+    for (const { text, jurisdiction, section } of cases) {
+      it(`should extract "${text}"`, () => {
+        const citations = extractCitations(text)
+        const statutes = citations.filter((c) => c.type === "statute")
+        expect(statutes).toHaveLength(1)
+        expect(statutes[0].jurisdiction).toBe(jurisdiction)
+        expect(statutes[0].section).toBe(section)
+      })
+    }
+  })
+
   describe("new fields via full pipeline", () => {
     it("should extract subsection through full pipeline", () => {
       const citations = extractCitations("42 U.S.C. § 1983(a)(1)")

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -299,6 +299,33 @@ describe("extractStatute", () => {
     })
   })
 
+  describe("new state jurisdictions — batch 5", () => {
+    const cases = [
+      { text: "Alaska Stat. § 11.41.100", jurisdiction: "AK", section: "11.41.100" },
+      { text: "AS § 11.41.100", jurisdiction: "AK", section: "11.41.100" },
+      { text: "Ariz. Rev. Stat. § 13-1105", jurisdiction: "AZ", section: "13-1105" },
+      { text: "A.R.S. § 13-1105", jurisdiction: "AZ", section: "13-1105" },
+      { text: "Ark. Code Ann. § 5-10-101", jurisdiction: "AR", section: "5-10-101" },
+      { text: "A.C.A. § 5-10-101", jurisdiction: "AR", section: "5-10-101" },
+      { text: "Conn. Gen. Stat. § 52-555", jurisdiction: "CT", section: "52-555" },
+      { text: "C.G.S. § 14-227a", jurisdiction: "CT", section: "14-227a" },
+      { text: "D.C. Code § 22-3211", jurisdiction: "DC", section: "22-3211" },
+      { text: "Haw. Rev. Stat. § 707-711", jurisdiction: "HI", section: "707-711" },
+      { text: "HRS § 707-711", jurisdiction: "HI", section: "707-711" },
+      { text: "Iowa Code § 714.1", jurisdiction: "IA", section: "714.1" },
+      { text: "Idaho Code § 18-4001", jurisdiction: "ID", section: "18-4001" },
+    ]
+    for (const { text, jurisdiction, section } of cases) {
+      it(`should extract "${text}"`, () => {
+        const citations = extractCitations(text)
+        const statutes = citations.filter((c) => c.type === "statute")
+        expect(statutes).toHaveLength(1)
+        expect(statutes[0].jurisdiction).toBe(jurisdiction)
+        expect(statutes[0].section).toBe(section)
+      })
+    }
+  })
+
   describe("new fields via full pipeline", () => {
     it("should extract subsection through full pipeline", () => {
       const citations = extractCitations("42 U.S.C. § 1983(a)(1)")

--- a/tests/patterns/statutePatterns.test.ts
+++ b/tests/patterns/statutePatterns.test.ts
@@ -272,6 +272,12 @@ describe("statutePatterns", () => {
     it("should not match text without §", () => {
       expect(getMatches("The N.Y. Penal Law was enacted in 1965")).toHaveLength(0)
     })
+    it("should not match W. Va. Code (handled by abbreviated-code)", () => {
+      expect(getMatches("W. Va. Code § 61-2-9")).toHaveLength(0)
+    })
+    it("should not match W.Va. Code (handled by abbreviated-code)", () => {
+      expect(getMatches("W.Va. Code § 61-2-9")).toHaveLength(0)
+    })
   })
 
   describe("mass-chapter pattern", () => {


### PR DESCRIPTION
## Summary

- Adds statute citation extraction for **31 new US state jurisdictions**, expanding coverage from 20 to 51 (all 50 states + DC)
- Introduces a **data-driven regex generation** approach — the `abbreviated-code` tokenizer regex is now built from a state abbreviation table (`stateStatuteEntries`) at import time, eliminating manual sync between regex and lookup data
- Fixes a **WV/VA disambiguation conflict** where `W. Va. Code` was partially matched by the Virginia `named-code` pattern

New jurisdictions: AK, AZ, AR, CT, DC, HI, IA, ID, KS, KY, LA, ME, MN, MO, MS, MT, ND, NE, NH, NM, NV, OK, OR, RI, SC, SD, TN, VT, WI, WV, WY.

Closes #155 (partially — state constitutions, federal rules, and bare section refs remain as follow-up work)

## Architecture

- **`src/data/stateStatutes.ts`** (new): Single source of truth — `StateStatuteEntry[]` with jurisdiction, abbreviations, and optional regex fragment
- **`src/patterns/statutePatterns.ts`**: `abbreviated-code` regex replaced with `buildAbbreviatedCodeRegex()` call
- **`src/data/knownCodes.ts`**: `abbreviatedCodes[]` derived from `stateStatuteEntries` via `.map()`
- Extraction logic (`extractAbbreviated.ts`) unchanged — capture groups are identical

## Test plan

- [x] 52 new integration smoke tests (2-3 per state, using `extractCitations` full pipeline)
- [x] 31 unit tests for `escapeForRegex` and `buildAbbreviatedCodeRegex`
- [x] 23 regression tests for existing 12 states
- [x] Full suite passes (1679 tests, 0 failures)
- [x] Typecheck clean
- [x] Bundle size within limits (18.8 kB / 50 kB)
- [x] Original issue examples verified against built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)