### PR TITLE
fix: drop phantom overlap citations via subsumption dedup (#209)

### DIFF
--- a/.changeset/fix-phantom-case-subsumption-209.md
+++ b/.changeset/fix-phantom-case-subsumption-209.md
@@ -1,0 +1,40 @@
+---
+"eyecite-ts": patch
+---
+
+fix: drop phantom overlap citations via priority-aware subsumption dedup (#209)
+
+0.11.3 regression: `extractCitations` emitted a phantom `case` citation
+alongside a legitimate `shortFormCase` whose pincite ended in a footnote
+suffix. Input `"... Smith, 100 F.3d at 462 n.14."` produced three
+citations — the real full-case, the real shortFormCase, and a phantom
+`case` whose span ended just before ` n.14` and whose `pinciteInfo.raw`
+was `undefined`.
+
+**Root cause.** The `state-reporter` tokenizer pattern is broad enough
+to match `100 F.3d at 462` by treating `F.3d at` as a multi-word reporter
+name. Before `#202`, the `shortFormCase` token covered the same span
+exactly, and position-key dedup kept only one. `#202` grew the
+shortFormCase token by ` n.14` to include the footnote. Same-span dedup
+no longer caught it, and the phantom state-reporter survived into
+extraction. Same shape as `#207` (law-review version of the same bug).
+
+**Fix.** Replaced the exact-position dedup with priority-aware
+subsumption dedup. Each token's priority is its first-occurrence index
+in the composed pattern list — more specific patterns (neutral,
+shortForm) come earlier than broader ones (case, journal). A token is
+dropped if another kept token's span covers it *and* that kept token is
+from an equal-or-more-specific pattern. This correctly:
+
+- drops the phantom `state-reporter [61,76]` inside
+  `shortFormCase [61,81]` (#209)
+- drops the phantom `law-review [x,y]` inside `shortFormCase` (#207,
+  now handled structurally rather than by the `(?!\s+at\s+\d)` band-aid,
+  which is kept as belt-and-braces defense)
+- **preserves** legitimate cases where a broader pattern contains a
+  more-specific one — e.g. a `named-code` token wrapping a
+  `state-constitution` token for `"Cal. Const. art. I, § 7."`. The
+  broader `named-code` has a *lower* priority (later in the pattern
+  list), so it does not swallow the more-specific `state-constitution`.
+
+Four new regression tests for #209. Full suite 1825/1825 green.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -233,24 +233,63 @@ export function extractCitations(
   ]
   const tokens = tokenize(cleaned, allPatterns)
 
-  // Step 3: Deduplicate overlapping tokens
-  // Multiple patterns may match the same text (e.g., "500 F.2d 123" matches both federal-reporter and state-reporter)
-  // Keep only the most specific match for each position
+  // Step 3: Deduplicate overlapping tokens via priority-aware subsumption.
+  //
+  // Multiple patterns may match the same or overlapping text:
+  //   (a) Exact-span duplicates — e.g., `100 F.3d 456` matches both
+  //       `federal-reporter` and `state-reporter`. Keep the higher-priority
+  //       one (earlier in the pattern list = more specific).
+  //   (b) Subsumed matches — a token whose span is a strict subset of
+  //       another token's span, and the containing token comes from a
+  //       more-or-equally-specific pattern. Canonical failure: `state-reporter`
+  //       or `law-review` treating `F.3d at` / `U.S. at` as a reporter/journal
+  //       name inside a `shortFormCase` cite (see #207, #209). Drop the
+  //       subsumed token only when the container is at least as specific —
+  //       otherwise we'd swallow legitimate shorter matches (e.g., a
+  //       `state-constitution` token that sits inside a broader `named-code`
+  //       match for "Cal. Const. art. I, § 7.").
+  //
+  // Priority = first occurrence index in `allPatterns`. Duplicate patternIds
+  // (e.g., "supra") share the earliest index, which is fine — they form a
+  // single priority bucket.
+  const priorityByPatternId = new Map<string, number>()
+  for (let i = 0; i < allPatterns.length; i++) {
+    const id = allPatterns[i].id
+    if (!priorityByPatternId.has(id)) priorityByPatternId.set(id, i)
+  }
+  const priorityOf = (t: (typeof tokens)[number]): number =>
+    priorityByPatternId.get(t.patternId) ?? Number.POSITIVE_INFINITY
+
+  // Sort by (cleanStart asc, cleanEnd desc, priority asc) so containers come
+  // before their contained tokens at each start position, and within any
+  // (start, end) bucket the higher-priority token comes first.
+  const sortedTokens = [...tokens].sort(
+    (a, b) =>
+      a.span.cleanStart - b.span.cleanStart ||
+      b.span.cleanEnd - a.span.cleanEnd ||
+      priorityOf(a) - priorityOf(b),
+  )
   const deduplicatedTokens: typeof tokens = []
-  const seenPositions = new Set<number | string>()
-
-  // Performance optimization: Use bitpacking for typical documents (<65K chars)
-  // For larger documents, fall back to string keys
-  const useBitpacking = cleaned.length < 65536
-
-  for (const token of tokens) {
-    const posKey = useBitpacking
-      ? (token.span.cleanStart << 16) | token.span.cleanEnd
-      : `${token.span.cleanStart}-${token.span.cleanEnd}`
-    if (!seenPositions.has(posKey)) {
-      seenPositions.add(posKey)
-      deduplicatedTokens.push(token)
+  for (const token of sortedTokens) {
+    let subsumed = false
+    for (const kept of deduplicatedTokens) {
+      const contains =
+        kept.span.cleanStart <= token.span.cleanStart &&
+        kept.span.cleanEnd >= token.span.cleanEnd
+      if (!contains) continue
+      if (priorityOf(kept) > priorityOf(token)) continue // kept is less specific, don't let it swallow
+      // `kept` is at least as specific AND contains this token. Drop `token`
+      // if this is a strict containment or an equal-span lower-priority duplicate.
+      if (
+        kept.span.cleanStart < token.span.cleanStart ||
+        kept.span.cleanEnd > token.span.cleanEnd ||
+        priorityOf(kept) < priorityOf(token)
+      ) {
+        subsumed = true
+        break
+      }
     }
+    if (!subsumed) deduplicatedTokens.push(token)
   }
 
   // Step 3.5: Detect parallel citation groups

--- a/tests/extract/issue209PhantomCase.test.ts
+++ b/tests/extract/issue209PhantomCase.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+describe("issue #209: phantom FullCase alongside ShortForm with footnote pincite", () => {
+  it("emits exactly 2 citations — no phantom case", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462 n.14.",
+    )
+    const types = cites.map((c) => c.type).sort()
+    expect(types).toEqual(["case", "shortFormCase"])
+  })
+
+  it("legit full-case has pinciteInfo.raw='460'", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462 n.14.",
+    )
+    const cases = cites.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect(cases[0].type === "case" ? cases[0].pinciteInfo?.raw : undefined).toBe("460")
+  })
+
+  it("shortFormCase carries the footnote pincite", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462 n.14.",
+    )
+    const sf = cites.find((c) => c.type === "shortFormCase")
+    expect(sf).toBeDefined()
+    const info = sf?.type === "shortFormCase" ? sf.pinciteInfo : undefined
+    expect(info?.raw).toBe("462 n.14")
+    expect(info?.footnote).toBe(14)
+  })
+
+  it("same guarantee without footnote (regression baseline)", () => {
+    const cites = extractCitations(
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462.",
+    )
+    const types = cites.map((c) => c.type).sort()
+    expect(types).toEqual(["case", "shortFormCase"])
+  })
+})


