### PR TITLE
fix: Louisiana date-in-number citations + 2-digit slash dates (#232)

### DIFF
--- a/.changeset/issue-232-louisiana-date-in-number.md
+++ b/.changeset/issue-232-louisiana-date-in-number.md
@@ -1,0 +1,47 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Louisiana date-in-number citations + two-digit-year slash dates (#232)
+
+Louisiana practice prepends a docket-style identifier and slash-date court
+parenthetical before the reporter citation:
+
+```
+Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07),
+  966 So. 2d 1127, 1130
+```
+
+Previously the docket-prefix segment bled into the case name on the trailing
+`So. 2d` / `So. 3d` citation, producing garbage like
+`Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07)`,
+and the year/court/date metadata in the docket paren was dropped entirely
+(no year, no court, no date on the citation).
+
+### Changes
+
+- **`parseDate` accepts two-digit years**. `10/3/07`, `2/15/10`, `6/30/20`
+  now parse with century inferred at the 50 pivot (00-50 → 21st century,
+  51-99 → 20th century). Four-digit years continue to parse as before.
+- **LA docket-prefix excision in case-name scanback**. The new
+  `LA_DOCKET_BOUNDARY_REGEX` recognizes the LA shape
+  `NN-NNNN (La. ... M/D/YY)` (with optional `, p. N` pincite) when it sits
+  between caption and reporter, splices it out of `precedingText` (leaving
+  just `, `), and surfaces the docket paren's court + date.
+- **Metadata transfer**. `extractCaseName` returns an optional
+  `precedingDocketMeta` field; `processCaseToken` applies its court / year /
+  date as fallback for the trailing reporter citation when that citation has
+  no court paren of its own.
+
+The Louisiana docket-prefix is not yet emitted as its own first-class
+citation (linked via `detectParallel.ts` per the issue's full acceptance
+criteria) — that remains follow-up work. The primary `So. 2d` / `So. 3d`
+citation now carries clean caseName plus structured year / court / date.
+
+### Tests
+
+- **`parseDate` two-digit years**: 7 new tests in `tests/extract/dates.test.ts`
+  covering the pivot, ranges, and 4-digit regression.
+- **Louisiana citations**: 3 new fixtures (all three from the issue
+  reproduction) + 2 regression controls (plain `(La. 2010)` and non-LA
+  month-name dates).

--- a/src/extract/dates.ts
+++ b/src/extract/dates.ts
@@ -166,12 +166,18 @@ export function parseDate(dateStr: string): StructuredDate | undefined {
     return { iso: toIsoDate(parsed), parsed }
   }
 
-  // Try numeric US format: 1/15/2020
-  const numericMatch = dateStr.match(/\b(\d{1,2})\/(\d{1,2})\/(\d{4})\b/)
+  // Try numeric US format: 1/15/2020 (full year) or 10/3/07 (two-digit year,
+  // Louisiana docket-prefix and other regional shorthand; #232). Two-digit
+  // years pivot at 50: 00-50 → 21st century, 51-99 → 20th century.
+  const numericMatch = dateStr.match(/\b(\d{1,2})\/(\d{1,2})\/(\d{2}|\d{4})\b/)
   if (numericMatch) {
     const month = Number.parseInt(numericMatch[1], 10)
     const day = Number.parseInt(numericMatch[2], 10)
-    const year = Number.parseInt(numericMatch[3], 10)
+    const rawYear = numericMatch[3]
+    let year = Number.parseInt(rawYear, 10)
+    if (rawYear.length === 2) {
+      year = year <= 50 ? 2000 + year : 1900 + year
+    }
     const parsed = { year, month, day }
     return { iso: toIsoDate(parsed), parsed }
   }

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1027,6 +1027,18 @@ const PAREN_SIGNAL_BOUNDARY_REGEX =
 /** Sentence boundary: closing paren or period, followed by space + uppercase letter. */
 const SENTENCE_BOUNDARY_REGEX = /[.)]\s+(?=[A-Z])/g
 
+/** Louisiana docket-prefix boundary (#232). Matches the Louisiana citation
+ *  shape `NN-NNNN (La. ... M/D/YY)` or `YYYY-K-NNNN (La. ... M/D/YY)` that
+ *  precedes the parallel `So. 2d` / `So. 3d` reporter citation. The capture
+ *  groups expose the court (group 2) and the date string (group 3) so the
+ *  trailing reporter citation can inherit the metadata. Includes an optional
+ *  `, p. N` pincite segment commonly present in LA practice.
+ *
+ *  The trailing `,` + whitespace is consumed so that everything BEFORE this
+ *  pattern is the caption. */
+const LA_DOCKET_BOUNDARY_REGEX =
+  /,?\s*(\d{2,4}-[A-Z\d-]+)(?:,\s*p\.\s*\d+)?\s*\((La\.[^)]*?)\s+(\d{1,2}\/\d{1,2}\/\d{2,4})\),\s*/g
+
 /**
  * Extract case name via backward search from citation core.
  * Looks for "v." pattern or procedural prefixes (In re, Ex parte, Matter of).
@@ -1059,6 +1071,15 @@ export function extractCaseName(
       yearStart?: number
       /** Clean-coordinate position after the year digits. */
       yearEnd?: number
