### PR TITLE
fix: suppress phantom citations from numeric-prefixed party names (#196)

### DIFF
--- a/.changeset/fix-phantom-citation-196.md
+++ b/.changeset/fix-phantom-citation-196.md
@@ -1,0 +1,26 @@
+---
+"eyecite-ts": patch
+---
+
+fix: suppress phantom citations emitted from numeric-prefixed party names (#196)
+
+Real-world NY caption like `Board of Mgrs. of the 15 Union Sq. W. Condominium
+v. BCRE 15 Union St., LLC, 2025 NY Slip Op 00784` emitted two `case`
+citations: the real slip op plus a phantom `15 Union Sq. W. Condominium v.
+BCRE 15` extracted from inside the plaintiff's name. The phantom read `15`
+as volume, `Union Sq. W. Condominium v. BCRE` as reporter, and `15` as page.
+
+**Root cause.** The `state-reporter` regex's non-greedy reporter capture
+(`[A-Za-z.\d\s]+?`) happily spanned the `" v. "` case-name separator and
+backtracked until a second number appeared. The downstream false-positive
+filter caught this only when `reporters-db` was loaded — which is opt-in for
+bundle-size reasons, so most consumers saw the phantom pass through.
+
+**Fix.** Added negative lookahead `(?!\s+vs?\.\s)` to both `state-reporter`
+and `law-review` patterns so the reporter/journal capture cannot span a
+`" v. "` or `" vs. "` token. No real US reporter or journal name contains
+that sequence. Applied to both patterns because a first-pass guard on just
+`state-reporter` surfaced the same phantom under `law-review`.
+
+Five new regression tests: the exact #196 text, a `vs.` variant, a cross-type
+guard (no phantom `journal`), and two adversarial controls.

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -40,9 +40,9 @@ export const casePatterns: Pattern[] = [
   {
     id: "state-reporter",
     regex:
-      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])[A-Za-z.\d\s])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)[A-Za-z.\d\s])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
     description:
-      'State reporters (broad pattern allowing multi-word reporters, excludes journal patterns with " L.J/Q/Rev", validated against reporters-db in Phase 3)',
+      'State reporters (broad pattern allowing multi-word reporters, excludes journal patterns with " L.J/Q/Rev" and phantom matches across a case-name separator " v. "/" vs. ", validated against reporters-db in Phase 3)',
     type: "case",
   },
 ]

--- a/src/patterns/journalPatterns.ts
+++ b/src/patterns/journalPatterns.ts
@@ -16,9 +16,9 @@ import type { Pattern } from "./casePatterns"
 export const journalPatterns: Pattern[] = [
   {
     id: "law-review",
-    regex: /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.\s]+)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?!\s+vs?\.\s)[A-Za-z.\s])+)\s+(\d+)\b/g,
     description:
-      'Law review citations (e.g., "120 Harv. L. Rev. 500"), validated against journals-db in Phase 3',
+      'Law review citations (e.g., "120 Harv. L. Rev. 500"), validated against journals-db in Phase 3. Negative lookahead excludes " v. "/" vs. " so party-name text isn\'t mis-captured as a journal name.',
     type: "journal",
   },
 ]

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -2502,3 +2502,54 @@ describe("reporters-db alignment + ampersand support", () => {
   })
 })
 
+describe("phantom-citation suppression (#196)", () => {
+  // Numeric-prefixed party names like "15 Union Sq. W. Condominium v. BCRE 15"
+  // used to emit a phantom state-reporter citation because the non-greedy
+  // reporter capture happily spanned the " v. " case-name separator and
+  // backtracked until a second number appeared. Negative lookahead for
+  // " v. " / " vs. " blocks this at tokenization.
+
+  it("does not emit a phantom from numeric-prefixed party name with v.", () => {
+    const text = `Board of Mgrs. of the 15 Union Sq. W. Condominium v. BCRE 15 Union St., LLC, 2025 NY Slip Op 00784 (1st Dep't 2025).`
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect(cases[0].text).toBe("2025 NY Slip Op 00784")
+  })
+
+  it("does not emit a phantom with 'vs.' form", () => {
+    const text = `See 10 Smith vs. Jones 10 Corp., 2025 NY Slip Op 00784.`
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect(cases[0].text).toBe("2025 NY Slip Op 00784")
+  })
+
+  it("does not mis-classify phantom as a law-review journal", () => {
+    // The phantom moved to the `journal` type before both patterns were
+    // guarded. Regression guard: check no journal type is emitted here.
+    const text = `Board of Mgrs. of the 15 Union Sq. W. Condominium v. BCRE 15 Union St., LLC, 2025 NY Slip Op 00784.`
+    const cits = extractCitations(text)
+    expect(cits.some((c) => c.type === "journal")).toBe(false)
+  })
+
+  describe("controls — real citations adjacent to a v. still work", () => {
+    it("'Smith v. Jones, 100 U.S. 1' extracts the core cite", () => {
+      const text = "Smith v. Jones, 100 U.S. 1 (2020)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      expect(cases[0].text).toBe("100 U.S. 1")
+    })
+
+    it("two adjacent v.-joined cites both extract", () => {
+      const text =
+        "Smith v. Jones, 100 F.3d 456 (2d Cir. 2020); see also Doe v. Roe, 200 F.3d 789 (9th Cir. 2021)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+    })
+  })
+})
+
+


### PR DESCRIPTION
Closes #196.

## Summary

Real-world NY caption like `Board of Mgrs. of the 15 Union Sq. W. Condominium v. BCRE 15 Union St., LLC, 2025 NY Slip Op 00784` emitted two `case` citations: the real slip op plus a phantom `15 Union Sq. W. Condominium v. BCRE 15` extracted from inside the plaintiff's name (vol=15, reporter=`Union Sq. W. Condominium v. BCRE`, page=15).

## Root cause

The `state-reporter` regex's non-greedy reporter capture (`[A-Za-z.\d\s]+?`) happily spanned the `" v. "` case-name separator and backtracked until a second number appeared. The downstream false-positive filter (`isSuspiciousSmallVolume`) only caught this when `reporters-db` was loaded — and the db is opt-in for bundle-size reasons, so most consumers saw the phantom pass through.

## Fix

Added negative lookahead `(?!\s+vs?\.\s)` to both `state-reporter` and `law-review` patterns. No real US reporter or journal name contains `" v. "` / `" vs. "`, so the lookahead is safe and precise.

The `law-review` pattern needed the same guard because when I first applied the fix only to `state-reporter`, the phantom re-emerged under the `journal` type via the equally permissive law-review regex.

## Test plan

- [x] 5 new regression tests: #196 exact case, `vs.` variant, cross-type guard (no phantom `journal`), two adversarial controls
- [x] `pnpm exec vitest run` — 1807 tests pass (+5), 9 skipped, 0 failing
- [x] `pnpm typecheck` — clean
- [x] Changeset (`patch`) added

## Architectural note

The broader issue is that neither `state-reporter` nor `law-review` patterns validate against a reporter/journal DB at tokenization time (deferred to `filterFalsePositives`, which is incomplete without the opt-in DB). Eager DB loading or tokenization-time validation would be a more robust fix, but that's a larger design change — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)