### PR TITLE
feat: paragraph-marker pincites (¶ N, ¶¶ N-M, para. N, paras. N-M) (#204)

### DIFF
--- a/.changeset/issue-204-paragraph-pincites.md
+++ b/.changeset/issue-204-paragraph-pincites.md
@@ -1,0 +1,37 @@
+---
+"eyecite-ts": minor
+---
+
+feat: paragraph-marker pincites — `¶ N`, `¶¶ N-M`, `para. N`, `paras. N-M` (#204)
+
+Paragraph-marker pincites are the standard form for NY Slip Op, Canadian
+neutrals, and other paragraph-numbered opinion sources. `Doe v. Roe, 45 NY2d
+101, ¶¶ 12-14 (1978)` previously produced a citation with `pinciteInfo`
+undefined; it now yields `{ paragraph: 12, endParagraph: 14, isRange: true,
+raw: "¶¶ 12-14" }`.
+
+### Schema changes (`PinciteInfo`)
+
+- `page` is now `number | undefined` (was required `number`). Paragraph-only
+  pincites leave `page` undefined.
+- New: `paragraph?: number`, `endParagraph?: number`.
+
+The top-level convenience `pincite` field on the citation continues to mirror
+`page` only, so it stays undefined for paragraph-only pincites. Consumers
+that need paragraph data read `pinciteInfo.paragraph` / `pinciteInfo.endParagraph`.
+
+### Coverage
+
+- Full case (lookahead from citation core): `45 NY2d 101, ¶ 12`,
+  `45 NY2d 101, ¶¶ 12-14`, `45 NY2d 101, para. 12`,
+  `45 NY2d 101, paras. 12-14`
+- Id.: `Id. ¶ 12`, `Id. at ¶ 12`, `Id. ¶¶ 12-14`
+- Supra: `Smith, supra, ¶ 12`, `Smith, supra, at ¶ 12`,
+  `Smith, supra, paras. 12-14`
+- `parsePincite` recognizes raw input directly.
+
+Regex zoo updated across `LOOKAHEAD_PINCITE_REGEX`, `PINCITE_SKIP_REGEX`,
+`ID_PATTERN`, `IBID_PATTERN`, `SUPRA_PATTERN`, `STANDALONE_SUPRA_PATTERN`,
+`SHORT_FORM_CASE_PATTERN`, and the four local copies in
+`extractShortForms.ts`. Paragraph forms allow `at` to be optional (lookahead-
+only on the marker); page forms still require `at` or the existing comma form.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -167,15 +167,18 @@ const LOOKAHEAD_PAREN_REGEX =
   /^(?:,\s*(?:at\s+)?\*?\d+(?:-\d+)?)*(?:\s+(?:n|note)\s*\.?\s*\d+)?\s*\(([^)]+)\)/
 
 /** Extracts pincite from look-ahead text.
- *  Accepts three prefix forms:
+ *  Accepts five prefix forms:
  *    - ", 125"       (comma-separated, numeric)
  *    - ", at *1"     (comma + "at" keyword; common with star-pagination)
  *    - " at *2"      (whitespace + "at" keyword; NY Slip Op repeat form)
  *    - ", at p. 115" (CSM form with `p.` / `pp.` prefix; #236)
+ *    - ", ¶ 12"      (paragraph-marker form; #204)
  *  The "*" prefix marks star-pagination (#191); a trailing " n.14" /
- *  " nn.14-15" footnote suffix is captured when present (#202). */
+ *  " nn.14-15" footnote suffix is captured when present (#202). Paragraph
+ *  forms (`¶ N` / `¶¶ N-M` / `para. N` / `paras. N-M`) are accepted in the
+ *  capture; `parsePincite` routes them to the `paragraph` field (#204). */
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
+  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -185,11 +188,12 @@ const PAREN_SKIP_REGEX = /[\s,]/
 
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.
- *  E.g., ", 199 n.2", ", 999-1000", ", 130 n.5", ", at p. 115" (CSM, #236).
+ *  E.g., ", 199 n.2", ", 999-1000", ", 130 n.5", ", at p. 115" (CSM, #236),
+ *  ", ¶ 12" / ", paras. 12-14" (paragraph form, #204).
  *  The outer `+` is intentionally greedy to handle multi-pincite citations
  *  (e.g., ", 199, 205, 210"). Safe because the scan window is bounded by maxLookahead. */
 const PINCITE_SKIP_REGEX =
-  /^(?:,\s*(?:at\s+(?:pp?\.\s*)?)?\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?)+/
+  /^(?:,\s*(?:(?:at\s+(?:pp?\.\s*)?)?\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?|(?:at\s+)?(?:¶¶?|paras?\.?)\s*\d+(?:[-–—]\d+)?))+/
 
 /**
  * Signal normalization table. Longer patterns first so "aff'd on other grounds"

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -81,9 +81,11 @@ export function extractId(
   // Parse Id. with optional pincite.
   // Pattern: Id. or Ibid. with optional comma + "at [page]" (handles "Id., at 5").
   // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
-  // trailing footnote suffix " n.14" / " nn.14-15" (#202), and an optional
-  // `p.` / `pp.` prefix for CSM form (`Id. at p. 125`; see #236).
-  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:at\s+(?:pp?\.\s*)?(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
+  // trailing footnote suffix " n.14" / " nn.14-15" (#202), an optional
+  // `p.` / `pp.` prefix for CSM form (`Id. at p. 125`; see #236), and
+  // `¶` / `¶¶` / `para.` / `paras.` paragraph markers (#204). When the
+  // pincite is a paragraph form, `at` is optional (`Id. ¶ 12`).
+  const idRegex = /([Ii])(?:d|bid)(\.)(,?)\s*(?:(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const match = idRegex.exec(text)
 
   if (!match) {
@@ -188,16 +190,18 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
 
   // Try party-name pattern first: "Smith, supra [note N] [, at page]".
   // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
-  // range end / `p.` / `pp.` prefix for CSM form (#236), and an optional
-  // trailing footnote suffix (#202).
+  // range end / `p.` / `pp.` prefix for CSM form (#236), an optional trailing
+  // footnote suffix (#202), and `¶` / `¶¶` / `para.` / `paras.` paragraph
+  // markers (#204). When the pincite is a paragraph form, `at` is optional.
   const partySupraRegex =
-    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
+    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const partyMatch = partySupraRegex.exec(text)
 
   // Fallback: standalone supra — "supra note N", "supra at N", "supra § N".
-  // The `at` page accepts the same `p.` / `pp.` prefix and range form (#236).
+  // The `at` page accepts the same `p.` / `pp.` prefix and range form (#236)
+  // plus paragraph markers (#204).
   const standaloneRegex =
-    /supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/d
+    /supra(?:\s+note\s+(\d+)(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?|\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const match = partyMatch || standaloneRegex.exec(text)
 
   if (!match) {
@@ -311,10 +315,11 @@ export function extractShortFormCase(
   // Handles comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
   // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
   // range end "462-65" / "462-*65" (#201), an optional trailing footnote
-  // suffix " n.14" / " nn.14-15" (#202), and an optional `p.` / `pp.` prefix
-  // for CSM form (`18 Cal.4th at p. 717`; see #236).
+  // suffix " n.14" / " nn.14-15" (#202), an optional `p.` / `pp.` prefix for
+  // CSM form (`18 Cal.4th at p. 717`; see #236), and `¶` / `¶¶` / `para.` /
+  // `paras.` paragraph markers (#204).
   const shortFormRegex =
-    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
+    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/extract/pincite.ts
+++ b/src/extract/pincite.ts
@@ -1,9 +1,16 @@
 /**
  * Structured pincite information parsed from citation text.
+ *
+ * `page` and `paragraph` are mutually exclusive — a pincite is either a page
+ * reference (the common case) or a paragraph reference (#204; common in
+ * NY Slip Op, Canadian neutrals, and other paragraph-numbered sources). The
+ * top-level convenience `pincite: number` field on the citation continues to
+ * mirror `page` only; paragraph consumers read `paragraph` / `endParagraph`
+ * from this struct directly.
  */
 export interface PinciteInfo {
-  /** Primary page number */
-  page: number
+  /** Primary page number. Undefined when the pincite is paragraph-only (#204). */
+  page?: number
   /** End page for ranges: "570-75" → 575 */
   endPage?: number
   /** Footnote number: "570 n.3" → 3. For multi-footnote refs ("nn.3-5"), the
@@ -11,15 +18,26 @@ export interface PinciteInfo {
   footnote?: number
   /** End footnote for multi-note refs: "570 nn.3-5" → 5 */
   footnoteEnd?: number
-  /** True if this is a page range */
+  /** True if this is a page or paragraph range */
   isRange: boolean
   /** True when the pincite uses star-pagination (e.g., "*2"), denoting a
    *  slip-opinion page or unreported-decision page rather than a reporter page.
    *  Common on NY Slip Op, Westlaw, and Lexis citations. */
   starPage?: boolean
+  /** Paragraph number for `¶ N` / `para. N` pincites (#204). */
+  paragraph?: number
+  /** End paragraph for `¶¶ N-M` / `paras. N-M` pincites (#204). */
+  endParagraph?: number
   /** Original text before parsing */
   raw: string
 }
+
+/** Paragraph-marker prefix: `¶`, `¶¶`, `para.`, `paras.` with optional leading
+ *  `at`. Routes the rest of the string into paragraph parsing. (#204) */
+const PARA_PREFIX_REGEX = /^(?:at\s+)?(?:¶¶?|paras?\.?)\s*/i
+
+/** Body of a paragraph pincite once the marker has been consumed: `N` or `N-M`. */
+const PARA_NUM_REGEX = /^(\d+)(?:\s*[-–—]\s*(\d+))?\s*$/
 
 /** Matches: optional "at ", optional "*" (star pagination), digits, optional
  *  "-/–/—[*]digits", optional "n./nn./note digits" with optional range end. */
@@ -42,6 +60,28 @@ const PINCITE_PARSE_REGEX =
 export function parsePincite(raw: string): PinciteInfo | null {
   const trimmed = raw.trim()
   if (!trimmed) return null
+
+  // Paragraph-marker pincite (`¶ 12`, `¶¶ 12-14`, `para. 12`, `paras. 12-14`).
+  // Checked first because the page parser would reject these forms anyway. (#204)
+  const paraPrefix = PARA_PREFIX_REGEX.exec(trimmed)
+  if (paraPrefix) {
+    const rest = trimmed.substring(paraPrefix[0].length)
+    const numMatch = PARA_NUM_REGEX.exec(rest)
+    if (numMatch) {
+      const paragraph = Number.parseInt(numMatch[1], 10)
+      const endParagraph = numMatch[2]
+        ? Number.parseInt(numMatch[2], 10)
+        : undefined
+      const result: PinciteInfo = {
+        paragraph,
+        isRange: endParagraph !== undefined,
+        raw: trimmed,
+      }
+      if (endParagraph !== undefined) result.endParagraph = endParagraph
+      return result
+    }
+    // Falls through to page parsing if the body isn't a clean number — defensive.
+  }
 
   const match = PINCITE_PARSE_REGEX.exec(trimmed)
   if (!match) return null

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -12,29 +12,34 @@
 
 import type { Pattern } from "./casePatterns"
 
-/** Id. with optional pincite: "Id." or "Id. at 253" or "Id., at 253".
+/** Id. with optional pincite: "Id." or "Id. at 253" or "Id., at 253" or
+ *  "Id. ¶ 12" (#204).
  *  Pincite captures an optional "*" prefix for star-pagination (NY Slip Op,
  *  Westlaw, Lexis; see #191), an optional trailing " n.14" / " nn.14-15"
- *  footnote suffix (see #202), and an optional `p.` / `pp.` prefix used by
- *  the California Style Manual (e.g., `Id. at p. 115`, `Id. at pp. 115-117`;
- *  see #236). */
+ *  footnote suffix (see #202), an optional `p.` / `pp.` prefix for
+ *  California Style Manual form (see #236), and `¶` / `¶¶` / `para.` /
+ *  `paras.` paragraph markers (#204). When the pincite is a paragraph form,
+ *  `at` is optional — `Id. ¶ 12` and `Id. at ¶ 12` both match. */
 export const ID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d\.(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d\.(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
-/** Ibid. with optional pincite (less common variant). */
+/** Ibid. with optional pincite (less common variant). Paragraph forms (#204)
+ *  follow the same convention as Id. */
 export const IBID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\.(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:\s*[-–]\s*\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\.(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /**
  * Supra with party name and optional pincite.
  * Pattern: word(s), supra [note N] [, at page]
  * Captures: (1) party name, (2) note number (if any), (3) pincite
  * Pincite accepts optional "*" prefix for star-pagination (#191), an optional
- * range end (#236), an optional trailing footnote suffix (#202), and an
- * optional `p.` / `pp.` prefix for California Style Manual form (#236).
+ * range end (#236), an optional trailing footnote suffix (#202), an optional
+ * `p.` / `pp.` prefix for California Style Manual form (#236), and `¶` /
+ * `¶¶` / `para.` / `paras.` paragraph markers (#204). When the pincite is a
+ * paragraph form, `at` is optional.
  */
 export const SUPRA_PATTERN: RegExp =
-  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?/g
+  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /**
  * Standalone supra without party name (common in footnotes).
@@ -42,11 +47,11 @@ export const SUPRA_PATTERN: RegExp =
  * Requires "note", "at", "§", "Part", or "p." after supra to avoid matching
  * the word "supra" in prose. Preceded by whitespace, start, or signal words.
  * Captures: (1) note number (if any), (2) pincite (with optional "*" prefix,
- * #191, optional range end / `p.`/`pp.` prefix #236, and optional trailing
- * footnote suffix, #202).
+ * #191, optional range end / `p.`/`pp.` prefix #236, optional trailing
+ * footnote suffix #202, and `¶`/`para.` paragraph markers #204).
  */
 export const STANDALONE_SUPRA_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)?|\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|\s+(?:§+|Part|p\.)\s*\S+)/g
+  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)|\s+(?:§+|Part|p\.)\s*\S+)/g
 
 /**
  * Short-form case: volume reporter [,] at page
@@ -56,11 +61,12 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
  * Handles SCOTUS/federal comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
  * Pincite accepts optional "*" prefix for star-pagination (#191), an optional
  * range end "462-65" / "462-*65" (#201), an optional trailing footnote suffix
- * " n.14" / " nn.14-15" (#202), and an optional `p.` / `pp.` prefix for
- * California Style Manual form (`18 Cal.4th at p. 717`; see #236).
+ * " n.14" / " nn.14-15" (#202), an optional `p.` / `pp.` prefix for
+ * California Style Manual form (`18 Cal.4th at p. 717`; see #236), and `¶` /
+ * `¶¶` / `para.` / `paras.` paragraph markers (#204).
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?)(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?\b/g
+  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5188,4 +5188,85 @@ describe("multi-stage subsequent history chains (#246)", () => {
   })
 })
 
+/**
+ * Paragraph-marker pincites in full case citations (#204).
+ *
+ * NY Slip Op and Canadian neutrals number paragraphs and reference them with
+ * `¶` / `¶¶` or `para.` / `paras.` after the volume-reporter-page. The
+ * pincite parser now recognizes these forms; the top-level `pincite` field
+ * remains page-only (undefined for paragraph-only) while `pinciteInfo.paragraph`
+ * and `pinciteInfo.endParagraph` carry the paragraph number(s).
+ */
+describe("paragraph-marker pincites in full case citations (#204)", () => {
+  it("captures `¶¶ 12-14` after `45 NY2d 101`", () => {
+    const text = "Doe v. Roe, 45 NY2d 101, ¶¶ 12-14 (1978)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].pinciteInfo?.paragraph).toBe(12)
+      expect(cases[0].pinciteInfo?.endParagraph).toBe(14)
+      expect(cases[0].pinciteInfo?.isRange).toBe(true)
+      // Top-level pincite stays page-only (undefined for paragraph-only).
+      expect(cases[0].pincite).toBeUndefined()
+    }
+  })
+
+  it("captures `¶ 12` after `45 NY2d 101`", () => {
+    const text = "Doe v. Roe, 45 NY2d 101, ¶ 12 (1978)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].pinciteInfo?.paragraph).toBe(12)
+      expect(cases[0].pinciteInfo?.endParagraph).toBeUndefined()
+    }
+  })
+
+  it("captures `para. 12` (spelled-out singular)", () => {
+    const text = "Doe v. Roe, 45 NY2d 101, para. 12 (1978)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].pinciteInfo?.paragraph).toBe(12)
+    }
+  })
+
+  it("captures `paras. 12-14` (spelled-out range)", () => {
+    const text = "Doe v. Roe, 45 NY2d 101, paras. 12-14 (1978)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].pinciteInfo?.paragraph).toBe(12)
+      expect(cases[0].pinciteInfo?.endParagraph).toBe(14)
+    }
+  })
+
+  describe("regression controls — page pincites still work", () => {
+    it("`, 105` (bare page) still parses", () => {
+      const text = "Doe v. Roe, 45 NY2d 101, 105 (1978)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].pincite).toBe(105)
+        expect(cases[0].pinciteInfo?.page).toBe(105)
+        expect(cases[0].pinciteInfo?.paragraph).toBeUndefined()
+      }
+    })
+
+    it("`, 105-107` (page range) still parses", () => {
+      const text = "Doe v. Roe, 45 NY2d 101, 105-107 (1978)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      if (cases[0].type === "case") {
+        expect(cases[0].pinciteInfo?.page).toBe(105)
+        expect(cases[0].pinciteInfo?.endPage).toBe(107)
+      }
+    })
+  })
+})
+
 

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -1139,3 +1139,75 @@ describe("supra party-name signal-leak (#216)", () => {
     })
   })
 })
