### PR TITLE
fix: strip citation signals from supra partyName (#216)

### DIFF
--- a/.changeset/issue-216-supra-signal-strip.md
+++ b/.changeset/issue-216-supra-signal-strip.md
@@ -1,0 +1,31 @@
+---
+"eyecite-ts": patch
+---
+
+fix: strip citation signals and sentence-initial connectors from supra partyName (#216)
+
+`SUPRA_PATTERN`'s party-name group greedily captures any sequence of
+capitalized words before `supra`, so `See Gall, supra`, `Cf. Gall, supra`,
+`Then Gall, supra`, and `In Gall, supra` all leaked the leading word into
+`partyName` — preventing `DocumentResolver` from matching the supra back to
+its full-cite antecedent.
+
+`extractSupra` now post-processes the captured party name through
+`stripSupraPartyPrefix`, which removes leading:
+
+- Citation signals: `See`, `See also`, `See, e.g.`, `But see`, `But cf.`,
+  `Compare`, `Cf.` / `Cf`, `Accord`, `E.g.`
+- Sentence-initial connectors: `Also`, `Then`, `In` (but never `In re` —
+  the `(?!\s+re\b)` negative lookahead preserves the bankruptcy/dependency
+  caption prefix)
+
+The original captured name is preserved when stripping would leave an empty
+string (defensive: prevents a wholesale signal token from blanking out the
+party name).
+
+### Tests
+
+12 new tests under `supra party-name signal-leak (#216)`: 5 citation signals
++ 3 sentence-initial connectors + 4 regression controls (including `In re
+Smith, supra` → preserves `Smith`, `Smith v. Jones, supra` → preserves both,
+`See Smith v. Jones, supra` → strips `See` but keeps `Smith v. Jones`).

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -19,6 +19,29 @@ import { COMMON_REPORTERS } from "./extractCase"
 import { parsePincite, type PinciteInfo } from "./pincite"
 
 /**
+ * Strip leading citation signals (`See`, `See also`, `Cf.`, `Compare`,
+ * `Accord`, `But see`, `But cf.`, `E.g.`) and sentence-initial connectors
+ * (`Also`, `Then`, `In` (but never `In re`)) from a captured supra party name.
+ *
+ * The `SUPRA_PATTERN` tokenizer is greedy with leading capitalized words, so
+ * `See Gall, supra` produces `partyName = "See Gall"` and prevents the
+ * resolver from matching the supra to its `Gall v. Colon-Sylvain` antecedent.
+ * The `In(?!\s+re\b)` negative lookahead preserves `In re Smith` — only the
+ * bare `In` directly preceding a proper-name party gets stripped (#216).
+ *
+ * The original captured name is returned unchanged when stripping would leave
+ * an empty string (defensive: prevents a wholesale signal token from blanking
+ * out the party name).
+ */
+const SUPRA_PARTY_PREFIX_REGEX =
+  /^(?:But\s+(?:see|cf\.?)|See(?:\s+also)?(?:\s*,\s*e\.\s*g\.?)?|Compare|Cf\.?|Accord|E\.\s*g\.?|Also|In(?!\s+re\b)|Then)\s+/i
+
+function stripSupraPartyPrefix(raw: string): string {
+  const stripped = raw.replace(SUPRA_PARTY_PREFIX_REGEX, "").trim()
+  return stripped.length > 0 ? stripped : raw
+}
+
+/**
  * Extracts Id. citation metadata from a tokenized citation.
  *
  * Parses token text to extract:
@@ -187,7 +210,7 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   let pinciteGroupIdx: number | undefined
 
   if (partyMatch) {
-    partyName = partyMatch[1]
+    partyName = stripSupraPartyPrefix(partyMatch[1])
     pinciteInfo = partyMatch[3]
       ? (parsePincite(partyMatch[3]) ?? undefined)
       : undefined

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -984,3 +984,158 @@ describe("star-pagination pincite (#191)", () => {
     })
   })
 })
+
+/**
+ * Supra party-name signal-leak (#216).
+ *
+ * `SUPRA_PATTERN`'s party-name group greedily captures any sequence of
+ * capitalized words before `supra`, so a citation that starts with a citation
+ * signal (`See`, `Cf.`, `Compare`) or a sentence-initial connector (`In`,
+ * `Also`, `Then`) bleeds that leading word into the captured `partyName`,
+ * preventing `DocumentResolver` from matching the supra back to its full-cite
+ * antecedent.
+ *
+ * Suite covers the issue's title fixtures (`Then Gall`, `See Gall`), the
+ * issue's enumerated signal list (See / But see / But cf. / Compare / Cf. /
+ * Accord / Also / E.g. / In), and the `In re` regression — `In re Smith`
+ * must NOT lose the `In` because the `re` is part of the prefix.
+ */
+describe("supra party-name signal-leak (#216)", () => {
+  describe("citation signals stripped from partyName", () => {
+    it("`See Gall, supra` → partyName = 'Gall'", () => {
+      const text =
+        "Bd. v. FirstService, 193 A.D.3d 672 (2d Dep't 2021). See Gall, supra, at 700."
+      const cits = extractCitations(text)
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+
+    it("`See also Gall, supra` → partyName = 'Gall'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). See also Gall, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+
+    it("`Compare Gall, supra` → partyName = 'Gall'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). Compare Gall, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+
+    it("`Cf. Gall, supra` → partyName = 'Gall'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). Cf. Gall, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+
+    it("`Accord Gall, supra` → partyName = 'Gall'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). Accord Gall, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+  })
+
+  describe("sentence-initial connectors stripped from partyName", () => {
+    it("`Then Gall, supra` → partyName = 'Gall'", () => {
+      const text =
+        "Bd. v. FirstService, 193 A.D.3d 672 (2d Dep't 2021). Then Gall, supra, at 700."
+      const cits = extractCitations(text)
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+
+    it("`Also Gall, supra` → partyName = 'Gall'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). Also Gall, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+
+    it("`In Gall, supra` → partyName = 'Gall' (but NOT 'In Gall')", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). In Gall, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+  })
+
+  describe("regression controls — must preserve real party names", () => {
+    it("`In re Smith, supra` → partyName = 'Smith'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). In re Smith, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Smith")
+      }
+    })
+
+    it("`Gall, supra` (no prefix) → partyName = 'Gall'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). Gall, supra, at 700.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Gall")
+      }
+    })
+
+    it("`Smith v. Jones, supra` (multi-word) → partyName = 'Smith v. Jones'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). Smith v. Jones, supra, at 460.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Smith v. Jones")
+      }
+    })
+
+    it("`See Smith v. Jones, supra` (signal + v.) → partyName = 'Smith v. Jones'", () => {
+      const cits = extractCitations(
+        "Foo v. Bar, 1 F.3d 2 (1990). See Smith v. Jones, supra, at 460.",
+      )
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.partyName).toBe("Smith v. Jones")
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #216.

`SUPRA_PATTERN`'s party-name group greedily captures any sequence of capitalized words before `supra`, so `See Gall, supra`, `Cf. Gall, supra`, `Then Gall, supra`, and `In Gall, supra` all leaked the leading word into `partyName` — preventing `DocumentResolver` from matching the supra back to its full-cite antecedent.

### Fix

`extractSupra` now post-processes the captured party name through `stripSupraPartyPrefix`, which removes leading:

- **Citation signals**: `See`, `See also`, `See, e.g.`, `But see`, `But cf.`, `Compare`, `Cf.` / `Cf`, `Accord`, `E.g.`
- **Sentence-initial connectors**: `Also`, `Then`, `In` (but never `In re` — the `(?!\s+re\b)` negative lookahead preserves the bankruptcy/dependency caption prefix)

The original captured name is preserved when stripping would leave an empty string (defensive).

### Tests

12 new tests under `supra party-name signal-leak (#216)`:

- 5 citation-signal fixtures: `See Gall`, `See also Gall`, `Compare Gall`, `Cf. Gall`, `Accord Gall`
- 3 sentence-initial connectors: `Then Gall`, `Also Gall`, `In Gall` (→ `Gall`)
- 4 regression controls: `In re Smith, supra` preserves `Smith`, `Smith v. Jones, supra` preserves both, `See Smith v. Jones, supra` strips `See` but keeps `Smith v. Jones`, `Gall, supra` (no prefix) untouched

## Test plan

- [x] 12/12 new tests pass
- [x] Full suite: 2283/2283 (was 2271)
- [x] \`pnpm typecheck\` clean
- [x] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)