### PR TITLE
feat: capture multiple discrete pincites (#247)

### DIFF
--- a/.changeset/issue-247-multiple-discrete-pincites.md
+++ b/.changeset/issue-247-multiple-discrete-pincites.md
@@ -1,0 +1,33 @@
+---
+"eyecite-ts": minor
+---
+
+feat: capture multiple discrete pincites (`113, 115, 153`) (#247)
+
+`Roe v. Wade, 410 U.S. 113, 115, 153 (1973)` previously dropped the `153`
+pincite — only the first comma-separated pincite survived. `PinciteInfo` now
+carries an optional `additionalPincites: PinciteInfo[]` array; the primary
+pincite continues to live in `page` / `endPage` / `paragraph` etc. (no API
+break) and subsequent pincites accumulate as nested entries that each preserve
+their own range / footnote / star-page semantics.
+
+### Coverage
+
+- `, 115, 153` → primary `page: 115`, additional `[{ page: 153 }]`
+- `, 105, 110, 120` → primary + 2 additional
+- Mixed range+discrete: `, 105-110, 120` → primary has `endPage: 110`,
+  additional `[{ page: 120 }]`
+- Discrete+range: `, 115, 105-110` → primary `page: 115`, additional has
+  range info preserved
+
+### API
+
+- New: `pinciteInfo.additionalPincites?: PinciteInfo[]`.
+- The top-level convenience `citation.pincite: number` continues to mirror
+  only the primary pincite — consumers needing all pincites read the
+  `additionalPincites` array.
+
+Implementation: after `LOOKAHEAD_PINCITE_REGEX` captures the primary pincite,
+a small loop matches a new `ADDITIONAL_PINCITE_REGEX` (comma + page form)
+repeatedly from the scan position, parsing each via `parsePincite` and
+appending to `additionalPincites`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -186,6 +186,16 @@ const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
 /** Whitespace/comma skip pattern for parenthetical scanning */
 const PAREN_SKIP_REGEX = /[\s,]/
 
+/** Additional discrete pincite (`, NNN` continuation) after the primary
+ *  pincite has been consumed (#247). Matches a comma + optional whitespace
+ *  followed by a pincite body. Used in a loop after `LOOKAHEAD_PINCITE_REGEX`
+ *  to collect `115, 153, 200` chains.
+ *
+ *  Excludes paragraph forms (`¶ 12` mixed with page numbers is exceedingly
+ *  rare and would conflict with the citation core's lookahead boundary). */
+const ADDITIONAL_PINCITE_REGEX =
+  /^,\s*(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)(?=\s|$|\(|,|;|\.)/
+
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.
  *  E.g., ", 199 n.2", ", 999-1000", ", 130 n.5", ", at p. 115" (CSM, #236),
@@ -2113,6 +2123,29 @@ export function extractCase(
             laPinciteMatch.indices[1],
             transformationMap,
           )
+        }
+
+        // Multiple discrete pincites (#247): continue scanning for additional
+        // comma-separated pincites (`, 115, 153, 200`). Each entry is parsed
+        // through `parsePincite` so range / footnote / paragraph semantics
+        // inside the chain are preserved. The convenience `pincite` field
+        // continues to point at the primary; consumers walk `additionalPincites`.
+        if (pinciteInfo) {
+          const additionalPincites: PinciteInfo[] = []
+          let scanStart =
+            (laPinciteMatch.index ?? 0) + laPinciteMatch[0].length
+          while (scanStart < afterToken.length) {
+            const remainder = afterToken.substring(scanStart)
+            const addMatch = ADDITIONAL_PINCITE_REGEX.exec(remainder)
+            if (!addMatch) break
+            const addInfo = parsePincite(addMatch[1])
+            if (!addInfo) break
+            additionalPincites.push(addInfo)
+            scanStart += addMatch[0].length
+          }
+          if (additionalPincites.length > 0) {
+            pinciteInfo = { ...pinciteInfo, additionalPincites }
+          }
         }
       }
     }

--- a/src/extract/pincite.ts
+++ b/src/extract/pincite.ts
@@ -28,6 +28,14 @@ export interface PinciteInfo {
   paragraph?: number
   /** End paragraph for `¶¶ N-M` / `paras. N-M` pincites (#204). */
   endParagraph?: number
+  /** Additional discrete pincites following the primary one (#247). E.g.,
+   *  `410 U.S. 113, 115, 153` → first pincite is page=115, additionalPincites
+   *  is `[{ page: 153, ... }]`. Each entry is a full `PinciteInfo` so ranges
+   *  / footnotes / star-pages inside the comma chain are preserved
+   *  (`115, 105-110` → additional has `endPage` set). The top-level
+   *  convenience `pincite: number` field on the citation continues to mirror
+   *  only the primary pincite; consumers needing all pincites read this array. */
+  additionalPincites?: PinciteInfo[]
   /** Original text before parsing */
   raw: string
 }

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5269,4 +5269,110 @@ describe("paragraph-marker pincites in full case citations (#204)", () => {
   })
 })
 