+
+/**
+ * Paragraph-marker pincites on short-form references (#204). The Id., supra,
+ * and short-form case patterns must accept `¶ 12`, `¶¶ 12-14`, `para. 12`,
+ * `paras. 12-14` after their respective anchors, with and without the `at`
+ * keyword.
+ */
+describe("paragraph-marker pincites on short-forms (#204)", () => {
+  describe("Id.", () => {
+    it("`Id. at ¶ 12` (with `at`)", () => {
+      const text = "Foo v. Bar, 1 F.3d 2 (1990). Id. at ¶ 12."
+      const cits = extractCitations(text)
+      const id = cits.find((c) => c.type === "id")
+      expect(id).toBeDefined()
+      if (id?.type === "id") {
+        expect(id.pinciteInfo?.paragraph).toBe(12)
+      }
+    })
+
+    it("`Id. ¶ 12` (no `at`)", () => {
+      const text = "Foo v. Bar, 1 F.3d 2 (1990). Id. ¶ 12."
+      const cits = extractCitations(text)
+      const id = cits.find((c) => c.type === "id")
+      expect(id).toBeDefined()
+      if (id?.type === "id") {
+        expect(id.pinciteInfo?.paragraph).toBe(12)
+      }
+    })
+
+    it("`Id. ¶¶ 12-14` (range, no `at`)", () => {
+      const text = "Foo v. Bar, 1 F.3d 2 (1990). Id. ¶¶ 12-14."
+      const cits = extractCitations(text)
+      const id = cits.find((c) => c.type === "id")
+      if (id?.type === "id") {
+        expect(id.pinciteInfo?.paragraph).toBe(12)
+        expect(id.pinciteInfo?.endParagraph).toBe(14)
+      }
+    })
+  })
+
+  describe("supra", () => {
+    it("`Smith, supra, ¶ 12`", () => {
+      const text = "Foo v. Bar, 1 F.3d 2 (1990). Smith, supra, ¶ 12."
+      const cits = extractCitations(text)
+      const sup = cits.find((c) => c.type === "supra")
+      expect(sup).toBeDefined()
+      if (sup?.type === "supra") {
+        expect(sup.pinciteInfo?.paragraph).toBe(12)
+      }
+    })
+
+    it("`Smith, supra, at ¶ 12`", () => {
+      const text = "Foo v. Bar, 1 F.3d 2 (1990). Smith, supra, at ¶ 12."
+      const cits = extractCitations(text)
+      const sup = cits.find((c) => c.type === "supra")
+      if (sup?.type === "supra") {
+        expect(sup.pinciteInfo?.paragraph).toBe(12)
+      }
+    })
+
+    it("`Smith, supra, paras. 12-14`", () => {
+      const text =
+        "Foo v. Bar, 1 F.3d 2 (1990). Smith, supra, paras. 12-14."
+      const cits = extractCitations(text)
+      const sup = cits.find((c) => c.type === "supra")
+      if (sup?.type === "supra") {
+        expect(sup.pinciteInfo?.paragraph).toBe(12)
+        expect(sup.pinciteInfo?.endParagraph).toBe(14)
+      }
+    })
+  })
+})

