### PR TITLE
fix: case-name extraction cluster (#220–#224)

### DIFF
--- a/.changeset/case-name-scanback-cluster.md
+++ b/.changeset/case-name-scanback-cluster.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+fix: case-name extraction cluster (#220, #221, #222, #223, #224)
+
+- **#220**: export `DocketCitation` type from package entry so consumers can `import type { DocketCitation } from "eyecite-ts"`.
+- **#221**: stop the case-name scanback at paragraph boundaries (`\n\n`) so a citation at the start of a new paragraph no longer absorbs the previous heading and intro prose. The default cleaner collapses newlines to spaces, so paragraph breaks are recovered from the original text via the `transformationMap`.
+- **#222**: detect consolidated captions (`X v. Y, Matter of A, P v. Q,` chained in one citation) and truncate the defendant at its first comma so `caseName` stays a single party pair instead of concatenating multiple segments.
+- **#223**: trim lead-in clauses ("Under the controlling authority of … in", "Pursuant to the rule announced in") off the plaintiff. Removed `"in"` from the party-name connector set (it's almost always a prose preposition) and tightened the `firstWordIsProperName` guard so it only suppresses trimming when an internal qualifier (`d/b/a`, `a/k/a`, `f/k/a`, `n/k/a`, with or without slashes) is present.
+- **#224**: in subsequent-history chains (`<cite-A>, modified on other grounds, <cite-B>`), inherit the chain root's case name onto the child citation per Bluebook 10.7. Without this pass, the second citation's `caseName` absorbed the first citation + history connector.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -267,13 +267,18 @@ const PROCEDURAL_PREFIX_REGEX =
  * Lowercase words that legitimately appear in legal party names.
  * Articles, prepositions, and legal connectors (e.g., "of", "the", "ex", "rel").
  * Used to distinguish real party names from sentence context captured by the regex.
+ *
+ * Note: "in" is intentionally NOT a connector. It's overwhelmingly a prose
+ * preposition ("the holding in", "the rule announced in") rather than a
+ * party-name internal token. Treating "in" as a connector lets lead-in
+ * clauses bleed into the captured plaintiff (#223). Procedural "In re"
+ * captions go through PROCEDURAL_PREFIX_REGEX instead.
  */
 const PARTY_NAME_CONNECTORS = new Set([
   "of",
   "the",
   "and",
   "for",
-  "in",
   "on",
   "by",
   "a",
@@ -294,6 +299,16 @@ const PARTY_NAME_CONNECTORS = new Set([
   "d",
   "or",
 ])
+
+/**
+ * Internal qualifier markers that appear inside legitimate party names
+ * (e.g., "Smith d/b/a Old Bob's Diner v. Jones", "Jones aka Johnson v. Smith").
+ * When such a marker is present, the plaintiff is correctly anchored at its
+ * first word — even if that word is followed by lowercase non-connector
+ * tokens. Without this signal, the firstWordIsProperName guard incorrectly
+ * preserves lead-in prose (#223).
+ */
+const INTERNAL_QUALIFIER_REGEX = /\b(?:d\/?b\/?a|a\/?k\/?a|f\/?k\/?a|n\/?k\/?a)\b/i
 
 /**
  * Check whether a string looks like a legal party name vs. sentence context.
@@ -823,6 +838,8 @@ const SENTENCE_BOUNDARY_REGEX = /[.)]\s+(?=[A-Z])/g
  * @param cleanedText - Full cleaned text
  * @param coreStart - Position where citation core begins (volume start)
  * @param maxLookback - Maximum characters to search backward (default 150)
+ * @param options - Optional original text + transformationMap to detect
+ *   paragraph-break boundaries that the cleaner has collapsed (#221).
  * @returns Case name and start position, or undefined if not found
  *
  * @example
@@ -835,25 +852,65 @@ export function extractCaseName(
   cleanedText: string,
   coreStart: number,
   maxLookback = 150,
+  options?: { originalText?: string; transformationMap?: TransformationMap },
 ): { caseName: string; nameStart: number } | undefined {
   const searchStart = Math.max(0, coreStart - maxLookback)
   let precedingText = cleanedText.substring(searchStart, coreStart)
   let adjustedSearchStart = searchStart
 
   // Split at last boundary to avoid crossing citation/sentence boundaries.
-  // We check four boundary types:
+  // We check five boundary types:
   //   1. Citation boundary: digit-period-space (e.g., "10. " from a previous cite's page number)
   //   2. Id. boundary: "Id. " short-form citation marker (#182)
   //   3. Parenthetical signal boundary: "(quoting ", "(citing ", "(cited in " (#182)
   //   4. Sentence boundary: period/paren + space + uppercase, skipped when the
   //      word before the period is a legal abbreviation (Bluebook T6/T10/T7)
+  //   5. Paragraph boundary: \n\s*\n in the original text, recovered via
+  //      transformationMap because the cleaner collapses newlines to spaces (#221)
   let lastBoundaryIndex = -1
   let match: RegExpExecArray | null
+
+  // Check paragraph boundaries via original text (#221).
+  // The default cleaner pipeline replaces \n with space, so paragraph breaks
+  // are invisible in cleanedText. Recover them from originalText by mapping
+  // the search window back to original coordinates.
+  if (options?.originalText && options.transformationMap) {
+    const { originalText, transformationMap } = options
+    const searchOriginalStart =
+      transformationMap.cleanToOriginal.get(searchStart) ?? searchStart
+    const coreOriginalStart =
+      transformationMap.cleanToOriginal.get(coreStart) ?? coreStart
+    if (coreOriginalStart > searchOriginalStart) {
+      const originalWindow = originalText.substring(searchOriginalStart, coreOriginalStart)
+      const paragraphBreakRegex = /\n[ \t\r]*\n/g
+      let pMatch: RegExpExecArray | null
+      while ((pMatch = paragraphBreakRegex.exec(originalWindow)) !== null) {
+        const breakOriginalEnd = searchOriginalStart + pMatch.index + pMatch[0].length
+        // Find the clean position immediately at/after the paragraph break.
+        // The break itself collapses to a space; the next non-whitespace char
+        // is the start of the new paragraph in cleanedText.
+        let cleanPos: number | undefined
+        for (let off = 0; off < 10; off++) {
+          cleanPos = transformationMap.originalToClean.get(breakOriginalEnd + off)
+          if (cleanPos !== undefined) break
+        }
+        if (cleanPos !== undefined && cleanPos >= searchStart && cleanPos <= coreStart) {
+          const relIndex = cleanPos - searchStart
+          if (relIndex > lastBoundaryIndex) {
+            lastBoundaryIndex = relIndex
+          }
+        }
+      }
+    }
+  }
 
   // Check citation boundaries (digit-period-space)
   CITATION_BOUNDARY_REGEX.lastIndex = 0
   while ((match = CITATION_BOUNDARY_REGEX.exec(precedingText)) !== null) {
-    lastBoundaryIndex = match.index + match[0].length
+    const boundaryEnd = match.index + match[0].length
+    if (boundaryEnd > lastBoundaryIndex) {
+      lastBoundaryIndex = boundaryEnd
+    }
   }
 
   // Check Id. boundaries (#182)
@@ -909,12 +966,12 @@ export function extractCaseName(
       // If the plaintiff contains lowercase non-connector words (e.g., "The court cited Smith"),
       // it captured sentence context. Trim from the left to the first valid party name start.
       //
-      // Two conditions must both hold for trimming to apply:
-      //   1. The plaintiff is not a valid party name (contains lowercase non-connector words)
-      //   2. The plaintiff does NOT start with a proper capitalized word (uppercase-initial,
-      //      non-connector). If the first word is already a capitalized party name word, the name
-      //      is correctly anchored — internal qualifiers like "d/b/a" or "aka" belong to the name
-      //      and should be left for downstream normalization, not trimmed away.
+      // The firstWordIsProperName guard preserves the original plaintiff when the
+      // first word is a real party name and the lowercase content is an internal
+      // qualifier ("Smith d/b/a Old Bob's Diner"). Without an internal-qualifier
+      // marker, a capitalized first word alone is NOT enough to suppress trimming —
+      // sentence-initial prepositions like "Under", "Pursuant", "Following" would
+      // otherwise be preserved as if they were proper nouns (#223).
       if (!isLikelyPartyName(plaintiff)) {
         const words = plaintiff.split(/\s+/)
         const firstWord = words[0] ?? ""
@@ -922,7 +979,8 @@ export function extractCaseName(
         const firstWordIsProperName =
           /^[A-Z]/.test(firstWord) &&
           !PARTY_NAME_CONNECTORS.has(firstWordClean) &&
-          !SENTENCE_INITIAL_WORDS.has(firstWordClean)
+          !SENTENCE_INITIAL_WORDS.has(firstWordClean) &&
+          INTERNAL_QUALIFIER_REGEX.test(plaintiff)
         if (!firstWordIsProperName) {
           // Check if the prefix starts with a signal word (See, See also, But see, etc.).
           // If so, keep it — extractPartyNames handles signal stripping downstream.
@@ -943,7 +1001,21 @@ export function extractCaseName(
         }
       }
 
-      const caseName = `${plaintiff} v. ${vMatch[2].trim()}`
+      // Detect consolidated captions: vMatch[0] contains 2+ "v." anchors.
+      // The non-greedy regex defendant (group 2) is anchored at the trailing
+      // ",$" and so absorbs downstream comma-separated caption segments
+      // including their own "v." anchors (#222). Recovery: truncate the
+      // defendant at its first comma to keep just the first "X v. Y" pair.
+      const vAnchorMatches = vMatch[0].match(/\bv(?:s)?\.\s/g)
+      let defendantText = vMatch[2].trim()
+      if (vAnchorMatches && vAnchorMatches.length >= 2) {
+        const firstCommaInDefendant = vMatch[2].indexOf(",")
+        if (firstCommaInDefendant !== -1) {
+          defendantText = vMatch[2].substring(0, firstCommaInDefendant).trim()
+        }
+      }
+
+      const caseName = `${plaintiff} v. ${defendantText}`
       const nameStart = adjustedSearchStart + vMatch.index + trimOffset
       return { caseName, nameStart }
     }
@@ -1460,6 +1532,7 @@ export function extractCase(
   token: Token,
   transformationMap: TransformationMap,
   cleanedText?: string,
+  originalText?: string,
 ): FullCaseCitation {
   const { text, span } = token
 
@@ -1729,7 +1802,10 @@ export function extractCase(
   // Phase 6: Extract case name via backward search
   let caseNameResult: ReturnType<typeof extractCaseName> | undefined
   if (cleanedText) {
-    caseNameResult = extractCaseName(cleanedText, span.cleanStart)
+    caseNameResult = extractCaseName(cleanedText, span.cleanStart, undefined, {
+      originalText,
+      transformationMap,
+    })
     if (caseNameResult) {
       caseName = caseNameResult.caseName
 

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -320,14 +320,14 @@ export function extractCitations(
         } else if (token.patternId === "shortFormCase") {
           citation = extractShortFormCase(token, transformationMap)
         } else {
-          citation = extractCase(token, transformationMap, cleaned)
+          citation = extractCase(token, transformationMap, cleaned, text)
         }
         break
       case "docket": {
         // Docket extractor returns undefined when no case-name anchor is
         // found — the bare "No. <N> (<court> <year>)" shape is too generic
         // to surface without context.
-        const result = extractDocket(token, transformationMap, cleaned)
+        const result = extractDocket(token, transformationMap, cleaned, text)
         if (!result) continue
         citation = result
         break
@@ -406,6 +406,13 @@ export function extractCitations(
   // Three-phase approach: match signals → union chains → aggregate entries.
   // Invariant: citations are in text order (guaranteed by token-order processing above).
   linkSubsequentHistory(citations)
+
+  // Step 4.55: Inherit case name from chain root for subsequent-history children (#224).
+  // Per Bluebook 10.7, all citations in a history chain reference one case.
+  // Without this, extractCaseName scans back from the child, captures the
+  // parent cite + connector ("Smith v. Doe, 100 F.3d 200 (...), aff'd"),
+  // and produces a nonsense caseName.
+  inheritSubsequentHistoryCaseName(citations)
 
   // Step 4.75: Detect string citation groups (semicolon-separated)
   detectStringCitations(citations, cleaned)
@@ -547,5 +554,55 @@ function linkSubsequentHistory(citations: Citation[]): void {
     }
 
     rootCitation.subsequentHistoryEntries = allEntries
+  }
+}
+
+/**
+ * Inherit case name fields from the chain root for subsequent-history children.
+ *
+ * In a chain like `<full cite A>, modified on other grounds, <full cite B>`,
+ * citation B has no preceding case-name string in the document — it implicitly
+ * shares A's case name (Bluebook Rule 10.7). The default case-name scanner
+ * walks left from B and captures all of A's text plus the history connector.
+ *
+ * After `linkSubsequentHistory` has set `subsequentHistoryOf` back-pointers,
+ * this pass overwrites the child's case-name fields with the chain root's,
+ * clears component spans (the child has no anchor), and trims `fullSpan`
+ * back to the child's own citation core.
+ *
+ * Closes #224.
+ */
+function inheritSubsequentHistoryCaseName(citations: Citation[]): void {
+  for (const child of citations) {
+    if (child.type !== "case") continue
+    if (!child.subsequentHistoryOf) continue
+    const parent = citations[child.subsequentHistoryOf.index]
+    if (!parent || parent.type !== "case") continue
+    if (!parent.caseName) continue
+
+    child.caseName = parent.caseName
+    child.plaintiff = parent.plaintiff
+    child.defendant = parent.defendant
+    child.plaintiffNormalized = parent.plaintiffNormalized
+    child.defendantNormalized = parent.defendantNormalized
+    child.proceduralPrefix = parent.proceduralPrefix
+
+    if (child.spans) {
+      child.spans.caseName = undefined
+      child.spans.plaintiff = undefined
+      child.spans.defendant = undefined
+    }
+
+    // Trim fullSpan to the child's own citation core. extractCaseName had
+    // anchored fullSpan at the parent's case name; that's not the child's
+    // text. Keep the original cleanEnd/originalEnd (parenthetical end).
+    if (child.fullSpan) {
+      child.fullSpan = {
+        cleanStart: child.span.cleanStart,
+        cleanEnd: child.fullSpan.cleanEnd,
+        originalStart: child.span.originalStart,
+        originalEnd: child.fullSpan.originalEnd,
+      }
+    }
   }
 }

--- a/src/extract/extractDocket.ts
+++ b/src/extract/extractDocket.ts
@@ -56,6 +56,7 @@ export function extractDocket(
   token: Token,
   transformationMap: TransformationMap,
   cleanedText: string,
+  originalText?: string,
 ): DocketCitation | undefined {
   const { text, span } = token
 
@@ -70,7 +71,10 @@ export function extractDocket(
   // Backward case-name search — anchor for disambiguation. Without a
   // case-name we don't emit a citation: a bare "No. 51 (N.Y. 2023)" lacks
   // the context needed to be confident this is a citation at all.
-  const caseNameResult = extractCaseName(cleanedText, span.cleanStart)
+  const caseNameResult = extractCaseName(cleanedText, span.cleanStart, undefined, {
+    originalText,
+    transformationMap,
+  })
   if (!caseNameResult) return undefined
 
   // The case-name extractor's V_CASE_NAME_REGEX requires "Party v. Party"

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export type {
   ConstitutionalCitation,
   ConstitutionalComponentSpans,
   CourtInference,
+  DocketCitation,
   ExtractorMap,
   FederalRegisterCitation,
   FederalRegisterComponentSpans,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export type {
   CitationType,
   ConstitutionalCitation,
   CourtInference,
+  DocketCitation,
   ExtractorMap,
   FederalRegisterCitation,
   FullCaseCitation,

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -2552,4 +2552,108 @@ describe("phantom-citation suppression (#196)", () => {
   })
 })
 
+describe("case name scanback cluster (#221, #222, #223, #224)", () => {
+  describe("#221: paragraph boundaries halt the scanback", () => {
+    it("does not cross a \\n\\n paragraph break above the case name", () => {
+      const text = `B. Comparative Fault and Contributory Negligence
+
+California adopted comparative fault in Li v. Yellow Cab Co., 13 Cal.3d 804, 813 (1975).`
+      const cits = extractCitations(text)
+      const cite = cits.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBe("Li v. Yellow Cab Co.")
+      }
+    })
+
+    it("does not cross a paragraph break above an ALL-CAPS heading", () => {
+      const text = `INTENTIONAL INFLICTION OF EMOTIONAL DISTRESS
+
+New York first recognized IIED as a cognizable cause of action in Fischer v. Maloney, 43 N.Y.2d 553, 557 (1978).`
+      const cits = extractCitations(text)
+      const cite = cits.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBe("Fischer v. Maloney")
+      }
+    })
+  })
+
+  describe("#222: consolidated captions do not produce multi-segment caseName", () => {
+    it("returns a single-segment caption when multiple v.-anchors precede the cite", () => {
+      const text = `In Matter of New York City Asbestos Litigation, Doris Kay Dummitt v. A.W. Chesterton, Matter of Eighth Judicial District Asbestos Litigation, Joann H. Suttner v. A.W. Chesterton Company, 27 N.Y.3d 765, 787 (2016), the court held that successor-liability principles apply.`
+      const cits = extractCitations(text)
+      const cite = cits.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        // Acceptable canonical caption: either the leading "Matter of …" segment
+        // or the first "X v. Y" segment. The invariant is that the second/third
+        // segments must NOT be concatenated in.
+        expect(cite.caseName).not.toMatch(/Joann H\. Suttner/)
+        expect(cite.caseName).not.toMatch(/, Matter of Eighth/)
+      }
+    })
+  })
+
+  describe("#223: lead-in clauses are trimmed off the plaintiff", () => {
+    it("trims 'Under the controlling authority of the Court of Appeals in'", () => {
+      const text = `Under the controlling authority of the Court of Appeals in Dormitory Auth. of the State of N.Y. v. Samson Constr. Co., 30 N.Y.3d 704, 708 (2018), the rule is settled.`
+      const cits = extractCitations(text)
+      const cite = cits.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBe("Dormitory Auth. of the State of N.Y. v. Samson Constr. Co.")
+      }
+    })
+
+    it("trims 'As the Supreme Court emphasized in'", () => {
+      const text = `As the Supreme Court emphasized in Bell Atlantic Corp. v. Twombly, 550 U.S. 544, 570 (2007), pleading must be plausible.`
+      const cits = extractCitations(text)
+      const cite = cits.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBe("Bell Atlantic Corp. v. Twombly")
+      }
+    })
+
+    it("trims 'Pursuant to the rule announced in'", () => {
+      const text = `Pursuant to the rule announced in Mathews v. Eldridge, 424 U.S. 319, 335 (1976), three factors apply.`
+      const cits = extractCitations(text)
+      const cite = cits.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.caseName).toBe("Mathews v. Eldridge")
+      }
+    })
+  })
+
+  describe("#224: subsequent-history chains share a caseName", () => {
+    it("'modified on other grounds' chain — both cites share the original caseName", () => {
+      const text = `The court applied Corsello v. Verizon N.Y., Inc., 77 A.D.3d 344, 368 (2d Dep't 2010), modified on other grounds, 18 N.Y.3d 777 (2012), to find the claim time-barred.`
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(2)
+      if (cases[0]?.type === "case") {
+        expect(cases[0].caseName).toBe("Corsello v. Verizon N.Y., Inc.")
+      }
+      if (cases[1]?.type === "case") {
+        expect(cases[1].caseName).toBe("Corsello v. Verizon N.Y., Inc.")
+      }
+    })
+
+    it("'aff'd' chain — both cites share the original caseName", () => {
+      const text = `The Court relied on Smith v. Doe, 100 F.3d 200, 205 (2d Cir. 1996), aff'd, 200 F.3d 300 (2d Cir. 1997), to reach this result.`
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(2)
+      if (cases[0]?.type === "case") {
+        expect(cases[0].caseName).toBe("Smith v. Doe")
+      }
+      if (cases[1]?.type === "case") {
+        expect(cases[1].caseName).toBe("Smith v. Doe")
+      }
+    })
+  })
+})
+
 


