### PR TITLE
fix: robust case-name boundary detection (#182, #183, #184)

### DIFF
--- a/.changeset/fix-case-name-boundaries.md
+++ b/.changeset/fix-case-name-boundaries.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+fix: robust case-name boundary detection with Bluebook T6/T10 abbreviations (#182, #183, #184)
+
+Replace the narrow LEGAL_ABBREVS regex (~30 entries) with a comprehensive Bluebook-sourced abbreviation set (200+ entries from T6/T7/T10) backed by heuristics for single-letter initials and dotted initialisms. Add hard boundary detection for Id. markers and parenthetical signal words (quoting, citing, cited in). Fixes case names that were undefined, truncated, or overshot when party names contained abbreviation chains like "Cent. Sch. Dist.", "Mgt., Inc.", or "A.N.L.Y.H. Invs."

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -373,7 +373,7 @@ const CASE_NAME_ABBREVS: ReadonlySet<string> = new Set([
   "mr", "mrs", "ms", "dr", "jr", "sr", "prof", "rev", "hon", "sgt", "capt",
   "col", "lt",
   // ── Other common legal abbreviations ──
-  "ed", "op", "ad", "dep", "ass", "is", "ry",
+  "ed", "op", "ad", "dep", "ass", "ry",
 ])
 
 /**
@@ -388,7 +388,7 @@ const CASE_NAME_ABBREVS: ReadonlySet<string> = new Set([
 function isLikelyAbbreviationPeriod(text: string, dotIndex: number): boolean {
   // Walk backward from the period to find the word
   let start = dotIndex
-  while (start > 0 && /[A-Za-z.'\-]/.test(text[start - 1])) {
+  while (start > 0 && /[-A-Za-z.']/.test(text[start - 1])) {
     start--
   }
   const word = text.substring(start, dotIndex)
@@ -409,14 +409,18 @@ function isLikelyAbbreviationPeriod(text: string, dotIndex: number): boolean {
   return false
 }
 
-/** Hard boundary: Id. citation marker — the scan must not cross this. */
-const ID_BOUNDARY_REGEX = /\bId\.\s+/gi
+/** Hard boundary: Id. citation marker — the scan must not cross this.
+ *  Case-sensitive: Bluebook convention is always capitalized "Id." */
+const ID_BOUNDARY_REGEX = /\bId\.\s+/g
 
 /** Hard boundary: parenthetical signal words that introduce nested citations.
  *  Matches opening paren + optional space + signal word + space.
  *  E.g., "(quoting ", "(citing ", "(cited in " */
 const PAREN_SIGNAL_BOUNDARY_REGEX =
-  /\(\s*(?:quoting|citing|cited\s+in|discussing|noting|explaining|describing|recognizing|applying|rejecting|adopting|requiring)\s+/gi
+  /\(\s*(?:quoting|citing|cited\s+in|discussing|noting|explaining|describing|recognizing|applying|rejecting|adopting|requiring|overruling|overruled\s+by|abrogated\s+by)\s+/gi
+
+/** Sentence boundary: closing paren or period, followed by space + uppercase letter. */
+const SENTENCE_BOUNDARY_REGEX = /[.)]\s+(?=[A-Z])/g
 
 /**
  * Extract case name via backward search from citation core.
@@ -453,6 +457,7 @@ function extractCaseName(
   let match: RegExpExecArray | null
 
   // Check citation boundaries (digit-period-space)
+  CITATION_BOUNDARY_REGEX.lastIndex = 0
   while ((match = CITATION_BOUNDARY_REGEX.exec(precedingText)) !== null) {
     lastBoundaryIndex = match.index + match[0].length
   }
@@ -477,8 +482,8 @@ function extractCaseName(
 
   // Check sentence boundaries: "). " or ". " followed by uppercase letter.
   // Skip when the period belongs to a legal abbreviation (comprehensive T6/T10/T7 check).
-  const SENTENCE_BOUNDARY = /[.)]\s+(?=[A-Z])/g
-  while ((match = SENTENCE_BOUNDARY.exec(precedingText)) !== null) {
+  SENTENCE_BOUNDARY_REGEX.lastIndex = 0
+  while ((match = SENTENCE_BOUNDARY_REGEX.exec(precedingText)) !== null) {
     // Only check abbreviation for period boundaries, not close-paren boundaries
     if (precedingText[match.index] === "." && isLikelyAbbreviationPeriod(precedingText, match.index)) {
       continue

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -319,6 +319,105 @@ function stripDateFromCourt(content: string): string | undefined {
   return court && /[A-Za-z]/.test(court) ? court : undefined
 }
 
+// ============================================================================
+// Case-name boundary detection: abbreviation set + heuristics
+// ============================================================================
+
+/**
+ * Comprehensive set of legal abbreviation stems (lowercase, without trailing period)
+ * used to distinguish abbreviation periods from sentence-ending periods during
+ * backward case-name scanning.
+ *
+ * Sources: Bluebook T6 (case name abbreviations), T7 (court abbreviations),
+ * T10 (geographic abbreviations), plus common titles and corporate suffixes.
+ */
+const CASE_NAME_ABBREVS: ReadonlySet<string> = new Set([
+  // ── Bluebook T6: Case name and institutional abbreviations ──
+  "acad", "acct", "accts", "admin", "adm", "advert", "advoc", "aff", "affs",
+  "afr", "agric", "all", "alt", "am", "ann", "app", "arb", "assoc", "assocs",
+  "atl", "auth", "auto", "ave", "bankr", "behav", "bd", "bor", "brit", "broad",
+  "bhd", "bros", "bldg", "bull", "bus", "can", "cap", "cas", "cath", "ctr",
+  "ctrs", "cent", "chem", "child", "chron", "coal", "coll", "com", "comm",
+  "compar", "comp", "comput", "condo", "conf", "cong", "consol", "const",
+  "constr", "cont", "coop", "corp", "corps", "corr", "cosm", "couns", "cntys",
+  "cnty", "crim", "def", "delinq", "det", "dev", "dig", "dir", "disc", "disp",
+  "distrib", "dist", "div", "econ", "educ", "elec", "emp", "eng", "enter",
+  "ent", "equal", "equip", "est", "eur", "exam", "exch", "exec", "expl", "exp",
+  "fac", "fam", "fams", "fed", "fid", "fin", "found", "gen", "glob", "grp",
+  "guar", "hist", "hosp", "hous", "hum", "immigr", "imp", "inc", "indem",
+  "indep", "indus", "info", "inj", "inst", "ins", "intell", "intel", "int",
+  "inv", "invs", "jurid", "just", "juv", "lab", "law", "liab", "ltd", "loc",
+  "mach", "mag", "maint", "mgmt", "mgt", "mfr", "mfrs", "mfg", "mar", "mkt",
+  "mktg", "matrim", "mech", "med", "merch", "metro", "min", "misc", "mod",
+  "mortg", "mun", "mut", "nat", "negl", "negot", "nw", "no", "nos", "off",
+  "org", "orgs", "pac", "pat", "pers", "pharm", "phil", "plan", "pol", "prac",
+  "pres", "priv", "prob", "proc", "prod", "pro", "prop", "psych", "pub", "rec",
+  "reg", "regul", "rehab", "rel", "rels", "rep", "reprod", "rsch", "rsrv",
+  "resol", "res", "resp", "rest", "ret", "rd", "sav", "sch", "schs", "sci",
+  "sec", "serv", "servs", "sess", "soc", "solic", "spec", "stat", "subcomm",
+  "sur", "surv", "sys", "tchr", "tech", "telecomm", "tel", "temp", "twp",
+  "transcon", "transp", "treas", "tr", "trs", "tpk", "unemplmt", "unif",
+  "univ", "urb", "util", "veh", "vehs", "vill", "voc", "whse", "whol",
+  "litig",
+  // ── T6: Directional abbreviations ──
+  "n", "s", "e", "w", "m", "ne", "se", "sw",
+  // ── T7: Court abbreviations ──
+  "v", "vs", "ct", "cir", "supp", "cl", "jud", "super", "sup", "magis",
+  "mil", "terr",
+  // ── T10: US state abbreviations ──
+  "ala", "ariz", "ark", "cal", "colo", "conn", "del", "fla", "ga", "haw",
+  "ida", "ill", "ind", "kan", "ky", "la", "me", "md", "mass", "mich", "minn",
+  "miss", "mo", "mont", "neb", "nev", "okla", "or", "pa", "tenn", "tex", "vt",
+  "va", "wash", "wis", "wyo",
+  // ── Titles and honorifics ──
+  "mr", "mrs", "ms", "dr", "jr", "sr", "prof", "rev", "hon", "sgt", "capt",
+  "col", "lt",
+  // ── Other common legal abbreviations ──
+  "ed", "op", "ad", "dep", "ass", "is", "ry",
+])
+
+/**
+ * Detect whether a period at `dotIndex` in `text` is likely an abbreviation
+ * rather than a sentence boundary.
+ *
+ * Three-tier check:
+ *   1. Word stem is in the comprehensive CASE_NAME_ABBREVS set
+ *   2. Single uppercase letter (initial: A., B., J., N.)
+ *   3. Word contains internal periods (dotted initialism: N.Y., U.S., D.C.)
+ */
+function isLikelyAbbreviationPeriod(text: string, dotIndex: number): boolean {
+  // Walk backward from the period to find the word
+  let start = dotIndex
+  while (start > 0 && /[A-Za-z.'\-]/.test(text[start - 1])) {
+    start--
+  }
+  const word = text.substring(start, dotIndex)
+  if (!word) return false
+
+  // Strip trailing periods/apostrophes for set lookup
+  const stem = word.replace(/[.']+$/, "").toLowerCase()
+
+  // Tier 1: Known legal abbreviation
+  if (CASE_NAME_ABBREVS.has(stem)) return true
+
+  // Tier 2: Single uppercase letter (initial)
+  if (stem.length === 1 && /[a-z]/i.test(stem)) return true
+
+  // Tier 3: Contains internal periods (dotted initialism like N.Y, U.S, D.C)
+  if (/\.[A-Za-z]/.test(word)) return true
+
+  return false
+}
+
+/** Hard boundary: Id. citation marker — the scan must not cross this. */
+const ID_BOUNDARY_REGEX = /\bId\.\s+/gi
+
+/** Hard boundary: parenthetical signal words that introduce nested citations.
+ *  Matches opening paren + optional space + signal word + space.
+ *  E.g., "(quoting ", "(citing ", "(cited in " */
+const PAREN_SIGNAL_BOUNDARY_REGEX =
+  /\(\s*(?:quoting|citing|cited\s+in|discussing|noting|explaining|describing|recognizing|applying|rejecting|adopting|requiring)\s+/gi
+
 /**
  * Extract case name via backward search from citation core.
  * Looks for "v." pattern or procedural prefixes (In re, Ex parte, Matter of).
@@ -344,11 +443,12 @@ function extractCaseName(
   let adjustedSearchStart = searchStart
 
   // Split at last boundary to avoid crossing citation/sentence boundaries.
-  // We check two boundary types:
+  // We check four boundary types:
   //   1. Citation boundary: digit-period-space (e.g., "10. " from a previous cite's page number)
-  //   2. Sentence boundary: closing paren + period + space + uppercase letter (e.g., "(2020). See")
-  //      Also handles plain sentence ends: period + space + uppercase, but ONLY when the
-  //      word before the period is NOT a known legal abbreviation (v, vs, Inc, Corp, etc.)
+  //   2. Id. boundary: "Id. " short-form citation marker (#182)
+  //   3. Parenthetical signal boundary: "(quoting ", "(citing ", "(cited in " (#182)
+  //   4. Sentence boundary: period/paren + space + uppercase, skipped when the
+  //      word before the period is a legal abbreviation (Bluebook T6/T10/T7)
   let lastBoundaryIndex = -1
   let match: RegExpExecArray | null
 
@@ -357,14 +457,32 @@ function extractCaseName(
     lastBoundaryIndex = match.index + match[0].length
   }
 
+  // Check Id. boundaries (#182)
+  ID_BOUNDARY_REGEX.lastIndex = 0
+  while ((match = ID_BOUNDARY_REGEX.exec(precedingText)) !== null) {
+    const boundaryEnd = match.index + match[0].length
+    if (boundaryEnd > lastBoundaryIndex) {
+      lastBoundaryIndex = boundaryEnd
+    }
+  }
+
+  // Check parenthetical signal boundaries (#182)
+  PAREN_SIGNAL_BOUNDARY_REGEX.lastIndex = 0
+  while ((match = PAREN_SIGNAL_BOUNDARY_REGEX.exec(precedingText)) !== null) {
+    const boundaryEnd = match.index + match[0].length
+    if (boundaryEnd > lastBoundaryIndex) {
+      lastBoundaryIndex = boundaryEnd
+    }
+  }
+
   // Check sentence boundaries: "). " or ". " followed by uppercase letter.
-  // Skip legal abbreviations that end with period.
-  const LEGAL_ABBREVS = /\b(?:v|vs|Inc|Corp|Ltd|Co|Cir|App|Ct|Supp|Dist|Rev|Stat|Gen|No|ed|Jr|Sr|Dr|Mr|Mrs|Ms|Prof|St|Dep|Auth|Ass|Comm)\.\s+$/i
+  // Skip when the period belongs to a legal abbreviation (comprehensive T6/T10/T7 check).
   const SENTENCE_BOUNDARY = /[.)]\s+(?=[A-Z])/g
   while ((match = SENTENCE_BOUNDARY.exec(precedingText)) !== null) {
-    // Check if this looks like a legal abbreviation before the period
-    const textBefore = precedingText.substring(Math.max(0, match.index - 15), match.index + 2)
-    if (LEGAL_ABBREVS.test(textBefore)) continue
+    // Only check abbreviation for period boundaries, not close-paren boundaries
+    if (precedingText[match.index] === "." && isLikelyAbbreviationPeriod(precedingText, match.index)) {
+      continue
+    }
     const boundaryEnd = match.index + match[0].length
     if (boundaryEnd > lastBoundaryIndex) {
       lastBoundaryIndex = boundaryEnd

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -2030,4 +2030,129 @@ describe("nominative reporter support (#49, #16)", () => {
       expect(cite.year).toBe(1990)
     })
   })
+
+  describe("case name boundary bugs (#182, #183, #184)", () => {
+    // ── Issue #184: caseName undefined when plaintiff has abbreviation/initials ──
+
+    it("#184: plaintiff with trailing Inc. before v.", () => {
+      const text =
+        "Men Women N.Y. Model Mgt., Inc. v. Elite Model Mgt. LLC, 183 A.D.3d 501 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBeDefined()
+        expect(cite.caseName).toContain("v.")
+        expect(cite.caseName).toContain("Elite Model Mgt. LLC")
+      }
+    })
+
+    it("#184: plaintiff with simpler Inc. before v.", () => {
+      const text =
+        "Men Women Model Mgt., Inc. v. Elite Model Mgt. LLC, 183 A.D.3d 501 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBeDefined()
+        expect(cite.caseName).toContain("v.")
+      }
+    })
+
+    it("#184: single-letter initials in party names", () => {
+      const text = "A. Smith v. B. Jones, 500 F.3d 123 (2d Cir. 2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBeDefined()
+        expect(cite.caseName).toBe("A. Smith v. B. Jones")
+      }
+    })
+
+    // ── Issue #183: case name stops at intra-name abbreviation chains ──
+
+    it("#183: consecutive abbreviations Cent. Sch. Dist.", () => {
+      const text =
+        "See Alfred-Almond Cent. Sch. Dist. v. NY44 Health Benefits Plan Trust, 2019 NY Slip Op 6303 (4th Dep't 2019)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toContain("Alfred-Almond Cent. Sch. Dist.")
+        expect(cite.caseName).toContain("NY44 Health Benefits Plan Trust")
+      }
+    })
+
+    it("#183: initialism followed by abbreviation (A.N.L.Y.H. Invs.)", () => {
+      const text =
+        "A.N.L.Y.H. Invs. LP v. JDS Principal Highline LLC, 2024 NY Slip Op 05133 (1st Dep't 2024)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toContain("A.N.L.Y.H. Invs. LP")
+        expect(cite.caseName).toContain("JDS Principal Highline LLC")
+      }
+    })
+
+    // ── Issue #182: case name overshoots across Id. and nested citations ──
+
+    it("#182: does not overshoot across Id. boundary", () => {
+      const text =
+        "Id. at 19-20 (quoting Northeast Gen. Corp. v. Wellington Adv., 82 N.Y.2d 158, 162 [1993])."
+      const cites = extractCitations(text)
+      const fullCite = cites.find(
+        (c) => c.type === "case" && c.reporter === "N.Y.2d",
+      )
+      expect(fullCite).toBeDefined()
+      if (fullCite?.type === "case") {
+        expect(fullCite.caseName).toBe(
+          "Northeast Gen. Corp. v. Wellington Adv.",
+        )
+        expect(fullCite.caseName).not.toContain("Id.")
+      }
+    })
+
+    it("#182: does not overshoot across (cited in) parenthetical", () => {
+      const text =
+        "Clark-Fitzpatrick, Inc. v. Long Is. R.R. Co., 70 N.Y.2d 382, 388 (1987) (cited in Polaris Venture Partners VI L.P. v. AD-Venture Capital Partners L.P., 179 A.D.3d 548, 548 (1st Dep't 2020))."
+      const cites = extractCitations(text)
+      const innerCite = cites.find(
+        (c) => c.type === "case" && c.reporter === "A.D.3d",
+      )
+      expect(innerCite).toBeDefined()
+      if (innerCite?.type === "case") {
+        expect(innerCite.caseName).toContain("Polaris Venture Partners")
+        expect(innerCite.caseName).not.toContain("Co.")
+        expect(innerCite.caseName).not.toContain("70 N.Y.2d")
+      }
+    })
+
+    // ── Additional edge cases from the research ──
+
+    it("handles Corp. Sec. Litig. abbreviation chain", () => {
+      const text =
+        "In re ABC Corp. Sec. Litig., 500 F. Supp. 2d 100 (S.D.N.Y. 2007)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toContain("ABC Corp. Sec. Litig.")
+      }
+    })
+
+    it("handles Fed. Sav. Bank abbreviation chain", () => {
+      const text = "Smith v. First Fed. Sav. Bank, 500 F.3d 100 (5th Cir. 2007)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Smith v. First Fed. Sav. Bank")
+      }
+    })
+
+    it("handles Mun. Util. Dist. abbreviation chain", () => {
+      const text =
+        "Nw. Austin Mun. Util. Dist. No. 1 v. Holder, 557 U.S. 193 (2009)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toContain("Nw. Austin Mun. Util. Dist.")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Replace the narrow `LEGAL_ABBREVS` regex (~30 entries) with a comprehensive Bluebook-sourced abbreviation set (200+ entries from T6/T7/T10) backed by heuristics for single-letter initials and dotted initialisms
- Add hard boundary detection for `Id.` markers and parenthetical signal words (`quoting`, `citing`, `cited in`)
- Fixes case names that were `undefined` (#184), truncated (#183), or overshot (#182) when party names contained abbreviation chains

Closes #182, closes #183, closes #184

## What changed

**`src/extract/extractCase.ts`** — `extractCaseName()` boundary detection:

| Before | After |
|--------|-------|
| `LEGAL_ABBREVS` regex with ~30 hardcoded abbreviations | `CASE_NAME_ABBREVS` set with 200+ entries from Bluebook T6/T7/T10 |
| No abbreviation heuristics | Three-tier check: set lookup → single-letter initial → dotted initialism |
| No citation-level boundaries | Hard stops at `Id.` and parenthetical signal words |

**`tests/extract/extractCase.test.ts`** — 10 new tests covering all reported cases plus edge cases (abbreviation chains, initialisms, nested citations).

## Test plan

- [x] All 10 new tests pass (3 for #184, 2 for #183, 2 for #182, 3 edge cases)
- [x] All 1758 existing tests pass — zero regressions
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (no new warnings)


🤖 Generated with [Claude Code](https://claude.com/claude-code)