### PR TITLE
feat: populate spans.pincite on ShortForm/Id/Supra/Neutral (#210)

### DIFF
--- a/.changeset/feat-spans-pincite-210.md
+++ b/.changeset/feat-spans-pincite-210.md
@@ -1,0 +1,38 @@
+---
+"eyecite-ts": minor
+---
+
+feat: populate `spans.pincite` on `ShortFormCaseCitation`, `IdCitation`, `SupraCitation`, and `NeutralCitation` (#210)
+
+Previously `spans.pincite` was populated only on `FullCaseCitation`. The
+four short-form / short-form-like citation types did not surface a
+pincite offset, so downstream consumers had to either trust
+`span.originalEnd` (which works for short-form/Id/supra by coincidence
+but sits *before* the pincite on `NeutralCitation`) or fall back to a
+brittle `indexOf(pinciteInfo.raw, ...)` search.
+
+**Added:**
+
+- `IdComponentSpans`, `SupraComponentSpans`, `ShortFormCaseComponentSpans`
+  types (currently carrying just `pincite?: Span`, extensible)
+- `pincite?: Span` on the existing `NeutralComponentSpans`
+- `spans?: <Type>ComponentSpans` on `IdCitation`, `SupraCitation`,
+  `ShortFormCaseCitation`
+- Populated `spans.pincite` in `extractId`, `extractSupra`,
+  `extractShortFormCase`, and `extractNeutral`, using the existing
+  `spanFromGroupIndex` helper and the same pattern used by
+  `FullCaseCitation`
+
+**Behavior:**
+
+- `spans.pincite` is set when (and only when) the extractor captures a
+  pincite via its regex. Absent pincite → `spans.pincite` undefined.
+- The `spans.pincite.originalStart` / `originalEnd` point to the pincite
+  substring in the original (pre-clean) text — e.g. `462-65`,
+  `462 n.14`, `*3-*5`.
+
+Seven new tests covering all four types, footnote-carrying pincite,
+star-page range pincite, and the no-pincite case.
+
+No breaking changes — all additions are optional fields on types that
+already permitted `spans` on their full-case counterpart.

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -94,6 +94,16 @@ export function extractNeutral(
     if (laMatch) {
       pinciteInfo = parsePincite(laMatch[1]) ?? undefined
       pincite = pinciteInfo?.page
+      // Component span for pincite (#210). Indices are relative to afterToken,
+      // which starts at span.cleanEnd in cleanedText.
+      if (laMatch.indices?.[1]) {
+        if (!spans) spans = {}
+        spans.pincite = spanFromGroupIndex(
+          span.cleanEnd,
+          laMatch.indices[1],
+          transformationMap,
+        )
+      }
     }
   }
 

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -9,7 +9,12 @@
 
 import type { Token } from "@/tokenize"
 import type { IdCitation, ShortFormCaseCitation, SupraCitation } from "@/types/citation"
-import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
+import type {
+  IdComponentSpans,
+  ShortFormCaseComponentSpans,
+  SupraComponentSpans,
+} from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
 import { COMMON_REPORTERS } from "./extractCase"
 import { parsePincite, type PinciteInfo } from "./pincite"
 
@@ -54,7 +59,7 @@ export function extractId(
   // Pattern: Id. or Ibid. with optional comma + "at [page]" (handles "Id., at 5").
   // Pincite accepts optional "*" prefix for star-pagination (#191) and an
   // optional trailing footnote suffix " n.14" / " nn.14-15" (#202).
-  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/
+  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
   const match = idRegex.exec(text)
 
   if (!match) {
@@ -67,6 +72,14 @@ export function extractId(
     ? (parsePincite(match[4]) ?? undefined)
     : undefined
   const pincite = pinciteInfo?.page
+
+  // Component span for pincite (#210)
+  let spans: IdComponentSpans | undefined
+  if (match[4] && match.indices?.[4]) {
+    spans = {
+      pincite: spanFromGroupIndex(span.cleanStart, match.indices[4], transformationMap),
+    }
+  }
 
   // Confidence scoring based on variant
   let confidence = 1.0
@@ -110,6 +123,7 @@ export function extractId(
     patternsChecked: 1,
     pincite,
     pinciteInfo,
+    spans,
   }
 }
 
@@ -152,12 +166,12 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   // Pincite accepts optional "*" prefix for star-pagination (#191) and an
   // optional trailing footnote suffix (#202).
   const partySupraRegex =
-    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/
+    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
   const partyMatch = partySupraRegex.exec(text)
 
   // Fallback: standalone supra — "supra note N", "supra at N", "supra § N".
   const standaloneRegex =
-    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/
+    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
   const match = partyMatch || standaloneRegex.exec(text)
 
   if (!match) {
@@ -167,6 +181,7 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   let partyName: string | undefined
   let pinciteInfo: PinciteInfo | undefined
   let confidence: number
+  let pinciteGroupIdx: number | undefined
 
   if (partyMatch) {
     partyName = partyMatch[1]
@@ -174,6 +189,7 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
       ? (parsePincite(partyMatch[3]) ?? undefined)
       : undefined
     confidence = 0.9
+    if (partyMatch[3]) pinciteGroupIdx = 3
   } else {
     // Standalone supra — no party name
     partyName = undefined
@@ -182,9 +198,23 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
     const rawPin = noteAtPage ?? atPage
     pinciteInfo = rawPin ? (parsePincite(rawPin) ?? undefined) : undefined
     confidence = 0.8 // Slightly lower — standalone supra is less specific
+    if (noteAtPage) pinciteGroupIdx = 2
+    else if (atPage) pinciteGroupIdx = 3
   }
 
   const pincite = pinciteInfo?.page
+
+  // Component span for pincite (#210)
+  let spans: SupraComponentSpans | undefined
+  if (pinciteGroupIdx !== undefined && match.indices?.[pinciteGroupIdx]) {
+    spans = {
+      pincite: spanFromGroupIndex(
+        span.cleanStart,
+        match.indices[pinciteGroupIdx],
+        transformationMap,
+      ),
+    }
+  }
 
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
@@ -205,6 +235,7 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
     partyName,
     pincite,
     pinciteInfo,
+    spans,
   }
 }
 
@@ -256,7 +287,7 @@ export function extractShortFormCase(
   // range end "462-65" / "462-*65" (#201), and an optional trailing footnote
   // suffix " n.14" / " nn.14-15" (#202).
   const shortFormRegex =
-    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/
+    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
   const match = shortFormRegex.exec(text)
 
   if (!match) {
@@ -268,6 +299,14 @@ export function extractShortFormCase(
   const reporter = match[2].trim() // Remove trailing spaces
   const pinciteInfo: PinciteInfo | undefined = parsePincite(match[3]) ?? undefined
   const pincite = pinciteInfo?.page
+
+  // Component span for pincite (#210)
+  let spans: ShortFormCaseComponentSpans | undefined
+  if (match.indices?.[3]) {
+    spans = {
+      pincite: spanFromGroupIndex(span.cleanStart, match.indices[3], transformationMap),
+    }
+  }
 
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
@@ -295,5 +334,6 @@ export function extractShortFormCase(
     reporter,
     pincite,
     pinciteInfo,
+    spans,
   }
 }

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -547,6 +547,8 @@ export interface IdCitation extends CitationBase {
   pincite?: number
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
+  /** Component-level spans (currently just `pincite`; extend when needed). */
+  spans?: import("./componentSpans").IdComponentSpans
 }
 
 /**
@@ -563,6 +565,8 @@ export interface SupraCitation extends CitationBase {
   pincite?: number
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
+  /** Component-level spans (currently just `pincite`; extend when needed). */
+  spans?: import("./componentSpans").SupraComponentSpans
 }
 
 /**
@@ -579,6 +583,8 @@ export interface ShortFormCaseCitation extends CitationBase {
   pincite?: number
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
+  /** Component-level spans (currently just `pincite`; extend when needed). */
+  spans?: import("./componentSpans").ShortFormCaseComponentSpans
 }
 
 /**

--- a/src/types/componentSpans.ts
+++ b/src/types/componentSpans.ts
@@ -75,7 +75,29 @@ export interface NeutralComponentSpans {
   year?: Span
   court?: Span
   documentNumber?: Span
+  pincite?: Span
   signal?: Span
+}
+
+/**
+ * Component spans for Id./Ibid. citations (type: "id").
+ */
+export interface IdComponentSpans {
+  pincite?: Span
+}
+
+/**
+ * Component spans for supra citations (type: "supra").
+ */
+export interface SupraComponentSpans {
+  pincite?: Span
+}
+
+/**
+ * Component spans for short-form case citations (type: "shortFormCase").
+ */
+export interface ShortFormCaseComponentSpans {
+  pincite?: Span
 }
 
 /**

--- a/tests/extract/issue210SpansPincite.test.ts
+++ b/tests/extract/issue210SpansPincite.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+function textAtSpan(text: string, s: { originalStart: number; originalEnd: number } | undefined) {
+  if (!s) return undefined
+  return text.substring(s.originalStart, s.originalEnd)
+}
+
+describe("issue #210: spans.pincite on short-form / id / supra / neutral", () => {
+  it("ShortFormCaseCitation — spans.pincite covers '462-65'", () => {
+    const text =
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462-65."
+    const cites = extractCitations(text)
+    const sf = cites.find((c) => c.type === "shortFormCase")
+    expect(sf).toBeDefined()
+    const s = sf?.type === "shortFormCase" ? sf.spans?.pincite : undefined
+    expect(textAtSpan(text, s)).toBe("462-65")
+  })
+
+  it("ShortFormCaseCitation — spans.pincite covers '462 n.14' with footnote", () => {
+    const text =
+      "See Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Smith, 100 F.3d at 462 n.14."
+    const cites = extractCitations(text)
+    const sf = cites.find((c) => c.type === "shortFormCase")
+    const s = sf?.type === "shortFormCase" ? sf.spans?.pincite : undefined
+    expect(textAtSpan(text, s)).toBe("462 n.14")
+  })
+
+  it("IdCitation — spans.pincite covers '462 n.14'", () => {
+    const text = "Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Id. at 462 n.14."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    const s = id?.type === "id" ? id.spans?.pincite : undefined
+    expect(textAtSpan(text, s)).toBe("462 n.14")
+  })
+
+  it("IdCitation — spans.pincite undefined when no pincite", () => {
+    const text = "Smith v. Jones, 100 F.3d 456, 460 (2d Cir. 2020). Id."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    const s = id?.type === "id" ? id.spans?.pincite : undefined
+    expect(s).toBeUndefined()
+  })
+
+  it("SupraCitation — spans.pincite covers '460'", () => {
+    const text = "Smith v. Jones, 100 F.3d 456 (2d Cir. 2020). Later: Smith, supra, at 460."
+    const cites = extractCitations(text)
+    const supra = cites.find((c) => c.type === "supra")
+    const s = supra?.type === "supra" ? supra.spans?.pincite : undefined
+    expect(textAtSpan(text, s)).toBe("460")
+  })
+
+  it("NeutralCitation — spans.pincite covers '*3-*5' (lookahead pincite)", () => {
+    const text = "See 2020 WL 1234567, at *3-*5 (S.D.N.Y. 2020)."
+    const cites = extractCitations(text)
+    const neutral = cites.find((c) => c.type === "neutral")
+    const s = neutral?.type === "neutral" ? neutral.spans?.pincite : undefined
+    expect(textAtSpan(text, s)).toBe("*3-*5")
+  })
+
+  it("NeutralCitation — spans.pincite undefined when no pincite", () => {
+    const text = "See 2020 WL 1234567 (S.D.N.Y. 2020)."
+    const cites = extractCitations(text)
+    const neutral = cites.find((c) => c.type === "neutral")
+    const s = neutral?.type === "neutral" ? neutral.spans?.pincite : undefined
+    expect(s).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #210.

## Summary

- Previously `spans.pincite` was populated only on `FullCaseCitation`. The four short-form / short-form-like citation types (`ShortFormCaseCitation`, `IdCitation`, `SupraCitation`, `NeutralCitation`) did not surface a pincite offset, so downstream consumers had to trust `span.originalEnd` (which sits *before* the pincite on `NeutralCitation`) or fall back to `indexOf(pinciteInfo.raw, ...)` — both brittle.
- Added:
  - `IdComponentSpans`, `SupraComponentSpans`, `ShortFormCaseComponentSpans` (currently just `pincite?: Span`, extensible)
  - `pincite?: Span` on existing `NeutralComponentSpans`
  - `spans?: <Type>ComponentSpans` on `IdCitation`, `SupraCitation`, `ShortFormCaseCitation`
  - Populated in the four extractors using `spanFromGroupIndex` (same pattern as `FullCaseCitation`). Added the `/d` flag to short-form extractor regexes to surface capture indices.

## Behavior
- `spans.pincite` is set when and only when a pincite is captured. Absent pincite → `spans.pincite` undefined.
- `spans.pincite.originalStart/originalEnd` point to the pincite substring in the original text — e.g. `462-65`, `462 n.14`, `*3-*5`.

## Test plan
- [x] 7 new tests in `tests/extract/issue210SpansPincite.test.ts`: ShortFormCase (`462-65`, `462 n.14`), Id. (with + without pincite), Supra, Neutral (`*3-*5`, without pincite)
- [x] Full suite: 1832/1832 passing (was 1825; +7 new)
- [x] `pnpm typecheck` clean
- [x] Changeset added (**minor** bump — new public types / fields)

No breaking changes — all additions are optional fields on existing types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)