### PR TITLE
fix: bankruptcy adversary (In re X) admin parenthetical cleanup (#241)

### DIFF
--- a/.changeset/bankruptcy-admin-parenthetical.md
+++ b/.changeset/bankruptcy-admin-parenthetical.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": patch
+---
+
+fix: bankruptcy adversary `(In re X)` admin parenthetical cleanup (#241)
+
+In bankruptcy adversary proceedings, the case caption includes an administrative parenthetical naming the underlying debtor:
+
+```text
+Spence v. Hintze (In re Hintze), 570 B.R. 369 (Bankr. D. Mass. 2017)
+```
+
+**Finding:** the acceptance criteria from the issue were already satisfied by the existing parser — `caseName` preserves `(In re Hintze)`, `court` and `year` are correct, `fullSpan` covers the entire caption. The bug surfaced as a quality issue: the `defendant` field carried the admin parenthetical (`"Hintze (In re Hintze)"`), which polluted downstream consumers and `defendantNormalized`.
+
+**Improvement:** the trailing `(In re <Debtor>)` is now stripped off the `defendant` field and exposed via a new `adminParenthetical?: string` field. The `caseName` continues to preserve the full caption text (including the admin paren) via the case-name rebuild step.
+
+Example output for `Spence v. Hintze (In re Hintze), 570 B.R. 369 (Bankr. D. Mass. 2017)`:
+
+| Field | Before | After |
+| --- | --- | --- |
+| `caseName` | `"Spence v. Hintze (In re Hintze)"` | `"Spence v. Hintze (In re Hintze)"` |
+| `plaintiff` | `"Spence"` | `"Spence"` |
+| `defendant` | `"Hintze (In re Hintze)"` | `"Hintze"` |
+| `defendantNormalized` | `"hintze (in re hintze)"` | `"hintze"` |
+| `adminParenthetical` | — | `"In re Hintze"` |
+| `court` | `"Bankr. D. Mass."` | `"Bankr. D. Mass."` |
+| `year` | 2017 | 2017 |
+
+Adds 7 regression tests: 2 acceptance-criteria assertions (caseName preservation + fullSpan + non-regression in explanatory parens), 3 cleanup assertions (defendant strip, compound debtor name, hyphenated debtor name), 2 regression controls confirming non-bankruptcy parens don't trigger admin-paren handling.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1662,6 +1662,8 @@ export function extractPartyNames(caseName: string): {
   defendantNormalized?: string
   proceduralPrefix?: string
   signal?: CitationSignal
+  /** Bankruptcy adversary admin parenthetical (#241), e.g., "In re Hintze". */
+  adminParenthetical?: string
 } {
   let signal: CitationSignal | undefined
   // Procedural prefix patterns (anchored to start, case-insensitive).
@@ -1764,7 +1766,20 @@ export function extractPartyNames(caseName: string): {
   const vMatch = vRegex.exec(caseName)
   if (vMatch) {
     let plaintiff = vMatch[1].trim()
-    const defendant = vMatch[2].trim()
+    let defendant = vMatch[2].trim()
+
+    // Bankruptcy adversary admin parenthetical (#241): trailing
+    // `(In re <Debtor>)` immediately after the defendant identifies the
+    // underlying bankruptcy debtor. Strip from defendant; expose separately
+    // via `adminParenthetical`. The leading "In re" anchor distinguishes the
+    // adversary admin form from explanatory parens which appear *after* the
+    // citation core, not inside the case name.
+    let adminParenthetical: string | undefined
+    const adminMatch = /\s*\(\s*(In\s+re\s+[^)]+?)\s*\)\s*$/i.exec(defendant)
+    if (adminMatch) {
+      adminParenthetical = adminMatch[1]
+      defendant = defendant.substring(0, adminMatch.index).trim()
+    }
 
     // Strip signal words from plaintiff (e.g., "See Jones" → "Jones")
     // Uses SIGNAL_STRIP_REGEX derived from VALID_SIGNALS for single source of truth.
@@ -1794,6 +1809,7 @@ export function extractPartyNames(caseName: string): {
       defendant,
       defendantNormalized: normalizePartyName(defendant),
       signal,
+      ...(adminParenthetical ? { adminParenthetical } : {}),
     }
   }
 
@@ -2235,6 +2251,7 @@ export function extractCase(
   let defendant: string | undefined
   let defendantNormalized: string | undefined
   let proceduralPrefix: string | undefined
+  let adminParenthetical: string | undefined
 
   let signal: CitationSignal | undefined
   if (caseName) {
@@ -2245,12 +2262,16 @@ export function extractCase(
     defendantNormalized = partyResult.defendantNormalized
     proceduralPrefix = partyResult.proceduralPrefix
     signal = partyResult.signal
+    adminParenthetical = partyResult.adminParenthetical
 
     // Rebuild caseName when extractPartyNames modified the plaintiff (signal stripped,
     // "In"/"Also" prefix removed, etc.). Find the plaintiff's actual position in the
-    // cleaned text to update fullSpan and caseName span.
+    // cleaned text to update fullSpan and caseName span. Bankruptcy admin
+    // parenthetical is preserved as part of the rebuilt caseName so it remains
+    // visible to consumers even though it's stripped off the `defendant` field.
     if (plaintiff && defendant) {
-      const rebuiltName = `${plaintiff} v. ${defendant}`
+      const adminSuffix = adminParenthetical ? ` (${adminParenthetical})` : ""
+      const rebuiltName = `${plaintiff} v. ${defendant}${adminSuffix}`
       if (rebuiltName !== caseName && fullSpan && cleanedText) {
         caseName = rebuiltName
 
@@ -2452,6 +2473,7 @@ export function extractCase(
     ...(unpublished ? { unpublished: true } : {}),
     ...(justices ? { justices } : {}),
     ...(scope ? { scope } : {}),
+    ...(adminParenthetical ? { adminParenthetical } : {}),
     plaintiff,
     plaintiffNormalized,
     defendant,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -415,6 +415,17 @@ export interface FullCaseCitation extends CitationBase {
   scope?: string
 
   /**
+   * Administrative parenthetical from a bankruptcy adversary caption (#241).
+   * In `Spence v. Hintze (In re Hintze), 570 B.R. 369`, the `(In re Hintze)`
+   * names the underlying debtor and is part of the case name (preserved on
+   * `caseName`). This field exposes the debtor identification separately so
+   * `defendant` / `defendantNormalized` can hold just the adversary defendant.
+   * Content is the parenthetical text without the surrounding parens — e.g.,
+   * `"In re Hintze"`.
+   */
+  adminParenthetical?: string
+
+  /**
    * Court level/jurisdiction inferred from reporter series.
    * Always populated independently of the parenthetical `court` field.
    * Uses a curated static lookup table — does not depend on the reporter DB

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3081,6 +3081,105 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("bankruptcy adversary admin parenthetical (#241)", () => {
+  // In bankruptcy adversary proceedings, the case caption includes an
+  // administrative parenthetical naming the underlying debtor:
+  //   Spence v. Hintze (In re Hintze), 570 B.R. 369 (Bankr. D. Mass. 2017)
+  // The `(In re Hintze)` is part of the case name, not an explanatory paren.
+  // Acceptance criteria: caseName preserves the clause, fullSpan covers it.
+  // Cleanup: defendant strips the admin paren; new adminParenthetical field.
+
+  describe("acceptance criteria (already satisfied — regression tests)", () => {
+    it("'Spence v. Hintze (In re Hintze), 570 B.R. 369 (...)' — caseName preserves admin paren", () => {
+      const cits = extractCitations(
+        "Spence v. Hintze (In re Hintze), 570 B.R. 369 (Bankr. D. Mass. 2017)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].caseName).toBe("Spence v. Hintze (In re Hintze)")
+        expect(cases[0].court).toBe("Bankr. D. Mass.")
+        expect(cases[0].year).toBe(2017)
+        // fullSpan must cover the entire caption-plus-parenthetical text
+        expect(cases[0].fullSpan?.originalStart).toBe(0)
+      }
+    })
+
+    it("no regression in explanatory parens after citation core", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 100 F.3d 200 (9th Cir. 2020) (holding that X requires Y)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].caseName).toBe("Smith v. Jones")
+        expect(cases[0].parentheticals?.[0]?.text).toMatch(/holding that X/)
+      }
+    })
+  })
+
+  describe("defendant cleanup + adminParenthetical field", () => {
+    it("strips '(In re Hintze)' from defendant; exposes via adminParenthetical", () => {
+      const cits = extractCitations(
+        "Spence v. Hintze (In re Hintze), 570 B.R. 369 (Bankr. D. Mass. 2017)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].defendant).toBe("Hintze")
+        expect(cases[0].defendantNormalized).toBe("hintze")
+        expect(cases[0].adminParenthetical).toBe("In re Hintze")
+      }
+    })
+
+    it("handles compound debtor name '(In re Roe Corp.)'", () => {
+      const cits = extractCitations(
+        "Doe v. Roe (In re Roe Corp.), 250 B.R. 50 (Bankr. S.D.N.Y. 2018)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].defendant).toBe("Roe")
+        expect(cases[0].adminParenthetical).toBe("In re Roe Corp.")
+      }
+    })
+
+    it("handles hyphenated debtor name '(In re Jones-Smith Estate)'", () => {
+      const cits = extractCitations(
+        "Trustee v. Jones-Smith (In re Jones-Smith Estate), 300 B.R. 100 (Bankr. D. Del. 2019)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].defendant).toBe("Jones-Smith")
+        expect(cases[0].adminParenthetical).toBe("In re Jones-Smith Estate")
+      }
+    })
+  })
+
+  describe("regression — non-bankruptcy parens don't trigger adminParenthetical", () => {
+    it("'Smith v. Jones' without admin paren — adminParenthetical is undefined", () => {
+      const cits = extractCitations("Smith v. Jones, 100 F.3d 200 (9th Cir. 2020)")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].adminParenthetical).toBeUndefined()
+        expect(cases[0].defendant).toBe("Jones")
+      }
+    })
+
+    it("non-(In re) paren after defendant doesn't trigger admin-paren treatment", () => {
+      // Hypothetical (rare but plausible): "X v. Y (publisher)" — not adversary
+      const cits = extractCitations("Smith v. Jones (publisher), 100 F.3d 200 (9th Cir. 2020)")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].adminParenthetical).toBeUndefined()
+      }
+    })
+  })
+})
+
 describe("justice-attribution parentheticals (#235)", () => {
   // Justice-attribution form: `(Brennan, J., dissenting)` and variants.
   // The parser now extracts structured fields: `disposition` (dissent /


### PR DESCRIPTION
## Summary

Closes #241.

### Finding

The issue's acceptance criteria were **already satisfied** by the existing parser. For \`Spence v. Hintze (In re Hintze), 570 B.R. 369 (Bankr. D. Mass. 2017)\`:
- \`caseName\` ✓ \`\"Spence v. Hintze (In re Hintze)\"\` (admin paren preserved)
- \`court\` ✓ \`\"Bankr. D. Mass.\"\`
- \`year\` ✓ \`2017\`
- \`fullSpan\` ✓ covers entire caption-plus-citation text

### The actual bug

The \`defendant\` field carried the admin paren (\`\"Hintze (In re Hintze)\"\`), which polluted downstream consumers querying the adversary defendant. \`defendantNormalized\` was likewise \`\"hintze (in re hintze)\"\`.

### Fix

Strip the trailing \`(In re <Debtor>)\` from the \`defendant\` field and expose the parenthetical content separately via a new \`adminParenthetical?: string\` field. The case-name rebuild step preserves the admin paren in \`caseName\` so the full caption text remains visible.

| Field | Before | After |
| --- | --- | --- |
| \`caseName\` | \`\"Spence v. Hintze (In re Hintze)\"\` | \`\"Spence v. Hintze (In re Hintze)\"\` |
| \`plaintiff\` | \`\"Spence\"\` | \`\"Spence\"\` |
| \`defendant\` | \`\"Hintze (In re Hintze)\"\` | \`\"Hintze\"\` |
| \`defendantNormalized\` | \`\"hintze (in re hintze)\"\` | \`\"hintze\"\` |
| \`adminParenthetical\` | — | \`\"In re Hintze\"\` |

### Heuristic

The detection regex (\`\\s*\\(\\s*(In\\s+re\\s+[^)]+?)\\s*\\)\\s*$\`) anchors at the *end* of the defendant string and requires the parenthetical to **start with \`In re\`**. This distinguishes the adversary admin form from any other parenthetical content that might follow the defendant.

## Test plan

- [x] 7 new tests covering:
  - 2 acceptance-criteria assertions (caseName preservation + fullSpan, no regression in explanatory parens after citation core)
  - 3 cleanup assertions (simple defendant strip, compound debtor name \`(In re Roe Corp.)\`, hyphenated debtor name \`(In re Jones-Smith Estate)\`)
  - 2 regression controls (non-bankruptcy parens don't trigger admin-paren handling; bare \`Smith v. Jones\` without admin paren has \`adminParenthetical = undefined\`)
- [x] \`pnpm exec vitest run\` — 2222 passed, 9 skipped (was 2215 + 7 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 168 pre-existing warnings unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)