### PR TITLE
fix: procedural prefix expansion (Commonwealth ex rel., In the Interest of, Adoption of, etc.) (#242)

### DIFF
--- a/.changeset/procedural-prefix-expansion.md
+++ b/.changeset/procedural-prefix-expansion.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix: procedural prefix expansion — Commonwealth ex rel., In the Interest of, Adoption of, etc. (#242)
+
+`PROCEDURAL_PREFIX_REGEX` and the parallel `proceduralPrefixes` array in
+`extractPartyNames` recognized only 9 procedural prefixes (`In re`,
+`Ex parte`, `Matter of`, `Estate of`, etc.). Several common family/probate
+and state-practice prefixes were missing, causing captions like `In re
+Marriage of Smith` to lose the `Marriage of` segment, `On Petition of
+P.Q.` to lose the leading `On`, and `Adoption of J.K.` / `Conservatorship
+of L.M.` / `Guardianship of N.O.` to fall through to the broad single-party
+fallback with no `proceduralPrefix` field set.
+
+Adds 7 prefixes (longer forms ordered before shorter ones so alternation
+prefers the longer match):
+
+- `Commonwealth ex rel.` (PA practice)
+- `In the Interest of` (juvenile / family — handles initials-only parties like A.B., J.K.)
+- `In re Marriage of` (CA family — must beat `In re`)
+- `Adoption of`
+- `Conservatorship of` (CA probate)
+- `Guardianship of`
+- `On Petition of` (older form — must beat `Petition of`)
+
+Adds 10 regression tests covering the 7 new prefixes plus 3 existing-prefix
+controls (`In re`, `Petition of`, `Estate of`).

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -276,10 +276,11 @@ const V_CASE_NAME_REGEX =
   /([A-Z][A-Za-z0-9\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9\s.,'&()/-]+?)\s*,\s*$/
 
 /** Procedural prefix case name format.
- *  Longer prefixes listed first so `In the Matter of X` beats `Matter of X`.
- *  See #193. */
+ *  Longer prefixes listed first so `In the Matter of X` beats `Matter of X`,
+ *  `In re Marriage of X` beats `In re X`, and `On Petition of X` beats
+ *  `Petition of X`. See #193, #242. */
 const PROCEDURAL_PREFIX_REGEX =
-  /\b(In\s+the\s+Matter\s+of|In re|Ex parte|Matter of|Estate of|State ex rel\.|United States ex rel\.|Application of|Petition of)\s+([A-Za-z0-9\s.,'&()/-]+?)\s*,\s*$/i
+  /\b(In\s+the\s+Matter\s+of|In\s+re\s+Marriage\s+of|In\s+the\s+Interest\s+of|Commonwealth\s+ex\s+rel\.|In re|Ex parte|Matter of|Estate of|State ex rel\.|United States ex rel\.|Application of|On Petition of|Petition of|Adoption of|Conservatorship of|Guardianship of)\s+([A-Za-z0-9\s.,'&()/-]+?)\s*,\s*$/i
 
 /**
  * Lowercase words that legitimately appear in legal party names.
@@ -1503,17 +1504,26 @@ export function extractPartyNames(caseName: string): {
   signal?: CitationSignal
 } {
   let signal: CitationSignal | undefined
-  // Procedural prefix patterns (anchored to start, case-insensitive)
-  // Longer prefixes first so "In the Matter of X" wins over "Matter of X".
+  // Procedural prefix patterns (anchored to start, case-insensitive).
+  // Longer prefixes first so "In the Matter of X" wins over "Matter of X",
+  // "In re Marriage of X" wins over "In re X", and "On Petition of X" wins
+  // over "Petition of X" (#242).
   const proceduralPrefixes = [
     "In the Matter of",
+    "In re Marriage of",
+    "In the Interest of",
+    "Commonwealth ex rel.",
     "In re",
     "Ex parte",
     "Matter of",
     "State ex rel.",
     "United States ex rel.",
     "Application of",
+    "On Petition of",
     "Petition of",
+    "Adoption of",
+    "Conservatorship of",
+    "Guardianship of",
     "Estate of",
   ]
 

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3026,6 +3026,128 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("procedural prefix expansion (#242)", () => {
+  // PROCEDURAL_PREFIX_REGEX covered In re, Ex parte, Matter of, Estate of,
+  // State ex rel., United States ex rel., Application of, Petition of. Many
+  // common procedural prefixes were missing, so captions like "In re Marriage
+  // of Smith" lost everything before the second word and "In the Interest of
+  // A.B." collapsed to "A.B." (the initials-only party form). All 7 prefixes
+  // below appear in real opinions across PA, NJ, CA, MA, NY, VT.
+
+  it("recognizes 'Commonwealth ex rel.' as a procedural plaintiff (PA)", () => {
+    const cits = extractCitations(
+      "See Commonwealth ex rel. Smith v. Jones, 100 Pa. 1 (2020).",
+    )
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].caseName).toBe("Commonwealth ex rel. Smith v. Jones")
+    }
+  })
+
+  it("recognizes 'In the Interest of' with initials-only party (juvenile)", () => {
+    const cits = extractCitations(
+      "See In the Interest of A.B., a Minor, 200 N.J. 1 (2020).",
+    )
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].caseName).toBe("In the Interest of A.B., a Minor")
+    }
+  })
+
+  it("recognizes 'In re Marriage of' (CA family) — beats 'In re' alone", () => {
+    const cits = extractCitations(
+      "See In re Marriage of Smith, 50 Cal.4th 100 (2010).",
+    )
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].caseName).toBe("In re Marriage of Smith")
+      expect(cases[0].proceduralPrefix).toBe("In re Marriage of")
+    }
+  })
+
+  it("recognizes 'Adoption of' with initials-only party", () => {
+    const cits = extractCitations("See Adoption of J.K., 100 Mass. 1 (2020).")
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].caseName).toBe("Adoption of J.K.")
+      expect(cases[0].proceduralPrefix).toBe("Adoption of")
+    }
+  })
+
+  it("recognizes 'Conservatorship of' with initials-only party (CA probate)", () => {
+    const cits = extractCitations(
+      "See Conservatorship of L.M., 1 Cal.5th 50 (2018).",
+    )
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].caseName).toBe("Conservatorship of L.M.")
+      expect(cases[0].proceduralPrefix).toBe("Conservatorship of")
+    }
+  })
+
+  it("recognizes 'Guardianship of' with initials-only party", () => {
+    const cits = extractCitations(
+      "See Guardianship of N.O., 300 N.Y.S.2d 100 (2020).",
+    )
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].caseName).toBe("Guardianship of N.O.")
+      expect(cases[0].proceduralPrefix).toBe("Guardianship of")
+    }
+  })
+
+  it("recognizes 'On Petition of' (older form) — beats 'Petition of' alone", () => {
+    const cits = extractCitations(
+      "See On Petition of P.Q., 100 Vt. 1 (2020).",
+    )
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].caseName).toBe("On Petition of P.Q.")
+      expect(cases[0].proceduralPrefix).toBe("On Petition of")
+    }
+  })
+
+  describe("regression controls — existing prefixes still work", () => {
+    it("still recognizes 'In re'", () => {
+      const cits = extractCitations("See In re Smith, 100 U.S. 1 (2020).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].proceduralPrefix).toBe("In re")
+      }
+    })
+
+    it("still recognizes 'Petition of' (without 'On')", () => {
+      const cits = extractCitations(
+        "See Petition of Smith, 100 U.S. 1 (2020).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].proceduralPrefix).toBe("Petition of")
+      }
+    })
+
+    it("still recognizes 'Estate of'", () => {
+      const cits = extractCitations(
+        "See Estate of Smith, 100 U.S. 1 (2020).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].proceduralPrefix).toBe("Estate of")
+      }
+    })
+  })
+})
+
 describe("reporter edition future-proofing (#234)", () => {
   // The federal-reporter pattern hard-codes editions (F., F.2d, F.3d, F.4th)
   // and the COMMON_REPORTERS confidence-boost set mirrors that enumeration.


### PR DESCRIPTION
## Summary

Closes #242.

`PROCEDURAL_PREFIX_REGEX` and the parallel `proceduralPrefixes` array in `extractPartyNames` recognized only 9 procedural prefixes. Adds 7 common family/probate and state-practice forms with the longer prefixes ordered before shorter ones so the regex alternation prefers the longer match.

### Prefixes added

| Prefix | Failing input | Notes |
| --- | --- | --- |
| `Commonwealth ex rel.` | `Commonwealth ex rel. Smith v. Jones` | PA practice; was working via `V_CASE_NAME_REGEX` but didn't set `proceduralPrefix` |
| `In the Interest of` | `In the Interest of A.B., a Minor` | Juvenile/family with initials-only parties |
| `In re Marriage of` | `In re Marriage of Smith` | CA family — **must be ordered before `In re`** |
| `Adoption of` | `Adoption of J.K.` | |
| `Conservatorship of` | `Conservatorship of L.M.` | CA probate |
| `Guardianship of` | `Guardianship of N.O.` | |
| `On Petition of` | `On Petition of P.Q.` | Older form — **must be ordered before `Petition of`** |

### Tests

10 new tests under `procedural prefix expansion (#242)`:
- 7 new-prefix tests covering each addition (one per acceptance-criteria failing input)
- 3 regression controls (`In re`, `Petition of`, `Estate of`) confirming existing prefixes still work

## Test plan

- [x] `pnpm exec vitest run` — 1943 passed, 9 skipped (was 1933 + 10 new)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 163 pre-existing warnings (no new warnings, no errors)
- [x] Existing procedural-prefix tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)