### PR TITLE
fix: California bracketed parallel citations [Cal.Rptr.] extract and link (#237)

### DIFF
--- a/.changeset/ca-bracketed-parallel.md
+++ b/.changeset/ca-bracketed-parallel.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix: California bracketed parallel citations `[266 Cal.Rptr. 569]` now extract and link (#237)
+
+California Style Manual wraps parallel reporter citations in brackets rather than placing them after a comma:
+
+```text
+Smith v. Jones, 50 Cal.3d 100 (Cal. 1990) [266 Cal.Rptr. 569]
+```
+
+Pre-fix, the bracketed cite either fell through to the journal pattern (wrong type) or failed to tokenize entirely. `detectParallel.ts` required a comma + shared parenthetical between citations to link them, so even when both extracted, they weren't recognized as parallels.
+
+Two coordinated changes:
+
+1. **`state-reporter` trailing lookahead** extended from `(?=\s|$|\(|,|;|\.|\[)` to `(?=\s|$|\(|,|;|\.|\[|\])` so a bracketed-end-of-citation pattern (`<vol> <Reporter> <page>` followed by `]`) tokenizes correctly. Without this, the broader journal pattern absorbed the citation with the wrong type.
+2. **CA bracket-mode parallel detection** added to `detectParallel.ts` ahead of the comma-requirement gate. When the gap text between two adjacent case citations contains `[` and the secondary citation is immediately followed by `]`, the pair is treated as a parallel — no shared-paren requirement (CA cites often have a `(<year>)` paren *between* the primary and the bracket, which would otherwise trip the existing separate-parens rejection).
+
+Example output for `Smith v. Jones, 50 Cal.3d 100 (Cal. 1990) [266 Cal.Rptr. 569]`:
+
+| Citation | volume | reporter | page | groupId |
+| --- | --- | --- | --- | --- |
+| Primary | 50 | `Cal.3d` | 100 | `50-Cal.3d-100` |
+| Bracketed | 266 | `Cal.Rptr.` | 569 | `50-Cal.3d-100` (same) |
+
+Adds 7 regression tests: 4 bracketed-cite extraction tests (incl. compound `Cal.Rptr.2d`, pincite inside brackets, `Cal.4th`+`P.3d` parallel), 1 parallel linking assertion (shared `groupId`), 2 regression controls confirming NY Slip Op `[U]` unpublished markers (#231) and existing comma-separated parallels still work.

--- a/src/extract/detectParallel.ts
+++ b/src/extract/detectParallel.ts
@@ -106,6 +106,19 @@ export function detectParallelCitations(tokens: Token[], cleanedText = ""): Map<
       // Extract the gap text between citations
       const gapText = cleanedText.substring(gapStart, gapEnd)
 
+      // California Style Manual bracket form (#237): the parallel citation
+      // is wrapped in brackets — `<primary> (<year>) [<secondary>]`. Check
+      // this BEFORE the comma-requirement gate so we don't reject CA parallels.
+      const inBracket =
+        gapText.includes("[") &&
+        cleanedText[secondary.span.cleanEnd] === "]"
+      if (inBracket) {
+        secondaryIndices.push(j)
+        usedAsSecondary.add(j)
+        // CA brackets always close after a single parallel cite — chain ends here.
+        break
+      }
+
       // Bluebook requires comma separator for parallel citations
       if (!gapText.includes(",")) {
         break // No comma = not parallel, stop looking

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -49,10 +49,11 @@ export const casePatterns: Pattern[] = [
     // (e.g., `I&N Dec.` and `I. & N. Dec.` for BIA immigration decisions — #244).
     // Apostrophe `'` is admitted for reporters like `F. App'x` already covered by
     // federal-reporter; including it here is harmless and future-proofs other
-    // possessive forms. Trailing lookahead also accepts `[` so NY Slip Op
-    // `[U]` unpublished markers don't break the boundary check (#231).
+    // possessive forms. Trailing lookahead also accepts `[` (NY Slip Op `[U]`
+    // markers — #231) and `]` (California Style Manual bracketed parallel
+    // cites like `[266 Cal.Rptr. 569]` — #237).
     regex:
-      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[)/g,
+      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[|\])/g,
     description:
       'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev" and phantom matches across a case-name separator " v. "/" vs. ", validated against reporters-db in Phase 3)',
     type: "case",

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -3081,6 +3081,101 @@ New York first recognized IIED as a cognizable cause of action in Fischer v. Mal
   })
 })
 