+      /** Metadata recovered from a Louisiana docket-prefix paren that sits
+       *  between the caption and the citation core (#232). Applied by the
+       *  caller as fallback for `year` / `court` / `date` when the citation's
+       *  own trailing paren is absent. */
+      precedingDocketMeta?: {
+        court: string
+        year: number
+        date: StructuredDate
+      }
     }
   | undefined {
   const searchStart = Math.max(0, coreStart - maxLookback)
@@ -1136,6 +1157,35 @@ export function extractCaseName(
     if (boundaryEnd > lastBoundaryIndex) {
       lastBoundaryIndex = boundaryEnd
     }
+  }
+
+  // Louisiana docket-prefix segments (#232) sit *between* the caption and
+  // the trailing reporter citation: `Smith v. Jones, 07-393, p. 2 (La. App.
+  // 3d Cir. 10/3/07), 966 So. 2d 1127`. Unlike sentence / Id. / paren-signal
+  // boundaries, the segment is INTERIOR — stripping it from `precedingText`
+  // preserves the caption to its left. Capture the docket paren's court +
+  // date for metadata transfer onto the trailing reporter citation.
+  let precedingDocketMeta:
+    | { court: string; year: number; date: StructuredDate }
+    | undefined
+  LA_DOCKET_BOUNDARY_REGEX.lastIndex = 0
+  const laDocketMatch = LA_DOCKET_BOUNDARY_REGEX.exec(precedingText)
+  if (laDocketMatch) {
+    const dateStr = laDocketMatch[3]
+    const date = parseDate(dateStr)
+    if (date) {
+      precedingDocketMeta = {
+        court: laDocketMatch[2].trim(),
+        year: date.parsed.year,
+        date,
+      }
+    }
+    // Excise the docket segment, leaving just the trailing ", " so the
+    // V_CASE_NAME_REGEX still sees a comma-terminated caption to its left.
+    precedingText =
+      precedingText.substring(0, laDocketMatch.index) +
+      ", " +
+      precedingText.substring(laDocketMatch.index + laDocketMatch[0].length)
   }
 
   // Check sentence boundaries: "). " or ". " followed by uppercase letter.
@@ -1235,7 +1285,14 @@ export function extractCaseName(
         yearStart = adjustedSearchStart + vMatch.indices[3][0]
         yearEnd = adjustedSearchStart + vMatch.indices[3][1]
       }
-      return { caseName, nameStart, year, yearStart, yearEnd }
+      return {
+        caseName,
+        nameStart,
+        year,
+        yearStart,
+        yearEnd,
+        precedingDocketMeta,
+      }
     }
   }
 
@@ -1255,7 +1312,14 @@ export function extractCaseName(
         yearStart = adjustedSearchStart + procMatch.indices[3][0]
         yearEnd = adjustedSearchStart + procMatch.indices[3][1]
       }
-      return { caseName, nameStart, year, yearStart, yearEnd }
+      return {
+        caseName,
+        nameStart,
+        year,
+        yearStart,
+        yearEnd,
+        precedingDocketMeta,
+      }
     }
   }
 
@@ -1288,7 +1352,7 @@ export function extractCaseName(
       // Skip multi-citation strings (joined by semicolons)
       if (!caption.includes(";")) {
         const nameStart = adjustedSearchStart + leadingWsLen + signalStripLen
-        return { caseName: caption, nameStart }
+        return { caseName: caption, nameStart, precedingDocketMeta }
       }
     }
   }
@@ -2353,6 +2417,18 @@ export function extractCase(
             originalEnd: yearOrig.originalEnd,
           }
         }
+      }
+
+      // Louisiana docket-prefix paren metadata transfer (#232). When a Louisiana
+      // citation places `NN-NNNN (La. ... M/D/YY)` between the caption and the
+      // reporter, the trailing reporter citation typically carries no court
+      // paren of its own — pull court/year/date from the docket paren so the
+      // citation surfaces structured metadata instead of dropping it.
+      if (caseNameResult.precedingDocketMeta) {
+        const meta = caseNameResult.precedingDocketMeta
+        if (!year) year = meta.year
+        if (!court) court = meta.court
+        if (!date) date = meta.date
       }
 
       // Calculate fullSpan: case name start through parenthetical end

