### PR TITLE
fix: rehearing signals + multi-stage chain regression coverage (#246)

### DIFF
--- a/.changeset/issue-246-rehearing-multi-stage-chains.md
+++ b/.changeset/issue-246-rehearing-multi-stage-chains.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix: rehearing signals + multi-stage subsequent-history chain regression coverage (#246)
+
+Add two new HistorySignal values — `rehearing_denied` and `rehearing_granted` —
+and four SIGNAL_TABLE entries covering `reh'g denied`, `rehearing denied`,
+`reh'g granted`, `rehearing granted`. Without these entries, `Acme Corp. v.
+Beta, 50 F.4th 1 (9th Cir. 2022), reh'g denied, 60 F.4th 50 (9th Cir. 2023)`
+silently dropped the rehearing link AND let the case-name scanback over-scan
+backward through the prior citation when extracting the next case name.
+
+The broader multi-stage chain machinery (`aff'd, X, overruled by Y`,
+`modified, X, cert. denied, Y`) already worked thanks to the earlier
+`pendingSignal` flush fix; this PR locks the behavior in with 9 regression
+tests under `multi-stage subsequent history chains (#246)`. Two of those test
+the working `aff'd` and `modified` chains, four test the new rehearing
+signals, two test single-link regression controls, and one tests the
+`review granted, opinion vacated` no-paren chain that the earlier fix
+landed.
+
+These additions are distinct from the CA-specific
+`modified_on_denial_of_rehearing` compound disposition, which anchors on
+`^as modified on denial of rehearing` and remains separately matched.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -247,6 +247,13 @@ const SIGNAL_TABLE: ReadonlyArray<readonly [RegExp, HistorySignal]> = [
   [/^distinguished\b/i, "distinguished"],
   [/^withdrawn\b/i, "withdrawn"],
   [/^reinstated\b/i, "reinstated"],
+  // Federal rehearing history (#246). `as modified on denial of rehearing`
+  // (CA compound, listed later) anchors on `^as modified` so the bare
+  // `reh'g denied` / `rehearing denied` entries here do not conflict.
+  [/^reh'?g\s+denied\b/i, "rehearing_denied"],
+  [/^rehearing\s+denied\b/i, "rehearing_denied"],
+  [/^reh'?g\s+granted\b/i, "rehearing_granted"],
+  [/^rehearing\s+granted\b/i, "rehearing_granted"],
   // Texas writ-of-error history (Tex. R. App. P. 47.7, pre-Sept. 1997).
   // Longer disposition modifiers must precede the bare forms so alternation
   // picks the more specific match (#229).

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -193,6 +193,10 @@ export type HistorySignal =
   | "distinguished"
   | "withdrawn"
   | "reinstated"
+  // Federal rehearing history (Bluebook 10.7; #246). `modified_on_denial_of_rehearing`
+  // below is a CA-specific compound disposition, distinct from these standalone signals.
+  | "rehearing_denied"
+  | "rehearing_granted"
   // Texas writ-of-error history (pre-Sept. 1, 1997 — older opinions still cite)
   | "writ_refused"
   | "writ_dismissed"

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5038,4 +5038,154 @@ describe("California year-first citation format (#19)", () => {
   })
 })
 
+/**
+ * Multi-stage subsequent history chains (#246).
+ *
+ * Bluebook 10.7 supports unlimited-depth subsequent-history chains, e.g.
+ * `Smith v. Jones, 100 F.2d 100 (2d Cir. 1990), aff'd, 200 U.S. 1 (1992),
+ * overruled by Doe v. Roe, 300 U.S. 50 (2010)`. The parent's
+ * `subsequentHistoryEntries` must contain BOTH `affirmed` and `overruled`
+ * (in order), and each follow-on citation must back-reference the parent
+ * with the correct signal in `subsequentHistoryOf`.
+ *
+ * The session that fixed the underlying `pendingSignal` flush bug
+ * (`review granted, opinion vacated` → keep both, not just the last) also
+ * resolved the basic case here; this suite locks that behavior in across
+ * representative chain shapes and surfaces the missing `reh'g denied` /
+ * `rehearing denied` signal entries.
+ */
+describe("multi-stage subsequent history chains (#246)", () => {
+  describe("two-link chains lock in correct parent entries + back-pointers", () => {
+    it("`aff'd, X, overruled by Y` produces two entries on the parent", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 100 (2d Cir. 1990), aff'd, 200 U.S. 1 (1992), overruled by Doe v. Roe, 300 U.S. 50 (2010)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(3)
+      const parent = cases[0]
+      const link2 = cases[1]
+      const link3 = cases[2]
+      if (
+        parent.type === "case" &&
+        link2.type === "case" &&
+        link3.type === "case"
+      ) {
+        expect(parent.text).toBe("100 F.2d 100")
+        expect(parent.subsequentHistoryEntries?.length).toBe(2)
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe("affirmed")
+        expect(parent.subsequentHistoryEntries?.[1]?.signal).toBe("overruled")
+        expect(link2.subsequentHistoryOf?.signal).toBe("affirmed")
+        expect(link3.subsequentHistoryOf?.signal).toBe("overruled")
+      }
+    })
+
+    it("`modified, X, cert. denied, Y` produces two entries on the parent", () => {
+      const text =
+        "Brown v. State, 100 S.W.3d 1 (Tex. 2003), modified, 200 S.W.3d 100 (Tex. 2004), cert. denied, 600 U.S. 1 (2005)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(3)
+      const parent = cases[0]
+      if (parent.type === "case") {
+        expect(parent.subsequentHistoryEntries?.length).toBe(2)
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe("modified")
+        expect(parent.subsequentHistoryEntries?.[1]?.signal).toBe("cert_denied")
+      }
+    })
+
+    it("`reh'g denied, X, cert. granted, Y` produces two entries on the parent", () => {
+      const text =
+        "Acme Corp. v. Beta, 50 F.4th 1 (9th Cir. 2022), reh'g denied, 60 F.4th 50 (9th Cir. 2023), cert. granted, 700 U.S. 1 (2024)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(3)
+      const parent = cases[0]
+      if (parent.type === "case") {
+        expect(parent.subsequentHistoryEntries?.length).toBe(2)
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe(
+          "rehearing_denied",
+        )
+        expect(parent.subsequentHistoryEntries?.[1]?.signal).toBe(
+          "cert_granted",
+        )
+      }
+    })
+  })
+
+  describe("rehearing signal variants (#246 missing-signal fix)", () => {
+    it("recognizes `reh'g denied` as `rehearing_denied`", () => {
+      const text = "Smith v. Jones, 50 F.3d 1 (1990), reh'g denied."
+      const cits = extractCitations(text)
+      const parent = cits.find((c) => c.type === "case")
+      expect(parent?.type).toBe("case")
+      if (parent?.type === "case") {
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe(
+          "rehearing_denied",
+        )
+      }
+    })
+
+    it("recognizes `rehearing denied` (long form) as `rehearing_denied`", () => {
+      const text = "Smith v. Jones, 50 F.3d 1 (1990), rehearing denied."
+      const cits = extractCitations(text)
+      const parent = cits.find((c) => c.type === "case")
+      if (parent?.type === "case") {
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe(
+          "rehearing_denied",
+        )
+      }
+    })
+
+    it("recognizes `reh'g granted` as `rehearing_granted`", () => {
+      const text = "Smith v. Jones, 50 F.3d 1 (1990), reh'g granted."
+      const cits = extractCitations(text)
+      const parent = cits.find((c) => c.type === "case")
+      if (parent?.type === "case") {
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe(
+          "rehearing_granted",
+        )
+      }
+    })
+
+    it("recognizes `rehearing granted` (long form)", () => {
+      const text = "Smith v. Jones, 50 F.3d 1 (1990), rehearing granted."
+      const cits = extractCitations(text)
+      const parent = cits.find((c) => c.type === "case")
+      if (parent?.type === "case") {
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe(
+          "rehearing_granted",
+        )
+      }
+    })
+  })
+
+  describe("regression controls — single-link chains still work", () => {
+    it("`aff'd, X` (single link) still produces one entry", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 100 (2d Cir. 1990), aff'd, 200 U.S. 1 (1992)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+      const parent = cases[0]
+      if (parent.type === "case") {
+        expect(parent.subsequentHistoryEntries?.length).toBe(1)
+        expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe("affirmed")
+      }
+    })
+
+    it("`review granted, opinion vacated` (no-paren chain) still works", () => {
+      const text =
+        "People v. Smith, 50 Cal.3d 100 (Cal. 1990), review granted, opinion vacated."
+      const cits = extractCitations(text)
+      const parent = cits.find((c) => c.type === "case")
+      if (parent?.type === "case") {
+        expect(parent.subsequentHistoryEntries?.length).toBe(2)
+        const sigs = parent.subsequentHistoryEntries?.map((e) => e.signal)
+        expect(sigs).toContain("review_granted")
+        expect(sigs).toContain("opinion_vacated")
+      }
+    })
+  })
+})
+
 


### PR DESCRIPTION
## Summary

Closes #246.

The broader multi-stage subsequent-history chain machinery (`aff'd, X, overruled by Y`, `modified, X, cert. denied, Y`) already worked thanks to the earlier session's `pendingSignal` flush fix. The remaining gap was `reh'g denied` / `rehearing denied` — they weren't in `SIGNAL_TABLE` at all, so the Acme Corp. variant from #246's failing-inputs list silently dropped the rehearing link AND let the case-name scanback over-scan backward through the prior citation.

### Changes

- New HistorySignal values: `rehearing_denied`, `rehearing_granted`.
- Four `SIGNAL_TABLE` entries (placed right after `withdrawn`/`reinstated`): `reh'g denied`, `rehearing denied`, `reh'g granted`, `rehearing granted`. The CA-specific compound `modified_on_denial_of_rehearing` anchors on `^as modified on denial of rehearing`, so the bare entries don't conflict.

### Tests

9 new regression tests under `multi-stage subsequent history chains (#246)`:

- **Two-link chains lock in correct parent entries + back-pointers**: \`aff'd, X, overruled by Y\` (existing behavior pinned), \`modified, X, cert. denied, Y\` (pinned), \`reh'g denied, X, cert. granted, Y\` (now works).
- **Rehearing signal variants**: \`reh'g denied\`, \`rehearing denied\`, \`reh'g granted\`, \`rehearing granted\`.
- **Regression controls**: \`aff'd, X\` single-link still 1 entry; \`review granted, opinion vacated\` no-paren chain still 2 entries.

## Test plan

- [x] 9/9 new tests pass
- [x] Full suite: 2292/2292 (was 2283)
- [x] \`pnpm typecheck\` clean
- [x] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)