### PR TITLE
fix: align CASE_NAME_ABBREVS with reporters-db (Bluebook T6) + ampersand support

### DIFF
--- a/.changeset/align-case-name-abbrevs-reporters-db.md
+++ b/.changeset/align-case-name-abbrevs-reporters-db.md
@@ -1,0 +1,33 @@
+---
+"eyecite-ts": patch
+---
+
+fix: align `CASE_NAME_ABBREVS` with reporters-db Bluebook T6 list + ampersand support
+
+After three consecutive bug reports (#187, #188, #193) exposing missing
+abbreviations, this change aligns `CASE_NAME_ABBREVS` with the canonical
+Bluebook T6 case-name abbreviation list maintained by Free Law Project
+([reporters-db/case_name_abbreviations.json](https://github.com/freelawproject/reporters-db/blob/main/reporters_db/data/case_name_abbreviations.json)).
+
+Three improvements:
+
+- **Strip internal apostrophes in stem lookup.** `isLikelyAbbreviationPeriod`
+  previously kept inner apostrophes, so `Nat'l.` computed stem `nat'l` which
+  no reasonable pure-letter set could match. Now normalized to `natl`, which
+  matches the Bluebook's apostrophe-form abbreviations as pure-letter stems.
+- **41 new entries in `CASE_NAME_ABBREVS`.** Period-forms (`co`, `cmty`,
+  `envtl`, `gend`, `par`, `prot`, `ref`, `sol`, `cty`, `adver`) and
+  apostrophe-forms (`assn`, `dept`, `natl`, `intl`, `govt`, `commn`, `commr`,
+  `contl`, `fedn`, `meml`, `pship`, `profl`, `secy`, `sholder`, `socy`,
+  `commcn`, `engg`, `engr`, `entmt`, `envt`, `examr`, `invr`, `admr`, `admx`,
+  `empr`, `empt`, `exr`, `exx`, `publg`, `publn`, `regl`). `co` was the
+  highest-impact gap — "Smith & Co. United States Corp." was silently
+  truncated to "United States Corp." because "Co. U" fired the
+  sentence-boundary scan.
+- **`&` in `isLikelyPartyName`.** Ampersand is ubiquitous in corporate
+  captions ("Smith & Jones", "Goldman, Sachs & Co.") and previously caused
+  the Priority-3 single-party fallback (#193) to reject such captions. Now
+  treated as a valid standalone token.
+
+7 new regression tests covering period-forms, apostrophe-forms with trailing
+period, adversarial `Dep't …` caption, and ampersand patterns.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -279,6 +279,9 @@ function isLikelyPartyName(name: string): boolean {
   const words = name.split(/\s+/)
   for (const word of words) {
     if (!word) continue
+    // Standalone ampersand is ubiquitous in corporate captions
+    // ("Smith & Jones", "Goldman, Sachs & Co.").
+    if (word === "&") continue
     // Strip trailing punctuation for comparison (handles "Inc.", "Corp.,")
     const clean = word.toLowerCase().replace(/[.,']+$/, "")
     if (PARTY_NAME_CONNECTORS.has(clean)) continue
@@ -394,6 +397,21 @@ const CASE_NAME_ABBREVS: ReadonlySet<string> = new Set([
   "col", "lt",
   // ── Other common legal abbreviations ──
   "ed", "op", "ad", "dep", "ass", "ry",
+  // ── reporters-db alignment (Bluebook T6-derived, 19th ed) ──
+  // Period-form abbreviations. Source: freelawproject/reporters-db
+  // data/case_name_abbreviations.json. `co` (Co./Company) was the most
+  // impactful gap — "Smith & Co. United States Corp." was truncated to
+  // just "United States Corp." because the sentence-boundary scan fired
+  // on "Co. U".
+  "co", "cmty", "cty", "envtl", "gend", "par", "prot", "ref", "sol", "adver",
+  // Apostrophe-form abbreviations. Stored as pure-letter stems because
+  // isLikelyAbbreviationPeriod now strips all apostrophes/periods before
+  // set lookup. These appear in nearly every NY appellate citation
+  // ("2d Dep't", "Nat'l", "Int'l", "Ass'n", "Gov't", etc.).
+  "admr", "admx", "assn", "commcn", "commn", "commr", "contl", "dept",
+  "empr", "empt", "engg", "engr", "entmt", "envt", "examr", "exr", "exx",
+  "fedn", "govt", "intl", "invr", "meml", "natl", "profl", "pship",
+  "publg", "publn", "regl", "secy", "sholder", "socy",
 ])
 
 /**
@@ -414,8 +432,10 @@ function isLikelyAbbreviationPeriod(text: string, dotIndex: number): boolean {
   const word = text.substring(start, dotIndex)
   if (!word) return false
 
-  // Strip trailing periods/apostrophes for set lookup
-  const stem = word.replace(/[.']+$/, "").toLowerCase()
+  // Strip ALL periods and apostrophes for set lookup. This normalizes
+  // apostrophe-form abbreviations ("Ass'n" → "assn", "Dep't" → "dept",
+  // "Nat'l" → "natl") so the set can store pure-letter stems.
+  const stem = word.replace(/['.]/g, "").toLowerCase()
 
   // Tier 1: Known legal abbreviation
   if (CASE_NAME_ABBREVS.has(stem)) return true

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -2424,3 +2424,81 @@ describe("case name boundary bugs (#193)", () => {
   })
 })
 
+describe("reporters-db alignment + ampersand support", () => {
+  // Follow-up to #193 after aligning CASE_NAME_ABBREVS with
+  // freelawproject/reporters-db/case_name_abbreviations.json (Bluebook T6).
+
+  describe("period-form abbreviations (Co./Company etc.)", () => {
+    it("handles 'Co.' mid-caption (previously truncated to suffix)", () => {
+      const text =
+        "Smith & Co. United States Corp., 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Smith & Co. United States Corp.")
+      }
+    })
+
+    it("handles 'Co.' followed by capital word", () => {
+      const text = "Acme Co. International Group, 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Acme Co. International Group")
+      }
+    })
+  })
+
+  describe("apostrophe-form abbreviations (Nat'l, Dep't, Ass'n)", () => {
+    it("handles 'Nat'l.' with trailing period mid-caption", () => {
+      // Rare but valid form. Without the stem-strip fix, "Nat'l. B" would
+      // trigger a sentence boundary because the old stem computation
+      // preserved internal apostrophes ("nat'l" not in set).
+      const text = "Nat'l. Board Corp., 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Nat'l. Board Corp.")
+      }
+    })
+
+    it("handles 'Dep't of Health v. Smith' adversarial", () => {
+      const text = "Dep't of Health v. Smith, 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Dep't of Health v. Smith")
+      }
+    })
+  })
+
+  describe("ampersand in party names", () => {
+    it("captures 'Smith & Jones' (no v.)", () => {
+      const text = "Smith & Jones, 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Smith & Jones")
+      }
+    })
+
+    it("captures 'Goldman, Sachs & Co.' (comma + ampersand)", () => {
+      const text = "Goldman, Sachs & Co., 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Goldman, Sachs & Co.")
+      }
+    })
+
+    it("captures 'Acme & Sons v. Jones' adversarial", () => {
+      const text = "See Acme & Sons v. Jones, 100 U.S. 1 (2020)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Acme & Sons v. Jones")
+      }
+    })
+  })
+})
+


### PR DESCRIPTION
Follow-up to #187/#188/#193. After three consecutive bug reports exposing gaps in `CASE_NAME_ABBREVS`, this PR aligns the set with [Free Law Project's reporters-db](https://github.com/freelawproject/reporters-db/blob/main/reporters_db/data/case_name_abbreviations.json) — the same organization that maintains Python eyecite, and the de facto open-source rendering of Bluebook T6.

## Changes

1. **Strip internal apostrophes in stem lookup.** `isLikelyAbbreviationPeriod` now strips all `.`/`'` when computing the stem, not just trailing ones. This lets apostrophe-form abbreviations (`Nat'l`, `Dep't`, `Ass'n`, `Gov't`, `Int'l`, `Comm'n`, `Comm'r`, …) be stored as pure-letter stems.

2. **41 new entries in `CASE_NAME_ABBREVS`.**
   - Period-forms (10): `co`, `cmty`, `envtl`, `gend`, `par`, `prot`, `ref`, `sol`, `cty`, `adver`
   - Apostrophe-forms (31): `assn`, `dept`, `natl`, `intl`, `govt`, `commn`, `commr`, `contl`, `fedn`, `meml`, `pship`, `profl`, `secy`, `sholder`, `socy`, `commcn`, `engg`, `engr`, `entmt`, `envt`, `examr`, `invr`, `admr`, `admx`, `empr`, `empt`, `exr`, `exx`, `publg`, `publn`, `regl`

   `co` (Co./Company) was the highest-impact active bug — `"Smith & Co. United States Corp., 100 U.S. 1"` was truncated to `"United States Corp."` because `"Co. U"` triggered the sentence-boundary scan.

3. **`&` in `isLikelyPartyName`.** Ampersand is ubiquitous in corporate captions (`Smith & Jones`, `Goldman, Sachs & Co.`) and previously caused the #193 single-party fallback to reject them. Now treated as a valid standalone token.

## Test plan

- [x] 7 new regression tests (period-form `Co.`, apostrophe-form `Nat'l.` + `Dep't`, three ampersand patterns)
- [x] `pnpm exec vitest run` — 1802 tests pass (+7), 9 skipped, 0 failing
- [x] `pnpm typecheck` — clean
- [x] Changeset (`patch`) added

Architectural note: Python eyecite uses a tokenizer-based approach rather than a closed abbreviation set, so there's a longer-term case for rearchitecting case-name extraction. That's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)