--- a/tests/extract/dates.test.ts
+++ b/tests/extract/dates.test.ts
@@ -212,4 +212,65 @@ describe("parseDate", () => {
       })
     })
   })
+
+  /**
+   * Two-digit year support in numeric format (Louisiana docket-prefix
+   * citations and other regional shorthand; #232). Century inferred from
+   * value: 00-50 → 21st century, 51-99 → 20th century. This matches the
+   * common practice in opinion text (LA opinions from 2007 cite as `10/3/07`,
+   * never `10/3/1907`).
+   */
+  describe("two-digit year (#232)", () => {
+    it("parses `10/3/07` as 2007-10-03 (00-50 → 21st century)", () => {
+      const result = parseDate("10/3/07")
+      expect(result).toEqual({
+        iso: "2007-10-03",
+        parsed: { year: 2007, month: 10, day: 3 },
+      })
+    })
+
+    it("parses `2/15/10` as 2010-02-15", () => {
+      const result = parseDate("2/15/10")
+      expect(result).toEqual({
+        iso: "2010-02-15",
+        parsed: { year: 2010, month: 2, day: 15 },
+      })
+    })
+
+    it("parses `6/30/20` as 2020-06-30", () => {
+      const result = parseDate("6/30/20")
+      expect(result).toEqual({
+        iso: "2020-06-30",
+        parsed: { year: 2020, month: 6, day: 30 },
+      })
+    })
+
+    it("parses `1/1/50` as 2050-01-01 (boundary)", () => {
+      expect(parseDate("1/1/50")).toEqual({
+        iso: "2050-01-01",
+        parsed: { year: 2050, month: 1, day: 1 },
+      })
+    })
+
+    it("parses `12/31/51` as 1951-12-31 (51-99 → 20th century)", () => {
+      expect(parseDate("12/31/51")).toEqual({
+        iso: "1951-12-31",
+        parsed: { year: 1951, month: 12, day: 31 },
+      })
+    })
+
+    it("parses `7/4/76` as 1976-07-04", () => {
+      expect(parseDate("7/4/76")).toEqual({
+        iso: "1976-07-04",
+        parsed: { year: 1976, month: 7, day: 4 },
+      })
+    })
+
+    it("still parses 4-digit years (regression)", () => {
+      expect(parseDate("1/15/2020")).toEqual({
+        iso: "2020-01-15",
+        parsed: { year: 2020, month: 1, day: 15 },
+      })
+    })
+  })
 })

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5375,4 +5375,100 @@ describe("multiple discrete pincites (#247)", () => {
   })
 })
 
