### PR TITLE
fix: generalize federal-reporter pattern + pre-register future editions (#234)

### DIFF
--- a/.changeset/reporter-edition-future-proofing.md
+++ b/.changeset/reporter-edition-future-proofing.md
@@ -1,0 +1,30 @@
+---
+"eyecite-ts": patch
+---
+
+fix: generalize federal-reporter pattern and pre-register future editions in COMMON_REPORTERS (#234)
+
+The `federal-reporter` and `supreme-court` tokenization regexes hard-coded
+edition suffixes (`F.|F.2d|F.3d|F.4th|F.Supp.*`, `L.Ed.|L.Ed.2d`). The broad
+`state-reporter` fallback already caught future formats like `F.5th` and
+`Cal.6th`, so extraction itself did not fail — but the missing entries in
+`COMMON_REPORTERS` cost the +0.3 reporter-match confidence boost, leaving
+`100 F.5th 200 (9th Cir. 2025)` at 0.65 confidence vs. 0.95 for `100 F.4th 200`.
+
+Two changes, both defensive:
+
+1. **Generalized regex edition suffix**: replace the explicit enumeration with
+   `(?:\d+(?:st|nd|rd|th)|2d|3d)?` so any ordinal — including `F.5th`, `F.10th`,
+   `F.Supp.5th`, `L.Ed.3d` — is captured by the precise federal/Supreme Court
+   patterns rather than falling through to the state-reporter fallback.
+
+2. **Pre-registered future editions in `COMMON_REPORTERS`**: added the next
+   one-to-two editions for every series already in the set (F.5th–F.7th,
+   F.Supp.5th–6th, P.4th, A.4th, N.E.4th, N.W.3d, S.E.3d, S.W.4th, So.4th,
+   L.Ed.3d) so confidence scoring stays accurate the moment a court adopts
+   them — no emergency patch needed.
+
+Adds 7 regression tests: 2 assert confidence parity between `F.5th` / `F.6th`
+and `F.4th`, 2 assert clean extraction of future state-reporter editions
+(`Cal.6th`, `Cal.7th`) via the broad fallback, and 3 are regression controls
+for existing editions (`F.4th`, `F.3d`, `F.2d`).

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -78,39 +78,57 @@ const MONTH_PATTERN =
 const CURRENT_YEAR = new Date().getFullYear()
 
 /** Common US reporters for confidence boost. Exact match to avoid substring false positives.
- *  Shared across extractCase and extractShortForms. */
+ *  Shared across extractCase and extractShortForms.
+ *
+ *  Future editions are pre-registered defensively (#234) so the eventual rollout
+ *  of F.5th / N.E.4th / etc. does not silently regress confidence scores. The
+ *  generalized federal-reporter regex captures these formats; this set ensures
+ *  they earn the +0.3 reporter-match boost out of the box. */
 export const COMMON_REPORTERS: ReadonlySet<string> = new Set([
   "F.",
   "F.2d",
   "F.3d",
   "F.4th",
+  "F.5th",
+  "F.6th",
+  "F.7th",
   "U.S.",
   "S. Ct.",
   "L. Ed.",
   "L. Ed. 2d",
+  "L. Ed. 3d",
   "P.",
   "P.2d",
   "P.3d",
+  "P.4th",
   "A.",
   "A.2d",
   "A.3d",
+  "A.4th",
   "N.E.",
   "N.E.2d",
   "N.E.3d",
+  "N.E.4th",
   "N.W.",
   "N.W.2d",
+  "N.W.3d",
   "S.E.",
   "S.E.2d",
+  "S.E.3d",
   "S.W.",
   "S.W.2d",
   "S.W.3d",
+  "S.W.4th",
   "So.",
   "So. 2d",
   "So. 3d",
+  "So. 4th",
   "F. Supp.",
   "F. Supp. 2d",
   "F. Supp. 3d",
   "F. Supp. 4th",
+  "F. Supp. 5th",
+  "F. Supp. 6th",
   "F. App'x",
 ])
 

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -24,15 +24,21 @@ export interface Pattern {
 export const casePatterns: Pattern[] = [
   {
     id: "federal-reporter",
+    // Edition suffix accepts any ordinal ("2d", "3d", or generic "Nth") so the
+    // pattern survives the eventual rollout of F.5th / F.6th / F.Supp.Nth (#234).
+    // F.Supp.* and F.App'x must come before the generic F.* alternative so the
+    // longer prefixes win during alternation.
     regex:
-      /\b(\d+(?:-\d+)?)\s+(F\.|F\.2d|F\.3d|F\.4th|F\.\s?Supp\.|F\.\s?Supp\.\s?2d|F\.\s?Supp\.\s?3d|F\.\s?Supp\.\s?4th|F\.\s?App'x)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
-    description: "Federal Reporter (F., F.2d, F.3d, F.4th, F.Supp., F.App'x, etc.)",
+      /\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+    description: "Federal Reporter (F., F.2d, F.3d, F.Nth, F.Supp., F.App'x, etc.)",
     type: "case",
   },
   {
     id: "supreme-court",
+    // L.Ed. edition suffix accepts any ordinal so a future L.Ed.3d edition does
+    // not silently fall through to the state-reporter fallback (#234).
     regex:
-      /\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?2d)?)\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+      /\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
     description:
       "U.S. Supreme Court reporters (with optional nominative reporter parenthetical)",
     type: "case",

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3026,4 +3026,100 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("reporter edition future-proofing (#234)", () => {
+  // The federal-reporter pattern hard-codes editions (F., F.2d, F.3d, F.4th)
+  // and the COMMON_REPORTERS confidence-boost set mirrors that enumeration.
+  // The state-reporter fallback catches future editions in extraction, but the
+  // missing COMMON_REPORTERS entries cost the +0.3 reporter-boost — so F.5th
+  // gets noticeably lower confidence than F.4th for the same surrounding
+  // context. These tests pin both extraction correctness and confidence parity.
+
+  describe("future federal-reporter editions", () => {
+    it("extracts F.5th as a case citation with the same confidence as F.4th", () => {
+      const f5 = extractCitations("Smith v. Jones, 100 F.5th 200 (9th Cir. 2025).")
+      const f4 = extractCitations("Smith v. Jones, 50 F.4th 1234 (9th Cir. 2024).")
+      const f5Cases = f5.filter((c) => c.type === "case")
+      const f4Cases = f4.filter((c) => c.type === "case")
+      expect(f5Cases).toHaveLength(1)
+      expect(f4Cases).toHaveLength(1)
+      if (f5Cases[0].type === "case" && f4Cases[0].type === "case") {
+        expect(f5Cases[0].volume).toBe(100)
+        expect(f5Cases[0].reporter).toBe("F.5th")
+        expect(f5Cases[0].page).toBe(200)
+        expect(f5Cases[0].confidence).toBe(f4Cases[0].confidence)
+      }
+    })
+
+    it("extracts F.6th as a case citation with the same confidence as F.4th", () => {
+      const f6 = extractCitations("Smith v. Jones, 50 F.6th 999 (D.C. Cir. 2030).")
+      const f4 = extractCitations("Smith v. Jones, 50 F.4th 999 (D.C. Cir. 2030).")
+      const f6Cases = f6.filter((c) => c.type === "case")
+      const f4Cases = f4.filter((c) => c.type === "case")
+      expect(f6Cases).toHaveLength(1)
+      expect(f4Cases).toHaveLength(1)
+      if (f6Cases[0].type === "case" && f4Cases[0].type === "case") {
+        expect(f6Cases[0].volume).toBe(50)
+        expect(f6Cases[0].reporter).toBe("F.6th")
+        expect(f6Cases[0].page).toBe(999)
+        expect(f6Cases[0].confidence).toBe(f4Cases[0].confidence)
+      }
+    })
+  })
+
+  describe("future regional-reporter editions", () => {
+    it("extracts Cal.6th as a case citation", () => {
+      const cits = extractCitations("Doe v. Roe, 1 Cal.6th 50 (Cal. 2027).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].volume).toBe(1)
+        expect(cases[0].reporter).toBe("Cal.6th")
+        expect(cases[0].page).toBe(50)
+      }
+    })
+
+    it("extracts Cal.7th as a case citation", () => {
+      const cits = extractCitations("Doe v. Roe, 10 Cal.7th 500 (Cal. 2040).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].volume).toBe(10)
+        expect(cases[0].reporter).toBe("Cal.7th")
+        expect(cases[0].page).toBe(500)
+      }
+    })
+  })
+
+  describe("regression controls — existing editions still work", () => {
+    it("extracts F.4th (existing)", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 50 F.4th 1234 (D.C. Cir. 2024).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].reporter).toBe("F.4th")
+      }
+    })
+
+    it("extracts F.3d (existing)", () => {
+      const cits = extractCitations("Smith v. Doe, 100 F.3d 200 (2d Cir. 1996).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].reporter).toBe("F.3d")
+      }
+    })
+
+    it("extracts F.2d (existing)", () => {
+      const cits = extractCitations("Smith v. Jones, 500 F.2d 123 (2020).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].reporter).toBe("F.2d")
+      }
+    })
+  })
+})
+
 


### PR DESCRIPTION
## Summary

Closes #234.

### Finding before fix

The original issue claimed `100 F.5th 200` and `1 Cal.6th 50` "currently fail to extract" — but they don't. The broad `state-reporter` fallback regex in `casePatterns.ts:42-43` catches any uppercase-prefixed `<vol> <Reporter> <page>` pattern, so future editions extract cleanly today. What *does* fail is the **confidence score**: `F.5th` is not in `COMMON_REPORTERS` (the offline confidence-boost set), so it gets 0.65 confidence vs. 0.95 for the equivalent `F.4th` citation in the same context.

### Two defensive changes

1. **Generalized edition suffix** in the precise `federal-reporter` and `supreme-court` regexes — `F.5th`/`F.6th`/`F.Supp.Nth`/`L.Ed.3d` now match the specific patterns rather than falling through to the broad state-reporter pattern.

2. **Pre-registered future editions** in `COMMON_REPORTERS` (extractCase.ts) for every series already present: `F.5th–F.7th`, `F.Supp.5th–6th`, `P.4th`, `A.4th`, `N.E.4th`, `N.W.3d`, `S.E.3d`, `S.W.4th`, `So.4th`, `L.Ed.3d`. The +0.3 reporter-match boost now applies the moment a court adopts a new edition — no emergency patch needed.

### Tests

7 new regression tests:
- **2 confidence parity assertions** — `F.5th`/`F.6th` confidence must equal `F.4th` confidence for the same surrounding context. These fail without the COMMON_REPORTERS additions.
- **2 state-reporter future editions** — `Cal.6th`, `Cal.7th` extract cleanly via the broad fallback (no COMMON_REPORTERS entry needed; those state-specific series aren't there anyway).
- **3 regression controls** — `F.4th`, `F.3d`, `F.2d` still extract correctly.

## Test plan

- [x] 7 new tests in `tests/extract/extractCase.test.ts` (under `reporter edition future-proofing (#234)`)
- [x] Existing reporter-edition tests still pass
- [x] `pnpm exec vitest run` — 1933 passed, 9 skipped (was 1926 + 7 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 163 pre-existing warnings (no new warnings, no errors)

## Out of scope

- Adding Cal.6th/N.Y.S.3d-style state-specific reporters to `COMMON_REPORTERS` (that set is federal + regional only by convention; state-reporter confidence-boost is a separate concern)
- Updating `data/reporters.json` (downstream reporters-db data; future editions don't exist in reality yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)