### PR TITLE
fix: populate PinciteInfo.footnote from n.N / nn.N-N suffixes (#202)

### DIFF
--- a/.changeset/fix-pincite-footnote-202.md
+++ b/.changeset/fix-pincite-footnote-202.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": patch
+---
+
+fix: populate `PinciteInfo.footnote` from `n.N` / `nn.N-N` pincite suffixes (#202)
+
+`PinciteInfo.footnote` was declared on the public type but never populated at
+runtime. A pincite like `460 n.14` produced `{ page: 460, isRange: false, raw: '460' }`
+instead of the expected `{ page: 460, footnote: 14, isRange: false, raw: '460 n.14' }`.
+The footnote suffix was dropped entirely, and `raw` was truncated so callers
+couldn't even recover the footnote text themselves.
+
+**Root cause.** `parsePincite` already supported `n.N` / `note N` in its
+regex, but every upstream capture regex that fed it stopped at
+`\*?\d+(?:-\d+)?` — page digits and an optional range, nothing more. So
+`parsePincite` never saw the footnote text. This affected all citation types
+with a `pinciteInfo` field: full-case, short-form case, `Id.`, `Ibid.`,
+`supra`, and neutral.
+
+**Fix.** Extended every pincite-capture regex (both tokenizer patterns in
+`shortForm.ts` and extractor regexes in `extractCase`, `extractShortForms`,
+`extractNeutral`) to include an optional trailing
+`(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?` suffix. Extended
+`parsePincite` to accept Bluebook's `nn.` multi-note prefix and to capture a
+range end into a new `footnoteEnd?: number` field: `460 nn.14-15` now parses
+as `{ page: 460, footnote: 14, footnoteEnd: 15, ... }`.
+
+Seven new regression tests across full-case, short-form, `Id.`, neutral, and
+`parsePincite` unit tests.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -96,9 +96,11 @@ const VOLUME_REPORTER_PAGE_REGEX =
 const BLANK_PAGE_REGEX = /^[_-]{3,}$/
 
 /** Extracts pincite (page reference after comma). Accepts optional "at "
- *  keyword and optional "*" prefix for star-pagination (NY Slip Op, Westlaw,
- *  Lexis, and other slip-opinion citations). See #191. */
-const PINCITE_REGEX = /,\s*(?:at\s+)?(\*?\d+(?:-\d+)?)/d
+ *  keyword, optional "*" prefix for star-pagination (NY Slip Op, Westlaw,
+ *  Lexis, and other slip-opinion citations; see #191), and an optional
+ *  trailing footnote suffix " n.14" / " nn.14-15" (see #202). */
+const PINCITE_REGEX =
+  /,\s*(?:at\s+)?(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
 
 /** Matches parenthetical content */
 const PAREN_REGEX = /\(([^)]+)\)/
@@ -113,9 +115,10 @@ const LOOKAHEAD_PAREN_REGEX =
  *    - ", 125"       (comma-separated, numeric)
  *    - ", at *1"     (comma + "at" keyword; common with star-pagination)
  *    - " at *2"      (whitespace + "at" keyword; NY Slip Op repeat form)
- *  The "*" prefix marks star-pagination (#191). */
+ *  The "*" prefix marks star-pagination (#191); a trailing " n.14" /
+ *  " nn.14-15" footnote suffix is captured when present (#202). */
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+|,\s*(?:at\s+)?)(\*?\d+(?:-\d+)?)/d
+  /^(?:\s+at\s+|,\s*(?:at\s+)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -15,9 +15,10 @@ import { parsePincite, type PinciteInfo } from "./pincite"
 
 /** Matches a trailing pincite on a neutral citation. Accepts both
  *  ", at *3" (comma + "at" keyword) and " at *3" (whitespace + "at") forms,
- *  with optional "*" prefix for star-pagination. See #191. */
+ *  with optional "*" prefix for star-pagination (#191) and an optional
+ *  trailing " n.14" / " nn.14-15" footnote suffix (#202). */
 const NEUTRAL_PINCITE_LOOKAHEAD =
-  /^(?:\s+at\s+|,\s*(?:at\s+)?)(\*?\d+(?:-\d+)?)/d
+  /^(?:\s+at\s+|,\s*(?:at\s+)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
 
 /**
  * Extracts neutral citation metadata from a tokenized citation.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -52,8 +52,9 @@ export function extractId(
 
   // Parse Id. with optional pincite.
   // Pattern: Id. or Ibid. with optional comma + "at [page]" (handles "Id., at 5").
-  // Pincite accepts optional "*" prefix for star-pagination (#191).
-  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?))?/
+  // Pincite accepts optional "*" prefix for star-pagination (#191) and an
+  // optional trailing footnote suffix " n.14" / " nn.14-15" (#202).
+  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/
   const match = idRegex.exec(text)
 
   if (!match) {
@@ -148,14 +149,15 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   const { text, span } = token
 
   // Try party-name pattern first: "Smith, supra [note N] [, at page]".
-  // Pincite accepts optional "*" prefix for star-pagination (#191).
+  // Pincite accepts optional "*" prefix for star-pagination (#191) and an
+  // optional trailing footnote suffix (#202).
   const partySupraRegex =
-    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+))?/
+    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/
   const partyMatch = partySupraRegex.exec(text)
 
   // Fallback: standalone supra — "supra note N", "supra at N", "supra § N".
   const standaloneRegex =
-    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+))?|\s+at\s+(\*?\d+))?/
+    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/
   const match = partyMatch || standaloneRegex.exec(text)
 
   if (!match) {
@@ -250,8 +252,10 @@ export function extractShortFormCase(
   // Pattern: number space abbreviation [, ] at space number.
   // Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
   // Handles comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
-  // Pincite accepts optional "*" prefix for star-pagination (#191).
-  const shortFormRegex = /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+)/
+  // Pincite accepts optional "*" prefix for star-pagination (#191) and an
+  // optional trailing footnote suffix " n.14" / " nn.14-15" (#202).
+  const shortFormRegex =
+    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/extract/pincite.ts
+++ b/src/extract/pincite.ts
@@ -6,8 +6,11 @@ export interface PinciteInfo {
   page: number
   /** End page for ranges: "570-75" → 575 */
   endPage?: number
-  /** Footnote number: "570 n.3" → 3 */
+  /** Footnote number: "570 n.3" → 3. For multi-footnote refs ("nn.3-5"), the
+   *  first note; see `footnoteEnd` for the range end. */
   footnote?: number
+  /** End footnote for multi-note refs: "570 nn.3-5" → 5 */
+  footnoteEnd?: number
   /** True if this is a page range */
   isRange: boolean
   /** True when the pincite uses star-pagination (e.g., "*2"), denoting a
@@ -19,9 +22,9 @@ export interface PinciteInfo {
 }
 
 /** Matches: optional "at ", optional "*" (star pagination), digits, optional
- *  "-/–/—[*]digits", optional "n./note digits". */
+ *  "-/–/—[*]digits", optional "n./nn./note digits" with optional range end. */
 const PINCITE_PARSE_REGEX =
-  /^(?:at\s+)?(\*?)(\d+)(?:[-–—]\*?(\d+))?\s*(?:(?:n|note)\s*\.?\s*(\d+))?$/i
+  /^(?:at\s+)?(\*?)(\d+)(?:[-–—]\*?(\d+))?\s*(?:(?:nn?|note)\s*\.?\s*(\d+)(?:[-–—](\d+))?)?$/i
 
 /**
  * Parse a pincite string into structured components.
@@ -47,6 +50,7 @@ export function parsePincite(raw: string): PinciteInfo | null {
   const pageRaw = match[2]
   const endRaw = match[3]
   const footnoteRaw = match[4]
+  const footnoteEndRaw = match[5]
   const page = Number.parseInt(pageRaw, 10)
 
   let endPage: number | undefined
@@ -65,10 +69,12 @@ export function parsePincite(raw: string): PinciteInfo | null {
   }
 
   const footnote = footnoteRaw ? Number.parseInt(footnoteRaw, 10) : undefined
+  const footnoteEnd = footnoteEndRaw ? Number.parseInt(footnoteEndRaw, 10) : undefined
 
   const result: PinciteInfo = { page, isRange, raw: trimmed }
   if (endPage !== undefined) result.endPage = endPage
   if (footnote !== undefined) result.footnote = footnote
+  if (footnoteEnd !== undefined) result.footnoteEnd = footnoteEnd
   if (starPrefix === "*") result.starPage = true
 
   return result

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -14,32 +14,35 @@ import type { Pattern } from "./casePatterns"
 
 /** Id. with optional pincite: "Id." or "Id. at 253" or "Id., at 253".
  *  Pincite captures an optional "*" prefix for star-pagination (NY Slip Op,
- *  Westlaw, Lexis; see #191). */
+ *  Westlaw, Lexis; see #191) and an optional trailing " n.14" /
+ *  " nn.14-15" footnote suffix (see #202). */
 export const ID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d\.(?:,?\s+at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d\.(?:,?\s+at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
 
 /** Ibid. with optional pincite (less common variant). */
 export const IBID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\.(?:,?\s+at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\.(?:,?\s+at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
 
 /**
  * Supra with party name and optional pincite.
  * Pattern: word(s), supra [note N] [, at page]
  * Captures: (1) party name, (2) note number (if any), (3) pincite
- * Pincite accepts optional "*" prefix for star-pagination (#191).
+ * Pincite accepts optional "*" prefix for star-pagination (#191) and an
+ * optional trailing footnote suffix (#202).
  */
 export const SUPRA_PATTERN: RegExp =
-  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+))?/g
+  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
 
 /**
  * Standalone supra without party name (common in footnotes).
  * Matches: "supra note 12", "supra at 15", "supra § 3", "supra Part II"
  * Requires "note", "at", "§", "Part", or "p." after supra to avoid matching
  * the word "supra" in prose. Preceded by whitespace, start, or signal words.
- * Captures: (1) note number (if any), (2) pincite (with optional "*" prefix, #191).
+ * Captures: (1) note number (if any), (2) pincite (with optional "*" prefix,
+ * #191, and optional trailing footnote suffix, #202).
  */
 export const STANDALONE_SUPRA_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+))?|\s+at\s+(\*?\d+)|\s+(?:§+|Part|p\.)\s*\S+)/g
+  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?|\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|\s+(?:§+|Part|p\.)\s*\S+)/g
 
 /**
  * Short-form case: volume reporter [,] at page
@@ -47,10 +50,11 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
  * Simplified detection; full parsing in extraction layer.
  * Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
  * Handles SCOTUS/federal comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
- * Pincite accepts optional "*" prefix for star-pagination (#191).
+ * Pincite accepts optional "*" prefix for star-pagination (#191) and an
+ * optional trailing footnote suffix " n.14" / " nn.14-15" (#202).
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+)\b/g
+  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/tests/extract/issue202Footnote.test.ts
+++ b/tests/extract/issue202Footnote.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+describe("issue #202: footnote in pincite", () => {
+  it("populates footnote for full-case n.N", () => {
+    const cites = extractCitations("Smith v. Jones, 100 F.3d 456, 460 n.14 (2d Cir. 2020).", {
+      resolve: true,
+    })
+    const c = cites.find((c) => c.type === "case")
+    expect(c).toBeDefined()
+    expect(c?.type === "case" ? c.pinciteInfo : undefined).toEqual({
+      page: 460,
+      footnote: 14,
+      isRange: false,
+      raw: "460 n.14",
+    })
+  })
+
+  it("populates footnote for full-case nn.N-N", () => {
+    const cites = extractCitations("Smith v. Jones, 100 F.3d 456, 460 nn.14-15 (2d Cir. 2020).")
+    const c = cites.find((c) => c.type === "case")
+    expect(c).toBeDefined()
+    const info = c?.type === "case" ? c.pinciteInfo : undefined
+    expect(info?.footnote).toBe(14)
+    expect(info?.footnoteEnd).toBe(15)
+    expect(info?.raw).toContain("nn.14-15")
+  })
+
+  it("populates footnote for short-form case", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462 n.14.",
+      { resolve: true },
+    )
+    const shortform = cites.find((c) => c.type === "shortFormCase")
+    expect(shortform).toBeDefined()
+    expect(shortform?.type === "shortFormCase" ? shortform.pinciteInfo?.footnote : undefined).toBe(
+      14,
+    )
+  })
+
+  it("populates footnote for Id. citation", () => {
+    const cites = extractCitations(
+      "Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Id. at 462 n.14.",
+      { resolve: true },
+    )
+    const id = cites.find((c) => c.type === "id")
+    expect(id).toBeDefined()
+    expect(id?.type === "id" ? id.pinciteInfo?.footnote : undefined).toBe(14)
+  })
+
+  it("populates footnote for neutral citation", () => {
+    const cites = extractCitations("See 2020 WL 1234567, at *3 n.4 (S.D.N.Y. Jan. 15, 2020).", {
+      resolve: true,
+    })
+    const neutral = cites.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    const info = neutral?.type === "neutral" ? neutral.pinciteInfo : undefined
+    expect(info?.footnote).toBe(4)
+    expect(info?.starPage).toBe(true)
+  })
+})

--- a/tests/extract/pincite.test.ts
+++ b/tests/extract/pincite.test.ts
@@ -64,6 +64,26 @@ describe("parsePincite", () => {
     })
   })
 
+  it("parses a multi-footnote reference with nn.", () => {
+    expect(parsePincite("460 nn.14-15")).toEqual({
+      page: 460,
+      footnote: 14,
+      footnoteEnd: 15,
+      isRange: false,
+      raw: "460 nn.14-15",
+    })
+  })
+
+  it("parses a single-n footnote range", () => {
+    expect(parsePincite("460 n.14-15")).toEqual({
+      page: 460,
+      footnote: 14,
+      footnoteEnd: 15,
+      isRange: false,
+      raw: "460 n.14-15",
+    })
+  })
+
   it("returns null for unparseable input", () => {
     expect(parsePincite("")).toBeNull()
     expect(parsePincite("abc")).toBeNull()


### PR DESCRIPTION
Closes #202.

## Summary

- `PinciteInfo.footnote` was declared on the public type but never populated at runtime — `460 n.14` produced `{ page: 460, raw: "460" }` instead of `{ page: 460, footnote: 14, raw: "460 n.14" }`. The footnote suffix was dropped entirely.
- Root cause: `parsePincite`'s regex already handled `n.N` / `note N`, but every upstream capture regex that fed it stopped at `\*?\d+(?:-\d+)?` — so the parser never saw the footnote text. Systemic across all five citation types that carry `pinciteInfo` (full-case, short-form case, `Id.`, `supra`, neutral).
- Fix: extend every pincite-capture regex (5 tokenizer patterns in `shortForm.ts`, plus extractor regexes in `extractCase`, `extractShortForms`, `extractNeutral`) to include an optional trailing `(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?` suffix. Extend `parsePincite` to accept Bluebook's `nn.` multi-note prefix and capture a range end into a new `footnoteEnd?: number` field: `460 nn.14-15` now parses as `{ page: 460, footnote: 14, footnoteEnd: 15, ... }`.

## Test plan
- [x] New `tests/extract/issue202Footnote.test.ts` covers full-case `n.N`, full-case `nn.N-N`, short-form case, `Id.`, and neutral (with `*3 n.4`)
- [x] New `parsePincite` unit tests for `nn.N-N` and single-`n` footnote ranges
- [x] Full suite: 1814/1814 passing, 9 skipped (unchanged)
- [x] `pnpm typecheck` clean
- [x] Changeset added (patch)

Does not touch #201 (short-form range pincites) or #203 (neutral star-page ranges) — same family but independent regex paths; will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)