### PR TITLE
fix: capture *N-*M neutral star-page ranges (#203)

### DIFF
--- a/.changeset/fix-neutral-starrange-203.md
+++ b/.changeset/fix-neutral-starrange-203.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix: capture `*N-*M` neutral-citation star-page ranges (#203)
+
+`NeutralCitation` with a star-page range pincite (common on Westlaw,
+Lexis, and NY Slip Op) captured only the starting page. Input
+`See 2020 WL 1234567, at *3-*5 (S.D.N.Y. 2020).` produced
+`{ page: 3, isRange: false, raw: '*3', starPage: true }` instead of
+`{ page: 3, endPage: 5, isRange: true, raw: '*3-*5', starPage: true }`.
+The `*3-5` form (star on first end only) already worked; `*3-*5` did not.
+
+**Root cause.** `NEUTRAL_PINCITE_LOOKAHEAD`'s range tail `(?:-\d+)?`
+accepted a trailing hyphen+digits but not the optional `*` prefix on the
+range end. `parsePincite` already handled `*3-*5` correctly (its existing
+unit test `parses a star-paginated range with star on both ends` passes);
+the lookahead just never sent it the full text.
+
+**Fix.** Changed the range tail to `(?:[-–—]\*?\d+)?` so the capture
+group includes an optional star on the range end (and also accepts
+en-dash/em-dash variants for consistency with `parsePincite`).
+
+Three new regression tests: `*3-*5`, `*3-5`, and a non-range `*3`
+regression guard.

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -15,10 +15,11 @@ import { parsePincite, type PinciteInfo } from "./pincite"
 
 /** Matches a trailing pincite on a neutral citation. Accepts both
  *  ", at *3" (comma + "at" keyword) and " at *3" (whitespace + "at") forms,
- *  with optional "*" prefix for star-pagination (#191) and an optional
- *  trailing " n.14" / " nn.14-15" footnote suffix (#202). */
+ *  with optional "*" prefix for star-pagination on both ends of a range
+ *  (#191, #203 — "*3-*5" is common on Westlaw/Lexis/NY Slip Op), and an
+ *  optional trailing " n.14" / " nn.14-15" footnote suffix (#202). */
 const NEUTRAL_PINCITE_LOOKAHEAD =
-  /^(?:\s+at\s+|,\s*(?:at\s+)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
+  /^(?:\s+at\s+|,\s*(?:at\s+)?)(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
 
 /**
  * Extracts neutral citation metadata from a tokenized citation.

--- a/tests/extract/issue203NeutralStarRange.test.ts
+++ b/tests/extract/issue203NeutralStarRange.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+describe("issue #203: neutral star-page range pincite", () => {
+  it("captures range end with star on both ends (*3-*5)", () => {
+    const cites = extractCitations(
+      "See 2020 WL 1234567, at *3-*5 (S.D.N.Y. Jan. 15, 2020).",
+      { resolve: true },
+    )
+    const neutral = cites.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    const info = neutral?.type === "neutral" ? neutral.pinciteInfo : undefined
+    expect(info).toEqual({
+      page: 3,
+      endPage: 5,
+      isRange: true,
+      starPage: true,
+      raw: "*3-*5",
+    })
+  })
+
+  it("captures range end with star on first only (*3-5)", () => {
+    const cites = extractCitations(
+      "See 2020 WL 1234567, at *3-5 (S.D.N.Y. 2020).",
+      { resolve: true },
+    )
+    const neutral = cites.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    const info = neutral?.type === "neutral" ? neutral.pinciteInfo : undefined
+    expect(info?.page).toBe(3)
+    expect(info?.endPage).toBe(5)
+    expect(info?.isRange).toBe(true)
+    expect(info?.starPage).toBe(true)
+  })
+
+  it("still captures non-range star-page (*3)", () => {
+    const cites = extractCitations("See 2020 WL 1234567, at *3 (S.D.N.Y. 2020).", {
+      resolve: true,
+    })
+    const neutral = cites.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    const info = neutral?.type === "neutral" ? neutral.pinciteInfo : undefined
+    expect(info?.page).toBe(3)
+    expect(info?.isRange).toBe(false)
+    expect(info?.starPage).toBe(true)
+    expect(info?.endPage).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #203.

## Summary

- Neutral cites with a star-page range pincite dropped the end page: `at *3-*5` produced `{ page: 3, isRange: false, raw: '*3', starPage: true }` instead of `{ page: 3, endPage: 5, isRange: true, raw: '*3-*5', starPage: true }`. The `*3-5` form (star on first only) already worked; `*3-*5` (star on both ends) didn't.
- **Root cause**: `NEUTRAL_PINCITE_LOOKAHEAD`'s range tail `(?:-\d+)?` accepted a trailing hyphen+digits but not the optional `*` on the range end. `parsePincite` already handled `*3-*5` correctly — the lookahead just never sent it the full text.
- **Fix**: changed the range tail to `(?:[-–—]\*?\d+)?` so the capture group includes an optional star on the range end (and accepts en/em-dash variants for parity with `parsePincite`).

## Test plan
- [x] New `tests/extract/issue203NeutralStarRange.test.ts`: `*3-*5`, `*3-5`, non-range `*3` regression guard
- [x] Full suite: 1821/1821 passing (was 1818; +3 new)
- [x] `pnpm typecheck` clean
- [x] Changeset added (patch)

Closes out the #201–#203 pincite bug trio filed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)