+/**
+ * Louisiana date-in-number citations (#232).
+ *
+ * Louisiana practice prepends a docket-style identifier and slash-date
+ * court parenthetical before the reporter citation:
+ *
+ *   Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07),
+ *     966 So. 2d 1127, 1130.
+ *
+ * Previously the docket-prefix segment bled into the case name on the
+ * trailing `So. 2d` / `So. 3d` citation, producing garbage like
+ * `Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07)`.
+ *
+ * This fix adds an LA-docket-prefix boundary detector to the backward
+ * case-name scan and transfers the docket paren's court / year / date
+ * metadata into the trailing reporter citation. The slash date `M/D/YY`
+ * (and `M/D/YYYY`) is parsed via the extended `parseDate`.
+ */
+describe("Louisiana date-in-number citations (#232)", () => {
+  it("`Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07), 966 So. 2d 1127`", () => {
+    const text =
+      "Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07), 966 So. 2d 1127, 1130."
+    const cits = extractCitations(text)
+    const cases = cits.filter((c) => c.type === "case")
+    const primary = cases.find(
+      (c) => c.type === "case" && c.reporter?.startsWith("So."),
+    )
+    expect(primary).toBeDefined()
+    if (primary?.type === "case") {
+      expect(primary.caseName).toBe("Herff Jones, Inc. v. Girouard")
+      expect(primary.year).toBe(2007)
+      // The default cleaner collapses the reporter-style space after "App."
+      // so the canonical court string is `La. App.3d Cir.` (matches the
+      // reporters-db normalization applied elsewhere in the parser).
+      expect(primary.court).toBe("La. App.3d Cir.")
+      expect(primary.date?.iso).toBe("2007-10-03")
+    }
+  })
+
+  it("`Boudreaux v. Doe, 09-1234 (La. App. 1st Cir. 2/15/10), 100 So. 3d 1`", () => {
+    const text =
+      "Boudreaux v. Doe, 09-1234 (La. App. 1st Cir. 2/15/10), 100 So. 3d 1."
+    const cits = extractCitations(text)
+    const primary = cits
+      .filter((c) => c.type === "case")
+      .find((c) => c.type === "case" && c.reporter?.startsWith("So."))
+    expect(primary).toBeDefined()
+    if (primary?.type === "case") {
+      expect(primary.caseName).toBe("Boudreaux v. Doe")
+      expect(primary.year).toBe(2010)
+      expect(primary.court).toBe("La. App.1st Cir.")
+      expect(primary.date?.iso).toBe("2010-02-15")
+    }
+  })
+
+  it("`State v. Smith, 2020-K-0500 (La. 6/30/20), 295 So. 3d 1`", () => {
+    const text = "State v. Smith, 2020-K-0500 (La. 6/30/20), 295 So. 3d 1."
+    const cits = extractCitations(text)
+    const primary = cits
+      .filter((c) => c.type === "case")
+      .find((c) => c.type === "case" && c.reporter?.startsWith("So."))
+    expect(primary).toBeDefined()
+    if (primary?.type === "case") {
+      expect(primary.caseName).toBe("State v. Smith")
+      expect(primary.year).toBe(2020)
+      expect(primary.court).toBe("La.")
+      expect(primary.date?.iso).toBe("2020-06-30")
+    }
+  })
+
+  describe("regression controls", () => {
+    it("plain `100 So. 3d 1 (La. 2010)` (no docket-prefix) still works", () => {
+      const text = "Smith v. Jones, 100 So. 3d 1 (La. 2010)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].caseName).toBe("Smith v. Jones")
+        expect(cases[0].year).toBe(2010)
+        expect(cases[0].court).toBe("La.")
+      }
+    })
+
+    it("non-LA citation with month-name date still parses", () => {
+      const text =
+        "Doe v. Roe, 100 F.3d 200, 205 (2d Cir. Jan. 15, 2020)."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      if (cases[0].type === "case") {
+        expect(cases[0].year).toBe(2020)
+        expect(cases[0].date?.iso).toBe("2020-01-15")
+      }
+    })
+  })
+})
+
 


### PR DESCRIPTION
## Summary

Closes #232 (primary acceptance criteria — see follow-up note below).

Louisiana practice prepends a docket-style identifier and slash-date court parenthetical before the reporter citation:

\`\`\`
Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07),
  966 So. 2d 1127, 1130
\`\`\`

Previously the docket-prefix segment bled into the case name on the trailing \`So. 2d\` / \`So. 3d\` citation, producing garbage like \`Herff Jones, Inc. v. Girouard, 07-393, p. 2 (La. App. 3d Cir. 10/3/07)\`, and the year/court/date metadata in the docket paren was dropped entirely.

### Changes

- **\`parseDate\` accepts two-digit years**. \`10/3/07\`, \`2/15/10\`, \`6/30/20\` now parse with century inferred at the 50 pivot (00-50 → 21st century, 51-99 → 20th century). Four-digit years continue to parse as before.
- **LA docket-prefix excision in case-name scanback**. The new \`LA_DOCKET_BOUNDARY_REGEX\` recognizes the LA shape \`NN-NNNN (La. ... M/D/YY)\` (with optional \`, p. N\` pincite) when it sits between caption and reporter, splices it out of \`precedingText\` (leaving just \`, \`), and surfaces the docket paren's court + date.
- **Metadata transfer**. \`extractCaseName\` returns an optional \`precedingDocketMeta\` field; \`processCaseToken\` applies its court / year / date as fallback for the trailing reporter citation when that citation has no court paren of its own.

### Tests

- **\`parseDate\` two-digit years**: 7 new tests covering the pivot, ranges, and 4-digit regression.
- **Louisiana citations**: 3 fixtures (all three failing inputs from the issue) + 2 regression controls (plain \`(La. 2010)\` and non-LA month-name dates).

### Follow-up

The Louisiana docket-prefix is not yet emitted as its own first-class citation (linked via \`detectParallel.ts\` per the issue's third acceptance bullet). That remains follow-up work — schema design for the docket-style citation type and \`detectParallel\` integration are scoped for a separate PR. The primary \`So. 2d\` / \`So. 3d\` citation now carries clean caseName plus structured year / court / date, which addresses the most visible bug.

## Test plan

- [x] 12/12 new tests pass (7 dates + 5 LA + 2 regression)
- [x] Full suite: 2330/2330 (was 2318)
- [x] \`pnpm typecheck\` clean
- [x] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)