+describe("California bracketed parallel citations (#237)", () => {
+  // California Style Manual uses `[<vol> <Reporter> <page>]` brackets for
+  // parallel reporter citations, e.g.,
+  //   People v. Smith, 50 Cal.3d 100 (Cal. 1990) [266 Cal.Rptr. 569]
+  // Pre-fix the bracketed cite was tokenized as a journal (wrong type) or
+  // missed entirely. After fix: the bracketed cite extracts as a `case`
+  // citation and is linked as a parallel to the preceding primary.
+
+  describe("bracketed cite extraction", () => {
+    it("extracts '[266 Cal.Rptr. 569]' as a case citation (Bluebook-form leading cite)", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 50 Cal.3d 100 (Cal. 1990) [266 Cal.Rptr. 569]",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+      const bracketed = cases.find((c) => c.type === "case" && c.reporter === "Cal.Rptr.")
+      expect(bracketed).toBeDefined()
+      if (bracketed?.type === "case") {
+        expect(bracketed.volume).toBe(266)
+        expect(bracketed.page).toBe(569)
+      }
+    })
+
+    it("extracts '[54 Cal.Rptr.2d 370]' (no pincite) as case", () => {
+      const cits = extractCitations(
+        "Smith v. Williams, 65 Cal.2d 263, 265 (Cal. 1966) [54 Cal.Rptr.2d 370]",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+      const bracketed = cases.find(
+        (c) => c.type === "case" && c.reporter === "Cal.Rptr.2d",
+      )
+      expect(bracketed).toBeDefined()
+    })
+
+    it("extracts bracketed cite with pincite '[266 Cal.Rptr. 569, 575]'", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 50 Cal.3d 100, 115 (Cal. 1990) [266 Cal.Rptr. 569, 575]",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+      const bracketed = cases.find((c) => c.type === "case" && c.reporter === "Cal.Rptr.")
+      expect(bracketed).toBeDefined()
+      if (bracketed?.type === "case") {
+        expect(bracketed.pincite).toBe(575)
+      }
+    })
+
+    it("extracts '[100 P.3d 1]' (Cal.4th + P.3d parallel)", () => {
+      const cits = extractCitations(
+        "Doe v. Roe, 1 Cal.4th 50 (Cal. 2010) [100 P.3d 1]",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+      const bracketed = cases.find((c) => c.type === "case" && c.reporter === "P.3d")
+      expect(bracketed).toBeDefined()
+    })
+  })
+
+  describe("parallel linking", () => {
+    it("links primary 'Cal.3d' with bracketed 'Cal.Rptr.' via parallelCitations", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 50 Cal.3d 100 (Cal. 1990) [266 Cal.Rptr. 569]",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases.length).toBeGreaterThanOrEqual(2)
+      // Both citations should share a groupId set by parallel detection
+      const primary = cases.find((c) => c.type === "case" && c.reporter === "Cal.3d")
+      const secondary = cases.find((c) => c.type === "case" && c.reporter === "Cal.Rptr.")
+      expect(primary?.groupId).toBeDefined()
+      expect(secondary?.groupId).toBeDefined()
+      expect(primary?.groupId).toBe(secondary?.groupId)
+    })
+  })
+
+  describe("regression — non-CA-bracket forms unaffected", () => {
+    it("NY Slip Op '[U]' unpublished marker is NOT treated as a bracket parallel", () => {
+      const cits = extractCitations("2024 NY Slip Op 51192[U]")
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].unpublished).toBe(true)
+      }
+    })
+
+    it("non-bracketed Cal.Rptr. parallel still works (comma-separated)", () => {
+      const cits = extractCitations(
+        "Smith v. Jones, 50 Cal.3d 100, 266 Cal.Rptr. 569 (Cal. 1990)",
+      )
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+    })
+  })
+})
+
 describe("bankruptcy adversary admin parenthetical (#241)", () => {
   // In bankruptcy adversary proceedings, the case caption includes an
   // administrative parenthetical naming the underlying debtor:


### PR DESCRIPTION
## Summary

Closes #237.

California Style Manual wraps parallel reporter citations in brackets rather than placing them after a comma:

\`\`\`text
Smith v. Jones, 50 Cal.3d 100 (Cal. 1990) [266 Cal.Rptr. 569]
\`\`\`

Pre-fix, the bracketed cite either fell through to the journal pattern (wrong \`type\`) or failed to tokenize entirely. \`detectParallel.ts\` required a comma + shared parenthetical between citations to link them, so even when both extracted, they weren't recognized as parallels.

### Two coordinated changes

1. **\`state-reporter\` trailing lookahead** extended from \`(?=\\s|$|\\(|,|;|\\.|\\[)\` to \`(?=\\s|$|\\(|,|;|\\.|\\[|\\])\` so a bracketed-end-of-citation pattern (\`<vol> <Reporter> <page>\` followed by \`]\`) tokenizes correctly. Without this, the broader journal pattern absorbed the citation with the wrong type.

2. **CA bracket-mode parallel detection** added to \`detectParallel.ts\` ahead of the comma-requirement gate. When the gap text between two adjacent case citations contains \`[\` AND the secondary citation is immediately followed by \`]\`, the pair is treated as a parallel — no shared-paren requirement (CA cites typically have a \`(<year>)\` paren *between* the primary and the bracket, which would otherwise trip the existing separate-parens rejection).

### Example output for \`Smith v. Jones, 50 Cal.3d 100 (Cal. 1990) [266 Cal.Rptr. 569]\`

| Citation | volume | reporter | page | groupId |
| --- | --- | --- | --- | --- |
| Primary | 50 | \`Cal.3d\` | 100 | \`50-Cal.3d-100\` |
| Bracketed | 266 | \`Cal.Rptr.\` | 569 | \`50-Cal.3d-100\` (same) |

## Test plan

- [x] 7 new tests:
  - 4 bracketed-cite extraction variants (basic, compound \`Cal.Rptr.2d\`, pincite inside brackets, \`Cal.4th\`+\`P.3d\` parallel)
  - 1 parallel linking assertion (\`groupId\` shared between primary and bracketed)
  - 2 regression controls (NY Slip Op \`[U]\` unpublished markers from #231, existing comma-separated parallels)
- [x] \`pnpm exec vitest run\` — 2229 passed, 9 skipped (was 2222 + 7 new)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` — 168 pre-existing warnings unchanged

## Note on case-name extraction

This PR scopes to **bracketed parallel extraction + linking**. Acceptance criterion 2 from the issue (\"both citations share the same case name\") is satisfied trivially when the case-name *is* captured — but full CA year-first format (\`(1990) 50 Cal.3d 100\` before the citation) is tracked separately as #19 and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)