### PR DESCRIPTION
Closes #209 (0.11.3 regression).

## Summary

- `extractCitations` emitted a phantom `case` citation alongside a legitimate `shortFormCase` whose pincite ended in a footnote suffix. Input `"... Smith, 100 F.3d at 462 n.14."` produced 3 citations — real full-case + real shortFormCase + phantom `case` with `pinciteInfo.raw === undefined` ending just before ` n.14`.
- **Root cause**: `state-reporter` pattern matches `100 F.3d at 462` by treating `F.3d at` as a multi-word reporter name. Before #202, `shortFormCase` covered the same span exactly → position-key dedup suppressed the phantom. #202 grew `shortFormCase` by ` n.14` → exact-span dedup missed it → phantom survived. Same shape as the journal case I patched around in #207.
- **Fix**: replaced exact-position dedup with priority-aware subsumption dedup. Priority = first-occurrence index in the composed pattern list; more specific patterns come earlier. A token is dropped only when another kept token contains it *and* that container is from an equal-or-more-specific pattern.
  - Drops phantom `state-reporter` inside `shortFormCase` (#209 ✓)
  - Drops phantom `law-review` inside `shortFormCase` structurally (#207 is now redundant, kept as belt-and-braces)
  - **Preserves** legitimate overlaps where the broader pattern is *less* specific — e.g. a `state-constitution` token inside a broader `named-code` match for `"Cal. Const. art. I, § 7."`. A naive longest-wins subsumption (my first attempt) would incorrectly swallow the constitutional token; priority-awareness prevents that.

## Test plan
- [x] New `tests/extract/issue209PhantomCase.test.ts`: exact issue repro, full-case has `raw='460'`, shortFormCase has `raw='462 n.14'`, regression guard without footnote
- [x] `tracks jurisdiction span for state constitutions` — confirms the constitutional/named-code overlap case still works (caught my initial over-aggressive dedup during development)
- [x] `dense-originalism-debate` — confirms the #207 journal case still works under subsumption (independently of the `(?!\s+at\s+\d)` band-aid)
- [x] Full suite: 1825/1825 passing (was 1821; +4 new)
- [x] `pnpm typecheck` clean
- [x] Changeset added (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)