### PR TITLE
docs: redact internal-org reference in state-statute design doc

### DIFF
--- a/docs/superpowers/specs/2026-04-06-state-statute-coverage-design.md
+++ b/docs/superpowers/specs/2026-04-06-state-statute-coverage-design.md
@@ -83,7 +83,7 @@ The existing `abbreviatedCodes[]` array in `knownCodes.ts` migrates to derive fr
 
 ### 4. Data Population
 
-Source: the OurFirm.ai statute repo's research docs (`docs/srcs/*.md`) and `citation-normalizer.ts`.
+Source: an internal statute repo's research docs (`docs/srcs/*.md`) and `citation-normalizer.ts`.
 
 For each of the ~30 missing states:
 1. Read the state's research doc for citation format variants and abbreviations


### PR DESCRIPTION
## Summary

Removes a specific reference to a private internal repo from `docs/superpowers/specs/2026-04-06-state-statute-coverage-design.md:86` and replaces it with a generic "internal statute repo" wording. The spec remains informative without leaking private project context.

## Test plan

- [x] `grep -rn` for the redacted term across the working tree returns no matches
- [x] No code/test changes (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)