### PR TITLE
fix: handle sentence-initial words and non-signal prefix stripping in case names

### DIFF
--- a/.changeset/fix-case-name-context-v2.md
+++ b/.changeset/fix-case-name-context-v2.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix case name extraction still capturing sentence context in two scenarios: sentence-initial pronouns like "This" bypassing the trimming guard, and "In" prefix not being stripped from caseName after extractPartyNames removes it from plaintiff.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -279,6 +279,26 @@ function isLikelyPartyName(name: string): boolean {
 }
 
 /**
+ * Capitalized words that are never proper names — only uppercase because they're
+ * sentence-initial. Prevents the firstWordIsProperName guard from treating
+ * "This landmark decision..." or "Those cases..." as party-name-anchored text.
+ */
+const SENTENCE_INITIAL_WORDS = new Set([
+  "this",
+  "that",
+  "these",
+  "those",
+  "here",
+  "there",
+  "such",
+  "its",
+  "his",
+  "her",
+  "their",
+  "our",
+])
+
+/**
  * Strips date components (month, day, year) from parenthetical content
  * to isolate the court abbreviation.
  * E.g., "2d Cir. Jan. 15, 2020" → "2d Cir."
@@ -380,7 +400,9 @@ function extractCaseName(
         const firstWord = words[0] ?? ""
         const firstWordClean = firstWord.toLowerCase().replace(/[.,']+$/, "")
         const firstWordIsProperName =
-          /^[A-Z]/.test(firstWord) && !PARTY_NAME_CONNECTORS.has(firstWordClean)
+          /^[A-Z]/.test(firstWord)
+          && !PARTY_NAME_CONNECTORS.has(firstWordClean)
+          && !SENTENCE_INITIAL_WORDS.has(firstWordClean)
         if (!firstWordIsProperName) {
           // Check if the prefix starts with a signal word (See, See also, But see, etc.).
           // If so, keep it — extractPartyNames handles signal stripping downstream.
@@ -1197,41 +1219,42 @@ export function extractCase(
     proceduralPrefix = partyResult.proceduralPrefix
     signal = partyResult.signal
 
-    // Rebuild caseName from cleaned party names (signal stripped).
-    // Signal stripping only occurs in the adversarial ("v.") branch of extractPartyNames,
-    // which always sets defendant, so we normalize to "v." (standard legal citation form).
-    if (signal && plaintiff && defendant) {
-      caseName = `${plaintiff} v. ${defendant}`
+    // Rebuild caseName when extractPartyNames modified the plaintiff (signal stripped,
+    // "In"/"Also" prefix removed, etc.). Find the plaintiff's actual position in the
+    // cleaned text to update fullSpan and caseName span.
+    if (plaintiff && defendant) {
+      const rebuiltName = `${plaintiff} v. ${defendant}`
+      if (rebuiltName !== caseName && fullSpan && cleanedText) {
+        caseName = rebuiltName
 
-      // Advance fullSpan.cleanStart past the signal word
-      if (fullSpan) {
-        const original = cleanedText?.substring(fullSpan.cleanStart, span.cleanStart) ?? ""
-        // Trim leading whitespace to handle edge cases where fullSpan starts at a boundary
-        const trimmed = original.trimStart()
-        const leadingWs = original.length - trimmed.length
-        const signalInSpan = SIGNAL_STRIP_REGEX.exec(trimmed)
-        if (signalInSpan) {
-          const newCleanStart = fullSpan.cleanStart + leadingWs + signalInSpan[0].length
-          const newOriginalStart =
-            transformationMap.cleanToOriginal.get(newCleanStart) ?? newCleanStart
-          fullSpan = { ...fullSpan, cleanStart: newCleanStart, originalStart: newOriginalStart }
+        // Advance fullSpan.cleanStart to where the plaintiff actually starts
+        const prefixRegion = cleanedText.substring(fullSpan.cleanStart, span.cleanStart)
+        const vSep = /\s+v\.?\s+/i.exec(prefixRegion)
+        if (vSep) {
+          const beforeV = prefixRegion.substring(0, vSep.index)
+          const pIdx = beforeV.lastIndexOf(plaintiff)
+          if (pIdx !== -1) {
+            const newCleanStart = fullSpan.cleanStart + pIdx
+            const newOriginalStart =
+              transformationMap.cleanToOriginal.get(newCleanStart) ?? newCleanStart
+            fullSpan = { ...fullSpan, cleanStart: newCleanStart, originalStart: newOriginalStart }
+          }
         }
-      }
 
-      // Update caseName span to reflect the signal-stripped name
-      if (caseNameResult) {
-        // After signal stripping, fullSpan.cleanStart is the start of the plaintiff
-        const strippedCleanStart = fullSpan?.cleanStart ?? caseNameResult.nameStart
-        const strippedCleanEnd = strippedCleanStart + caseName.length
-        const strippedOrig = resolveOriginalSpan(
-          { cleanStart: strippedCleanStart, cleanEnd: strippedCleanEnd },
-          transformationMap,
-        )
-        spans.caseName = {
-          cleanStart: strippedCleanStart,
-          cleanEnd: strippedCleanEnd,
-          originalStart: strippedOrig.originalStart,
-          originalEnd: strippedOrig.originalEnd,
+        // Update caseName span to reflect the cleaned name
+        if (caseNameResult) {
+          const strippedCleanStart = fullSpan.cleanStart
+          const strippedCleanEnd = strippedCleanStart + caseName.length
+          const strippedOrig = resolveOriginalSpan(
+            { cleanStart: strippedCleanStart, cleanEnd: strippedCleanEnd },
+            transformationMap,
+          )
+          spans.caseName = {
+            cleanStart: strippedCleanStart,
+            cleanEnd: strippedCleanEnd,
+            originalStart: strippedOrig.originalStart,
+            originalEnd: strippedOrig.originalEnd,
+          }
         }
       }
     }
@@ -1240,10 +1263,7 @@ export function extractCase(
     // so each name is only matched on the correct side, avoiding indexOf collisions
     // when a name substring appears in both halves (e.g., "Smith v. Smith").
     if (plaintiff && caseNameResult && cleanedText) {
-      // For signal-stripped names, caseName was rebuilt as "plaintiff v. defendant"
-      // but the clean text still has the original layout. Use fullSpan.cleanStart
-      // (post-signal) as the anchor for plaintiff position.
-      const nameAnchor = signal && fullSpan ? fullSpan.cleanStart : caseNameResult.nameStart
+      const nameAnchor = fullSpan?.cleanStart ?? caseNameResult.nameStart
       const searchRegion = cleanedText.substring(nameAnchor, span.cleanStart)
       const vSepMatch = /\s+v\.?\s+/i.exec(searchRegion)
       if (vSepMatch) {

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -829,6 +829,31 @@ describe("case name extraction (Phase 6)", () => {
       }
     })
 
+    it("trims sentence-initial pronouns like 'This'", () => {
+      const citations = extractCitations(
+        "This landmark decision effectively overruled Plessy v. Ferguson, 163 U.S. 537 (1896).",
+      )
+      const cite = citations.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBe("Plessy v. Ferguson")
+        expect(cite.plaintiff).toBe("Plessy")
+      }
+    })
+
+    it("strips 'In' prefix and rebuilds caseName", () => {
+      const citations = extractCitations(
+        "In Brown v. Board of Education, 347 U.S. 483, 495 (1954), the Court held that segregation was unconstitutional.",
+      )
+      const cite = citations.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBe("Brown v. Board of Education")
+        expect(cite.plaintiff).toBe("Brown")
+        expect(cite.defendant).toBe("Board of Education")
+      }
+    })
+
     it("adjusts fullSpan.originalStart after trimming", () => {
       const text =
         "The court cited Smith v. Jones, 500 F.2d 123 (2020)."


### PR DESCRIPTION
## Summary

- Add `SENTENCE_INITIAL_WORDS` set to prevent pronouns like "This", "That", "Those" from blocking plaintiff trimming
- Generalize caseName rebuild to trigger whenever `extractPartyNames` modifies the plaintiff, not just when a signal is detected

## Problem

Two remaining bugs in case name extraction after #175:

1. **"This landmark decision effectively overruled Plessy v. Ferguson"** — `firstWordIsProperName` treated "This" as a proper name anchor (uppercase + not a connector), so trimming was skipped entirely. The caseName captured the full sentence context.

2. **"In Brown v. Board of Education"** — `isLikelyPartyName("In Brown")` returned TRUE because "in" is a connector. Then `extractPartyNames` stripped "In" from plaintiff, but caseName was not rebuilt because the rebuild only triggered when `signal` was set — and "In" doesn't set a signal.

## How It Works

**Fix 1:** New `SENTENCE_INITIAL_WORDS` set contains words that are only capitalized because they start a sentence (this, that, these, those, here, there, such, its, his, her, their, our). These bypass the `firstWordIsProperName` guard, allowing the trimming loop to run.

**Fix 2:** The caseName rebuild block now triggers whenever `plaintiff + " v. " + defendant` differs from the original caseName, regardless of whether a signal was detected. It finds the plaintiff's position in the cleaned text using the "v." separator and updates fullSpan and caseName span accordingly.

## Test plan

- [x] New test: trims sentence-initial pronouns like "This"
- [x] New test: strips "In" prefix and rebuilds caseName
- [x] All 175 extractCase tests pass
- [x] Full suite: 1748/1748 tests pass, 0 regressions
- [x] Typecheck clean

Closes #168, closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)