### PR TITLE
fix: California review denied/granted + chained-signal history (#238)

### DIFF
--- a/.changeset/ca-review-history.md
+++ b/.changeset/ca-review-history.md
@@ -1,0 +1,15 @@
+---
+"eyecite-ts": patch
+---
+
+fix: California `review denied/granted` and chained-signal history (#238)
+
+`SIGNAL_TABLE` covered federal `cert. denied/granted` and the standard Bluebook subsequent-history words, but missed California Supreme Court's `review denied` / `review granted` / `opinion vacated` and the CA-specific `disapproved on other grounds` form. After-citation history clauses with these phrases silently dropped.
+
+Three coordinated changes:
+
+1. **`HistorySignal` discriminated union** gains 4 California-specific values: `review_denied`, `review_granted`, `opinion_vacated`, `disapproved_other_grounds`.
+2. **`SIGNAL_TABLE`** gets matching regex entries. The longer `disapproved on other grounds` precedes the bare `disapproved` so alternation prefers the more specific match. `review den.` (abbreviated) and `review denied` both map to `review_denied` via `^review\s+den(?:ied|\.)`.
+3. **`collectParentheticals` multi-stage chain bug fix.** Found while writing tests: when a second signal arrives without an intervening parenthetical (e.g., `..., review granted, opinion vacated.`), the previous `pendingSignal` was overwritten and lost. The fix flushes `pendingSignal` to `signals` (with `nextParenIndex = -1`) before assigning the new one. This also enables federal chains like `aff'd, cert. denied` (without trailing paren) to capture both links.
+
+Adds 9 regression tests: 3 `review denied` / `review den.` / `review granted`, 1 `opinion vacated`, 1 `disapproved on other grounds`, 1 multi-stage chain (`review granted, opinion vacated` → 2 entries), and 3 regression controls confirming bare `disapproved`, federal `cert. denied`, and the existing `aff'd` chain are unaffected.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -233,6 +233,9 @@ const SIGNAL_TABLE: ReadonlyArray<readonly [RegExp, HistorySignal]> = [
   // additional signals
   [/^superseded\s+by\b/i, "superseded"],
   [/^superseded\b/i, "superseded"],
+  // CA-specific "disapproved on other grounds" precedes the bare/of forms
+  // so alternation prefers the more specific match (#238).
+  [/^disapproved\s+on\s+other\s+grounds\b/i, "disapproved_other_grounds"],
   [/^disapproved\s+of\b/i, "disapproved"],
   [/^disapproved\b/i, "disapproved"],
   [/^questioned\s+by\b/i, "questioned"],
@@ -260,6 +263,12 @@ const SIGNAL_TABLE: ReadonlyArray<readonly [RegExp, HistorySignal]> = [
   [/^pet\.\s+filed\b/i, "pet_filed"],
   [/^no\s+pet\.\s+h\./i, "no_pet"],
   [/^no\s+pet\./i, "no_pet"],
+  // California Supreme Court review history (#238). Bluebook T8 only covers
+  // federal cert. denied/granted — these CA-specific forms appear in Cal.,
+  // Cal.App., and federal opinions citing CA cases.
+  [/^review\s+den(?:ied|\.)/i, "review_denied"],
+  [/^review\s+granted\b/i, "review_granted"],
+  [/^opinion\s+vacated\b/i, "opinion_vacated"],
 ]
 
 /**
@@ -1281,6 +1290,13 @@ function collectParentheticals(
       const remainingText = text.substring(pos, endLimit)
       const normalized = normalizeSignal(remainingText)
       if (normalized) {
+        // Multi-stage chain (e.g., "review granted, opinion vacated"): if a
+        // prior signal is still pending with no following paren, flush it
+        // before overwriting. Without this, only the last link of a chain
+        // survives. (#238)
+        if (pendingSignal) {
+          signals.push({ signal: pendingSignal, nextParenIndex: -1 })
+        }
         pendingSignal = {
           text: remainingText.substring(0, normalized.matchLength).replace(/\s+$/, ""),
           normalized: normalized.signal,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -206,6 +206,11 @@ export type HistorySignal =
   | "pet_granted"
   | "pet_filed"
   | "no_pet"
+  // California Supreme Court review history + CA-specific signals (#238)
+  | "review_denied"
+  | "review_granted"
+  | "opinion_vacated"
+  | "disapproved_other_grounds"
 
 /**
  * A single subsequent history entry from a case citation.

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3081,6 +3081,128 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("California review history signals (#238)", () => {
+  // California Supreme Court history uses "review denied" / "review granted"
+  // / "opinion vacated" / "disapproved on other grounds" — signals distinct
+  // from federal cert. denied/granted. The current SIGNAL_TABLE has no
+  // entries for these, so the after-citation history clause is dropped.
+
+  describe("review denied / granted", () => {
+    it("captures 'review denied' as review_denied", () => {
+      const cits = extractCitations(
+        "People v. Smith, 50 Cal. 3d 100 (Cal. 1990), review denied.",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe("review_denied")
+      }
+    })
+
+    it("captures 'review den.' (abbreviated) as review_denied", () => {
+      const cits = extractCitations(
+        "People v. Smith, 50 Cal. 3d 100 (Cal. 1990), review den.",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe("review_denied")
+      }
+    })
+
+    it("captures 'review granted' as review_granted", () => {
+      const cits = extractCitations(
+        "Doe v. Roe, 1 Cal. 4th 50 (Cal. 2010), review granted.",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe("review_granted")
+      }
+    })
+  })
+
+  describe("opinion vacated", () => {
+    it("captures 'opinion vacated' as opinion_vacated", () => {
+      const cits = extractCitations(
+        "Doe v. Roe, 1 Cal. 4th 50 (Cal. 2010), opinion vacated.",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe("opinion_vacated")
+      }
+    })
+  })
+
+  describe("disapproved on other grounds (CA-specific)", () => {
+    it("captures 'disapproved on other grounds' as disapproved_other_grounds (beats bare 'disapproved')", () => {
+      const cits = extractCitations(
+        "People v. Davis, 5 Cal. 5th 200 (Cal. 2020), disapproved on other grounds in People v. Jones.",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe(
+          "disapproved_other_grounds",
+        )
+      }
+    })
+  })
+
+  describe("multi-stage chains", () => {
+    it("captures 'review granted, opinion vacated' as 2 chained entries", () => {
+      const cits = extractCitations(
+        "Doe v. Roe, 1 Cal. 4th 50 (Cal. 2010), review granted, opinion vacated.",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        const entries = cases[0].subsequentHistoryEntries
+        expect(entries?.length).toBeGreaterThanOrEqual(2)
+        expect(entries?.[0]?.signal).toBe("review_granted")
+        expect(entries?.[1]?.signal).toBe("opinion_vacated")
+      }
+    })
+  })
+
+  describe("regression — existing signals still work", () => {
+    it("still recognizes 'disapproved' (bare) as disapproved", () => {
+      // The longer "disapproved on other grounds" must not over-match the bare form.
+      const cits = extractCitations(
+        "Smith v. Jones, 100 F.3d 200 (2d Cir. 1996), disapproved, 200 F.3d 300 (2d Cir. 1997).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe("disapproved")
+      }
+    })
+
+    it("still recognizes 'cert. denied' (federal — distinct from CA review)", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 100 F.3d 200 (2d Cir. 1996), cert. denied, 500 U.S. 100 (1997).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe("cert_denied")
+      }
+    })
+
+    it("still recognizes 'aff'd' chain", () => {
+      const cits = extractCitations(
+        "Smith v. Doe, 100 F.3d 200 (2d Cir. 1996), aff'd, 200 F.3d 300 (2d Cir. 1997).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].subsequentHistoryEntries?.[0]?.signal).toBe("affirmed")
+      }
+    })
+  })
+})
+
 describe("Texas writ/petition history (#229)", () => {
   // Texas Greenbook places writ/petition history inside the court-and-year
   // parenthetical, after a second comma — e.g.,


### PR DESCRIPTION
## Summary

Closes #238.

\`SIGNAL_TABLE\` covered federal \`cert. denied/granted\` and the standard Bluebook subsequent-history words, but missed California Supreme Court's \`review denied\` / \`review granted\` / \`opinion vacated\` and the CA-specific \`disapproved on other grounds\` form. After-citation history clauses with these phrases silently dropped.

### Three coordinated changes

1. **\`HistorySignal\` discriminated union** gains 4 California-specific values: \`review_denied\`, \`review_granted\`, \`opinion_vacated\`, \`disapproved_other_grounds\`.

2. **\`SIGNAL_TABLE\`** gets matching regex entries. The longer \`disapproved on other grounds\` precedes the bare \`disapproved\` so alternation prefers the more specific match. \`review den.\` (abbreviated) and \`review denied\` both map to \`review_denied\` via \`^review\\s+den(?:ied|\\.)\`.

3. **\`collectParentheticals\` multi-stage chain bug fix.** Found while writing tests: when a second signal arrives without an intervening parenthetical (e.g., \`..., review granted, opinion vacated.\`), the previous \`pendingSignal\` was overwritten and lost. Now flushes the prior \`pendingSignal\` to \`signals\` (with \`nextParenIndex = -1\`) before assigning the new one. As a bonus, this also enables federal chains like \`aff'd, cert. denied\` (without trailing paren) to capture both links.

### Example output

| Input | First entry | Second entry |
| --- | --- | --- |
| \`..., review denied.\` | \`review_denied\` | — |
| \`..., review den.\` | \`review_denied\` | — |
| \`..., review granted.\` | \`review_granted\` | — |
| \`..., opinion vacated.\` | \`opinion_vacated\` | — |
| \`..., disapproved on other grounds in X.\` | \`disapproved_other_grounds\` | — |
| \`..., review granted, opinion vacated.\` | \`review_granted\` | \`opinion_vacated\` |

## Test plan

- [x] 9 new tests covering the 5 new signal variants + 1 multi-stage chain test + 3 regression controls (bare \`disapproved\`, federal \`cert. denied\`, federal \`aff'd\` chain — all still pass)
- [x] \`pnpm exec vitest run\` — 2199 passed, 9 skipped (was 2190 + 9 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 168 pre-existing warnings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)