### PR TITLE
fix: recognize single-party corporate captions and In the Matter of (#193)

### DIFF
--- a/.changeset/fix-single-party-captions-193.md
+++ b/.changeset/fix-single-party-captions-193.md
@@ -1,0 +1,33 @@
+---
+"eyecite-ts": patch
+---
+
+fix: recognize single-party corporate captions and `In the Matter of …` prefix (#193)
+
+`FullCaseCitation.caseName` came back `null` for any caption that didn't
+contain ` v. ` or match the short procedural-prefix list (`In re`,
+`Matter of`, `Estate of`, `Ex parte`, etc.). Common NY patterns like
+`Board of Mgrs. of the St. Tropez Condominium` and `Board of Directors
+of Hill Park` silently lost their case names — downstream UI fell back
+to displaying the bare reporter triple.
+
+Two root causes:
+
+- **Missing long-form procedural prefix.** `In the Matter of X` was
+  reduced to `Matter of X` because the short prefix matched mid-string
+  before the long one could. Added `In the Matter of` to
+  `PROCEDURAL_PREFIX_REGEX` and the `extractPartyNames` prefix list, both
+  with priority over `Matter of`.
+- **No generic fallback for single-party captions.** When both `V.` and
+  procedural-prefix scans fail, the backward scanner now uses the
+  post-truncation `precedingText` itself as the caption, after stripping
+  any leading signal word (`See`, `cf.`, etc.) and validating via
+  `isLikelyPartyName` + `SENTENCE_INITIAL_WORDS`. Because the truncation
+  step already bounds `precedingText` by sentence/citation/paren-signal
+  boundaries, sentence prose like "The court held that..." is not
+  mis-matched.
+
+11 new regression tests cover corporate captions (`Board of Mgrs. of`,
+`Board of Managers of`, `Board of Directors of`, bare `Corp.`),
+`In the Matter of` priority over `Matter of`, sentence-prose safety, and
+pre-existing adversarial/`Estate of`/`ex rel.` controls.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -228,9 +228,11 @@ const LEADING_WORD_REGEX = /^([a-z]+)\b/i
 const V_CASE_NAME_REGEX =
   /([A-Z][A-Za-z0-9\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9\s.,'&()/-]+?)\s*,\s*$/
 
-/** Procedural prefix case name format */
+/** Procedural prefix case name format.
+ *  Longer prefixes listed first so `In the Matter of X` beats `Matter of X`.
+ *  See #193. */
 const PROCEDURAL_PREFIX_REGEX =
-  /\b(In re|Ex parte|Matter of|Estate of|State ex rel\.|United States ex rel\.|Application of|Petition of)\s+([A-Za-z0-9\s.,'&()/-]+?)\s*,\s*$/i
+  /\b(In\s+the\s+Matter\s+of|In re|Ex parte|Matter of|Estate of|State ex rel\.|United States ex rel\.|Application of|Petition of)\s+([A-Za-z0-9\s.,'&()/-]+?)\s*,\s*$/i
 
 /**
  * Lowercase words that legitimately appear in legal party names.
@@ -574,7 +576,7 @@ function extractCaseName(
     }
   }
 
-  // Priority 2: Procedural prefixes (including Estate of)
+  // Priority 2: Procedural prefixes (including Estate of, In the Matter of)
   const procMatch = PROCEDURAL_PREFIX_REGEX.exec(precedingText)
   if (procMatch) {
     // Check for semicolon in matched text (multi-citation separator)
@@ -582,6 +584,40 @@ function extractCaseName(
       const caseName = `${procMatch[1]} ${procMatch[2].trim()}`
       const nameStart = adjustedSearchStart + procMatch.index
       return { caseName, nameStart }
+    }
+  }
+
+  // Priority 3: Generic single-party caption (#193).
+  //
+  // V. and procedural-prefix scans failed. The precedingText is already
+  // bounded by sentence/citation/paren-signal boundaries, so whatever
+  // remains — typically a capitalized-words-only caption ending at ", " —
+  // is the caption candidate. Strip any leading signal word (See, cf., etc.)
+  // and validate via isLikelyPartyName to filter out sentence prose.
+  //
+  // Handles single-party corporate captions like "Board of Mgrs. of X",
+  // "Board of Directors of X", and unrecognized organizational prefixes
+  // that don't fit PROCEDURAL_PREFIX_REGEX.
+  const commaStrippedBody = precedingText.replace(/,\s*$/, "")
+  const leadingWsLen = commaStrippedBody.length - commaStrippedBody.trimStart().length
+  let captionBody = commaStrippedBody.substring(leadingWsLen)
+  let signalStripLen = 0
+  const sigStripMatch = SIGNAL_STRIP_REGEX.exec(captionBody)
+  if (sigStripMatch) {
+    signalStripLen = sigStripMatch[0].length
+    captionBody = captionBody.substring(signalStripLen)
+  }
+  const caption = captionBody.trim()
+
+  if (caption.length > 0 && isLikelyPartyName(caption)) {
+    const firstWord = caption.split(/\s+/)[0] ?? ""
+    const firstWordClean = firstWord.toLowerCase().replace(/[.,']+$/, "")
+    if (!SENTENCE_INITIAL_WORDS.has(firstWordClean)) {
+      // Skip multi-citation strings (joined by semicolons)
+      if (!caption.includes(";")) {
+        const nameStart = adjustedSearchStart + leadingWsLen + signalStripLen
+        return { caseName: caption, nameStart }
+      }
     }
   }
 
@@ -916,7 +952,9 @@ function extractPartyNames(caseName: string): {
 } {
   let signal: CitationSignal | undefined
   // Procedural prefix patterns (anchored to start, case-insensitive)
+  // Longer prefixes first so "In the Matter of X" wins over "Matter of X".
   const proceduralPrefixes = [
+    "In the Matter of",
     "In re",
     "Ex parte",
     "Matter of",

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -2302,3 +2302,125 @@ describe("case name boundary bugs (#187, #188)", () => {
     })
   })
 })
+
+describe("case name boundary bugs (#193)", () => {
+  // Single-party corporate / association captions that don't use ` v. ` and
+  // aren't matched by the procedural-prefix list. Previously `caseName`
+  // came back null; the generic Priority-3 fallback now recognizes them.
+
+  describe("#193: single-party corporate captions", () => {
+    it("captures 'Board of Mgrs. of X' (abbreviated)", () => {
+      const text =
+        "See Board of Mgrs. of the St. Tropez Condominium, 2021 NY Slip Op 00520, at *1."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe(
+          "Board of Mgrs. of the St. Tropez Condominium",
+        )
+      }
+    })
+
+    it("captures 'Board of Managers of X' (spelled out)", () => {
+      const text =
+        "See Board of Managers of the St. Tropez Condominium, 2021 NY Slip Op 00520, at *1."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe(
+          "Board of Managers of the St. Tropez Condominium",
+        )
+      }
+    })
+
+    it("captures 'Board of Directors of X'", () => {
+      const text =
+        "See Board of Directors of Hill Park, 2021 NY Slip Op 00520."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Board of Directors of Hill Park")
+      }
+    })
+
+    it("captures bare corporate caption with 'Corp.' suffix", () => {
+      const text = "Acme Widgets Corp., 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Acme Widgets Corp.")
+      }
+    })
+  })
+
+  describe("#193: procedural prefix long form", () => {
+    it("prefers 'In the Matter of' over 'Matter of' when present", () => {
+      const text =
+        "See In the Matter of Long Is. Power Auth. Litig., 2021 NY Slip Op 00520."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe(
+          "In the Matter of Long Is. Power Auth. Litig.",
+        )
+      }
+    })
+
+    it("still matches 'Matter of X' (short form)", () => {
+      const text = "See Matter of Smith, 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Matter of Smith")
+      }
+    })
+  })
+
+  describe("#193: safety — fallback does not fire on sentence prose", () => {
+    it("returns null for 'The court held that this is fine. 100 U.S. 1.'", () => {
+      const text = "The court held that this is fine. 100 U.S. 1."
+      const [cite] = extractCitations(text)
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBeUndefined()
+      }
+    })
+
+    it("returns null for 'The argument was strong. 100 U.S. 1.'", () => {
+      const text = "The argument was strong. 100 U.S. 1."
+      const [cite] = extractCitations(text)
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBeUndefined()
+      }
+    })
+  })
+
+  describe("#193: control — adversarial captions still work", () => {
+    it("'Smith v. Jones' still matches via V. regex", () => {
+      const text = "See Smith v. Jones, 2021 NY Slip Op 00520, at *1."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Smith v. Jones")
+      }
+    })
+
+    it("'People ex rel. Smith v. Jones' still matches via V. regex", () => {
+      const text = "See People ex rel. Smith v. Jones, 2021 NY Slip Op 00520."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("People ex rel. Smith v. Jones")
+      }
+    })
+
+    it("'Estate of X' still matches via procedural prefix", () => {
+      const text = "See Estate of Smith, 2021 NY Slip Op 00520, at *1."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Estate of Smith")
+      }
+    })
+  })
+})
+


### PR DESCRIPTION
Closes #193.

## Summary

`FullCaseCitation.caseName` came back `null` for any caption without ` v. ` and not matching the existing short procedural-prefix list. Common NY patterns like `Board of Mgrs. of the St. Tropez Condominium` and `Board of Directors of Hill Park` silently lost their case names — downstream UI fell back to displaying the bare reporter triple.

## Root causes

1. **Missing long-form prefix.** `In the Matter of X` reduced to `Matter of X` because the short prefix matched mid-string before the long one could (regex alternation processes left-to-right by position). Added `In the Matter of` to `PROCEDURAL_PREFIX_REGEX` and the `extractPartyNames` prefix list, both with priority over `Matter of`.
2. **No generic fallback.** When both `V.` and procedural-prefix scans fail, the backward scanner now uses the post-truncation `precedingText` as the caption, stripping any leading signal word (`See`, `cf.`, etc.) and validating via `isLikelyPartyName` + `SENTENCE_INITIAL_WORDS`. Because the truncation step already bounds `precedingText` by sentence/citation/paren-signal boundaries, sentence prose like "The court held that..." is not mis-matched.

## Test plan

- [x] 11 new regression tests: 4 corporate caption variants, 2 procedural long-form (`In the Matter of` priority + `Matter of` still works), 2 sentence-prose safety, 3 pre-existing controls (adversarial, `Estate of`, `People ex rel. … v. …`)
- [x] `pnpm exec vitest run` — 1795 tests pass (+11), 9 skipped, 0 failing
- [x] `pnpm typecheck` — clean
- [x] Changeset (`patch`) added

🤖 Generated with [Claude Code](https://claude.com/claude-code)