### PR TITLE
fix: state LEXIS variants (Cal. LEXIS, Tex. App. LEXIS, etc.) (#228)

### DIFF
--- a/.changeset/state-lexis-variants.md
+++ b/.changeset/state-lexis-variants.md
@@ -1,0 +1,17 @@
+---
+"eyecite-ts": patch
+---
+
+fix: state LEXIS variants (Cal. LEXIS, Tex. App. LEXIS, N.Y. Misc. LEXIS, etc.) now extract (#228)
+
+The existing `lexis` pattern in `neutralPatterns.ts` was hard-coded for federal courts only — `\b(\d{4})\s+U\.S\.(?:\s+(?:App|Dist)\.)?\s+LEXIS\s+(\d+)\b`. State LEXIS variants (Cal. LEXIS, Tex. App. LEXIS, N.Y. Misc. LEXIS, Ill. App. LEXIS, Fla. LEXIS, Pa. Super. LEXIS, etc.) silently fell through to the broad state-reporter fallback and surfaced as weak `case` matches with no court/year/documentNumber populated.
+
+Generalized the regex to accept any uppercase-prefixed court abbreviation before LEXIS:
+
+```regex
+\b(\d{4})\s+[A-Z][A-Za-z.\s]+?\s+LEXIS\s+(\d+)\b
+```
+
+The non-greedy `[A-Z][A-Za-z.\s]+?` is bounded by the literal `\s+LEXIS` that follows it, so there's no runaway risk. The downstream `extractNeutral.ts` already parses arbitrary `<court> LEXIS` shapes via the generalized 3-group regex from #233, so no extractor changes were required.
+
+Adds 13 corpus-shaped regression tests in `tests/extract/extractLexisStateVariants.test.ts`: 2 California (Cal. + Cal. App.), 2 Texas (Tex. + Tex. App.), 2 New York (N.Y. Misc. + N.Y. App. Div.), 1 Illinois (Ill. App.), 3 additional high-corpus jurisdictions (Fla., Ohio, Pa. Super.), and 3 federal regression controls (U.S., U.S. App., U.S. Dist.) confirming the existing tokenizations still pass.

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -49,10 +49,15 @@ export const neutralPatterns: Pattern[] = [
     type: "neutral",
   },
   {
+    // Generalized to accept any uppercase-prefixed court abbreviation before
+    // LEXIS so state variants (Cal. LEXIS, Tex. App. LEXIS, N.Y. Misc. LEXIS,
+    // Ill. App. LEXIS, etc.) tokenize alongside the federal U.S. forms (#228).
+    // The non-greedy `[A-Z][A-Za-z.\s]+?` is bounded by the literal `\s+LEXIS`
+    // that follows it, so it can't run away.
     id: "lexis",
-    regex: /\b(\d{4})\s+U\.S\.(?:\s+(?:App|Dist)\.)?\s+LEXIS\s+(\d+)\b/g,
+    regex: /\b(\d{4})\s+[A-Z][A-Za-z.\s]+?\s+LEXIS\s+(\d+)\b/g,
     description:
-      'LexisNexis citations (e.g., "2021 U.S. LEXIS 5000", "2021 U.S. App. LEXIS 12345", "2021 U.S. Dist. LEXIS 67890")',
+      'LexisNexis citations (federal: "2021 U.S. LEXIS 5000", "2021 U.S. App. LEXIS 12345"; state: "2020 Cal. LEXIS 1000", "2020 Tex. App. LEXIS 5000")',
     type: "neutral",
   },
   {

--- a/tests/extract/extractLexisStateVariants.test.ts
+++ b/tests/extract/extractLexisStateVariants.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { NeutralCitation } from "@/types/citation"
+
+/**
+ * State LEXIS variants (#228) — the existing `lexis` pattern in
+ * `neutralPatterns.ts` is hard-coded for federal courts only:
+ *
+ *   /\b(\d{4})\s+U\.S\.(?:\s+(?:App|Dist)\.)?\s+LEXIS\s+(\d+)\b/g
+ *
+ * State LEXIS forms (`Cal. LEXIS`, `Tex. App. LEXIS`, `N.Y. Misc. LEXIS`,
+ * `Ill. App. LEXIS`, etc.) are not recognized as neutral citations. The
+ * broad state-reporter fallback catches them as weak `case` matches with
+ * no court/year/documentNumber populated. Generalizing the LEXIS regex
+ * to accept any court-abbreviation prefix is the fix.
+ */
+describe("state LEXIS variants (#228)", () => {
+  describe("California LEXIS", () => {
+    it("extracts '2020 Cal. LEXIS 1000'", () => {
+      const cits = extractCitations("Smith v. Jones, 2020 Cal. LEXIS 1000.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2020)
+      expect(neutrals[0].court).toBe("Cal. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("1000")
+    })
+
+    it("extracts '2019 Cal. App. LEXIS 250' (court of appeal)", () => {
+      const cits = extractCitations("See 2019 Cal. App. LEXIS 250.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2019)
+      expect(neutrals[0].court).toBe("Cal. App. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("250")
+    })
+  })
+
+  describe("Texas LEXIS", () => {
+    it("extracts '2020 Tex. App. LEXIS 5000'", () => {
+      const cits = extractCitations("Brown v. State, 2020 Tex. App. LEXIS 5000.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2020)
+      expect(neutrals[0].court).toBe("Tex. App. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("5000")
+    })
+
+    it("extracts '2022 Tex. LEXIS 750' (Texas Supreme Court)", () => {
+      const cits = extractCitations("See 2022 Tex. LEXIS 750.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2022)
+      expect(neutrals[0].court).toBe("Tex. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("750")
+    })
+  })
+
+  describe("New York LEXIS", () => {
+    it("extracts '2020 N.Y. Misc. LEXIS 500'", () => {
+      const cits = extractCitations("Doe v. Roe, 2020 N.Y. Misc. LEXIS 500.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2020)
+      expect(neutrals[0].court).toBe("N.Y. Misc. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("500")
+    })
+
+    it("extracts '2021 N.Y. App. Div. LEXIS 800'", () => {
+      const cits = extractCitations("See 2021 N.Y. App. Div. LEXIS 800.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2021)
+      expect(neutrals[0].court).toBe("N.Y. App. Div. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("800")
+    })
+  })
+
+  describe("Illinois LEXIS", () => {
+    it("extracts '2024 Ill. App. LEXIS 100'", () => {
+      const cits = extractCitations("Smith v. Jones, 2024 Ill. App. LEXIS 100.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2024)
+      expect(neutrals[0].court).toBe("Ill. App. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("100")
+    })
+  })
+
+  describe("other state LEXIS variants (high-corpus jurisdictions)", () => {
+    it("extracts '2020 Fla. LEXIS 1500'", () => {
+      const cits = extractCitations("See 2020 Fla. LEXIS 1500.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("Fla. LEXIS")
+    })
+
+    it("extracts '2021 Ohio LEXIS 250'", () => {
+      const cits = extractCitations("See 2021 Ohio LEXIS 250.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("Ohio LEXIS")
+    })
+
+    it("extracts '2023 Pa. Super. LEXIS 90'", () => {
+      const cits = extractCitations("See 2023 Pa. Super. LEXIS 90.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("Pa. Super. LEXIS")
+    })
+  })
+
+  describe("regression — federal LEXIS still works", () => {
+    it("extracts '2021 U.S. LEXIS 5000' (SCOTUS)", () => {
+      const cits = extractCitations("Smith v. Jones, 2021 U.S. LEXIS 5000.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2021)
+      expect(neutrals[0].court).toBe("U.S. LEXIS")
+      expect(neutrals[0].documentNumber).toBe("5000")
+    })
+
+    it("extracts '2021 U.S. App. LEXIS 12345' (circuit court)", () => {
+      const cits = extractCitations("Smith v. Jones, 2021 U.S. App. LEXIS 12345.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("U.S. App. LEXIS")
+    })
+
+    it("extracts '2021 U.S. Dist. LEXIS 67890' (district court)", () => {
+      const cits = extractCitations("Smith v. Jones, 2021 U.S. Dist. LEXIS 67890.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("U.S. Dist. LEXIS")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #228.

The existing \`lexis\` pattern in \`neutralPatterns.ts\` was hard-coded for federal courts only — \`\\b(\\d{4})\\s+U\\.S\\.(?:\\s+(?:App|Dist)\\.)?\\s+LEXIS\\s+(\\d+)\\b\`. State LEXIS variants (\`Cal. LEXIS\`, \`Tex. App. LEXIS\`, \`N.Y. Misc. LEXIS\`, \`Ill. App. LEXIS\`, etc.) silently fell through to the broad state-reporter fallback and surfaced as weak \`case\` matches with **no court/year/documentNumber populated**.

### Generalized regex

\`\`\`regex
\\b(\\d{4})\\s+[A-Z][A-Za-z.\\s]+?\\s+LEXIS\\s+(\\d+)\\b
\`\`\`

The non-greedy \`[A-Z][A-Za-z.\\s]+?\` is bounded by the literal \`\\s+LEXIS\` that follows it, so there's no runaway risk. The downstream \`extractNeutral.ts\` already parses arbitrary \`<court> LEXIS\` shapes via the generalized 3-group regex landed in #233, so no extractor changes were required.

### Example output

| Input | year | court | documentNumber |
| --- | --- | --- | --- |
| \`2020 Cal. LEXIS 1000\` | 2020 | \`Cal. LEXIS\` | \`1000\` |
| \`2020 Tex. App. LEXIS 5000\` | 2020 | \`Tex. App. LEXIS\` | \`5000\` |
| \`2020 N.Y. Misc. LEXIS 500\` | 2020 | \`N.Y. Misc. LEXIS\` | \`500\` |
| \`2024 Ill. App. LEXIS 100\` | 2024 | \`Ill. App. LEXIS\` | \`100\` |
| \`2021 U.S. App. LEXIS 12345\` (existing) | 2021 | \`U.S. App. LEXIS\` | \`12345\` |

## Test plan

- [x] 13 new tests in \`tests/extract/extractLexisStateVariants.test.ts\`:
  - 2 California (\`Cal.\`, \`Cal. App.\`)
  - 2 Texas (\`Tex.\`, \`Tex. App.\`)
  - 2 New York (\`N.Y. Misc.\`, \`N.Y. App. Div.\`)
  - 1 Illinois (\`Ill. App.\`)
  - 3 additional high-corpus jurisdictions (\`Fla.\`, \`Ohio\`, \`Pa. Super.\`)
  - 3 federal regression controls (\`U.S.\`, \`U.S. App.\`, \`U.S. Dist.\`) confirming the existing tokenizations still pass
- [x] \`pnpm exec vitest run\` — 2045 passed, 9 skipped (was 2032 + 13 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 167 pre-existing warnings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)