### PR TITLE
fix: multi-word neutral court designations (IL App, OK CIV APP, OK CR) (#230)

### DIFF
--- a/.changeset/multi-word-neutral-courts.md
+++ b/.changeset/multi-word-neutral-courts.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix: multi-word neutral court designations (IL App, OK CIV APP, OK CR) now extract (#230)
+
+The existing `state-vendor-neutral` court group was `[A-Z]{2}(?:\s+App\.?)?` — only single-word state codes with an optional `App.` suffix. Two real-world formats fell through:
+
+- **Illinois Rule 23 appellate form** — `2011 IL App (1st) 101234`, `2020 IL App (2d) 190123-U`. The district parenthetical `(1st)/(2d)/(3d)/(4th)/(5th)` was treated as the start of a court parenthetical, so the document number got misbound and the citation silently extracted as zero matches.
+- **Oklahoma multi-word courts** — `2020 OK CIV APP 67` (Civil Court of Appeals), `2019 OK CR 1` (Court of Criminal Appeals), `2024 OK AG 5` (Attorney General opinions). These surfaced as weak `case` matches with no court/year/documentNumber populated.
+
+Additionally, Illinois Rule 23 unpublished decisions carry a `-U` suffix on the document number (e.g., `190123-U`). Previously this was not handled at all.
+
+### Three coordinated changes
+
+1. **`state-vendor-neutral` regex** extended with two new alternatives ordered before the existing single-word fallback:
+   ```regex
+   \b(\d{4})\s+(
+     IL\s+App\s+\(\d+(?:st|nd|rd|th|d)\)
+     |OK\s+(?:CIV\s+APP|CR|AG)
+     |[A-Z]{2}(?:\s+App\.?)?
+   )\s+(\d+(?:-U)?)\b
+   ```
+2. **`extractNeutral.ts`** consumes the `-U` suffix into a new `unpublished` flag and strips it from `documentNumber`.
+3. **`NeutralCitation` interface** gains an `unpublished?: boolean` field. Only set to `true` for citations with the `-U` suffix; absent or `false` otherwise.
+
+Adds 15 corpus-shaped regression tests in `tests/extract/extractNeutralMultiWord.test.ts`: 6 IL App district variants (1st/2d/3d/4th/5th plus the `-U` unpublished case), 4 OK forms (CIV APP, CR, AG, plus bare OK as fallback), and 5 regression controls (bare IL, UT, WI, Ohio hyphenated from #233, U.S. App. LEXIS from #228).

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -71,6 +71,7 @@ export function extractNeutral(
   let year: number
   let court: string
   let documentNumber: string
+  let unpublished = false
   let spans: NeutralComponentSpans | undefined
 
   const msMatch = /^(\d{4})-([A-Z]+)-(\d+)-([A-Z]+)$/d.exec(text)
@@ -96,7 +97,9 @@ export function extractNeutral(
     }
   } else {
     // 3-segment forms: hyphenated (NM/Ohio/NC) or whitespace (UT/WI/IL/WL).
-    const neutralRegex = /^(\d{4})[-\s]+(.+?)[-\s]+(\d+)$/d
+    // Trailing `(-U)?` captures Illinois Rule 23 unpublished marker (#230);
+    // the suffix is consumed but excluded from `documentNumber`.
+    const neutralRegex = /^(\d{4})[-\s]+(.+?)[-\s]+(\d+)(-U)?$/d
     const match = neutralRegex.exec(text)
     if (!match) {
       throw new Error(`Failed to parse neutral citation: ${text}`)
@@ -104,6 +107,9 @@ export function extractNeutral(
     year = Number.parseInt(match[1], 10)
     court = match[2]
     documentNumber = match[3]
+    if (match[4] === "-U") {
+      unpublished = true
+    }
     if (match.indices) {
       spans = {
         year: spanFromGroupIndex(span.cleanStart, match.indices[1]!, transformationMap),
@@ -162,6 +168,7 @@ export function extractNeutral(
     year,
     court,
     documentNumber,
+    ...(unpublished ? { unpublished: true } : {}),
     pincite,
     pinciteInfo,
     spans,

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -36,10 +36,21 @@ export const neutralPatterns: Pattern[] = [
     type: "neutral",
   },
   {
+    // Multi-word neutral courts (#230). Alternation order matters — longer,
+    // more specific patterns must precede the bare `[A-Z]{2}` fallback so the
+    // regex prefers the more specific match:
+    //   - `IL App (Nst)` — Illinois Rule 23 form with district parenthetical
+    //     (districts 1st / 2d / 3d / 4th / 5th)
+    //   - `OK CIV APP|CR|AG` — Oklahoma multi-word courts
+    //   - `[A-Z]{2}(?:\s+App\.?)?` — existing single-word + optional App fallback
+    // The trailing `(-U)?` captures Illinois Rule 23 unpublished marker; the
+    // extractor consumes it into the `unpublished` flag and strips it from
+    // `documentNumber`.
     id: "state-vendor-neutral",
-    regex: /\b(\d{4})\s+([A-Z]{2}(?:\s+App\.?)?)\s+(\d+)\b/g,
+    regex:
+      /\b(\d{4})\s+(IL\s+App\s+\(\d+(?:st|nd|rd|th|d)\)|OK\s+(?:CIV\s+APP|CR|AG)|[A-Z]{2}(?:\s+App\.?)?)\s+(\d+(?:-U)?)\b/g,
     description:
-      'State vendor-neutral citations (e.g., "2007 UT 49", "2017 WI 17", "2013 IL 112116")',
+      'State vendor-neutral citations (e.g., "2007 UT 49", "2017 WI 17", "2013 IL 112116", "2011 IL App (1st) 101234", "2020 OK CIV APP 67", "2020 IL App (2d) 190123-U")',
     type: "neutral",
   },
   {

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -473,6 +473,12 @@ export interface NeutralCitation extends CitationBase {
   court: string
   /** Document number */
   documentNumber: string
+  /**
+   * True when the citation has an Illinois Rule 23 `-U` suffix (or analogous
+   * unpublished marker). The suffix is consumed and stripped from
+   * `documentNumber`. Absent or `false` for published decisions. (#230)
+   */
+  unpublished?: boolean
   /** Pincite page (numeric portion, without "*" for star-pagination). */
   pincite?: number
   /** Structured pincite information (page, range, footnote, star-pagination). */

--- a/tests/extract/extractNeutralMultiWord.test.ts
+++ b/tests/extract/extractNeutralMultiWord.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { NeutralCitation } from "@/types/citation"
+
+/**
+ * Multi-word neutral court designations (#230). The existing
+ * `state-vendor-neutral` regex caps the court at `[A-Z]{2}(?:\s+App\.?)?`,
+ * so Illinois's paren-district form (`IL App (1st)`, `IL App (2d)`) and
+ * Oklahoma's three-token forms (`OK CIV APP`, `OK CR`, `OK AG`) silently
+ * fail to extract. Illinois Rule 23 unpublished decisions add a `-U` suffix
+ * on the document number that the current extractor cannot parse.
+ */
+describe("multi-word neutral court designations (#230)", () => {
+  describe("Illinois — IL App with district parenthetical", () => {
+    it("extracts '2011 IL App (1st) 101234'", () => {
+      const cits = extractCitations("People v. Doe, 2011 IL App (1st) 101234.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2011)
+      expect(neutrals[0].court).toBe("IL App (1st)")
+      expect(neutrals[0].documentNumber).toBe("101234")
+      expect(neutrals[0].unpublished).toBeFalsy()
+    })
+
+    it("extracts '2020 IL App (2d) 190123' (Bluebook 2d form)", () => {
+      const cits = extractCitations("See 2020 IL App (2d) 190123.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("IL App (2d)")
+      expect(neutrals[0].documentNumber).toBe("190123")
+    })
+
+    it("extracts '2019 IL App (3d) 170567'", () => {
+      const cits = extractCitations("See 2019 IL App (3d) 170567.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("IL App (3d)")
+    })
+
+    it("extracts '2022 IL App (4th) 210888'", () => {
+      const cits = extractCitations("See 2022 IL App (4th) 210888.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("IL App (4th)")
+    })
+
+    it("extracts '2024 IL App (5th) 230445'", () => {
+      const cits = extractCitations("See 2024 IL App (5th) 230445.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("IL App (5th)")
+    })
+
+    it("extracts '2020 IL App (2d) 190123-U' with unpublished=true", () => {
+      const cits = extractCitations("See 2020 IL App (2d) 190123-U.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("IL App (2d)")
+      expect(neutrals[0].documentNumber).toBe("190123")
+      expect(neutrals[0].unpublished).toBe(true)
+    })
+  })
+
+  describe("Oklahoma — multi-word forms", () => {
+    it("extracts '2020 OK CIV APP 67' (Civil Court of Appeals)", () => {
+      const cits = extractCitations("Stewart v. Gonzalez, 2020 OK CIV APP 67.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2020)
+      expect(neutrals[0].court).toBe("OK CIV APP")
+      expect(neutrals[0].documentNumber).toBe("67")
+    })
+
+    it("extracts '2019 OK CR 1' (Court of Criminal Appeals)", () => {
+      const cits = extractCitations("State v. Smith, 2019 OK CR 1.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2019)
+      expect(neutrals[0].court).toBe("OK CR")
+      expect(neutrals[0].documentNumber).toBe("1")
+    })
+
+    it("extracts '2024 OK AG 5' (Attorney General opinions)", () => {
+      const cits = extractCitations("See 2024 OK AG 5.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("OK AG")
+      expect(neutrals[0].documentNumber).toBe("5")
+    })
+
+    it("extracts bare '2020 OK 25' (Oklahoma Supreme Court, single-word fallback)", () => {
+      const cits = extractCitations("See 2020 OK 25.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("OK")
+      expect(neutrals[0].documentNumber).toBe("25")
+    })
+  })
+
+  describe("regression — existing single-word and App-suffixed forms", () => {
+    it("extracts '2013 IL 112116' (bare IL, no App)", () => {
+      const cits = extractCitations("People v. Smith, 2013 IL 112116.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("IL")
+      expect(neutrals[0].documentNumber).toBe("112116")
+    })
+
+    it("extracts '2007 UT 49'", () => {
+      const cits = extractCitations("Brown v. Bd. of Educ., 2007 UT 49.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("UT")
+    })
+
+    it("extracts '2017 WI 17'", () => {
+      const cits = extractCitations("State v. Avila, 2017 WI 17.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("WI")
+    })
+
+    it("extracts '2024-Ohio-764' (hyphenated, from #233)", () => {
+      const cits = extractCitations("Smith v. Ohio State Univ., 2024-Ohio-764.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("Ohio")
+      expect(neutrals[0].unpublished).toBeFalsy()
+    })
+
+    it("extracts '2021 U.S. App. LEXIS 12345' (LEXIS, from #228)", () => {
+      const cits = extractCitations("See 2021 U.S. App. LEXIS 12345.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].court).toBe("U.S. App. LEXIS")
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #230.

The existing \`state-vendor-neutral\` court group was \`[A-Z]{2}(?:\\s+App\\.?)?\` — only single-word state codes with an optional \`App.\` suffix. Two real-world formats fell through:

- **Illinois Rule 23 appellate form** — \`2011 IL App (1st) 101234\`, \`2020 IL App (2d) 190123-U\`. The district parenthetical \`(1st)/(2d)/(3d)/(4th)/(5th)\` was treated as the start of a court parenthetical, so the document number got misbound and the citation silently extracted as **zero matches**.
- **Oklahoma multi-word courts** — \`2020 OK CIV APP 67\` (Civil Court of Appeals), \`2019 OK CR 1\` (Court of Criminal Appeals), \`2024 OK AG 5\` (Attorney General opinions). These surfaced as weak \`case\` matches with no court/year/documentNumber populated.

Plus Illinois Rule 23 unpublished decisions carry a \`-U\` suffix on the document number (e.g., \`190123-U\`). Previously not handled at all.

### Three coordinated changes

1. **\`state-vendor-neutral\` regex** extended with two new alternatives ordered before the existing single-word fallback:

\`\`\`regex
\\b(\\d{4})\\s+(
  IL\\s+App\\s+\\(\\d+(?:st|nd|rd|th|d)\\)
  |OK\\s+(?:CIV\\s+APP|CR|AG)
  |[A-Z]{2}(?:\\s+App\\.?)?
)\\s+(\\d+(?:-U)?)\\b
\`\`\`

2. **\`extractNeutral.ts\`** consumes the \`-U\` suffix into a new \`unpublished\` flag and strips it from \`documentNumber\`.
3. **\`NeutralCitation\` interface** gains an \`unpublished?: boolean\` field — only set to \`true\` for citations with the \`-U\` suffix; absent or \`false\` otherwise.

### Example output

| Input | year | court | documentNumber | unpublished |
| --- | --- | --- | --- | --- |
| \`2011 IL App (1st) 101234\` | 2011 | \`IL App (1st)\` | \`101234\` | — |
| \`2020 IL App (2d) 190123-U\` | 2020 | \`IL App (2d)\` | \`190123\` | \`true\` |
| \`2020 OK CIV APP 67\` | 2020 | \`OK CIV APP\` | \`67\` | — |
| \`2019 OK CR 1\` | 2019 | \`OK CR\` | \`1\` | — |
| \`2013 IL 112116\` (existing) | 2013 | \`IL\` | \`112116\` | — |

## Test plan

- [x] 15 corpus-shaped regression tests in \`tests/extract/extractNeutralMultiWord.test.ts\`:
  - 6 IL App district variants (\`1st\`/\`2d\`/\`3d\`/\`4th\`/\`5th\` plus the \`-U\` unpublished case)
  - 4 OK forms (\`CIV APP\`, \`CR\`, \`AG\`, plus bare \`OK\` as the single-word fallback)
  - 5 regression controls (bare \`IL\`, \`UT\`, \`WI\`, \`Ohio\` hyphenated from #233, \`U.S. App. LEXIS\` from #228)
- [x] \`pnpm exec vitest run\` — 2060 passed, 9 skipped (was 2045 + 15 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 167 pre-existing warnings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)