### PR DESCRIPTION
## Summary

Lands five targeted fixes in `extractCaseName` (and one trivial type re-export). All four bug families slipped past the prior April 10 fix that added `isLikelyPartyName` — the offending text in each case is shaped from capitalized words and connectors that the validator accepts. Rather than rewrite the scanback, this PR layers four small deterministic fixes, each scoped to its symptom.

- **#220** — export `DocketCitation` type from package entry. One-line re-export change.
- **#221** — stop the case-name scanback at `\n\n` paragraph boundaries. The default cleaner collapses newlines, so paragraph positions are recovered from the original text via the `transformationMap` (new optional 4th arg threaded through `extractCase` / `extractDocket`).
- **#222** — detect consolidated captions (multiple `v.` anchors in one match) and truncate the defendant at its first comma to keep just the first `X v. Y` pair.
- **#223** — trim lead-in clauses off the plaintiff. Drop `"in"` from `PARTY_NAME_CONNECTORS` (almost always a prose preposition) and tighten the `firstWordIsProperName` guard so it only fires when an internal qualifier (`d/b/a`, `a/k/a`, `f/k/a`, `n/k/a`) is present.
- **#224** — in subsequent-history chains, copy the chain root's case name onto each child citation per Bluebook 10.7. New post-pass `inheritSubsequentHistoryCaseName` runs after the existing `linkSubsequentHistory` step.

## Test plan

- [x] All 8 new regression tests in the `case name scanback cluster (#221, #222, #223, #224)` describe block pass.
- [x] Full vitest suite (79 files, 228 in extractCase) passes — no regressions, including the existing `sentence context trimming (#168, #169)` and party-normalization tests (the `"aka"`-stripping test in particular, which the guard refinement initially regressed before adding `aka`/`a/k/a` variants to the qualifier regex).
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` produces dist with `DocketCitation` in the type re-export list.

Closes #220, closes #221, closes #222, closes #223, closes #224.

🤖 Generated with [Claude Code](https://claude.com/claude-code)