### PR TITLE
fix: hyphenated public-domain neutral citations (NM, Ohio, NC, MS) (#233)

### DIFF
--- a/.changeset/hyphenated-neutral-citations.md
+++ b/.changeset/hyphenated-neutral-citations.md
@@ -1,0 +1,16 @@
+---
+"eyecite-ts": patch
+---
+
+fix: hyphenated public-domain neutral citations (NM, Ohio, NC, MS) now extract (#233)
+
+The `casePatterns.state-vendor-neutral` regex was whitespace-separated only. Hyphenated public-domain formats used by New Mexico, Ohio, North Carolina, and Mississippi silently produced zero citations.
+
+Two new tokenization patterns in `neutralPatterns.ts`:
+
+- **`state-vendor-neutral-hyphenated`** (3-segment) — `\b(\d{4})-([A-Z][A-Za-z]+)-(\d+)\b/g`. Covers NM (`2010-NMSC-007`, `2012-NMCA-004`, `2015-NMCERT-009`), Ohio (`2024-Ohio-764` — note the mixed-case "Ohio" token), and NC (`2020-NCSC-118`, `2023-NCCOA-450`).
+- **`state-vendor-neutral-hyphenated-ms`** (4-segment) — `\b(\d{4})-([A-Z]+)-(\d+)-([A-Z]+)\b/g`. Covers Mississippi's `year-caseType-number-appellateTrack` form (`2010-CT-01234-SCT`, `2015-CA-00567-COA`). Listed first in the pattern array so the regex engine prefers the longer match when both could fire.
+
+`extractNeutral.ts` extended with a Mississippi-aware parse path. The 4-segment form composes the `court` field as `${caseType}-${appellateTrack}` (e.g., `CT-SCT`) so the single `court` field preserves the full sovereign identifier. The 3-segment hyphenated form falls through to a generalized whitespace-or-hyphen separator regex that also covers the existing UT/WI/IL/WL/LEXIS shapes.
+
+Adds 13 corpus-shaped regression tests in `tests/extract/extractNeutralHyphenated.test.ts`: 3 NM variants, 2 Ohio, 2 NC, 2 MS, and 4 whitespace-separated regression controls (UT, WI, IL, WL) confirming the existing pattern shapes are unaffected.

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -62,25 +62,58 @@ export function extractNeutral(
 ): NeutralCitation {
   const { text, span } = token
 
-  // Parse year-court-documentNumber using regex
-  // Pattern: 4-digit year + court identifier (WL, LEXIS, state codes, etc.) + document number
-  const neutralRegex = /^(\d{4})\s+(.+?)\s+(\d+)$/d
-  const match = neutralRegex.exec(text)
-
-  if (!match) {
-    throw new Error(`Failed to parse neutral citation: ${text}`)
-  }
-
-  const year = Number.parseInt(match[1], 10)
-  const court = match[2]
-  const documentNumber = match[3]
-
+  // Parse year-court-documentNumber. Two-step:
+  // 1. Try the Mississippi 4-segment hyphenated form (#233):
+  //    year-caseType-number-appellateTrack, e.g., "2010-CT-01234-SCT".
+  //    Court is composed as `${caseType}-${appellateTrack}` so the single
+  //    `court` field preserves the full sovereign identifier.
+  // 2. Try the 3-segment hyphenated form (NM/Ohio/NC) or the whitespace form.
+  let year: number
+  let court: string
+  let documentNumber: string
   let spans: NeutralComponentSpans | undefined
-  if (match.indices) {
-    spans = {
-      year: spanFromGroupIndex(span.cleanStart, match.indices[1]!, transformationMap),
-      court: spanFromGroupIndex(span.cleanStart, match.indices[2]!, transformationMap),
-      documentNumber: spanFromGroupIndex(span.cleanStart, match.indices[3]!, transformationMap),
+
+  const msMatch = /^(\d{4})-([A-Z]+)-(\d+)-([A-Z]+)$/d.exec(text)
+  if (msMatch) {
+    year = Number.parseInt(msMatch[1], 10)
+    court = `${msMatch[2]}-${msMatch[4]}`
+    documentNumber = msMatch[3]
+    if (msMatch.indices) {
+      const caseTypeIndices = msMatch.indices[2]!
+      const trackIndices = msMatch.indices[4]!
+      // Span covers the case-type token through the appellate-track token so
+      // the position range reflects the combined court identifier.
+      const courtIndices: [number, number] = [caseTypeIndices[0], trackIndices[1]]
+      spans = {
+        year: spanFromGroupIndex(span.cleanStart, msMatch.indices[1]!, transformationMap),
+        court: spanFromGroupIndex(span.cleanStart, courtIndices, transformationMap),
+        documentNumber: spanFromGroupIndex(
+          span.cleanStart,
+          msMatch.indices[3]!,
+          transformationMap,
+        ),
+      }
+    }
+  } else {
+    // 3-segment forms: hyphenated (NM/Ohio/NC) or whitespace (UT/WI/IL/WL).
+    const neutralRegex = /^(\d{4})[-\s]+(.+?)[-\s]+(\d+)$/d
+    const match = neutralRegex.exec(text)
+    if (!match) {
+      throw new Error(`Failed to parse neutral citation: ${text}`)
+    }
+    year = Number.parseInt(match[1], 10)
+    court = match[2]
+    documentNumber = match[3]
+    if (match.indices) {
+      spans = {
+        year: spanFromGroupIndex(span.cleanStart, match.indices[1]!, transformationMap),
+        court: spanFromGroupIndex(span.cleanStart, match.indices[2]!, transformationMap),
+        documentNumber: spanFromGroupIndex(
+          span.cleanStart,
+          match.indices[3]!,
+          transformationMap,
+        ),
+      }
     }
   }
 

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -15,6 +15,27 @@ import type { Pattern } from "./casePatterns"
 
 export const neutralPatterns: Pattern[] = [
   {
+    // Mississippi 4-segment form: year-caseType-number-appellateTrack. Listed
+    // before the 3-segment hyphenated pattern so it wins on the longer match
+    // (e.g., "2010-CT-01234-SCT"). (#233)
+    id: "state-vendor-neutral-hyphenated-ms",
+    regex: /\b(\d{4})-([A-Z]+)-(\d+)-([A-Z]+)\b/g,
+    description:
+      'Mississippi 4-segment vendor-neutral (e.g., "2010-CT-01234-SCT", "2015-CA-00567-COA")',
+    type: "neutral",
+  },
+  {
+    // 3-segment hyphenated form used by NM (NMSC, NMCA, NMCERT), Ohio
+    // (mixed-case "Ohio" token), and NC (NCSC, NCCOA). The court token starts
+    // with an uppercase letter and may contain lowercase (so the Ohio token
+    // matches). (#233)
+    id: "state-vendor-neutral-hyphenated",
+    regex: /\b(\d{4})-([A-Z][A-Za-z]+)-(\d+)\b/g,
+    description:
+      'Hyphenated vendor-neutral (e.g., "2010-NMSC-007", "2024-Ohio-764", "2020-NCSC-118")',
+    type: "neutral",
+  },
+  {
     id: "state-vendor-neutral",
     regex: /\b(\d{4})\s+([A-Z]{2}(?:\s+App\.?)?)\s+(\d+)\b/g,
     description:

--- a/tests/extract/extractNeutralHyphenated.test.ts
+++ b/tests/extract/extractNeutralHyphenated.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { NeutralCitation } from "@/types/citation"
+
+/**
+ * Hyphenated neutral citations (#233) — public-domain "vendor-neutral" formats
+ * used by New Mexico (NMSC, NMCA, NMCERT), Ohio (Ohio-N), North Carolina
+ * (NCSC, NCCOA), and Mississippi (year-CT-NNNNN-track).
+ *
+ * The existing `state-vendor-neutral` pattern is whitespace-separated only.
+ * These tests pin down that hyphenated formats — which represent a sizeable
+ * share of public-domain state caselaw — extract as neutral citations with
+ * year, court, and documentNumber populated.
+ */
+describe("hyphenated neutral citations (#233)", () => {
+  describe("New Mexico — NMSC / NMCA / NMCERT", () => {
+    it("extracts '2010-NMSC-007' (NM Supreme Court)", () => {
+      const cits = extractCitations("The court held in 2010-NMSC-007 that the rule applies.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2010)
+      expect(neutrals[0].court).toBe("NMSC")
+      expect(neutrals[0].documentNumber).toBe("007")
+    })
+
+    it("extracts '2012-NMCA-004' (NM Court of Appeals)", () => {
+      const cits = extractCitations("State v. Dickert, 2012-NMCA-004.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2012)
+      expect(neutrals[0].court).toBe("NMCA")
+      expect(neutrals[0].documentNumber).toBe("004")
+    })
+
+    it("extracts '2015-NMCERT-009' (NM cert. granted record)", () => {
+      const cits = extractCitations("See 2015-NMCERT-009.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2015)
+      expect(neutrals[0].court).toBe("NMCERT")
+      expect(neutrals[0].documentNumber).toBe("009")
+    })
+  })
+
+  describe("Ohio (mixed-case court token)", () => {
+    it("extracts '2024-Ohio-764'", () => {
+      const cits = extractCitations("Smith v. Ohio State Univ., 2024-Ohio-764.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2024)
+      expect(neutrals[0].court).toBe("Ohio")
+      expect(neutrals[0].documentNumber).toBe("764")
+    })
+
+    it("extracts '2010-Ohio-5012'", () => {
+      const cits = extractCitations("In State ex rel. Doe, 2010-Ohio-5012.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2010)
+      expect(neutrals[0].court).toBe("Ohio")
+      expect(neutrals[0].documentNumber).toBe("5012")
+    })
+  })
+
+  describe("North Carolina — NCSC / NCCOA", () => {
+    it("extracts '2020-NCSC-118'", () => {
+      const cits = extractCitations("Doe v. Roe, 2020-NCSC-118.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2020)
+      expect(neutrals[0].court).toBe("NCSC")
+      expect(neutrals[0].documentNumber).toBe("118")
+    })
+
+    it("extracts '2023-NCCOA-450' (NC Court of Appeals)", () => {
+      const cits = extractCitations("See 2023-NCCOA-450.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2023)
+      expect(neutrals[0].court).toBe("NCCOA")
+      expect(neutrals[0].documentNumber).toBe("450")
+    })
+  })
+
+  describe("Mississippi — 4-segment year-case-number-track", () => {
+    it("extracts '2010-CT-01234-SCT' (Supreme Court track)", () => {
+      const cits = extractCitations("State v. Smith, 2010-CT-01234-SCT.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2010)
+      // Court combines the case-type token with the appellate track so the
+      // single `court` field preserves the full sovereign identifier.
+      expect(neutrals[0].court).toBe("CT-SCT")
+      expect(neutrals[0].documentNumber).toBe("01234")
+    })
+
+    it("extracts '2015-CA-00567-COA' (Court of Appeals track)", () => {
+      const cits = extractCitations("Doe v. Roe, 2015-CA-00567-COA.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2015)
+      expect(neutrals[0].court).toBe("CA-COA")
+      expect(neutrals[0].documentNumber).toBe("00567")
+    })
+  })
+
+  describe("regression — whitespace-separated neutrals still work", () => {
+    it("extracts '2007 UT 49'", () => {
+      const cits = extractCitations("Brown v. Bd. of Educ., 2007 UT 49.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2007)
+      expect(neutrals[0].court).toBe("UT")
+      expect(neutrals[0].documentNumber).toBe("49")
+    })
+
+    it("extracts '2017 WI 17'", () => {
+      const cits = extractCitations("State v. Avila, 2017 WI 17.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2017)
+      expect(neutrals[0].court).toBe("WI")
+      expect(neutrals[0].documentNumber).toBe("17")
+    })
+
+    it("extracts '2013 IL 112116' (large IL document number)", () => {
+      const cits = extractCitations("People v. Smith, 2013 IL 112116.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2013)
+      expect(neutrals[0].court).toBe("IL")
+      expect(neutrals[0].documentNumber).toBe("112116")
+    })
+
+    it("extracts '2020 WL 123456' (Westlaw)", () => {
+      const cits = extractCitations("In re X, 2020 WL 123456.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("WL")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #233.

The \`casePatterns.state-vendor-neutral\` regex was whitespace-separated only (\`\\b(\\d{4})\\s+([A-Z]{2}(?:\\s+App\\.?)?)\\s+(\\d+)\\b\`). Hyphenated public-domain formats used by New Mexico, Ohio, North Carolina, and Mississippi silently produced **zero citations** — the tokenizer never matched them, so they never reached \`extractNeutral\` at all.

### Two new tokenization patterns

| Pattern | Regex | Covers |
| --- | --- | --- |
| \`state-vendor-neutral-hyphenated\` (3-seg) | \`\\b(\\d{4})-([A-Z][A-Za-z]+)-(\\d+)\\b\` | NM (\`NMSC\`, \`NMCA\`, \`NMCERT\`), Ohio (mixed-case \`Ohio\` token), NC (\`NCSC\`, \`NCCOA\`) |
| \`state-vendor-neutral-hyphenated-ms\` (4-seg) | \`\\b(\\d{4})-([A-Z]+)-(\\d+)-([A-Z]+)\\b\` | Mississippi (\`year-caseType-number-appellateTrack\`, e.g., \`2010-CT-01234-SCT\`) |

The MS 4-segment pattern is listed **first** in the array so the regex engine prefers the longer match when both could fire on the same text.

### extractNeutral updates

The existing parse regex \`/^(\\d{4})\\s+(.+?)\\s+(\\d+)$/d\` only handled whitespace separators. Two changes:

1. **Mississippi 4-segment path** — composes the \`court\` field as \`\${caseType}-\${appellateTrack}\` (e.g., \`CT-SCT\`, \`CA-COA\`) so the single \`court\` field preserves the full sovereign identifier without requiring schema changes.
2. **Generalized 3-segment path** — \`/^(\\d{4})[-\\s]+(.+?)[-\\s]+(\\d+)$/d\` allows either hyphen or whitespace as separator. The existing UT/WI/IL/WL/LEXIS shapes continue to work through this path.

### Example output

| Input | year | court | documentNumber |
| --- | --- | --- | --- |
| \`2010-NMSC-007\` | 2010 | \`NMSC\` | \`007\` |
| \`2024-Ohio-764\` | 2024 | \`Ohio\` | \`764\` |
| \`2020-NCSC-118\` | 2020 | \`NCSC\` | \`118\` |
| \`2010-CT-01234-SCT\` | 2010 | \`CT-SCT\` | \`01234\` |

## Test plan

- [x] 13 new tests in \`tests/extract/extractNeutralHyphenated.test.ts\`:
  - 3 NM variants (\`NMSC\`, \`NMCA\`, \`NMCERT\`)
  - 2 Ohio (mixed-case)
  - 2 NC (\`NCSC\`, \`NCCOA\`)
  - 2 MS (4-segment, both \`-SCT\` and \`-COA\` tracks)
  - 4 whitespace-separated regression controls (\`UT\`, \`WI\`, \`IL\`, \`WL\`)
- [x] \`pnpm exec vitest run\` — 2032 passed, 9 skipped (was 2017 + 13 new + 2 integration pickup)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — no new warnings on changed files (delta of +4 is pre-existing \`noUselessEscapeInRegex\` in untouched \`extractShortForms.ts\` / \`shortForm.ts\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)