### PR TITLE
chore: ignore Claude Code skills and playground.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ mise.local.toml
 
 # Worktrees
 .worktrees/
+
+# Claude Code local files
+.claude/skills/
+
+# Dev artifacts
+playground.html


### PR DESCRIPTION
## Summary
- Add `.claude/skills/` to `.gitignore` — local skill definitions from the Superpowers plugin, not project code
- Add `playground.html` to `.gitignore` — one-off dev artifact

## Test plan
- [x] Verify `git status` is clean after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)