+/**
+ * Multiple discrete pincites (#247).
+ *
+ * Citations to multiple pages of the same opinion (`410 U.S. 113, 115, 153`)
+ * previously produced a single-element pincite — only the first page survived.
+ * The first pincite continues to live in `pinciteInfo.page` / `endPage` /
+ * `paragraph` etc. (no API break); additional pincites are appended to
+ * `pinciteInfo.additionalPincites` as nested `PinciteInfo` entries so each
+ * preserves its own range / footnote / star-page semantics.
+ *
+ * The top-level convenience `pincite: number | undefined` field continues to
+ * mirror the FIRST pincite's `page` — consumers needing all pincites read
+ * the `additionalPincites` array.
+ */
+describe("multiple discrete pincites (#247)", () => {
+  it("captures `113, 115, 153` as primary + 2 additional", () => {
+    const text = "See Roe v. Wade, 410 U.S. 113, 115, 153 (1973)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].pincite).toBe(115)
+      expect(cases[0].pinciteInfo?.page).toBe(115)
+      expect(cases[0].pinciteInfo?.additionalPincites).toHaveLength(1)
+      expect(cases[0].pinciteInfo?.additionalPincites?.[0]?.page).toBe(153)
+    }
+  })
+
+  it("captures `100, 105, 110, 120` as primary + 3 additional", () => {
+    const text = "See Smith v. Jones, 500 F.2d 100, 105, 110, 120 (9th Cir. 2020)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].pincite).toBe(105)
+      expect(cases[0].pinciteInfo?.additionalPincites).toHaveLength(2)
+      expect(cases[0].pinciteInfo?.additionalPincites?.[0]?.page).toBe(110)
+      expect(cases[0].pinciteInfo?.additionalPincites?.[1]?.page).toBe(120)
+    }
+  })
+
+  it("handles mixed range + discrete: `105-110, 120` keeps range info", () => {
+    const text = "See Roe, 410 U.S. 113, 105-110, 120 (1973)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      // Primary pincite is the range "105-110"
+      expect(cases[0].pinciteInfo?.page).toBe(105)
+      expect(cases[0].pinciteInfo?.endPage).toBe(110)
+      expect(cases[0].pinciteInfo?.isRange).toBe(true)
+      // Additional pincite is the discrete page "120"
+      expect(cases[0].pinciteInfo?.additionalPincites).toHaveLength(1)
+      expect(cases[0].pinciteInfo?.additionalPincites?.[0]?.page).toBe(120)
+    }
+  })
+
+  it("handles `113, 105-110` (discrete then range)", () => {
+    const text = "See Roe, 410 U.S. 113, 115, 105-110 (1973)."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0].type === "case") {
+      expect(cases[0].pinciteInfo?.page).toBe(115)
+      expect(cases[0].pinciteInfo?.additionalPincites?.[0]?.page).toBe(105)
+      expect(cases[0].pinciteInfo?.additionalPincites?.[0]?.endPage).toBe(110)
+      expect(cases[0].pinciteInfo?.additionalPincites?.[0]?.isRange).toBe(true)
+    }
+  })
+
+  describe("regression controls — single-pincite citations", () => {
+    it("`, 115` (one pincite) → no additionalPincites field", () => {
+      const text = "See Roe v. Wade, 410 U.S. 113, 115 (1973)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].pincite).toBe(115)
+        expect(cases[0].pinciteInfo?.additionalPincites).toBeUndefined()
+      }
+    })
+
+    it("range only `, 100-110` → no additionalPincites", () => {
+      const text = "Smith v. Jones, 500 F.2d 100, 105-110 (9th Cir. 2020)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      if (cases[0].type === "case") {
+        expect(cases[0].pinciteInfo?.page).toBe(105)
+        expect(cases[0].pinciteInfo?.endPage).toBe(110)
+        expect(cases[0].pinciteInfo?.additionalPincites).toBeUndefined()
+      }
+    })
+
+    it("`, 115 n.5` (footnote) still parses without additionalPincites", () => {
+      const text = "Roe v. Wade, 410 U.S. 113, 115 n.5 (1973)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      if (cases[0].type === "case") {
+        expect(cases[0].pinciteInfo?.page).toBe(115)
+        expect(cases[0].pinciteInfo?.footnote).toBe(5)
+        expect(cases[0].pinciteInfo?.additionalPincites).toBeUndefined()
+      }
+    })
+  })
+})
+
 


### PR DESCRIPTION
## Summary

Closes #247.

`Roe v. Wade, 410 U.S. 113, 115, 153 (1973)` previously dropped the `153` pincite — only the first comma-separated pincite survived. `PinciteInfo` now carries an optional `additionalPincites: PinciteInfo[]` array; the primary pincite continues to live in `page` / `endPage` / `paragraph` etc. (no API break) and subsequent pincites accumulate as nested entries that each preserve their own range / footnote / star-page semantics.

### Coverage

- `, 115, 153` → primary `page: 115`, additional `[{ page: 153 }]`
- `, 105, 110, 120` → primary + 2 additional
- Mixed range+discrete: `, 105-110, 120` → primary has `endPage: 110`, additional `[{ page: 120 }]`
- Discrete+range: `, 115, 105-110` → primary `page: 115`, additional preserves the range

### API

- New: `pinciteInfo.additionalPincites?: PinciteInfo[]`.
- The top-level convenience `citation.pincite: number` continues to mirror only the primary pincite — consumers needing all pincites read the `additionalPincites` array. No breaking change.

### Implementation

After `LOOKAHEAD_PINCITE_REGEX` captures the primary pincite, a small loop matches a new `ADDITIONAL_PINCITE_REGEX` (`,\\s*(<page form>)`) repeatedly from the scan position, parsing each match via `parsePincite` and appending to `additionalPincites`. The loop terminates when the regex fails to match (e.g., on encountering ` (` for the court paren, `.`, `;`, or end-of-string).

### Tests

7 new tests under `multiple discrete pincites (#247)`:

- 4 multi-pincite fixtures (2 discrete, 1 range+discrete, 1 discrete+range)
- 3 regression controls (single pincite → no additionalPincites, range-only, footnote-only)

## Test plan

- [x] 7/7 new tests pass
- [x] Full suite: 2318/2318 (was 2311)
- [x] \`pnpm typecheck\` clean
- [x] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)