--- a/tests/extract/pincite.test.ts
+++ b/tests/extract/pincite.test.ts
@@ -160,4 +160,65 @@ describe("parsePincite", () => {
     const result = parsePincite("570")
     expect(result?.starPage).toBeUndefined()
   })
+
+  /**
+   * Paragraph-marker pincites (#204). Common in NY Slip Op, Canadian, and
+   * other paragraph-numbered opinion sources. The `page` field is left
+   * undefined for paragraph-only pincites — consumers read `paragraph` /
+   * `endParagraph` instead. The top-level convenience `pincite` field on the
+   * citation stays page-only and remains undefined for these.
+   */
+  describe("paragraph-marker pincites (#204)", () => {
+    it("parses `¶ 12` as single paragraph", () => {
+      expect(parsePincite("¶ 12")).toEqual({
+        paragraph: 12,
+        isRange: false,
+        raw: "¶ 12",
+      })
+    })
+
+    it("parses `¶¶ 12-14` as paragraph range", () => {
+      expect(parsePincite("¶¶ 12-14")).toEqual({
+        paragraph: 12,
+        endParagraph: 14,
+        isRange: true,
+        raw: "¶¶ 12-14",
+      })
+    })
+
+    it("parses `para. 12` (spelled-out, singular)", () => {
+      expect(parsePincite("para. 12")).toEqual({
+        paragraph: 12,
+        isRange: false,
+        raw: "para. 12",
+      })
+    })
+
+    it("parses `paras. 12-14` (spelled-out, plural+range)", () => {
+      expect(parsePincite("paras. 12-14")).toEqual({
+        paragraph: 12,
+        endParagraph: 14,
+        isRange: true,
+        raw: "paras. 12-14",
+      })
+    })
+
+    it("parses `at ¶ 12` (with 'at' prefix)", () => {
+      expect(parsePincite("at ¶ 12")).toEqual({
+        paragraph: 12,
+        isRange: false,
+        raw: "at ¶ 12",
+      })
+    })
+
+    it("paragraph result has no page field", () => {
+      const r = parsePincite("¶ 12")
+      expect(r?.page).toBeUndefined()
+    })
+
+    it("page result has no paragraph field", () => {
+      const r = parsePincite("570")
+      expect(r?.paragraph).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #204.

Paragraph-marker pincites (`¶ 12`, `¶¶ 12-14`, `para. 12`, `paras. 12-14`) are the standard form for NY Slip Op, Canadian neutrals, and other paragraph-numbered opinion sources. `Doe v. Roe, 45 NY2d 101, ¶¶ 12-14 (1978)` previously produced a citation with `pinciteInfo: undefined`; it now yields `{ paragraph: 12, endParagraph: 14, isRange: true, raw: \"¶¶ 12-14\" }`.

### Schema changes (`PinciteInfo`)

- `page` is now `number | undefined` (was required `number`). Paragraph-only pincites leave `page` undefined.
- New: `paragraph?: number`, `endParagraph?: number`.

The top-level convenience `pincite: number | undefined` field on the citation continues to mirror `page` only, so it stays undefined for paragraph-only pincites. Consumers that need paragraph data read `pinciteInfo.paragraph` / `pinciteInfo.endParagraph`. This keeps the existing API contract: \`pincite\` always means \"page number\".

### Coverage

- **Full case** (lookahead from citation core): `45 NY2d 101, ¶ 12`, `45 NY2d 101, ¶¶ 12-14`, `45 NY2d 101, para. 12`, `45 NY2d 101, paras. 12-14`
- **Id.** / **Ibid.**: `Id. ¶ 12`, `Id. at ¶ 12`, `Id. ¶¶ 12-14`
- **Supra**: `Smith, supra, ¶ 12`, `Smith, supra, at ¶ 12`, `Smith, supra, paras. 12-14`
- **Short-form case**: handled implicitly via short-form pattern updates
- **parsePincite** recognizes raw input directly (`parsePincite(\"¶ 12\")`)

### Implementation

`parsePincite` checks for a paragraph marker prefix first (`¶ | ¶¶ | para. | paras.`) and routes to a dedicated paragraph parser, falling through to the existing page parser otherwise. Regex zoo updated across `LOOKAHEAD_PINCITE_REGEX`, `PINCITE_SKIP_REGEX`, `ID_PATTERN`, `IBID_PATTERN`, `SUPRA_PATTERN`, `STANDALONE_SUPRA_PATTERN`, `SHORT_FORM_CASE_PATTERN`, and the four local copies in `extractShortForms.ts`. Paragraph forms allow `at` to be optional via a lookahead-only prefix `(?=¶|paras?\\.?\\b)`; page forms still require `at` or the existing comma form.

### Tests

- **parsePincite** (7 new): `¶ 12`, `¶¶ 12-14`, `para. 12`, `paras. 12-14`, `at ¶ 12`, mutual-exclusion controls
- **Full case** (6 new): paragraph forms + page-pincite regression controls
- **Id./supra** (6 new): with and without `at`, ranges
- **Total**: 19 new tests, all passing

## Test plan

- [x] 19/19 new tests pass
- [x] Full suite: 2311/2311 (was 2292)
- [x] \`pnpm typecheck\` clean
- [x] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)