### PR TITLE
fix: close case-name boundary gaps for NY-style citations (#187, #188)

### DIFF
--- a/.changeset/fix-case-name-187-188.md
+++ b/.changeset/fix-case-name-187-188.md
@@ -1,0 +1,19 @@
+---
+"eyecite-ts": patch
+---
+
+fix: close remaining case-name boundary gaps for NY-style citations (#187, #188)
+
+Two root causes behind remaining `caseName` failures on real-world NY briefs:
+
+- **Missing geographic/street abbreviations.** `Is.` (Island), `Mt.` (Mount),
+  `Ft.` (Fort), `Pt.` (Point), `Rt.` (Route), `St.` (Saint/Street), `Blvd.`,
+  `Sq.`, `Hwy.`, `Pkwy.`, and `Hts.` were not in `CASE_NAME_ABBREVS`, so the
+  backward scanner treated their periods as sentence boundaries and truncated
+  names like `Clark-Fitzpatrick, Inc. v. Long Is. R.R. Co.` and
+  `Matter of Long Is. Power Auth. Hurricane Sandy Litig.`. Added to the
+  Bluebook T6/T10 set.
+- **Missing paren signal words.** `quoted in`, `accord`, and the
+  `citing, e.g.,` form were not recognized as hard boundaries, so backward
+  scans of citations introduced by those signals overshot into the prior
+  citation's trailing parenthetical. Extended `PAREN_SIGNAL_BOUNDARY_REGEX`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -361,6 +361,13 @@ const CASE_NAME_ABBREVS: ReadonlySet<string> = new Set([
   "litig",
   // ── T6: Directional abbreviations ──
   "n", "s", "e", "w", "m", "ne", "se", "sw",
+  // ── T6/T10: Geographic features and street types ──
+  // Appear mid-party-name as "Long Is.", "Mt. Sinai", "Ft. Worth", "Stony Pt.",
+  // "Route 66" (Rt.), "St. Paul" / "Main St.", "Wilshire Blvd.", "Times Sq.",
+  // "Pacific Hwy.", "Grand Central Pkwy.", "Washington Hts.". Without these,
+  // the backward scanner treats "Is. R" / "Mt. S" as sentence boundaries and
+  // truncates the case name. See #188.
+  "is", "mt", "ft", "pt", "rt", "st", "blvd", "sq", "hwy", "pkwy", "hts",
   // ── T7: Court abbreviations ──
   "v", "vs", "ct", "cir", "supp", "cl", "jud", "super", "sup", "magis",
   "mil", "terr",
@@ -414,10 +421,14 @@ function isLikelyAbbreviationPeriod(text: string, dotIndex: number): boolean {
 const ID_BOUNDARY_REGEX = /\bId\.\s+/g
 
 /** Hard boundary: parenthetical signal words that introduce nested citations.
- *  Matches opening paren + optional space + signal word + space.
- *  E.g., "(quoting ", "(citing ", "(cited in " */
+ *  Matches opening paren + optional space + signal word (+ optional ", e.g.,")
+ *  + whitespace.
+ *
+ *  E.g., "(quoting ", "(citing ", "(cited in ", "(quoted in ", "(accord ",
+ *  "(citing, e.g., ". The optional `, e.g.[,]` tail handles the common form
+ *  where a citing parenthetical introduces multiple authorities. See #187. */
 const PAREN_SIGNAL_BOUNDARY_REGEX =
-  /\(\s*(?:quoting|citing|cited\s+in|discussing|noting|explaining|describing|recognizing|applying|rejecting|adopting|requiring|overruling|overruled\s+by|abrogated\s+by)\s+/gi
+  /\(\s*(?:quoting|citing|cited\s+in|quoted\s+in|accord|discussing|noting|explaining|describing|recognizing|applying|rejecting|adopting|requiring|overruling|overruled\s+by|abrogated\s+by)(?:,\s*e\.g\.,?)?\s+/gi
 
 /** Sentence boundary: closing paren or period, followed by space + uppercase letter. */
 const SENTENCE_BOUNDARY_REGEX = /[.)]\s+(?=[A-Z])/g

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -2156,3 +2156,149 @@ describe("nominative reporter support (#49, #16)", () => {
     })
   })
 })
