### PR TITLE
fix: California Style Manual  /  pincites (#236)

### DIFF
--- a/.changeset/issue-236-at-p-pincites.md
+++ b/.changeset/issue-236-at-p-pincites.md
@@ -1,0 +1,37 @@
+---
+"eyecite-ts": patch
+---
+
+fix: California Style Manual `at p.` / `at pp.` pincites (#236)
+
+`LOOKAHEAD_PINCITE_REGEX`, `PINCITE_SKIP_REGEX`, all five short-form tokenizer
+patterns (`ID_PATTERN`, `IBID_PATTERN`, `SUPRA_PATTERN`,
+`STANDALONE_SUPRA_PATTERN`, `SHORT_FORM_CASE_PATTERN`), and the four local
+regexes in `extractShortForms.ts` (`idRegex`, `partySupraRegex`,
+`standaloneRegex`, `shortFormRegex`) now accept an optional `p.` / `pp.`
+prefix between `at` and the page number, plus page-range support on supra
+matches. This is the California Style Manual standard form
+(`Smith, supra, at p. 115`, `Id. at pp. 125-130`, `18 Cal.4th at p. 717`,
+`50 Cal.3d 100, at p. 115`).
+
+### Why
+
+CSM rule 1:1 requires `at p.` / `at pp.` for pincites, not Bluebook bare
+`at <N>`. Every CA `supra at p.`, `Id. at p.`, and short-form `at p.` reference
+previously produced a partial match with the pincite silently dropped, and
+the bare full-case form `50 Cal.3d 100, at p. 115` lost the trailing pincite
+entirely.
+
+### State-reporter pattern tightened
+
+The state-reporter pattern in `casePatterns.ts` previously absorbed
+`18 Cal.4th at p. 717` as `reporter: "Cal.4th at p."` because the broad
+multi-word reporter character class accepts `[A-Za-z.\d\s&']` and the
+non-greedy quantifier extended through the literal "at" word. A negative
+lookahead `(?!\s+at\s)` now rejects that boundary, letting the short-form
+case pattern correctly handle CSM mid-paragraph short-form references.
+
+### Tests
+
+11 new tests (8 fixtures + 3 regression controls) cover supra, Id., short-form
+case, and full case with `at p.` / `at pp.`, plus page-range forms.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -171,10 +171,11 @@ const LOOKAHEAD_PAREN_REGEX =
  *    - ", 125"       (comma-separated, numeric)
  *    - ", at *1"     (comma + "at" keyword; common with star-pagination)
  *    - " at *2"      (whitespace + "at" keyword; NY Slip Op repeat form)
+ *    - ", at p. 115" (CSM form with `p.` / `pp.` prefix; #236)
  *  The "*" prefix marks star-pagination (#191); a trailing " n.14" /
  *  " nn.14-15" footnote suffix is captured when present (#202). */
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+|,\s*(?:at\s+)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
+  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -184,11 +185,11 @@ const PAREN_SKIP_REGEX = /[\s,]/
 
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.
- *  E.g., ", 199 n.2", ", 999-1000", ", 130 n.5"
+ *  E.g., ", 199 n.2", ", 999-1000", ", 130 n.5", ", at p. 115" (CSM, #236).
  *  The outer `+` is intentionally greedy to handle multi-pincite citations
  *  (e.g., ", 199, 205, 210"). Safe because the scan window is bounded by maxLookahead. */
 const PINCITE_SKIP_REGEX =
-  /^(?:,\s*(?:at\s+)?\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?)+/
+  /^(?:,\s*(?:at\s+(?:pp?\.\s*)?)?\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?)+/
 
 /**
  * Signal normalization table. Longer patterns first so "aff'd on other grounds"

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -57,9 +57,10 @@ export function extractId(
 
   // Parse Id. with optional pincite.
   // Pattern: Id. or Ibid. with optional comma + "at [page]" (handles "Id., at 5").
-  // Pincite accepts optional "*" prefix for star-pagination (#191) and an
-  // optional trailing footnote suffix " n.14" / " nn.14-15" (#202).
-  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
+  // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
+  // trailing footnote suffix " n.14" / " nn.14-15" (#202), and an optional
+  // `p.` / `pp.` prefix for CSM form (`Id. at p. 125`; see #236).
+  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(?:pp?\.\s*)?(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
   const match = idRegex.exec(text)
 
   if (!match) {
@@ -163,15 +164,17 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   const { text, span } = token
 
   // Try party-name pattern first: "Smith, supra [note N] [, at page]".
-  // Pincite accepts optional "*" prefix for star-pagination (#191) and an
-  // optional trailing footnote suffix (#202).
+  // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
+  // range end / `p.` / `pp.` prefix for CSM form (#236), and an optional
+  // trailing footnote suffix (#202).
   const partySupraRegex =
-    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
+    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
   const partyMatch = partySupraRegex.exec(text)
 
   // Fallback: standalone supra — "supra note N", "supra at N", "supra § N".
+  // The `at` page accepts the same `p.` / `pp.` prefix and range form (#236).
   const standaloneRegex =
-    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+at\s+(\*?\d+(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
+    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
   const match = partyMatch || standaloneRegex.exec(text)
 
   if (!match) {
@@ -284,10 +287,11 @@ export function extractShortFormCase(
   // Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
   // Handles comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
   // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
-  // range end "462-65" / "462-*65" (#201), and an optional trailing footnote
-  // suffix " n.14" / " nn.14-15" (#202).
+  // range end "462-65" / "462-*65" (#201), an optional trailing footnote
+  // suffix " n.14" / " nn.14-15" (#202), and an optional `p.` / `pp.` prefix
+  // for CSM form (`18 Cal.4th at p. 717`; see #236).
   const shortFormRegex =
-    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
+    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -51,11 +51,14 @@ export const casePatterns: Pattern[] = [
     // federal-reporter; including it here is harmless and future-proofs other
     // possessive forms. Trailing lookahead also accepts `[` (NY Slip Op `[U]`
     // markers — #231) and `]` (California Style Manual bracketed parallel
-    // cites like `[266 Cal.Rptr. 569]` — #237).
+    // cites like `[266 Cal.Rptr. 569]` — #237). Negative lookahead on the
+    // reporter body rejects ` at ` so `18 Cal.4th at p. 717` (CSM short-form,
+    // #236) doesn't absorb `at p.` into the reporter; the short-form pattern
+    // handles it instead.
     regex:
-      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[|\])/g,
+      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)(?!\s+at\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[|\])/g,
     description:
-      'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev" and phantom matches across a case-name separator " v. "/" vs. ", validated against reporters-db in Phase 3)',
+      'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev", phantom matches across " v. "/" vs. ", and CSM " at " short-form boundaries, validated against reporters-db in Phase 3)',
     type: "case",
   },
 ]

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -14,24 +14,27 @@ import type { Pattern } from "./casePatterns"
 
 /** Id. with optional pincite: "Id." or "Id. at 253" or "Id., at 253".
  *  Pincite captures an optional "*" prefix for star-pagination (NY Slip Op,
- *  Westlaw, Lexis; see #191) and an optional trailing " n.14" /
- *  " nn.14-15" footnote suffix (see #202). */
+ *  Westlaw, Lexis; see #191), an optional trailing " n.14" / " nn.14-15"
+ *  footnote suffix (see #202), and an optional `p.` / `pp.` prefix used by
+ *  the California Style Manual (e.g., `Id. at p. 115`, `Id. at pp. 115-117`;
+ *  see #236). */
 export const ID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d\.(?:,?\s+at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d\.(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
 
 /** Ibid. with optional pincite (less common variant). */
 export const IBID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\.(?:,?\s+at\s+(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\.(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
 
 /**
  * Supra with party name and optional pincite.
  * Pattern: word(s), supra [note N] [, at page]
  * Captures: (1) party name, (2) note number (if any), (3) pincite
- * Pincite accepts optional "*" prefix for star-pagination (#191) and an
- * optional trailing footnote suffix (#202).
+ * Pincite accepts optional "*" prefix for star-pagination (#191), an optional
+ * range end (#236), an optional trailing footnote suffix (#202), and an
+ * optional `p.` / `pp.` prefix for California Style Manual form (#236).
  */
 export const SUPRA_PATTERN: RegExp =
-  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
+  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
 
 /**
  * Standalone supra without party name (common in footnotes).
@@ -39,10 +42,11 @@ export const SUPRA_PATTERN: RegExp =
  * Requires "note", "at", "§", "Part", or "p." after supra to avoid matching
  * the word "supra" in prose. Preceded by whitespace, start, or signal words.
  * Captures: (1) note number (if any), (2) pincite (with optional "*" prefix,
- * #191, and optional trailing footnote suffix, #202).
+ * #191, optional range end / `p.`/`pp.` prefix #236, and optional trailing
+ * footnote suffix, #202).
  */
 export const STANDALONE_SUPRA_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?|\s+at\s+(\*?\d+)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|\s+(?:§+|Part|p\.)\s*\S+)/g
+  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?|\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|\s+(?:§+|Part|p\.)\s*\S+)/g
 
 /**
  * Short-form case: volume reporter [,] at page
@@ -51,11 +55,12 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
  * Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
  * Handles SCOTUS/federal comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
  * Pincite accepts optional "*" prefix for star-pagination (#191), an optional
- * range end "462-65" / "462-*65" (#201), and an optional trailing footnote
- * suffix " n.14" / " nn.14-15" (#202).
+ * range end "462-65" / "462-*65" (#201), an optional trailing footnote suffix
+ * " n.14" / " nn.14-15" (#202), and an optional `p.` / `pp.` prefix for
+ * California Style Manual form (`18 Cal.4th at p. 717`; see #236).
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?\b/g
+  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -829,4 +829,158 @@ describe("star-pagination pincite (#191)", () => {
       }
     })
   })
+
+  /**
+   * California Style Manual `at p.` / `at pp.` pincite forms (#236).
+   *
+   * CSM rule 1:1 uses `at p. <N>` for a single pincite and `at pp. <N-M>` for
+   * a range — never bare `at <N>` as Bluebook does. Every CA `supra at p.`,
+   * Id. at p., and short-form at-p. reference previously produced an
+   * incomplete match with the pincite silently dropped.
+   *
+   * Coverage:
+   *   - Supra with `, at p.` and `, at pp.` (ranges)
+   *   - Supra with volume+reporter then `at p.` (short-form-ish)
+   *   - Id. with `at p.` and `at pp.`
+   *   - Short-form case with `at p.` and `at pp.`
+   *   - Full case with trailing `, at p.` pincite
+   *
+   * Regression controls confirm existing Bluebook `at N` forms still work.
+   */
+  describe("California `at p.` / `at pp.` pincites (#236)", () => {
+    describe("supra", () => {
+      it("`Smith, supra, at p. 115`", () => {
+        const cits = extractCitations("As Smith, supra, at p. 115 held.")
+        const sup = cits.find((c) => c.type === "supra")
+        expect(sup).toBeDefined()
+        if (sup?.type === "supra") {
+          expect(sup.pincite).toBe(115)
+        }
+      })
+
+      it("`Smith, supra, at pp. 115-117` (range)", () => {
+        const cits = extractCitations("See Smith, supra, at pp. 115-117 here.")
+        const sup = cits.find((c) => c.type === "supra")
+        expect(sup).toBeDefined()
+        if (sup?.type === "supra") {
+          expect(sup.pincite).toBe(115)
+          expect(sup.pinciteInfo?.endPage).toBe(117)
+          expect(sup.pinciteInfo?.isRange).toBe(true)
+        }
+      })
+    })
+
+    describe("Id.", () => {
+      it("`Id. at p. 125`", () => {
+        const text =
+          "Smith v. Jones, 50 Cal.3d 100, 110 (Cal. 1990). Id. at p. 125."
+        const cits = extractCitations(text)
+        const id = cits.find((c) => c.type === "id")
+        expect(id).toBeDefined()
+        if (id?.type === "id") {
+          expect(id.pincite).toBe(125)
+        }
+      })
+
+      it("`Id. at pp. 125-130` (range)", () => {
+        const text =
+          "Smith v. Jones, 50 Cal.3d 100, 110 (Cal. 1990). Id. at pp. 125-130."
+        const cits = extractCitations(text)
+        const id = cits.find((c) => c.type === "id")
+        expect(id).toBeDefined()
+        if (id?.type === "id") {
+          expect(id.pincite).toBe(125)
+          expect(id.pinciteInfo?.endPage).toBe(130)
+        }
+      })
+    })
+
+    describe("short-form case", () => {
+      it("`(Davis, supra, 18 Cal.4th at p. 717.)`", () => {
+        // Should produce a Davis supra AND a short-form case with the Cal.4th
+        // reporter intact (not absorbed as `Cal.4th at p.`).
+        const cits = extractCitations("(Davis, supra, 18 Cal.4th at p. 717.)")
+        const sf = cits.find((c) => c.type === "shortFormCase")
+        expect(sf).toBeDefined()
+        if (sf?.type === "shortFormCase") {
+          expect(sf.volume).toBe(18)
+          expect(sf.reporter).toBe("Cal.4th")
+          expect(sf.pincite).toBe(717)
+        }
+      })
+
+      it("`50 Cal.3d at pp. 115-117` range", () => {
+        const cits = extractCitations(
+          "(Smith, supra, 50 Cal.3d at pp. 115-117 held.)",
+        )
+        const sf = cits.find((c) => c.type === "shortFormCase")
+        expect(sf).toBeDefined()
+        if (sf?.type === "shortFormCase") {
+          expect(sf.volume).toBe(50)
+          expect(sf.reporter).toBe("Cal.3d")
+          expect(sf.pincite).toBe(115)
+          expect(sf.pinciteInfo?.endPage).toBe(117)
+        }
+      })
+    })
+
+    describe("full case with trailing at p. pincite", () => {
+      it("`People v. Smith (1990) 50 Cal.3d 100, at p. 115`", () => {
+        const cits = extractCitations(
+          "People v. Smith (1990) 50 Cal.3d 100, at p. 115.",
+        )
+        const cases = cits.filter((c) => c.type === "case")
+        expect(cases).toHaveLength(1)
+        if (cases[0].type === "case") {
+          expect(cases[0].pincite).toBe(115)
+        }
+      })
+
+      it("`People v. Smith (1990) 50 Cal.3d 100, at pp. 115-118` range", () => {
+        const cits = extractCitations(
+          "People v. Smith (1990) 50 Cal.3d 100, at pp. 115-118.",
+        )
+        const cases = cits.filter((c) => c.type === "case")
+        expect(cases).toHaveLength(1)
+        if (cases[0].type === "case") {
+          expect(cases[0].pincite).toBe(115)
+          expect(cases[0].pinciteInfo?.endPage).toBe(118)
+        }
+      })
+    })
+
+    describe("regression controls — Bluebook `at N` still works", () => {
+      it("`Id. at 125` (Bluebook)", () => {
+        const text =
+          "Smith v. Jones, 50 F.3d 100, 110 (2d Cir. 1995). Id. at 125."
+        const cits = extractCitations(text)
+        const id = cits.find((c) => c.type === "id")
+        expect(id).toBeDefined()
+        if (id?.type === "id") {
+          expect(id.pincite).toBe(125)
+        }
+      })
+
+      it("`Smith, supra, at 460` (Bluebook)", () => {
+        const cits = extractCitations("See Smith, supra, at 460 held.")
+        const sup = cits.find((c) => c.type === "supra")
+        expect(sup).toBeDefined()
+        if (sup?.type === "supra") {
+          expect(sup.pincite).toBe(460)
+        }
+      })
+
+      it("`50 F.2d at 125` (Bluebook short-form)", () => {
+        const text = "Smith v. Jones, 50 F.2d 100 (1990). 50 F.2d at 125."
+        const cits = extractCitations(text)
+        const sf = cits.find((c) => c.type === "shortFormCase")
+        expect(sf).toBeDefined()
+        if (sf?.type === "shortFormCase") {
+          expect(sf.volume).toBe(50)
+          expect(sf.reporter).toBe("F.2d")
+          expect(sf.pincite).toBe(125)
+        }
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #236.

CSM rule 1:1 requires `at p.` (single page) and `at pp.` (range) for pincites, not Bluebook bare `at <N>`. Every CA `supra at p.`, `Id. at p.`, and short-form `at p.` reference previously produced a partial match with the pincite silently dropped, and the bare full-case form `50 Cal.3d 100, at p. 115` lost the trailing pincite entirely.

### Changes

Add optional `pp?\.\s*` between `at` and the page number across the pincite regex zoo:

- `LOOKAHEAD_PINCITE_REGEX`, `PINCITE_SKIP_REGEX` in `extractCase.ts`
- `ID_PATTERN`, `IBID_PATTERN`, `SUPRA_PATTERN`, `STANDALONE_SUPRA_PATTERN`, `SHORT_FORM_CASE_PATTERN` in `shortForm.ts`
- `idRegex`, `partySupraRegex`, `standaloneRegex`, `shortFormRegex` (local copies in `extractShortForms.ts`)
- Page-range support added to supra matches (was previously single-page only)

### State-reporter pattern tightened

The state-reporter pattern previously absorbed `18 Cal.4th at p. 717` as `reporter: \"Cal.4th at p.\"` because the broad multi-word reporter character class accepts `[A-Za-z.\\d\\s&']` and the non-greedy quantifier extended through the literal `at` word. A new negative lookahead `(?!\\s+at\\s)` rejects that boundary, letting the short-form case pattern correctly handle CSM mid-paragraph short-form references.

### Tests

11 new tests under `California \`at p.\` / \`at pp.\` pincites (#236)` cover:

- Supra: `Smith, supra, at p. 115`, `Smith, supra, at pp. 115-117` (range)
- Id.: `Id. at p. 125`, `Id. at pp. 125-130` (range)
- Short-form case: `(Davis, supra, 18 Cal.4th at p. 717.)`, `50 Cal.3d at pp. 115-117`
- Full case trailing pincite: `People v. Smith (1990) 50 Cal.3d 100, at p. 115`, `50 Cal.3d 100, at pp. 115-118`
- Regression controls: `Id. at 125`, `Smith, supra, at 460`, `50 F.2d at 125` (Bluebook bare-`at`)

## Test plan

- [x] 11/11 new tests pass
- [x] Full suite: 2271/2271 (was 2260)
- [x] 30/30 ReDoS tests still pass
- [x] `pnpm typecheck` clean
- [x] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)