### PR TITLE
fix: capture range end page on ShortFormCaseCitation pincites (#201)

### DIFF
--- a/.changeset/fix-shortform-range-201.md
+++ b/.changeset/fix-shortform-range-201.md
@@ -1,0 +1,34 @@
+---
+"eyecite-ts": patch
+---
+
+fix: capture range end page on `ShortFormCaseCitation` pincites (#201)
+
+`ShortFormCaseCitation` dropped the end page of range pincites. Input
+`Smith, 100 F.3d at 462-65.` produced `pinciteInfo = { page: 462,
+isRange: false, raw: '462' }` instead of the expected `{ page: 462,
+endPage: 465, isRange: true, raw: '462-65' }`. The same range shape works
+correctly on `FullCaseCitation`.
+
+**Root cause.** `SHORT_FORM_CASE_PATTERN` (tokenizer) and `shortFormRegex`
+(extractor) captured only `(\*?\d+)` for the pincite — no range. When
+`parsePincite` finally ran, the text had already been truncated to the
+starting page.
+
+**Fix.** Extended both regexes to capture an optional range tail
+`(?:[-–—]\*?\d+)?` after the starting page. Also permits mixed star
+prefixes on range ends (`462-*65`) for neutral-cite compatibility.
+
+**Collateral fix — journal false-positive.** Growing the short-form span
+by `-NN` broke an identical-span dedup that had been silently absorbing a
+latent law-review false-positive: the pattern
+`\b(\d+)\s+([A-Z][A-Za-z.\s]+)\s+(\d+)\b` matched `554 U.S. at 621`
+inside a short-form cite, treating `U.S. at` as a journal name. Before
+`#201`, the short-form token covered the exact same span and won dedup;
+after `#201`, the short-form token ends at `-22` and the phantom journal
+slips through. Tightened the law-review pattern with an extra negative
+lookahead `(?!\s+at\s+\d)` so a run of capitalised words can't span an
+`at <digit>` token. No real journal name contains `" at <digit>"`.
+
+Four new regression tests for short-form ranges (plain, full digits,
+range + footnote, single-page regression guard). Full suite 1818/1818.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -252,10 +252,11 @@ export function extractShortFormCase(
   // Pattern: number space abbreviation [, ] at space number.
   // Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
   // Handles comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
-  // Pincite accepts optional "*" prefix for star-pagination (#191) and an
-  // optional trailing footnote suffix " n.14" / " nn.14-15" (#202).
+  // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
+  // range end "462-65" / "462-*65" (#201), and an optional trailing footnote
+  // suffix " n.14" / " nn.14-15" (#202).
   const shortFormRegex =
-    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/
+    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/patterns/journalPatterns.ts
+++ b/src/patterns/journalPatterns.ts
@@ -16,9 +16,9 @@ import type { Pattern } from "./casePatterns"
 export const journalPatterns: Pattern[] = [
   {
     id: "law-review",
-    regex: /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?!\s+vs?\.\s)[A-Za-z.\s])+)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?!\s+vs?\.\s)(?!\s+at\s+\d)[A-Za-z.\s])+)\s+(\d+)\b/g,
     description:
-      'Law review citations (e.g., "120 Harv. L. Rev. 500"), validated against journals-db in Phase 3. Negative lookahead excludes " v. "/" vs. " so party-name text isn\'t mis-captured as a journal name.',
+      'Law review citations (e.g., "120 Harv. L. Rev. 500"), validated against journals-db in Phase 3. Negative lookaheads exclude " v. "/" vs. " (so a party-name run isn\'t mis-captured as a journal) and " at <digit>" (so a short-form pincite like "554 U.S. at 621" isn\'t mis-captured as a journal).',
     type: "journal",
   },
 ]

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -50,11 +50,12 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
  * Simplified detection; full parsing in extraction layer.
  * Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
  * Handles SCOTUS/federal comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
