### PR TITLE
fix: structured justice-attribution parentheticals + en-banc FP fix (#235)

### DIFF
--- a/.changeset/justice-attribution-parens.md
+++ b/.changeset/justice-attribution-parens.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix: structured justice-attribution parentheticals + en-banc false-positive fix (#235)
+
+`parseParenthetical` previously recognized only `en banc` and `per curiam` as metadata-dispositions, so the very common justice-attribution form `(Brennan, J., dissenting)` landed as an unstructured "other" parenthetical. Three coordinated changes plus an en-banc false-positive fix:
+
+1. **`FullCaseCitation`** gains two new fields:
+   - `justices?: string[]` — surnames captured from `(Brennan, J., dissenting)` or `(Brennan and Marshall, JJ., dissenting)`.
+   - `scope?: string` — qualifier value (`in_judgment`, `in_part`, `from_denial`).
+2. **`parseParenthetical`** detects the justice-attribution pattern (`<Surname>(, <Surname>)*(?:,? and <Surname>)?,? (C\.J\.|J\.|JJ\.),? <role>`) and classifies the role into:
+   - `disposition`: `"dissent"`, `"concurrence"`, `"mixed"` (concurring in part and dissenting in part), `"majority"` (joining).
+   - `scope`: `"in_judgment"`, `"in_part"`, or `"from_denial"`.
+3. **Non-justice disposition parens** newly recognized: `(plurality opinion)`, `(mem.)`, `(unpublished table decision)`.
+4. **En-banc false-positive fix:** the `\ben banc\b` check is now anchored at the trimmed content end (`/\\ben banc\\b\\s*$/`) so a parenthetical like `(Cabranes, J., dissenting from denial of rehearing en banc)` no longer mistakenly sets `disposition = "en banc"`.
+
+Example output for `(Roberts, C.J., concurring in part and dissenting in part)`:
+
+```ts
+{
+  disposition: "mixed",
+  justices: ["Roberts"],
+  scope: "in_part",
+}
+```
+
+Adds 9 regression tests covering: single-justice dissent/concurrence, scope qualifiers (in_judgment / in_part / from_denial), `(plurality opinion)` / `(mem.)`, and 2 regression controls confirming `(en banc)` and `(per curiam)` still extract.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1373,6 +1373,10 @@ export function parseParenthetical(content: string): {
   year?: number
   date?: StructuredDate
   disposition?: string
+  /** Surname(s) of justice(s) attributed to a justice-attribution paren (#235) */
+  justices?: string[]
+  /** Scope qualifier for a justice-attribution paren (#235): in_judgment | in_part | from_denial */
+  scope?: string
   /** Texas Greenbook writ/petition history clause inside the parenthetical (#229) */
   internalHistory?: { signal: HistorySignal; rawSignal: string; start: number; end: number }
   courtStart?: number
@@ -1385,6 +1389,8 @@ export function parseParenthetical(content: string): {
     year?: number
     date?: StructuredDate
     disposition?: string
+    justices?: string[]
+    scope?: string
     internalHistory?: {
       signal: HistorySignal
       rawSignal: string
@@ -1457,10 +1463,73 @@ export function parseParenthetical(content: string): {
     }
   }
 
-  // Check for disposition
-  if (/\ben banc\b/i.test(content)) {
+  // Justice-attribution parenthetical (#235). Detected BEFORE the bare
+  // en banc / per curiam check so a parenthetical like
+  // `Cabranes, J., dissenting from denial of rehearing en banc` doesn't
+  // false-positive on the trailing `en banc` substring.
+  //
+  // Pattern: <Surname>(, <Surname>)*(?:,? and <Surname>)?,? (C\.J\.|J\.|JJ\.),? <role>
+  const justiceMatch = /^(?<surnames>[A-Z][a-z]+(?:(?:,\s+|\s+and\s+)[A-Z][a-z]+)*)\s*,?\s*(?<title>C\.J\.|J\.|JJ\.)\s*,?\s*(?<role>.+)$/.exec(
+    content.trim(),
+  )
+  if (justiceMatch?.groups) {
+    const surnameText = justiceMatch.groups.surnames
+    const roleText = justiceMatch.groups.role.trim().replace(/[.,]+$/, "")
+    const justices = surnameText
+      .split(/(?:,\s+and\s+|,\s+|\s+and\s+)/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    result.justices = justices
+
+    // Classify the role into a disposition + optional scope.
+    const lower = roleText.toLowerCase()
+    if (/^concurring\s+in\s+part\s+and\s+dissenting\s+in\s+part/.test(lower)) {
+      result.disposition = "mixed"
+      result.scope = "in_part"
+    } else if (/^concurring\s+in\s+the\s+judgment/.test(lower)) {
+      result.disposition = "concurrence"
+      result.scope = "in_judgment"
+    } else if (/^concurring\s+in\s+part/.test(lower)) {
+      result.disposition = "concurrence"
+      result.scope = "in_part"
+    } else if (/^dissenting\s+in\s+part/.test(lower)) {
+      result.disposition = "dissent"
+      result.scope = "in_part"
+    } else if (/^dissenting\s+from\s+denial\s+of/.test(lower)) {
+      result.disposition = "dissent"
+      result.scope = "from_denial"
+    } else if (/^concurring/.test(lower)) {
+      result.disposition = "concurrence"
+    } else if (/^dissenting/.test(lower)) {
+      result.disposition = "dissent"
+    } else if (/^joining/.test(lower)) {
+      result.disposition = "majority"
+    }
+    return result
+  }
+
+  // Non-justice disposition parens (#235): plurality opinion, mem.,
+  // unpublished table decision. Checked before en banc/per curiam.
+  if (/^plurality\s+opinion\b/i.test(content.trim())) {
+    result.disposition = "plurality opinion"
+    return result
+  }
+  if (/^mem\.\s*$/i.test(content.trim())) {
+    result.disposition = "mem."
+    return result
+  }
+  if (/^unpublished\s+table\s+decision\b/i.test(content.trim())) {
+    result.disposition = "unpublished table decision"
+    return result
+  }
+
+  // Check for disposition (en banc / per curiam). Anchored at content end
+  // (\s*$) so a parenthetical like `Cabranes, J., dissenting from denial of
+  // rehearing en banc` — caught above by the justice-attribution branch —
+  // does not also trip the en-banc check via substring match (#235).
+  if (/\ben banc\b\s*$/i.test(content.trim())) {
     result.disposition = "en banc"
-  } else if (/\bper curiam\b/i.test(content)) {
+  } else if (/\bper curiam\b\s*$/i.test(content.trim())) {
     result.disposition = "per curiam"
   }
 
@@ -1480,6 +1549,8 @@ function classifyParenthetical(raw: string):
       year?: number
       date?: StructuredDate
       disposition?: string
+      justices?: string[]
+      scope?: string
     }
   | {
       kind: "explanatory"
@@ -1504,7 +1575,7 @@ function classifyParenthetical(raw: string):
   // like "(9th Cir.)" will fall through to "other". This is acceptable since
   // court-only parens without year/date are extremely rare in legal text.
   const meta = parseParenthetical(raw)
-  if (meta.year || meta.date || meta.disposition) {
+  if (meta.year || meta.date || meta.disposition || meta.justices) {
     return { kind: "metadata", ...meta }
   }
 
@@ -1858,6 +1929,8 @@ export function extractCase(
   let court: string | undefined
   let date: StructuredDate | undefined
   let disposition: string | undefined
+  let justices: string[] | undefined
+  let scope: string | undefined
   let caseName: string | undefined
   let fullSpan: Span | undefined
 
@@ -1880,6 +1953,8 @@ export function extractCase(
     court = metaParenResult.court
     date = metaParenResult.date
     disposition = metaParenResult.disposition
+    justices = metaParenResult.justices
+    scope = metaParenResult.scope
   }
 
   // NY Slip Op unpublished marker (#231): `(U)` (older) or `[U]` (newer)
@@ -1915,6 +1990,8 @@ export function extractCase(
       court = metaParenResult.court
       date = metaParenResult.date
       disposition = metaParenResult.disposition
+      justices = metaParenResult.justices
+      scope = metaParenResult.scope
     }
 
     // Extract pincite from look-ahead independently of the parenthetical match.
@@ -1965,6 +2042,12 @@ export function extractCase(
         }
         if (classified.disposition && !disposition) {
           disposition = classified.disposition
+        }
+        if (classified.justices && !justices) {
+          justices = classified.justices
+        }
+        if (classified.scope && !scope) {
+          scope = classified.scope
         }
       } else {
         parentheticals ??= []
@@ -2367,6 +2450,8 @@ export function extractCase(
     parentheticals,
     subsequentHistoryEntries,
     ...(unpublished ? { unpublished: true } : {}),
+    ...(justices ? { justices } : {}),
+    ...(scope ? { scope } : {}),
     plaintiff,
     plaintiffNormalized,
     defendant,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -394,9 +394,25 @@ export interface FullCaseCitation extends CitationBase {
   /**
    * Disposition or procedural status from parenthetical.
    * Populated by Phase 6 (Complex Parentheticals).
-   * @example "en banc", "per curiam"
+   * @example "en banc", "per curiam", "dissent", "concurrence", "mixed", "plurality opinion", "mem."
    */
   disposition?: string
+
+  /**
+   * Surname(s) of justice(s) attributed to the parenthetical disposition.
+   * Populated for justice-attribution parens (#235) like
+   * `(Brennan, J., dissenting)` → `["Brennan"]` or
+   * `(Brennan and Marshall, JJ., dissenting)` → `["Brennan", "Marshall"]`.
+   */
+  justices?: string[]
+
+  /**
+   * Scope qualifier from a justice-attribution parenthetical (#235).
+   * `in_judgment` — "concurring in the judgment"
+   * `in_part`     — "concurring in part" / "concurring in part and dissenting in part"
+   * `from_denial` — "dissenting from denial of <X>"
+   */
+  scope?: string
 
   /**
    * Court level/jurisdiction inferred from reporter series.

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3081,6 +3081,122 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("justice-attribution parentheticals (#235)", () => {
+  // Justice-attribution form: `(Brennan, J., dissenting)` and variants.
+  // The parser now extracts structured fields: `disposition` (dissent /
+  // concurrence / mixed / majority / plurality opinion / etc.), `justices[]`
+  // (surnames), and optional `scope` (in_judgment / in_part / from_denial).
+  // Existing `(en banc)` / `(per curiam)` disposition handling is preserved.
+
+  describe("single-justice attribution", () => {
+    it("captures 'Brennan, J., dissenting' as disposition=dissent + justice", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 410 U.S. 113, 130 (1973) (Brennan, J., dissenting).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("dissent")
+        expect(cases[0].justices).toEqual(["Brennan"])
+      }
+    })
+
+    it("captures 'Roberts, C.J., concurring' as disposition=concurrence", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 410 U.S. 113 (1973) (Roberts, C.J., concurring).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("concurrence")
+        expect(cases[0].justices).toEqual(["Roberts"])
+      }
+    })
+  })
+
+  describe("scope qualifiers", () => {
+    it("captures 'Kennedy, J., concurring in the judgment' with scope=in_judgment", () => {
+      const cits = extractCitations(
+        "Doe v. Roe, 500 U.S. 200, 215 (1991) (Kennedy, J., concurring in the judgment).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("concurrence")
+        expect(cases[0].justices).toEqual(["Kennedy"])
+        expect(cases[0].scope).toBe("in_judgment")
+      }
+    })
+
+    it("captures 'Roberts, C.J., concurring in part and dissenting in part' with disposition=mixed", () => {
+      const cits = extractCitations(
+        "United States v. Smith, 600 U.S. 1, 50 (2023) (Roberts, C.J., concurring in part and dissenting in part).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("mixed")
+        expect(cases[0].justices).toEqual(["Roberts"])
+        expect(cases[0].scope).toBe("in_part")
+      }
+    })
+
+    it("captures 'Cabranes, J., dissenting from denial of rehearing en banc' with scope=from_denial — no en banc false positive", () => {
+      const cits = extractCitations(
+        "Acme Corp. v. Beta, 100 F.3d 1, 25 (2d Cir. 2020) (Cabranes, J., dissenting from denial of rehearing en banc).",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("dissent")
+        expect(cases[0].justices).toEqual(["Cabranes"])
+        expect(cases[0].scope).toBe("from_denial")
+      }
+    })
+  })
+
+  describe("non-justice disposition parens", () => {
+    it("captures '(plurality opinion)' as disposition=plurality opinion", () => {
+      const cits = extractCitations("Smith v. Jones, 100 U.S. 1 (1990) (plurality opinion).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("plurality opinion")
+      }
+    })
+
+    it("captures '(mem.)' as disposition=mem.", () => {
+      const cits = extractCitations("Smith v. Jones, 100 U.S. 1 (1990) (mem.).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("mem.")
+      }
+    })
+  })
+
+  describe("regression — en banc / per curiam still work", () => {
+    it("captures '(en banc)' as disposition=en banc", () => {
+      const cits = extractCitations("Smith v. Jones, 100 U.S. 1 (1990) (en banc).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("en banc")
+        expect(cases[0].justices).toBeUndefined()
+      }
+    })
+
+    it("captures '(per curiam)' as disposition=per curiam", () => {
+      const cits = extractCitations("Smith v. Jones, 100 U.S. 1 (1990) (per curiam).")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].disposition).toBe("per curiam")
+      }
+    })
+  })
+})
+
 describe("NY Slip Op (U)/[U] unpublished markers (#231)", () => {
   // New York Slip Opinion citations carry a trailing `(U)` (older form) or
   // `[U]` (newer form) marker immediately after the document number to flag


### PR DESCRIPTION
## Summary

Closes #235.

\`parseParenthetical\` previously recognized only \`en banc\` and \`per curiam\` as metadata dispositions. The very common justice-attribution form \`(Brennan, J., dissenting)\` and its variants landed as unstructured \"other\" parentheticals, losing all information about which justice authored which disposition.

### Four coordinated changes

1. **\`FullCaseCitation\`** gains two new fields:
   - \`justices?: string[]\` — surnames from \`(Brennan, J., dissenting)\` (single) or \`(Brennan and Marshall, JJ., dissenting)\` (multi).
   - \`scope?: string\` — qualifier value (\`in_judgment\`, \`in_part\`, \`from_denial\`).

2. **\`parseParenthetical\`** detects the justice-attribution pattern:
   \`\`\`regex
   ^(?<surnames>[A-Z][a-z]+(?:(?:,\\s+|\\s+and\\s+)[A-Z][a-z]+)*)\\s*,?\\s*(?<title>C\\.J\\.|J\\.|JJ\\.)\\s*,?\\s*(?<role>.+)$
   \`\`\`
   The role is classified into a \`disposition\` (\`dissent\` / \`concurrence\` / \`mixed\` / \`majority\`) and optional \`scope\` (\`in_judgment\` / \`in_part\` / \`from_denial\`).

3. **Non-justice disposition parens** newly recognized: \`(plurality opinion)\`, \`(mem.)\`, \`(unpublished table decision)\`.

4. **En-banc false-positive fix:** the \`\\ben banc\\b\` check is now anchored at the trimmed content end (\`/\\\\ben banc\\\\b\\\\s*$/\`) so a parenthetical like \`(Cabranes, J., dissenting from denial of rehearing en banc)\` — caught above by the justice-attribution branch — no longer mistakenly sets \`disposition = \"en banc\"\` via substring match. Same fix applied to \`per curiam\`.

### Example output

| Input | disposition | justices | scope |
| --- | --- | --- | --- |
| \`(Brennan, J., dissenting)\` | \`\"dissent\"\` | \`[\"Brennan\"]\` | — |
| \`(Roberts, C.J., concurring)\` | \`\"concurrence\"\` | \`[\"Roberts\"]\` | — |
| \`(Kennedy, J., concurring in the judgment)\` | \`\"concurrence\"\` | \`[\"Kennedy\"]\` | \`\"in_judgment\"\` |
| \`(Roberts, C.J., concurring in part and dissenting in part)\` | \`\"mixed\"\` | \`[\"Roberts\"]\` | \`\"in_part\"\` |
| \`(Cabranes, J., dissenting from denial of rehearing en banc)\` | \`\"dissent\"\` | \`[\"Cabranes\"]\` | \`\"from_denial\"\` |
| \`(plurality opinion)\` | \`\"plurality opinion\"\` | — | — |
| \`(mem.)\` | \`\"mem.\"\` | — | — |
| \`(en banc)\` (regression) | \`\"en banc\"\` | — | — |
| \`(per curiam)\` (regression) | \`\"per curiam\"\` | — | — |

## Test plan

- [x] 9 new tests covering: single-justice dissent/concurrence, 4 scope qualifiers (in_judgment, in_part, mixed in_part, from_denial), 2 non-justice dispositions (plurality opinion, mem.), 2 regression controls (en banc, per curiam)
- [x] \`pnpm exec vitest run\` — 2215 passed, 9 skipped (was 2206 + 9 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 168 pre-existing warnings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)