### PR TITLE
fix: resolve Id. through short-form/supra citations (#170)

### DIFF
--- a/.changeset/fix-id-resolution-short-form.md
+++ b/.changeset/fix-id-resolution-short-form.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix Id. resolution to correctly resolve through short-form, supra, and non-case citations. Remove dead `allowNestedResolution` option.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ const resolved = resolveCitations(citations, text, {
 | `paragraphBoundaryPattern` | `RegExp` | `/\n\n+/` | Pattern to detect paragraphs |
 | `fuzzyPartyMatching` | `boolean` | `true` | Enable fuzzy party name matching for supra |
 | `partyMatchThreshold` | `number` | `0.8` | Similarity threshold (0-1) for fuzzy matching |
-| `allowNestedResolution` | `boolean` | `false` | Allow Id. to resolve to other short-form citations |
 | `reportUnresolved` | `boolean` | `true` | Report failure reasons for unresolved citations |
 
 ### Resolution Examples

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ const citations = extractCitations(text, { resolve: true })
 ```typescript
 const text = 'Id. at 100.' // Orphan Id. with no preceding citation
 const citations = extractCitations(text, { resolve: true })
-// citations[0].resolution.failureReason === 'No preceding full case citation found'
+// citations[0].resolution.failureReason === 'No preceding citation found'
 ```
 
 ## Citation Annotation

--- a/docs/superpowers/plans/2026-04-10-id-resolution-fix.md
+++ b/docs/superpowers/plans/2026-04-10-id-resolution-fix.md
@@ -1,0 +1,420 @@
+# Fix #170: Id. Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Id. citation resolution so it correctly resolves through short-form citations, supra, and non-case citation types, matching Bluebook rules and Python eyecite behavior.
+
+**Architecture:** Replace the backward search in `resolveId` with a forward-tracking `lastResolvedIndex` pointer that updates after every successfully resolved citation (full or short-form). Remove dead `lastFullCitation` field.
+
+**Tech Stack:** TypeScript, Vitest
+
+---
+
+### Task 1: Write Failing Tests for Id. After Short-Form
+
+**Files:**
+- Modify: `tests/integration/resolution.test.ts`
+
+These tests capture the bug from #170 and the additional scenarios from the spec.
+
+- [ ] **Step 1: Add new test describe block with all five test cases**
+
+Add inside the top-level `describe("Resolution Integration Tests")`, after the existing `"Id. Citation Resolution"` block:
+
+```typescript
+describe("Id. Resolution Through Short-Form Citations (#170)", () => {
+  it("resolves Id. through preceding short-form case citation", () => {
+    const text =
+      "Smith v. Jones, 500 F.2d 123 (2020). " +
+      "Celotex Corp. v. Catrett, 477 U.S. 317 (1986). " +
+      "500 F.2d at 128. " +
+      "Id. at 129."
+
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+    // Find citations by type
+    const smith = citations.find(c => c.type === "case" && c.reporter === "F.2d")
+    const celotex = citations.find(c => c.type === "case" && c.reporter === "U.S.")
+    const shortForm = citations.find(c => c.type === "shortFormCase")
+    const id = citations.find(c => c.type === "id")
+
+    expect(smith).toBeDefined()
+    expect(celotex).toBeDefined()
+    expect(shortForm).toBeDefined()
+    expect(id).toBeDefined()
+
+    const smithIndex = citations.indexOf(smith!)
+
+    // Short-form resolves to Smith (not Celotex)
+    expect(shortForm!.resolution?.resolvedTo).toBe(smithIndex)
+
+    // Id. resolves to Smith (via short-form), NOT Celotex
+    expect(id!.resolution?.resolvedTo).toBe(smithIndex)
+    expect(id!.resolution?.confidence).toBe(1.0)
+  })
+
+  it("resolves Id. through preceding supra citation", () => {
+    const text =
+      "Smith v. Jones, 500 F.2d 123 (2020). " +
+      "Brown v. Board, 347 U.S. 483 (1954). " +
+      "Smith, supra, at 130. " +
+      "Id. at 131."
+
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+    const smith = citations.find(c => c.type === "case" && c.reporter === "F.2d")
+    const id = citations.find(c => c.type === "id")
+
+    expect(smith).toBeDefined()
+    expect(id).toBeDefined()
+
+    const smithIndex = citations.indexOf(smith!)
+
+    // Id. resolves to Smith (via supra), NOT Brown
+    expect(id!.resolution?.resolvedTo).toBe(smithIndex)
+  })
+
+  it("fails Id. when preceding short-form fails to resolve", () => {
+    const text = "400 F.3d at 200. Id. at 201."
+
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+    const shortForm = citations.find(c => c.type === "shortFormCase")
+    const id = citations.find(c => c.type === "id")
+
+    expect(shortForm).toBeDefined()
+    expect(id).toBeDefined()
+
+    // Short-form fails (no matching full citation)
+    expect(shortForm!.resolution?.resolvedTo).toBeUndefined()
+
+    // Id. also fails (preceding resolution failed)
+    expect(id!.resolution?.resolvedTo).toBeUndefined()
+    expect(id!.resolution?.failureReason).toBeDefined()
+  })
+
+  it("resolves Id. after statute citation", () => {
+    const text =
+      "Smith v. Jones, 500 F.2d 123 (2020). " +
+      "42 U.S.C. § 1983. " +
+      "Id."
+
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+    const statute = citations.find(c => c.type === "statute")
+    const id = citations.find(c => c.type === "id")
+
+    expect(statute).toBeDefined()
+    expect(id).toBeDefined()
+
+    const statuteIndex = citations.indexOf(statute!)
+
+    // Id. resolves to statute (the most recently cited authority)
+    expect(id!.resolution?.resolvedTo).toBe(statuteIndex)
+  })
+
+  it("resolves chain of Id. through short-form", () => {
+    const text =
+      "Smith v. Jones, 500 F.2d 123 (2020). " +
+      "Celotex Corp. v. Catrett, 477 U.S. 317 (1986). " +
+      "500 F.2d at 128. " +
+      "Id. at 129. " +
+      "Id. at 130."
+
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+    const smith = citations.find(c => c.type === "case" && c.reporter === "F.2d")
+    const ids = citations.filter(c => c.type === "id")
+
+    expect(smith).toBeDefined()
+    expect(ids).toHaveLength(2)
+
+    const smithIndex = citations.indexOf(smith!)
+
+    // Both Id. citations resolve to Smith
+    expect(ids[0].resolution?.resolvedTo).toBe(smithIndex)
+    expect(ids[1].resolution?.resolvedTo).toBe(smithIndex)
+  })
+})
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run: `pnpm exec vitest run tests/integration/resolution.test.ts -t "Id. Resolution Through Short-Form"`
+
+Expected: At least the first test (`resolves Id. through preceding short-form case citation`) and the statute test fail. The Id. resolves to Celotex instead of Smith, and the statute test fails because `resolveId` only looks for `type === "case"`.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add tests/integration/resolution.test.ts
+git commit -m "test: add failing tests for Id. resolution through short-form citations (#170)"
+```
+
+---
+
+### Task 2: Update ResolutionContext Type
+
+**Files:**
+- Modify: `src/resolve/types.ts:118-143`
+
+- [ ] **Step 1: Replace `lastFullCitation` with `lastResolvedIndex` in ResolutionContext**
+
+Replace the `lastFullCitation` field:
+
+```typescript
+export interface ResolutionContext {
+  /** Current citation index being processed */
+  citationIndex: number
+
+  /** All citations in document (for lookback) */
+  allCitations: Citation[]
+
+  /**
+   * Index of the full citation most recently cited (directly or via resolution).
+   * Updated after every successfully resolved citation.
+   * Used by Id. resolution -- Id. inherits this value.
+   *
+   * For full citations: set to the citation's own index.
+   * For resolved short-form/supra/Id.: set to resolvedTo (the full antecedent index).
+   * For failed resolutions: NOT updated (Id. after a failed citation also fails).
+   */
+  lastResolvedIndex?: number
+
+  /**
+   * History of all full citations by party name.
+   * Maps normalized party name to citation index.
+   * Used for supra resolution.
+   */
+  fullCitationHistory: Map<string, number>
+
+  /**
+   * Map of citation index to paragraph number.
+   * Used for scope boundary checking.
+   */
+  paragraphMap: Map<number, number>
+}
+```
+
+- [ ] **Step 2: Run typecheck to see what breaks**
+
+Run: `pnpm typecheck`
+
+Expected: Error in `DocumentResolver.ts` at lines 73 and 121 where `lastFullCitation` is referenced.
+
+- [ ] **Step 3: Commit type change**
+
+```bash
+git add src/resolve/types.ts
+git commit -m "refactor: replace dead lastFullCitation with lastResolvedIndex in ResolutionContext (#170)"
+```
+
+---
+
+### Task 3: Update DocumentResolver
+
+**Files:**
+- Modify: `src/resolve/DocumentResolver.ts:70-168`
+
+- [ ] **Step 1: Update context initialization (line 70-76)**
+
+Replace:
+
+```typescript
+    // Initialize resolution context
+    this.context = {
+      citationIndex: 0,
+      allCitations: citations,
+      lastFullCitation: undefined,
+      fullCitationHistory: new Map(),
+      paragraphMap: new Map(),
+    }
+```
+
+With:
+
+```typescript
+    // Initialize resolution context
+    this.context = {
+      citationIndex: 0,
+      allCitations: citations,
+      lastResolvedIndex: undefined,
+      fullCitationHistory: new Map(),
+      paragraphMap: new Map(),
+    }
+```
+
+- [ ] **Step 2: Update the resolve() loop (lines 98-136)**
+
+Replace the entire `resolve()` method:
+
+```typescript
+  resolve(): ResolvedCitation[] {
+    const resolved: ResolvedCitation[] = []
+
+    for (let i = 0; i < this.citations.length; i++) {
+      this.context.citationIndex = i
+      const citation = this.citations[i]
+
+      // Resolve based on citation type
+      let resolution: ResolutionResult | undefined
+
+      switch (citation.type) {
+        case "id":
+          resolution = this.resolveId(citation)
+          break
+        case "supra":
+          resolution = this.resolveSupra(citation)
+          break
+        case "shortFormCase":
+          resolution = this.resolveShortFormCase(citation)
+          break
+        default:
+          // Full citation - update context for future resolutions
+          if (isFullCitation(citation)) {
+            this.context.lastResolvedIndex = i
+            this.trackFullCitation(citation, i)
+          }
+          break
+      }
+
+      // After resolving a short-form citation, update lastResolvedIndex
+      // to the full citation it resolved to (transitive resolution).
+      // If resolution failed, lastResolvedIndex is NOT updated --
+      // a subsequent Id. will also fail (matching Python eyecite behavior).
+      if (resolution?.resolvedTo !== undefined) {
+        this.context.lastResolvedIndex = resolution.resolvedTo
+      }
+
+      // Add citation with resolution metadata
+      // Type assertion is safe: runtime logic only sets resolution on short-form citations
+      resolved.push({
+        ...citation,
+        resolution,
+      } as ResolvedCitation)
+    }
+
+    return resolved
+  }
+```
+
+- [ ] **Step 3: Replace resolveId (lines 141-168)**
+
+Replace the entire `resolveId` method:
+
+```typescript
+  /**
+   * Resolves Id. citation to the most recently cited authority.
+   * Uses lastResolvedIndex which tracks the most recent successfully
+   * resolved citation (full, short-form, supra, or Id.).
+   */
+  private resolveId(_citation: IdCitation): ResolutionResult | undefined {
+    const currentIndex = this.context.citationIndex
+    const antecedentIndex = this.context.lastResolvedIndex
+
+    // No preceding citation has been resolved yet
+    if (antecedentIndex === undefined) {
+      return this.createFailureResult("No preceding citation found")
+    }
+
+    // Check scope boundary
+    if (!this.isWithinScope(antecedentIndex, currentIndex)) {
+      return this.createFailureResult("Antecedent citation outside scope boundary")
+    }
+
+    return {
+      resolvedTo: antecedentIndex,
+      confidence: 1.0, // Id. resolution is unambiguous when successful
+    }
+  }
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `pnpm typecheck`
+
+Expected: PASS — no type errors.
+
+- [ ] **Step 5: Run all resolution tests**
+
+Run: `pnpm exec vitest run tests/integration/resolution.test.ts`
+
+Expected: All tests pass, including the new #170 tests from Task 1.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `pnpm exec vitest run`
+
+Expected: All tests pass. No regressions.
+
+- [ ] **Step 7: Commit implementation**
+
+```bash
+git add src/resolve/DocumentResolver.ts
+git commit -m "fix: resolve Id. through short-form/supra citations (#170)
+
+Replace backward search in resolveId with forward-tracking
+lastResolvedIndex pointer that updates after every successfully
+resolved citation. Matches Python eyecite's last_resolution pattern
+and Bluebook Rule 4.1.
+
+Fixes: Id. after short-form, Id. after supra, Id. after statute,
+failed-preceding-propagation."
+```
+
+---
+
+### Task 4: Update Error Message in Existing Test and README
+
+**Files:**
+- Modify: `tests/integration/resolution.test.ts:57`
+- Modify: `README.md:350`
+
+The error message changed from `"No preceding full case citation found"` to `"No preceding citation found"`.
+
+- [ ] **Step 1: Update the existing test assertion**
+
+In `tests/integration/resolution.test.ts`, line 57, replace:
+
+```typescript
+      expect(citations[0].resolution?.failureReason).toContain("No preceding full case citation")
+```
+
+With:
+
+```typescript
+      expect(citations[0].resolution?.failureReason).toContain("No preceding citation found")
+```
+
+- [ ] **Step 2: Update README example**
+
+In `README.md`, line 350, replace:
+
+```
+// citations[0].resolution.failureReason === 'No preceding full case citation found'
+```
+
+With:
+
+```
+// citations[0].resolution.failureReason === 'No preceding citation found'
+```
+
+- [ ] **Step 3: Run the updated test**
+
+Run: `pnpm exec vitest run tests/integration/resolution.test.ts -t "fails to resolve orphan Id"`
+
+Expected: PASS
+
+- [ ] **Step 4: Run full test suite one final time**
+
+Run: `pnpm exec vitest run`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/resolution.test.ts README.md
+git commit -m "docs: update Id. resolution error message in test and README (#170)"
+```

--- a/docs/superpowers/specs/2026-04-10-id-resolution-fix-design.md
+++ b/docs/superpowers/specs/2026-04-10-id-resolution-fix-design.md
@@ -1,0 +1,150 @@
+# Fix #170: Id. Resolution Ignores Preceding Short-Form Citations
+
+**Date**: 2026-04-10
+**Issue**: [#170](https://github.com/medelman17/eyecite-ts/issues/170)
+**Status**: Design
+
+## Problem
+
+`resolveId` in `DocumentResolver.ts` searches backward for `candidate.type === "case"`, skipping short-form citations, supra, statutes, and journals. This causes Id. to resolve to the wrong antecedent when a short-form citation intervenes.
+
+**Example**: `Celotex, 477 U.S. 317. 500 F.2d at 128. Id. at 129.`
+- Current: Id. resolves to Celotex (last full case) -- wrong
+- Expected: Id. resolves to Smith v. Jones (via the short-form) -- correct
+
+The bug has two independent failure modes:
+1. The `lastFullCitation` pointer only updates on full citations, not after short-form resolution
+2. The backward search in `resolveId` only matches `type === "case"`, ignoring short-form/supra/statutes/journals
+
+## Approach: Port the Python eyecite `last_resolution` Pattern
+
+Replace the backward search with a forward-tracking `lastResolvedIndex` variable, matching the upstream Python eyecite architecture.
+
+### Bluebook Justification
+
+Bluebook Rule 4.1: Id. refers to the "immediately preceding cited authority" -- the underlying source, regardless of citation form. The sequence Full -> Short-form -> Id. is standard legal writing. Id. can follow any citation type (case, statute, journal).
+
+### Python eyecite Reference
+
+Python eyecite tracks `last_resolution` that updates after every citation:
+
+```python
+for citation in citations:
+    resolution = resolve(citation, ...)
+    last_resolution = resolution  # updates for ALL types
+```
+
+Id. simply inherits `last_resolution`. No backward search needed.
+
+## Design
+
+### Change 1: Add `lastResolvedIndex` to Resolution Context
+
+In `ResolutionContext` (resolve/types.ts):
+
+```typescript
+interface ResolutionContext {
+  // ... existing fields ...
+
+  /**
+   * Index of the full citation most recently cited (directly or via resolution).
+   * Updated after every successfully resolved citation.
+   * Used by Id. resolution -- Id. inherits this value.
+   */
+  lastResolvedIndex?: number
+}
+```
+
+This replaces `lastFullCitation`, which is currently dead code (set but never read -- `resolveId` does a backward search instead of using it). We remove `lastFullCitation` and use `lastResolvedIndex` for both Id. resolution and the full-citation pointer update.
+
+### Change 2: Update the Main Resolution Loop
+
+In `DocumentResolver.resolve()`, update `lastResolvedIndex` after every citation:
+
+```typescript
+resolve(): ResolvedCitation[] {
+  const resolved: ResolvedCitation[] = []
+
+  for (let i = 0; i < this.citations.length; i++) {
+    this.context.citationIndex = i
+    const citation = this.citations[i]
+    let resolution: ResolutionResult | undefined
+
+    switch (citation.type) {
+      case "id":
+        resolution = this.resolveId(citation)
+        break
+      case "supra":
+        resolution = this.resolveSupra(citation)
+        break
+      case "shortFormCase":
+        resolution = this.resolveShortFormCase(citation)
+        break
+      default:
+        if (isFullCitation(citation)) {
+          this.context.lastResolvedIndex = i  // Full citation: point at itself
+          this.trackFullCitation(citation, i)
+        }
+        break
+    }
+
+    // After resolving a short-form citation, update lastResolvedIndex
+    // to the full citation it resolved to (transitive resolution)
+    if (resolution?.resolvedTo !== undefined) {
+      this.context.lastResolvedIndex = resolution.resolvedTo
+    }
+
+    resolved.push({ ...citation, resolution } as ResolvedCitation)
+  }
+
+  return resolved
+}
+```
+
+### Change 3: Simplify `resolveId`
+
+Replace the backward search with a simple lookup:
+
+```typescript
+private resolveId(_citation: IdCitation): ResolutionResult | undefined {
+  const currentIndex = this.context.citationIndex
+  const antecedentIndex = this.context.lastResolvedIndex
+
+  if (antecedentIndex === undefined) {
+    return this.createFailureResult("No preceding citation found")
+  }
+
+  if (!this.isWithinScope(antecedentIndex, currentIndex)) {
+    return this.createFailureResult("Antecedent citation outside scope boundary")
+  }
+
+  return {
+    resolvedTo: antecedentIndex,
+    confidence: 1.0,
+  }
+}
+```
+
+### What Changes for Consumers
+
+- Id. now correctly resolves through short-form citations, supra, and other Id. citations
+- Id. can resolve to non-case citations (statutes, journals, etc.) -- matching Bluebook
+- If a preceding short-form/supra fails to resolve, Id. also fails (the pointer doesn't update on failure)
+- `resolvedTo` still points to the **full citation index**, not the short-form -- this is transitive resolution
+- Error message changes: "No preceding full case citation found" -> "No preceding citation found"
+
+### What Doesn't Change
+
+- `trackFullCitation` and the BK-tree logic are untouched
+- `resolveShortFormCase` and `resolveSupra` are untouched
+- Scope boundary checking works the same way
+- All existing passing tests should continue to pass (the backward search happened to produce correct results when no short-form intervened)
+
+## Test Plan
+
+1. **New: Id. after short-form case** -- `Full(Smith) -> Full(Celotex) -> ShortForm(Smith) -> Id.` -- Id. resolves to Smith
+2. **New: Id. after supra** -- `Full(Smith) -> Full(Jones) -> Supra(Smith) -> Id.` -- Id. resolves to Smith
+3. **New: Id. after failed short-form** -- `ShortForm(no match) -> Id.` -- both fail
+4. **New: Id. after statute** -- `Full(case) -> Statute -> Id.` -- Id. resolves to statute
+5. **New: Chain of Id.** -- `Full -> ShortForm -> Id. -> Id.` -- both Id. resolve to Full
+6. **Existing tests**: All current resolution tests pass unchanged

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,314 @@
+# eyecite-ts
+
+> TypeScript legal citation extraction library with zero runtime dependencies. Extract, resolve, and annotate legal citations from court opinions and legal documents.
+
+Port of Python [eyecite](https://github.com/freelawproject/eyecite) by Free Law Project. This TypeScript implementation adds parallel citation linking, party name extraction, full span tracking, structured date parsing, constitutional citations, and court inference.
+
+- Version: 0.6.0
+- License: MIT
+- Node.js: >=18.0.0
+- Runtime dependencies: 0
+- Core bundle: ~10KB gzipped (core), ~50KB limit
+- Repository: https://github.com/medelman17/eyecite-ts
+
+## Installation
+
+```bash
+npm install eyecite-ts
+```
+
+## Quick Start
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+
+const text = "See Smith v. Jones, 500 F.2d 123 (9th Cir. Jan. 15, 2020)"
+const citations = extractCitations(text)
+// Returns: [{ type: "case", volume: 500, reporter: "F.2d", page: 123, court: "9th Cir.", year: 2020, caseName: "Smith v. Jones", ... }]
+```
+
+## Architecture
+
+Citations flow through a 4-stage pipeline: clean → tokenize → extract → resolve.
+
+1. **Clean** (`src/clean/`): Strip HTML, normalize whitespace/Unicode, fix smart quotes. Builds a `TransformationMap` tracking position shifts between original and cleaned text.
+2. **Tokenize** (`src/tokenize/`): Apply regex patterns from `src/patterns/` to find citation candidates. Intentionally broad to capture potential matches without validation. Patterns applied in specificity order: neutral → shortForm → case → constitutional → statute → journal.
+3. **Extract** (`src/extract/`): Parse metadata from tokens (volume, reporter, page, court, year). Each citation type has its own extractor. The main orchestrator is `extractCitations.ts`. Handles case name backward search, full span calculation, parenthetical parsing, disposition extraction, and structured date parsing.
+4. **Resolve** (`src/resolve/`): Link short-form citations (Id., supra, short-form case) to full antecedents. Uses scope boundaries, BKTree-based Levenshtein fuzzy matching, and paragraph/section/footnote awareness.
+
+Footnote detection is opt-in (`detectFootnotes: true`), runs before cleaning on raw text to preserve newline structure, and supports both HTML and plain-text footnote formats.
+
+Position tracking uses dual coordinates: `cleanStart/cleanEnd` (internal parsing) and `originalStart/originalEnd` (user-facing results), connected by `TransformationMap`.
+
+## Package Entry Points
+
+Four entry points for optimal tree-shaking:
+
+| Entry Point | Import Path | Contents |
+|---|---|---|
+| Core | `eyecite-ts` | Extraction, resolution, types, type guards, footnote detection |
+| Data | `eyecite-ts/data` | Reporter database (1,200+ reporters), jurisdiction code registry |
+| Annotate | `eyecite-ts/annotate` | HTML annotation with template and callback modes |
+| Utils | `eyecite-ts/utils` | Post-extraction utilities: Bluebook formatting, case grouping, context extraction |
+
+## Citation Types
+
+Discriminated union on the `type` field. Switch on `citation.type` for type-safe field access.
+
+### Full Citation Types (8)
+
+- `case` — `FullCaseCitation`: volume, reporter, page, court, year, caseName, plaintiff, defendant, proceduralPrefix, disposition, date (ISO + parsed), parallelCitations, groupId, fullSpan, inferredCourt, hasBlankPage, parentheticals, subsequentHistoryEntries, nominativeVolume/Reporter, possibleInterpretations
+- `statute` — `StatuteCitation`: title, code, section, subsection, pincite, jurisdiction, hasEtSeq
+- `constitutional` — `ConstitutionalCitation`: jurisdiction (US + 50 states), article, amendment, section, clause
+- `journal` — `JournalCitation`: author, title, volume, journal, abbreviation, page, pincite, year
+- `neutral` — `NeutralCitation`: year, court (WL, LEXIS), documentNumber
+- `publicLaw` — `PublicLawCitation`: congress, lawNumber, title
+- `federalRegister` — `FederalRegisterCitation`: volume, page, year
+- `statutesAtLarge` — `StatutesAtLargeCitation`: volume, page, year
+
+### Short-Form Citation Types (3)
+
+- `id` — `IdCitation`: pincite (resolves to preceding full case citation)
+- `supra` — `SupraCitation`: partyName, pincite (resolves by party name match)
+- `shortFormCase` — `ShortFormCaseCitation`: volume, reporter, page, pincite (resolves by volume/reporter match)
+
+### Common Fields (CitationBase)
+
+All citations share: text, span, confidence (0–1), matchedText, processTimeMs, patternsChecked, warnings[], signal (see, see also, accord, cf, etc.), inFootnote, footnoteNumber, stringCitationGroupId/Index/GroupSize.
+
+## Main API
+
+### Convenience Functions
+
+```typescript
+import { extractCitations, extractCitationsAsync } from "eyecite-ts"
+
+// Synchronous extraction
+const citations = extractCitations(text, options?)
+
+// Async wrapper
+const citations = await extractCitationsAsync(text, options?)
+```
+
+### ExtractOptions
+
+```typescript
+interface ExtractOptions {
+  cleaners?: Array<(text: string) => string>  // Custom text cleaners (default: HTML strip, whitespace normalize, Unicode normalize, smart quote fix)
+  patterns?: Pattern[]                         // Custom regex patterns (default: all built-in patterns)
+  resolve?: boolean                            // Enable short-form resolution (default: false)
+  resolutionOptions?: ResolutionOptions        // Resolution configuration
+  filterFalsePositives?: boolean               // Remove non-US citations (default: false)
+  detectFootnotes?: boolean                    // Enable footnote zone detection (default: false)
+}
+```
+
+### Resolution
+
+```typescript
+import { resolveCitations, DocumentResolver } from "eyecite-ts"
+
+// Convenience function
+const resolved = resolveCitations(citations, text, options?)
+
+// Or use resolve: true in extractCitations
+const citations = extractCitations(text, { resolve: true })
+```
+
+#### ResolutionOptions
+
+```typescript
+interface ResolutionOptions {
+  scopeStrategy?: "paragraph" | "section" | "footnote" | "none"  // Default: "paragraph"
+  autoDetectParagraphs?: boolean       // Default: true
+  paragraphBoundaryPattern?: RegExp    // Default: /\n\n+/
+  fuzzyPartyMatching?: boolean         // Default: true
+  partyMatchThreshold?: number         // Default: 0.8 (0–1 range, Levenshtein similarity)
+  reportUnresolved?: boolean           // Default: true
+}
+```
+
+### Annotation
+
+```typescript
+import { annotate } from "eyecite-ts/annotate"
+
+// Template mode
+const result = annotate(text, citations, {
+  template: { before: "<cite>", after: "</cite>" }
+})
+
+// Callback mode
+const result = annotate(text, citations, {
+  callback: (citation, surrounding) => `<a href="...">${citation.matchedText}</a>`
+})
+```
+
+#### AnnotationOptions
+
+```typescript
+interface AnnotationOptions {
+  useCleanText?: boolean     // Use cleaned text positions (default: false)
+  autoEscape?: boolean       // HTML entity escaping / XSS protection (default: true)
+  useFullSpan?: boolean      // Annotate from case name through closing parenthetical (default: false)
+  callback?: (citation, surrounding: string) => string
+  template?: { before: string; after: string }
+}
+```
+
+### Utilities
+
+```typescript
+import { toReporterKey, toReporterKeys, toBluebook, groupByCase, getSurroundingContext } from "eyecite-ts/utils"
+
+toReporterKey(citation)           // "550 U.S. 544"
+toReporterKeys(citation)          // ["550 U.S. 544", "127 S. Ct. 1955"] (includes parallel citations)
+toBluebook(citation)              // Canonical Bluebook-formatted citation string
+groupByCase(citations)            // CaseGroup[] grouped by volume-reporter-page
+getSurroundingContext(text, span, { type: "sentence" | "paragraph", maxLength: 500 })
+```
+
+### Type Guards
+
+```typescript
+import { isFullCitation, isShortFormCitation, isCaseCitation, isCitationType, assertUnreachable } from "eyecite-ts"
+
+isFullCitation(citation)            // Narrows to FullCitation union (8 types)
+isShortFormCitation(citation)       // Narrows to ShortFormCitation union (3 types)
+isCaseCitation(citation)            // Narrows to FullCaseCitation
+isCitationType(citation, "statute") // Generic guard, narrows to StatuteCitation
+assertUnreachable(x)                // Exhaustiveness check for switch statements
+```
+
+### Granular / Power-User API
+
+```typescript
+import { cleanText, tokenize, extractCase, extractStatute, extractJournal, extractNeutral, extractPublicLaw, extractFederalRegister, extractStatutesAtLarge, extractConstitutional, parsePincite, normalizeCourt } from "eyecite-ts"
+
+const { cleaned, transformationMap, warnings } = cleanText(text, cleaners?)
+const tokens = tokenize(cleaned, patterns?)
+// Individual extractors for custom pipelines
+```
+
+### Footnote Detection
+
+```typescript
+import { detectFootnotes } from "eyecite-ts"
+
+const footnoteMap = detectFootnotes(text) // Auto-detects HTML or plain-text footnotes
+// Returns FootnoteZone[] with { start, end, footnoteNumber }
+// Use with extractCitations(text, { detectFootnotes: true }) for automatic integration
+```
+
+### Reporter Database
+
+```typescript
+import { loadReporters } from "eyecite-ts/data"
+
+const reporters = await loadReporters()  // 1,200+ reporters, lazy-loaded (~86.5KB gzipped)
+// Library works in degraded mode (pattern-only) without loading reporters
+```
+
+## Supported Jurisdictions (Statutes)
+
+| Family | Jurisdictions |
+|---|---|
+| Federal | USC, CFR, prose ("section X of title Y") |
+| Named-code | NY (21 laws), CA (29 codes), TX (29 codes), MD (36 articles), VA, AL, MA |
+| Abbreviated-code | FL, OH, MI, UT, CO, WA, NC, GA, PA, IN, NJ, DE |
+| Chapter-act | IL (ILCS) |
+
+Constitutional citations support U.S. Constitution + all 50 state constitutions. Roman numerals (I–XXVII) are automatically parsed to integers.
+
+## Key Features
+
+- **Parallel citation linking**: Automatic grouping of comma-separated citations sharing a parenthetical (e.g., "410 U.S. 113, 93 S. Ct. 705 (1973)") via shared `groupId`
+- **Case name extraction**: Backward search for party names including procedural prefixes (In re, Ex parte, etc.)
+- **Full span tracking**: `fullSpan` covers case name through final closing parenthetical; `span` covers citation core only
+- **Structured dates**: Parenthetical dates parsed to `{ iso, parsed: { year, month?, day? } }`. Supports "Jan. 15, 2020", "January 15, 2020", and "1/15/2020".
+- **Subsequent history**: Tracks procedural history signals (affirmed, reversed, cert. denied, etc.) with `subsequentHistoryEntries[]`
+- **Court inference**: `inferredCourt` provides court level (supreme/appellate/trial), jurisdiction (federal/state), and confidence
+- **Confidence scoring**: 0–1 scale. 1.0 for exact reporter match; penalties for unknown reporters, ambiguous matches
+- **String citation groups**: Semicolon-separated citations sharing same proposition tracked via `stringCitationGroupId`
+- **Blank page citations**: Handles "___" and "---" placeholders in slip opinions
+- **Nominative reporter support**: Early SCOTUS citations (e.g., "67 U.S. (2 Black) 635")
+- **Possible interpretations**: `possibleInterpretations[]` for ambiguous citations
+
+## Patterns
+
+26 regex patterns across 6 files in `src/patterns/`:
+
+- `casePatterns.ts` — Federal reporters (F., F.2d, F.3d, F.4th, F.Supp., F.App'x), Supreme Court (U.S., S.Ct., L.Ed.), state reporters
+- `statutePatterns.ts` — Federal codes (U.S.C., C.F.R.), named codes (NY, CA, TX, etc.), abbreviated codes (FL, OH, etc.), chapter-act (ILCS), prose format
+- `neutralPatterns.ts` — Westlaw, Lexis, Google Scholar, court-specific neutral formats
+- `constitutionalPatterns.ts` — U.S. and state constitutional citations with article/amendment/section/clause parsing
+- `shortForm.ts` — Id./Ibid., supra, short-form case
+- `journalPatterns.ts` — Law review/journal citations
+
+## Development
+
+```bash
+pnpm install                      # Install dependencies (corepack, pnpm 10)
+pnpm test                         # Run all tests (vitest, watch mode)
+pnpm exec vitest run              # Run all tests once
+pnpm build                        # Build with tsdown (ESM + CJS + DTS)
+pnpm typecheck                    # Type-check with tsc --noEmit
+pnpm lint                         # Lint with Biome 2.x
+pnpm format                       # Format with Biome (auto-fix)
+pnpm size                         # Check bundle size limits
+```
+
+1,000+ tests across 57 test files. Tests mirror source structure in `tests/`. CI: GitHub Actions with Node 18/20/22 matrix. Releases via Changesets.
+
+## Source Structure
+
+```
+src/
+  index.ts                   # Main entry point exports
+  types.ts                   # All citation type definitions (discriminated union)
+  clean/                     # Text cleaning + TransformationMap
+    cleanText.ts             # HTML strip, whitespace/Unicode normalize, smart quotes
+  tokenize/                  # Regex pattern matching
+    tokenizer.ts             # Apply patterns, deduplicate by position
+  patterns/                  # 26 regex patterns across 6 files
+    casePatterns.ts
+    statutePatterns.ts
+    neutralPatterns.ts
+    constitutionalPatterns.ts
+    shortForm.ts
+    journalPatterns.ts
+  extract/                   # Metadata extraction from tokens
+    extractCitations.ts      # Main orchestrator + ExtractOptions
+    extractCase.ts           # Case name, parenthetical, full span, dates, disposition
+    extractStatute.ts
+    extractConstitutional.ts
+    extractJournal.ts
+    extractNeutral.ts
+    extractPublicLaw.ts
+    extractFederalRegister.ts
+    extractStatutesAtLarge.ts
+    pincite.ts               # Pincite parsing
+    courtNormalization.ts    # Court name normalization
+    dates.ts                 # Date parsing (parseMonth, parseDate, toIsoDate)
+    filterFalsePositives.ts
+  resolve/                   # Short-form citation resolution
+    resolver.ts              # DocumentResolver class
+    types.ts                 # ResolutionOptions, ResolvedCitation
+    bkTree.ts                # BKTree for fuzzy party name matching
+    levenshtein.ts           # Levenshtein distance
+  footnotes/                 # Footnote zone detection
+    htmlDetector.ts          # HTML tag-based detection
+    textDetector.ts          # Plain-text separator/marker detection
+  annotate/                  # Citation annotation
+    annotate.ts              # Template + callback annotation modes
+    types.ts                 # AnnotationOptions, AnnotationResult
+  data/                      # Reporter database (lazy-loaded)
+    reporters.ts             # 1,200+ reporters
+    knownCodes.ts            # Jurisdiction code registry
+  utils/                     # Post-extraction utilities
+    reporterKey.ts           # toReporterKey, toReporterKeys
+    bluebook.ts              # toBluebook formatting
+    groupByCase.ts           # Group citations by case
+    context.ts               # getSurroundingContext (legal-aware sentence detection)
+    types.ts                 # CaseGroup, ContextOptions, SurroundingContext
+```

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -59,7 +59,6 @@ export class DocumentResolver {
       paragraphBoundaryPattern: options.paragraphBoundaryPattern ?? /\n\n+/g,
       fuzzyPartyMatching: options.fuzzyPartyMatching ?? true,
       partyMatchThreshold: options.partyMatchThreshold ?? 0.8,
-      allowNestedResolution: options.allowNestedResolution ?? false,
       reportUnresolved: options.reportUnresolved ?? true,
       footnoteMap: options.footnoteMap,
     }

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -70,7 +70,7 @@ export class DocumentResolver {
     this.context = {
       citationIndex: 0,
       allCitations: citations,
-      lastFullCitation: undefined,
+      lastResolvedIndex: undefined,
       fullCitationHistory: new Map(),
       paragraphMap: new Map(),
     }
@@ -118,10 +118,18 @@ export class DocumentResolver {
         default:
           // Full citation - update context for future resolutions
           if (isFullCitation(citation)) {
-            this.context.lastFullCitation = i
+            this.context.lastResolvedIndex = i
             this.trackFullCitation(citation, i)
           }
           break
+      }
+
+      // After resolving a short-form citation, update lastResolvedIndex
+      // to the full citation it resolved to (transitive resolution).
+      // If resolution failed, lastResolvedIndex is NOT updated --
+      // a subsequent Id. will also fail (matching Python eyecite behavior).
+      if (resolution?.resolvedTo !== undefined) {
+        this.context.lastResolvedIndex = resolution.resolvedTo
       }
 
       // Add citation with resolution metadata
@@ -136,24 +144,17 @@ export class DocumentResolver {
   }
 
   /**
-   * Resolves Id. citation to immediately preceding full case citation.
+   * Resolves Id. citation to the most recently cited authority.
+   * Uses lastResolvedIndex which tracks the most recent successfully
+   * resolved citation (full, short-form, supra, or Id.).
    */
   private resolveId(_citation: IdCitation): ResolutionResult | undefined {
     const currentIndex = this.context.citationIndex
+    const antecedentIndex = this.context.lastResolvedIndex
 
-    // Find most recent full case citation (Id. only resolves to case citations, not statutes/journals)
-    let antecedentIndex: number | undefined
-    for (let i = currentIndex - 1; i >= 0; i--) {
-      const candidate = this.citations[i]
-      if (candidate.type === "case") {
-        antecedentIndex = i
-        break
-      }
-    }
-
-    // Check if we have a previous case citation
+    // No preceding citation has been resolved yet
     if (antecedentIndex === undefined) {
-      return this.createFailureResult("No preceding full case citation found")
+      return this.createFailureResult("No preceding citation found")
     }
 
     // Check scope boundary

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -5,7 +5,7 @@
  * by maintaining resolution context and enforcing scope boundaries.
  *
  * Resolution rules:
- * - Id. resolves to immediately preceding full citation (within scope)
+ * - Id. resolves to the most recently cited authority (within scope)
  * - Supra resolves to full citation with matching party name (within scope)
  * - Short-form case resolves to full case with matching volume/reporter (within scope)
  */

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -123,10 +123,15 @@ export interface ResolutionContext {
   allCitations: Citation[]
 
   /**
-   * Index of immediately preceding full citation.
-   * Updated as citations are processed.
+   * Index of the full citation most recently cited (directly or via resolution).
+   * Updated after every successfully resolved citation.
+   * Used by Id. resolution -- Id. inherits this value.
+   *
+   * For full citations: set to the citation's own index.
+   * For resolved short-form/supra/Id.: set to resolvedTo (the full antecedent index).
+   * For failed resolutions: NOT updated (Id. after a failed citation also fails).
    */
-  lastFullCitation?: number
+  lastResolvedIndex?: number
 
   /**
    * History of all full citations by party name.

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -53,13 +53,6 @@ export interface ResolutionOptions {
   partyMatchThreshold?: number
 
   /**
-   * Allow Id. citations to resolve to other short-form citations (default: false)
-   * If true: "Smith v. Jones, 500 F.2d 100" -> "Id." -> "Id. at 105"
-   * If false: Second Id. fails to resolve (no full citation between them)
-   */
-  allowNestedResolution?: boolean
-
-  /**
    * Report unresolved citations with failure reasons (default: true)
    * If false: resolution field will be undefined for unresolved citations
    */

--- a/tests/integration/resolution.test.ts
+++ b/tests/integration/resolution.test.ts
@@ -58,6 +58,108 @@ describe("Resolution Integration Tests", () => {
     })
   })
 
+  describe("Id. Resolution Through Short-Form Citations (#170)", () => {
+    it("resolves Id. through preceding short-form case citation", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 123 (2020). " +
+        "Celotex Corp. v. Catrett, 477 U.S. 317 (1986). " +
+        "500 F.2d at 128. " +
+        "Id. at 129."
+
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+      const smith = citations.find(c => c.type === "case" && c.reporter === "F.2d")
+      const celotex = citations.find(c => c.type === "case" && c.reporter === "U.S.")
+      const shortForm = citations.find(c => c.type === "shortFormCase")
+      const id = citations.find(c => c.type === "id")
+
+      expect(smith).toBeDefined()
+      expect(celotex).toBeDefined()
+      expect(shortForm).toBeDefined()
+      expect(id).toBeDefined()
+
+      const smithIndex = citations.indexOf(smith!)
+
+      expect(shortForm!.resolution?.resolvedTo).toBe(smithIndex)
+      expect(id!.resolution?.resolvedTo).toBe(smithIndex)
+      expect(id!.resolution?.confidence).toBe(1.0)
+    })
+
+    it("resolves Id. through preceding supra citation", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 123 (2020). " +
+        "Brown v. Board, 347 U.S. 483 (1954). " +
+        "Smith, supra, at 130. " +
+        "Id. at 131."
+
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+      const smith = citations.find(c => c.type === "case" && c.reporter === "F.2d")
+      const id = citations.find(c => c.type === "id")
+
+      expect(smith).toBeDefined()
+      expect(id).toBeDefined()
+
+      const smithIndex = citations.indexOf(smith!)
+      expect(id!.resolution?.resolvedTo).toBe(smithIndex)
+    })
+
+    it("fails Id. when preceding short-form fails to resolve", () => {
+      const text = "400 F.3d at 200. Id. at 201."
+
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+      const shortForm = citations.find(c => c.type === "shortFormCase")
+      const id = citations.find(c => c.type === "id")
+
+      expect(shortForm).toBeDefined()
+      expect(id).toBeDefined()
+
+      expect(shortForm!.resolution?.resolvedTo).toBeUndefined()
+      expect(id!.resolution?.resolvedTo).toBeUndefined()
+      expect(id!.resolution?.failureReason).toBeDefined()
+    })
+
+    it("resolves Id. after statute citation", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 123 (2020). " +
+        "42 U.S.C. § 1983. " +
+        "Id."
+
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+      const statute = citations.find(c => c.type === "statute")
+      const id = citations.find(c => c.type === "id")
+
+      expect(statute).toBeDefined()
+      expect(id).toBeDefined()
+
+      const statuteIndex = citations.indexOf(statute!)
+      expect(id!.resolution?.resolvedTo).toBe(statuteIndex)
+    })
+
+    it("resolves chain of Id. through short-form", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 123 (2020). " +
+        "Celotex Corp. v. Catrett, 477 U.S. 317 (1986). " +
+        "500 F.2d at 128. " +
+        "Id. at 129. " +
+        "Id. at 130."
+
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+
+      const smith = citations.find(c => c.type === "case" && c.reporter === "F.2d")
+      const ids = citations.filter(c => c.type === "id")
+
+      expect(smith).toBeDefined()
+      expect(ids).toHaveLength(2)
+
+      const smithIndex = citations.indexOf(smith!)
+      expect(ids[0].resolution?.resolvedTo).toBe(smithIndex)
+      expect(ids[1].resolution?.resolvedTo).toBe(smithIndex)
+    })
+  })
+
   describe("Paragraph Scope Boundaries", () => {
     it("Id. resolves across paragraph boundaries with default scope (none)", () => {
       const text = `First paragraph: Smith v. Jones, 500 F.2d 123 (2020).

--- a/tests/integration/resolution.test.ts
+++ b/tests/integration/resolution.test.ts
@@ -54,7 +54,7 @@ describe("Resolution Integration Tests", () => {
       expect(citations[0].type).toBe("id")
       expect(citations[0].resolution?.resolvedTo).toBeUndefined()
       expect(citations[0].resolution?.failureReason).toBeDefined()
-      expect(citations[0].resolution?.failureReason).toContain("No preceding full case citation")
+      expect(citations[0].resolution?.failureReason).toContain("No preceding citation found")
     })
   })
 
@@ -579,9 +579,9 @@ Second paragraph: Id. at 125.`
       expect(citations[1].type).toBe("statute")
       expect(citations[1].resolution).toBeUndefined()
 
-      // Id. resolves to case (index 0)
+      // Id. resolves to statute (the most recently cited authority, index 1)
       expect(citations[2].type).toBe("id")
-      expect(citations[2].resolution?.resolvedTo).toBe(0)
+      expect(citations[2].resolution?.resolvedTo).toBe(1)
 
       // Supra resolves to case (index 0)
       expect(citations[3].type).toBe("supra")


### PR DESCRIPTION
## Summary

- Replace backward search in `resolveId` with a forward-tracking `lastResolvedIndex` pointer that updates after every successfully resolved citation
- Id. now correctly resolves through short-form case citations, supra citations, and non-case citation types (statutes, journals)
- Matches Python eyecite's `last_resolution` pattern and Bluebook Rule 4.1

## Problem

`resolveId` searched backward for `candidate.type === "case"`, skipping short-form citations, supra, statutes, and journals. In sequences like `Full(Celotex) → ShortForm(Smith) → Id.`, the Id. incorrectly resolved to Celotex instead of Smith.

## Changes

- **`src/resolve/types.ts`**: Replace dead `lastFullCitation` field with `lastResolvedIndex` in `ResolutionContext`
- **`src/resolve/DocumentResolver.ts`**: Update `resolve()` loop to set `lastResolvedIndex` after every full citation and every successful short-form resolution; simplify `resolveId` to a single pointer lookup
- **`tests/integration/resolution.test.ts`**: 5 new test cases covering short-form, supra, failed resolution, statute, and chained Id.; update 2 existing assertions
- **`README.md`**: Update error message in example

## Test plan

- [x] 5 new tests for Id. resolution through short-form citations
- [x] All 41 resolution integration tests pass
- [x] Full suite: 1686/1686 tests pass, 0 regressions
- [x] Typecheck clean

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)