### PR TITLE
fix: recognize combined ', e.g.' signals (Bluebook Rule 1.3) (#239)

### DIFF
--- a/.changeset/combined-signals.md
+++ b/.changeset/combined-signals.md
@@ -1,0 +1,32 @@
+---
+"eyecite-ts": patch
+---
+
+fix: recognize combined `, e.g.` signals (Bluebook Rule 1.3) — `see, e.g.`, `but see, e.g.`, etc. (#239)
+
+`VALID_SIGNALS` and the `SIGNAL_PATTERNS` lookup in `detectStringCites.ts`
+recognized only the bare introductory signals (`see`, `but see`, `cf`, …),
+not the combined `, e.g.,` forms. Captions like `See, e.g., Smith v. Jones`
+silently fell back to the bare `see` signal because the trailing `, e.g.,`
+between the signal stem and the case name confused the regex anchors.
+
+Three coordinated changes:
+
+1. **`CitationSignal` discriminated union** gains five values: `"e.g."`,
+   `"see, e.g."`, `"see also, e.g."`, `"but see, e.g."`, `"cf., e.g."`,
+   `"but cf., e.g."`. Mirrors `VALID_SIGNALS` in `extractCase.ts`.
+2. **`SIGNAL_PATTERNS` in `detectStringCites.ts`** now lists the combined forms
+   *before* their bare counterparts so the alternation prefers the longer match.
+   Trailing `,?` accommodates the comma that normally separates the signal from
+   the citation.
+3. **`SIGNAL_STRIP_REGEX` in `extractCase.ts`** now allows an optional trailing
+   comma (`,?\s+`) so `See also, e.g.,` strips correctly off the plaintiff in
+   `extractPartyNames`. The signal-lookup checks the un-stripped form first
+   (because combined signals end with a real period that belongs in the
+   canonical signal value) before falling back to the period-stripping path
+   that handles `Cf.` → `cf`.
+
+Adds 5 regression tests covering each combined-signal form plus a non-regression
+control for bare `see`. The `Compare ... with ...` grouping (a related issue
+from #239) is structurally different — it requires multi-citation scope
+linking, not a new signal entry — and is deferred.

--- a/src/extract/detectStringCites.ts
+++ b/src/extract/detectStringCites.ts
@@ -25,7 +25,16 @@ const SIGNAL_PATTERNS: ReadonlyArray<{
 }> = buildSignalPatterns()
 
 function buildSignalPatterns() {
+  // Combined `, e.g.` forms (Bluebook Rule 1.3) come BEFORE their bare-signal
+  // counterparts so the alternation prefers the more specific match. The
+  // trailing `,?` after `e\.g\.` allows the optional comma that typically
+  // separates the signal from the citation (e.g., "See, e.g., Smith v. Jones").
   const raw: ReadonlyArray<{ regex: RegExp; signal: CitationSignal }> = [
+    { regex: /^but\s+cf\.,\s+e\.g\.,?(?=\s|$)/i, signal: "but cf., e.g." },
+    { regex: /^see\s+also,\s+e\.g\.,?(?=\s|$)/i, signal: "see also, e.g." },
+    { regex: /^but\s+see,\s+e\.g\.,?(?=\s|$)/i, signal: "but see, e.g." },
+    { regex: /^cf\.,\s+e\.g\.,?(?=\s|$)/i, signal: "cf., e.g." },
+    { regex: /^see,\s+e\.g\.,?(?=\s|$)/i, signal: "see, e.g." },
     { regex: /^see\s+generally\b/i, signal: "see generally" },
     { regex: /^see\s+also\b/i, signal: "see also" },
     { regex: /^but\s+see\b/i, signal: "but see" },
@@ -35,6 +44,7 @@ function buildSignalPatterns() {
     { regex: /^contra\b/i, signal: "contra" },
     { regex: /^see\b/i, signal: "see" },
     { regex: /^cf\.?(?=\s|$)/i, signal: "cf" },
+    { regex: /^e\.g\.,?(?=\s|$)/i, signal: "e.g." },
   ]
   return raw.map(({ regex, signal }) => ({
     regex,

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -47,17 +47,27 @@ const VALID_SIGNALS = new Set([
   "compare",
   "accord",
   "contra",
+  // Combined `, e.g.` forms (Bluebook Rule 1.3) — must be matched by SIGNAL_PATTERNS
+  // in detectStringCites.ts before the bare-signal forms (#239).
+  "e.g.",
+  "see, e.g.",
+  "see also, e.g.",
+  "but see, e.g.",
+  "cf., e.g.",
+  "but cf., e.g.",
 ])
 
 /**
  * Regex matching any VALID_SIGNALS entry at the start of a string, followed by whitespace.
  * Derived from VALID_SIGNALS to ensure a single source of truth.
  * Multi-word signals are listed first so "See also" matches before "See".
+ * The trailing `,?` accommodates combined `, e.g.` signals (Bluebook Rule 1.3)
+ * whose source-text form has a trailing comma between the signal and citation.
  */
 const SIGNAL_STRIP_REGEX = (() => {
   const sorted = [...VALID_SIGNALS].sort((a, b) => b.length - a.length)
   const alternatives = sorted.map((s) => s.replace(/\s+/g, "\\s+").replace(/\./g, "\\."))
-  return new RegExp(`^(${alternatives.join("|")})\\s+`, "i")
+  return new RegExp(`^(${alternatives.join("|")}),?\\s+`, "i")
 })()
 
 /** Parse a volume string as number when purely numeric, string when hyphenated */
@@ -1614,9 +1624,18 @@ export function extractPartyNames(caseName: string): {
     const signalMatch =
       plaintiff.match(SIGNAL_STRIP_REGEX) ?? plaintiff.match(/^(Also|In(?!\s+re\b))\s+/i)
     if (signalMatch) {
-      const raw = signalMatch[1].toLowerCase().replace(/\.$/, "")
-      if (VALID_SIGNALS.has(raw)) {
-        signal = raw as CitationSignal
+      const lowered = signalMatch[1].toLowerCase()
+      // Combined `, e.g.` signals end with a period that is part of the canonical
+      // form (e.g., "see, e.g."); strip the trailing period only if the lowered
+      // form isn't itself a valid signal (handles "Cf." → "cf" without breaking
+      // "see, e.g." → "see, e.g.").
+      if (VALID_SIGNALS.has(lowered)) {
+        signal = lowered as CitationSignal
+      } else {
+        const stripped = lowered.replace(/\.$/, "")
+        if (VALID_SIGNALS.has(stripped)) {
+          signal = stripped as CitationSignal
+        }
       }
       plaintiff = plaintiff.substring(signalMatch[0].length).trim()
     }

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -43,7 +43,9 @@ export interface Warning {
 
 /**
  * Introductory signal word classification for citation support level.
- * Based on Bluebook signal categories (Rule 1.2).
+ * Based on Bluebook signal categories (Rule 1.2). The `, e.g.` combined
+ * forms (Rule 1.3) carry distinct meaning ("one of many illustrative
+ * authorities") and are tracked separately from the bare signals.
  */
 export type CitationSignal =
   | "see"
@@ -55,6 +57,12 @@ export type CitationSignal =
   | "compare"
   | "accord"
   | "contra"
+  | "e.g."
+  | "see, e.g."
+  | "see also, e.g."
+  | "but see, e.g."
+  | "cf., e.g."
+  | "but cf., e.g."
 
 /**
  * Base fields shared by all citation types.

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -1930,6 +1930,61 @@ describe("signal word extraction", () => {
     expect(caseCite?.plaintiff).toBe("Smith")
     expect(caseCite?.signal).toBe("see")
   })
+
+  describe("combined signals with 'e.g.' (#239)", () => {
+    // The `, e.g.,` interjection between a signal and the citation has both
+    // an internal comma (after the signal stem) and a trailing comma (before
+    // the case name). Without combined-signal support, the case-name backward
+    // scanner gets confused — `e.g.,` looks like noise prefix and the signal
+    // field stays unset.
+
+    it("captures 'see, e.g.' as the signal", () => {
+      const text = "See, e.g., Smith v. Jones, 500 F.2d 123 (9th Cir. 2020)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case") as FullCaseCitation | undefined
+      expect(caseCite).toBeDefined()
+      expect(caseCite?.signal).toBe("see, e.g.")
+      expect(caseCite?.plaintiff).toBe("Smith")
+      expect(caseCite?.defendant).toBe("Jones")
+    })
+
+    it("captures 'but see, e.g.' as the signal", () => {
+      const text =
+        "But see, e.g., Acme Corp. v. Beta Inc., 100 U.S. 1 (2020)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case") as FullCaseCitation | undefined
+      expect(caseCite).toBeDefined()
+      expect(caseCite?.signal).toBe("but see, e.g.")
+      expect(caseCite?.plaintiff).toBe("Acme Corp.")
+    })
+
+    it("captures 'see also, e.g.' as the signal", () => {
+      const text =
+        "See also, e.g., Gamma LLC v. Delta Co., 200 U.S. 2 (2021)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case") as FullCaseCitation | undefined
+      expect(caseCite).toBeDefined()
+      expect(caseCite?.signal).toBe("see also, e.g.")
+      expect(caseCite?.plaintiff).toBe("Gamma LLC")
+    })
+
+    it("captures 'cf., e.g.' as the signal", () => {
+      const text = "Cf., e.g., Smith v. Jones, 500 F.2d 123 (9th Cir. 2020)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case") as FullCaseCitation | undefined
+      expect(caseCite).toBeDefined()
+      expect(caseCite?.signal).toBe("cf., e.g.")
+      expect(caseCite?.plaintiff).toBe("Smith")
+    })
+
+    it("does not regress bare 'see' for non-combined captions", () => {
+      const text = "See Smith v. Jones, 500 F.2d 123 (9th Cir. 2020)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case") as FullCaseCitation | undefined
+      expect(caseCite?.signal).toBe("see")
+      expect(caseCite?.plaintiff).toBe("Smith")
+    })
+  })
 })
 
 describe("nominative reporter support (#49, #16)", () => {


### PR DESCRIPTION
## Summary

Closes #239 (partial — see deferred section).

\`VALID_SIGNALS\` and the \`SIGNAL_PATTERNS\` lookup in \`detectStringCites.ts\` recognized only the bare introductory signals (\`see\`, \`but see\`, \`cf\`, …). Captions like \`See, e.g., Smith v. Jones\` silently fell back to the bare \`see\` signal because the trailing \`, e.g.,\` between the stem and the case name confused the regex anchors.

### Three coordinated changes

1. **\`CitationSignal\` discriminated union** gains 6 values: \`"e.g."\`, \`"see, e.g."\`, \`"see also, e.g."\`, \`"but see, e.g."\`, \`"cf., e.g."\`, \`"but cf., e.g."\`. Mirrors \`VALID_SIGNALS\` in \`extractCase.ts\`.
2. **\`SIGNAL_PATTERNS\` in \`detectStringCites.ts\`** lists the combined forms *before* their bare counterparts so alternation prefers the longer match. Trailing \`,?\` accommodates the comma that normally separates the signal from the citation.
3. **\`SIGNAL_STRIP_REGEX\` in \`extractCase.ts\`** allows an optional trailing comma (\`,?\\s+\`) so \`See also, e.g.,\` strips correctly off the plaintiff in \`extractPartyNames\`. Signal-lookup checks the un-stripped form first (because combined signals end with a real period that belongs in the canonical signal value) before falling back to the period-stripping path that handles \`Cf.\` → \`cf\`.

### Why two paths

eyecite-ts has two signal-detection paths:
- \`extractPartyNames\` (called per citation during case-name extraction) uses \`SIGNAL_STRIP_REGEX\` to strip the signal off the plaintiff candidate.
- \`detectLeadingSignals\` (post-extraction pass) uses \`SIGNAL_PATTERNS\` to set the \`signal\` field on each citation.

Both needed updates: \`SIGNAL_PATTERNS\` for detection, \`SIGNAL_STRIP_REGEX\` for plaintiff cleanup. Without the \`SIGNAL_STRIP_REGEX\` change, \`See also, e.g., Gamma LLC v. Delta Co.\` would set signal correctly via the post-extraction path but leave \`also, e.g.,\` glued to the plaintiff.

## Test plan

- [x] 5 new tests: \`see, e.g.\`, \`but see, e.g.\`, \`see also, e.g.\`, \`cf., e.g.\`, plus non-regression control for bare \`see\`
- [x] \`pnpm exec vitest run\` — 1979 passed, 9 skipped (was 1974 + 5 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 163 pre-existing warnings (no new warnings, no errors)
- [x] Regression: existing 9 bare signals (\`see\`, \`but see\`, \`cf\`, \`compare\`, etc.) still recognized

## Deferred from #239

The \`Compare ... with ...\` grouping (multiple citations sharing a comparison signal scope) is structurally different — it requires multi-citation scope linking, not a new signal entry — and is best handled in a follow-up that extends \`detectStringCitations\` to recognize \`with\` as an intra-group connector. Flagged in the changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)