- * Pincite accepts optional "*" prefix for star-pagination (#191) and an
- * optional trailing footnote suffix " n.14" / " nn.14-15" (#202).
+ * Pincite accepts optional "*" prefix for star-pagination (#191), an optional
+ * range end "462-65" / "462-*65" (#201), and an optional trailing footnote
+ * suffix " n.14" / " nn.14-15" (#202).
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?\b/g
+  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/tests/extract/issue201ShortFormRange.test.ts
+++ b/tests/extract/issue201ShortFormRange.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+describe("issue #201: short-form case range pincite", () => {
+  it("captures range end page (at 462-65)", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462-65.",
+      { resolve: true },
+    )
+    const shortform = cites.find((c) => c.type === "shortFormCase")
+    expect(shortform).toBeDefined()
+    const info = shortform?.type === "shortFormCase" ? shortform.pinciteInfo : undefined
+    expect(info).toEqual({
+      page: 462,
+      endPage: 465,
+      isRange: true,
+      raw: "462-65",
+    })
+  })
+
+  it("captures range end page with full digits (at 462-465)", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462-465.",
+      { resolve: true },
+    )
+    const shortform = cites.find((c) => c.type === "shortFormCase")
+    expect(shortform).toBeDefined()
+    const info = shortform?.type === "shortFormCase" ? shortform.pinciteInfo : undefined
+    expect(info?.page).toBe(462)
+    expect(info?.endPage).toBe(465)
+    expect(info?.isRange).toBe(true)
+  })
+
+  it("captures range with footnote (at 462-65 n.3)", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462-65 n.3.",
+      { resolve: true },
+    )
+    const shortform = cites.find((c) => c.type === "shortFormCase")
+    expect(shortform).toBeDefined()
+    const info = shortform?.type === "shortFormCase" ? shortform.pinciteInfo : undefined
+    expect(info?.page).toBe(462)
+    expect(info?.endPage).toBe(465)
+    expect(info?.footnote).toBe(3)
+    expect(info?.isRange).toBe(true)
+  })
+
+  it("still captures single-page pincite (at 462)", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462.",
+      { resolve: true },
+    )
+    const shortform = cites.find((c) => c.type === "shortFormCase")
+    expect(shortform).toBeDefined()
+    const info = shortform?.type === "shortFormCase" ? shortform.pinciteInfo : undefined
+    expect(info?.page).toBe(462)
+    expect(info?.isRange).toBe(false)
+    expect(info?.endPage).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #201.

## Summary

- `ShortFormCaseCitation` dropped the end page of range pincites: `Smith, 100 F.3d at 462-65.` produced `{ page: 462, isRange: false, raw: '462' }` instead of `{ page: 462, endPage: 465, isRange: true, raw: '462-65' }`. Same range shape works on `FullCaseCitation`.
- **Root cause**: `SHORT_FORM_CASE_PATTERN` (tokenizer) and `shortFormRegex` (extractor) captured only `(\*?\d+)` — no range. `parsePincite` was fed the already-truncated starting page.
- **Fix**: extend both regexes with an optional `(?:[-–—]\*?\d+)?` range tail. Permits mixed star prefixes (`462-*65`) for neutral-cite compatibility.
- **Collateral fix**: growing the short-form span by `-NN` broke an identical-span dedup that had been silently suppressing a latent law-review false-positive — the journal pattern matched `554 U.S. at 621` inside the short-form cite, treating `U.S. at` as a journal name. Tightened the journal pattern with a negative lookahead `(?!\s+at\s+\d)`. No real journal name contains `" at <digit>"`.

## Test plan
- [x] New `tests/extract/issue201ShortFormRange.test.ts`: range (`462-65`), full digits (`462-465`), range + footnote (`462-65 n.3`), single-page regression guard (`462`)
- [x] Full suite: 1818/1818 passing (was 1814 before; +4 new)
- [x] `pnpm typecheck` clean
- [x] Changeset added (patch)

Does not touch #203 (neutral star-page ranges) — separate regex path, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)