+
+describe("case name boundary bugs (#187, #188)", () => {
+  // ── #187: backward scan overshoots into prior citation's (…) parenthetical ──
+
+  describe("#187: paren signal boundaries", () => {
+    it("stops at `(quoted in `", () => {
+      const text =
+        "Prior v. Case, 100 U.S. 1 (2020) (quoted in Target v. Name, 200 U.S. 2 [2000])."
+      const cites = extractCitations(text)
+      const target = cites.find(
+        (c) => c.type === "case" && c.text.includes("200 U.S. 2"),
+      )
+      expect(target?.type).toBe("case")
+      if (target?.type === "case") {
+        expect(target.caseName).toBe("Target v. Name")
+      }
+    })
+
+    it("stops at `(accord `", () => {
+      const text =
+        "Prior v. Case, 100 U.S. 1 (2020) (accord Target v. Name, 200 U.S. 2 [2000])."
+      const cites = extractCitations(text)
+      const target = cites.find(
+        (c) => c.type === "case" && c.text.includes("200 U.S. 2"),
+      )
+      expect(target?.type).toBe("case")
+      if (target?.type === "case") {
+        expect(target.caseName).toBe("Target v. Name")
+      }
+    })
+
+    it("stops at `(citing, e.g., ` with comma-prefixed e.g.", () => {
+      const text =
+        "Prior v. Case, 100 U.S. 1 (2020) (citing, e.g., Target v. Name, 200 U.S. 2 [2000])."
+      const cites = extractCitations(text)
+      const target = cites.find(
+        (c) => c.type === "case" && c.text.includes("200 U.S. 2"),
+      )
+      expect(target?.type).toBe("case")
+      if (target?.type === "case") {
+        expect(target.caseName).toBe("Target v. Name")
+      }
+    })
+  })
+
+  // ── #188: backward scan returns null for common NY reporter variants ──
+
+  describe("#188: geographic abbreviations in party names", () => {
+    it("handles `Long Is.` inside party name (NY2d, Inc. plaintiff)", () => {
+      const text =
+        "See Clark-Fitzpatrick, Inc. v. Long Is. R.R. Co., 70 NY2d 382, 388 [1987]."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe(
+          "Clark-Fitzpatrick, Inc. v. Long Is. R.R. Co.",
+        )
+      }
+    })
+
+    it("handles `Long Is.` inside `Matter of` proceeding", () => {
+      const text =
+        "See Matter of Long Is. Power Auth. Hurricane Sandy Litig., 134 A.D.3d 1119, 1120 (2d Dep't 2015)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe(
+          "Matter of Long Is. Power Auth. Hurricane Sandy Litig.",
+        )
+      }
+    })
+
+    it("handles `Mt.` (Mount) in party name", () => {
+      const text = "See Mt. Sinai Hosp. v. Jones, 500 F.3d 100 (2d Cir. 2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Mt. Sinai Hosp. v. Jones")
+      }
+    })
+
+    it("handles `Ft.` (Fort) in party name", () => {
+      const text = "See Ft. Worth, Inc. v. Jones, 500 F.3d 100 (5th Cir. 2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Ft. Worth, Inc. v. Jones")
+      }
+    })
+
+    it("handles `Pt.` (Point) in party name", () => {
+      const text =
+        "See Smith v. Stony Pt. Realty Corp., 500 F.3d 100 (2d Cir. 2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Smith v. Stony Pt. Realty Corp.")
+      }
+    })
+
+    it("handles `St.` (Saint/Street) in party name", () => {
+      const text =
+        "See St. Paul Fire & Marine Ins. Co. v. Jones, 500 F.3d 100 (8th Cir. 2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("St. Paul Fire & Marine Ins. Co. v. Jones")
+      }
+    })
+  })
+
+  // Additional #188 variants the reporter documented as already broken.
+
+  describe("#188: NY reporters without periods", () => {
+    it("scans past `NY3d`", () => {
+      const text =
+        "Dormitory Auth. of the State of N.Y. v. Samson Constr. Co., 30 NY3d 704, 712 [2018]."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe(
+          "Dormitory Auth. of the State of N.Y. v. Samson Constr. Co.",
+        )
+      }
+    })
+
+    it("scans past `NY3d` with short case name", () => {
+      const text = "See Cox v. NAP Constr. Co., Inc., 10 NY3d 592, 607 [2008]."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Cox v. NAP Constr. Co., Inc.")
+      }
+    })
+
+    it("handles party with internal abbreviations + commas", () => {
+      const text =
+        "See Dembeck v. 220 Cent. Park S., LLC, 33 A.D.3d 491, 492 [1st Dep't 2006]."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Dembeck v. 220 Cent. Park S., LLC")
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #187 and #188. Two root causes behind the remaining `caseName` failures on real-world NY briefs:

- **Missing geographic/street abbreviations.** `Is.` (Island), `Mt.`, `Ft.`, `Pt.`, `Rt.`, `St.` (Saint/Street), `Blvd.`, `Sq.`, `Hwy.`, `Pkwy.`, `Hts.` were not in `CASE_NAME_ABBREVS`, so the backward scanner treated `Long Is. R` / `Mt. S` as sentence boundaries and truncated names like `Clark-Fitzpatrick, Inc. v. Long Is. R.R. Co.` and `Matter of Long Is. Power Auth. Hurricane Sandy Litig.`.
- **Missing paren signal words.** `quoted in`, `accord`, and the `(citing, e.g., …)` form were not recognized as hard boundaries, so backward scans overshot into the prior citation's trailing parenthetical. Extended `PAREN_SIGNAL_BOUNDARY_REGEX`.

Note: the `quoting` / `citing` / `cited in` variants from #187 were already fixed by #185 (last week). This PR closes the remaining `quoted in` / `accord` / `citing, e.g.,` gap the issue flagged.

## Test plan

- [x] 12 new regression tests covering every pattern listed in #187 and #188, plus the newly discovered `Mt.` / `Ft.` / `Pt.` / `St.` variants
- [x] `pnpm exec vitest run` — 1770 tests pass (+12), 9 skipped, 0 failing
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no new warnings on changed files
- [x] Changeset (`patch`) added

🤖 Generated with [Claude Code](https://claude.com/claude-code)