### PR TITLE
fix: NY Slip Op (U)/[U] markers no longer pollute court (#231)

### DIFF
--- a/.changeset/ny-slip-op-unpublished.md
+++ b/.changeset/ny-slip-op-unpublished.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix: NY Slip Op `(U)` / `[U]` unpublished markers no longer pollute the court field (#231)
+
+New York Slip Opinion citations carry a trailing `(U)` (older form) or `[U]` (newer form) marker immediately after the document number to flag an unpublished disposition. Pre-fix, the parser misread `(U)` as a court parenthetical and set `court = "U"`. The `[U]` bracket form additionally caused mis-classification as a `journal` citation because the state-reporter regex's trailing-character lookahead didn't accept `[`.
+
+Three coordinated changes:
+
+1. **`FullCaseCitation` interface** gains an `unpublished?: boolean` field (mirrors the existing flag on `NeutralCitation` from #230).
+2. **`state-reporter` regex trailing lookahead** extended from `(?=\s|$|\(|,|;|\.)` to `(?=\s|$|\(|,|;|\.|\[)` so `[U]` doesn't break the page-boundary check.
+3. **Pre-lookahead `(U)`/`[U]` consumer in `extractCase`.** Before `LOOKAHEAD_PAREN_REGEX` runs on the post-token text, a small regex `/^\s*(?:\(U\)|\[U\])/` detects and consumes the unpublished marker so the lookahead reaches the real court parenthetical (e.g., `(Sup. Ct. 2007)`) instead of capturing `(U)` as the court.
+
+Result for `Pickard v. Tarnow, 2007 N.Y. Slip Op. 52377(U) (Sup. Ct. 2007)`:
+
+| Field | Before | After |
+| --- | --- | --- |
+| `page` | 52377 | 52377 |
+| `court` | `"U"` | `"Sup. Ct."` |
+| `year` | undefined | 2007 |
+| `unpublished` | — | `true` |
+| `caseName` | (sometimes lost) | `"Pickard v. Tarnow"` |
+
+Adds 7 regression tests covering the bare `(U)` form, the `[U]` bracket form, citations with a following real court paren, and 2 regression controls (non-(U) Slip Op + federal cite) confirming no regression.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1882,11 +1882,29 @@ export function extractCase(
     disposition = metaParenResult.disposition
   }
 
+  // NY Slip Op unpublished marker (#231): `(U)` (older) or `[U]` (newer)
+  // appears immediately after the page number and must be consumed *before*
+  // LOOKAHEAD_PAREN_REGEX runs, otherwise the regex captures `(U)` as the
+  // court parenthetical and produces `court = "U"`. Detected once and used
+  // both in the in-token paren path and the lookahead path.
+  let unpublished = false
+  if (cleanedText) {
+    const afterTokenForFlag = cleanedText.substring(span.cleanEnd)
+    if (/^\s*(?:\(U\)|\[U\])/.test(afterTokenForFlag)) {
+      unpublished = true
+    }
+  }
+
   // Look ahead in cleaned text for parenthetical after the token
   // Tokenization patterns only capture volume-reporter-page, so parentheticals
   // like "(1989)" or "(9th Cir. 2020)" are not in the token text.
   if (cleanedText && !parentheticalContent) {
-    const afterToken = cleanedText.substring(span.cleanEnd)
+    let afterToken = cleanedText.substring(span.cleanEnd)
+    // Consume any leading (U)/[U] marker so the real court paren is found.
+    const unpubMatch = /^\s*(?:\(U\)|\[U\])/.exec(afterToken)
+    if (unpubMatch) {
+      afterToken = afterToken.substring(unpubMatch[0].length)
+    }
     const lookAheadMatch = LOOKAHEAD_PAREN_REGEX.exec(afterToken)
     if (lookAheadMatch) {
       parentheticalContent = lookAheadMatch[1]
@@ -2348,6 +2366,7 @@ export function extractCase(
     disposition,
     parentheticals,
     subsequentHistoryEntries,
+    ...(unpublished ? { unpublished: true } : {}),
     plaintiff,
     plaintiffNormalized,
     defendant,

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -49,9 +49,10 @@ export const casePatterns: Pattern[] = [
     // (e.g., `I&N Dec.` and `I. & N. Dec.` for BIA immigration decisions — #244).
     // Apostrophe `'` is admitted for reporters like `F. App'x` already covered by
     // federal-reporter; including it here is harmless and future-proofs other
-    // possessive forms.
+    // possessive forms. Trailing lookahead also accepts `[` so NY Slip Op
+    // `[U]` unpublished markers don't break the boundary check (#231).
     regex:
-      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[)/g,
     description:
       'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev" and phantom matches across a case-name separator " v. "/" vs. ", validated against reporters-db in Phase 3)',
     type: "case",

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -247,6 +247,12 @@ export interface FullCaseCitation extends CitationBase {
   /** Structured pincite information (page, range, footnote) */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
   court?: string
+  /**
+   * True for citations whose source carried an unpublished-disposition marker.
+   * Set by NY Slip Op `(U)` / `[U]` suffix detection (#231). Absent or `false`
+   * for published decisions.
+   */
+  unpublished?: boolean
   /** Normalized court string: spaces collapsed, trailing period ensured */
   normalizedCourt?: string
   year?: number

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3081,6 +3081,102 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("NY Slip Op (U)/[U] unpublished markers (#231)", () => {
+  // New York Slip Opinion citations carry a trailing `(U)` (older form) or
+  // `[U]` (newer form) marker immediately after the document number to flag
+  // an unpublished disposition. Pre-fix, the parser misread `(U)` as a court
+  // parenthetical and set `court = "U"`. These tests pin down the fix:
+  // the marker is consumed and exposed via `unpublished: true`, and a
+  // following real court paren (e.g., `(Sup. Ct. 2007)`) is still captured.
+
+  describe("bare (U) suffix", () => {
+    it("recognizes '52377(U)' as unpublished, court is not 'U'", () => {
+      const cits = extractCitations("2007 N.Y. Slip Op. 52377(U)")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].page).toBe(52377)
+        expect(cases[0].unpublished).toBe(true)
+        // The (U) must not pollute the court field
+        expect(cases[0].court).not.toBe("U")
+      }
+    })
+
+    it("recognizes '64325(U)' as unpublished", () => {
+      const cits = extractCitations("2024 NY Slip Op 64325(U)")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].page).toBe(64325)
+        expect(cases[0].unpublished).toBe(true)
+      }
+    })
+  })
+
+  describe("bracket [U] suffix (newer form)", () => {
+    it("recognizes '51192[U]' as unpublished", () => {
+      const cits = extractCitations("2024 NY Slip Op 51192[U]")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].page).toBe(51192)
+        expect(cases[0].unpublished).toBe(true)
+      }
+    })
+  })
+
+  describe("with following real court parenthetical", () => {
+    it("captures '52377(U) ... (Sup. Ct. 2007)' — court is 'Sup. Ct.', not 'U'", () => {
+      const cits = extractCitations(
+        "Pickard v. Tarnow, 2007 N.Y. Slip Op. 52377(U) (Sup. Ct. 2007)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].page).toBe(52377)
+        expect(cases[0].unpublished).toBe(true)
+        expect(cases[0].court).toBe("Sup. Ct.")
+        expect(cases[0].year).toBe(2007)
+      }
+    })
+
+    it("captures case name preceding (U)-suffixed Slip Op", () => {
+      const cits = extractCitations(
+        "Doe v. Roe, 2024 NY Slip Op 51192[U] (Sup. Ct. 2024)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].unpublished).toBe(true)
+        expect(cases[0].caseName).toBe("Doe v. Roe")
+      }
+    })
+  })
+
+  describe("regression — non-(U) Slip Op still extracts normally", () => {
+    it("'2020 NY Slip Op 12345' without (U) — unpublished is undefined/false", () => {
+      const cits = extractCitations("Smith v. Jones, 2020 NY Slip Op 12345 (Sup. Ct. 2020)")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].page).toBe(12345)
+        expect(cases[0].unpublished).toBeFalsy()
+        expect(cases[0].court).toBe("Sup. Ct.")
+      }
+    })
+
+    it("'500 F.3d 123 (9th Cir. 2020)' — normal federal cite unaffected", () => {
+      const cits = extractCitations("Smith v. Jones, 500 F.3d 123 (9th Cir. 2020)")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].unpublished).toBeFalsy()
+        expect(cases[0].court).toBe("9th Cir.")
+      }
+    })
+  })
+})
+
 describe("California review history signals (#238)", () => {
   // California Supreme Court history uses "review denied" / "review granted"
   // / "opinion vacated" / "disapproved on other grounds" — signals distinct


### PR DESCRIPTION
## Summary

Closes #231.

New York Slip Opinion citations carry a trailing \`(U)\` (older form) or \`[U]\` (newer form) marker immediately after the document number to flag an unpublished disposition. Pre-fix, the parser misread \`(U)\` as a court parenthetical and set \`court = \"U\"\`. The \`[U]\` bracket form additionally caused mis-classification as a \`journal\` citation because the state-reporter regex's trailing-character lookahead didn't accept \`[\`.

### Three coordinated changes

1. **\`FullCaseCitation\` interface** gains an \`unpublished?: boolean\` field. Mirrors the existing flag on \`NeutralCitation\` (added in #230).
2. **\`state-reporter\` regex trailing lookahead** extended from \`(?=\\s|$|\\(|,|;|\\.)\` to \`(?=\\s|$|\\(|,|;|\\.|\\[)\` so \`[U]\` doesn't break the page-boundary check. Without this, the journal pattern caught the citation instead.
3. **Pre-lookahead \`(U)\`/\`[U]\` consumer in \`extractCase\`.** Before \`LOOKAHEAD_PAREN_REGEX\` runs on the post-token text, a small regex \`/^\\s*(?:\\(U\\)|\\[U\\])/\` detects and consumes the unpublished marker so the lookahead reaches the real court parenthetical (e.g., \`(Sup. Ct. 2007)\`) instead of capturing \`(U)\` as the court.

### Result for \`Pickard v. Tarnow, 2007 N.Y. Slip Op. 52377(U) (Sup. Ct. 2007)\`

| Field | Before | After |
| --- | --- | --- |
| \`page\` | 52377 | 52377 |
| \`court\` | \`\"U\"\` | \`\"Sup. Ct.\"\` |
| \`year\` | undefined | 2007 |
| \`unpublished\` | — | \`true\` |
| \`caseName\` | (sometimes lost) | \`\"Pickard v. Tarnow\"\` |

## Test plan

- [x] 7 new tests in \`tests/extract/extractCase.test.ts\` (under \`NY Slip Op (U)/[U] unpublished markers (#231)\`):
  - 2 bare \`(U)\` tests
  - 1 \`[U]\` bracket test
  - 2 with following real court paren (including case name preserved)
  - 2 regression controls (non-(U) Slip Op + federal cite)
- [x] \`pnpm exec vitest run\` — 2206 passed, 9 skipped (was 2199 + 7 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 168 pre-existing warnings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)