### PR TITLE
fix: normalizePartyName strips slash-alias variants f/k/a, n/k/a, a/k/a (#240)

### DIFF
--- a/.changeset/party-name-slash-aliases.md
+++ b/.changeset/party-name-slash-aliases.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+fix: normalizePartyName strips slash-alias variants `f/k/a`, `n/k/a`, `a/k/a` (#240)
+
+Case captions commonly use slash-form party-name aliases to indicate prior or alternative names (e.g., `Acme Corp. f/k/a Beta Inc. v. Jones`). The case-name extractor already preserves these in the full caseName via `INTERNAL_QUALIFIER_REGEX`, but `normalizePartyName` only stripped the `d/b/a` slash form and the bare-word `aka`. The forms `f/k/a` (formerly known as), `n/k/a` (now known as), and `a/k/a` (also known as) leaked into `plaintiffNormalized`/`defendantNormalized`, producing canonical-form values like `"acme corp. f/k/a beta"` instead of `"acme"`.
+
+Combines all four slash-form aliases into a single strip rule so the canonical form is the head-of-name only. Estimated corpus impact: ~96k captions per the cross-jurisdictional parser audit (`docs/research/2026-05-10-citation-style-quirks.md` §M, government-agencies + entity-forms research).
+
+Adds 4 regression tests covering each alias variant with both `caseName` preservation and `plaintiffNormalized` stripping assertions.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1408,7 +1408,7 @@ function classifyParenthetical(raw: string):
  * Normalize party name for matching by removing legal noise.
  * Normalization pipeline:
  * 1. Strip "et al." (case-insensitive)
- * 2. Strip "d/b/a" and everything after (case-insensitive)
+ * 2. Strip slash-aliases "d/b/a", "f/k/a", "n/k/a", "a/k/a" and everything after
  * 3. Strip "aka" and everything after (case-insensitive, word boundary)
  * 4. Strip trailing corporate suffixes (Inc., LLC, Corp., Ltd., Co., LLP, LP, P.C.) - iterative
  * 5. Strip leading articles (The, A, An)
@@ -1431,8 +1431,10 @@ function normalizePartyName(name: string): string {
   // Strip "et al." (with or without period, case-insensitive)
   normalized = normalized.replace(/\bet\s+al\.?/gi, "")
 
-  // Strip "d/b/a" and everything after it (case-insensitive)
-  normalized = normalized.replace(/\s+d\/b\/a\b.*/gi, "")
+  // Strip slash-alias variants ("d/b/a", "f/k/a", "n/k/a", "a/k/a") and
+  // everything after them. Matches the slash forms produced by Bluebook-style
+  // captions; the non-slash "aka" form is handled below (#240).
+  normalized = normalized.replace(/\s+(?:d\/b\/a|[fna]\/k\/a)\b.*/gi, "")
 
   // Strip "aka" and everything after it (case-insensitive, word boundary)
   normalized = normalized.replace(/\s+aka\b.*/gi, "")

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -1661,6 +1661,60 @@ describe("party name extraction (Phase 7)", () => {
       }
     })
 
+    describe("slash-alias party-name aliases (#240)", () => {
+      // d/b/a, f/k/a, n/k/a, a/k/a are slash-form party-name aliases that appear
+      // mid-caption (~96k corpus matches). The full caseName must be preserved
+      // verbatim with the alias clause intact; plaintiffNormalized strips it.
+
+      it('preserves "f/k/a" in caseName and strips it in plaintiffNormalized', () => {
+        const citations = extractCitations(
+          "Acme Corp. f/k/a Beta Inc. v. Jones, 500 F.3d 100 (2d Cir. 2020)",
+        )
+        expect(citations).toHaveLength(1)
+        if (citations[0].type === "case") {
+          expect(citations[0].caseName).toBe("Acme Corp. f/k/a Beta Inc. v. Jones")
+          expect(citations[0].plaintiff).toBe("Acme Corp. f/k/a Beta Inc.")
+          expect(citations[0].plaintiffNormalized).toBe("acme")
+        }
+      })
+
+      it('preserves "d/b/a" in caseName and strips it in plaintiffNormalized', () => {
+        const citations = extractCitations(
+          "Smith d/b/a Old Bob's Diner v. Roe, 100 U.S. 1 (2020)",
+        )
+        expect(citations).toHaveLength(1)
+        if (citations[0].type === "case") {
+          expect(citations[0].caseName).toBe("Smith d/b/a Old Bob's Diner v. Roe")
+          expect(citations[0].plaintiff).toBe("Smith d/b/a Old Bob's Diner")
+          expect(citations[0].plaintiffNormalized).toBe("smith")
+        }
+      })
+
+      it('preserves "n/k/a" in caseName and strips it in plaintiffNormalized', () => {
+        const citations = extractCitations(
+          "Doe n/k/a Doe-Smith v. State, 200 U.S. 2 (2020)",
+        )
+        expect(citations).toHaveLength(1)
+        if (citations[0].type === "case") {
+          expect(citations[0].caseName).toBe("Doe n/k/a Doe-Smith v. State")
+          expect(citations[0].plaintiff).toBe("Doe n/k/a Doe-Smith")
+          expect(citations[0].plaintiffNormalized).toBe("doe")
+        }
+      })
+
+      it('preserves "a/k/a" in caseName and strips it in plaintiffNormalized', () => {
+        const citations = extractCitations(
+          "Acme LLC a/k/a Acme Holdings v. Beta Corp., 300 F.3d 200 (9th Cir. 2020)",
+        )
+        expect(citations).toHaveLength(1)
+        if (citations[0].type === "case") {
+          expect(citations[0].caseName).toBe("Acme LLC a/k/a Acme Holdings v. Beta Corp.")
+          expect(citations[0].plaintiff).toBe("Acme LLC a/k/a Acme Holdings")
+          expect(citations[0].plaintiffNormalized).toBe("acme")
+        }
+      })
+    })
+
     it('strips leading article "The"', () => {
       const citations = extractCitations("The Ford Motor Co. v. Smith, 500 F.2d 123 (2020)")
       expect(citations).toHaveLength(1)


### PR DESCRIPTION
## Summary

Closes #240.

- Adds `f/k/a`, `n/k/a`, `a/k/a` to the `normalizePartyName` strip rule (combined with the existing `d/b/a` form into a single regex).
- Adds 4 regression tests covering each slash-form alias with both `caseName` preservation and `plaintiffNormalized` stripping assertions.

The case-name extractor already preserved slash-form party-name aliases in the full caseName via the existing `INTERNAL_QUALIFIER_REGEX` integration (line 311 / line 1070), so no extraction-side change was needed. The gap was strictly in canonicalization — only `d/b/a` and the bare-word `aka` were stripped, leaving `f/k/a Beta Inc.`-style clauses leaking into the normalized form.

Estimated corpus impact: ~96k captions per the 2026-05-10 cross-jurisdictional parser audit (`docs/research/2026-05-10-citation-style-quirks.md` §M).

## Test plan

- [x] 4 new tests in `tests/extract/extractCase.test.ts` covering `d/b/a`, `f/k/a`, `n/k/a`, `a/k/a` — each asserts `caseName` preservation, `plaintiff` raw value, and `plaintiffNormalized` stripping
- [x] Existing `strips "d/b/a" from party name` and `strips "aka" from party name` regression tests still pass
- [x] `pnpm exec vitest run` — 1926 passed, 9 skipped (was 1922 + 4 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 163 pre-existing warnings (no new warnings, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)