### PR TITLE
feat: short-form party-name back-reference + resolver disambiguation (#278)

### DIFF
--- a/.changeset/issue-278-short-form-partyname.md
+++ b/.changeset/issue-278-short-form-partyname.md
@@ -1,0 +1,46 @@
+---
+"eyecite-ts": minor
+---
+
+feat: short-form case back-reference party name + resolver disambiguation (#278)
+
+Bluebook short-forms commonly include a leading back-reference name
+(`Smith, 500 F.2d at 125`). Previously the tokenizer recognized only the bare
+`vol reporter at page` form, dropping the disambiguating name. The resolver
+then matched purely on volume + reporter, so when two earlier full citations
+shared those values the short-form silently resolved to the wrong antecedent.
+
+### Changes
+
+- **`ShortFormCaseCitation`** gains `partyName?: string` and
+  `partyNameNormalized?: string` mirroring `SupraCitation.partyName`.
+- **`SHORT_FORM_CASE_PATTERN`** (tokenizer) and the local `shortFormRegex`
+  (extractor) now accept an optional leading `[A-Z][a-zA-Z''\-]+(\s+v\.?\s+|\s+)...,\s+`
+  party-name segment before the volume. Group order shifts:
+  `1 = partyName? | 2 = volume | 3 = reporter | 4 = pincite`.
+- **`extractShortFormCase`** runs the captured raw party name through
+  `stripSupraPartyPrefix` (#216 helper) so leading citation signals
+  (`See`, `Cf.`, `Compare`, etc.) and sentence-initial connectors (`Then`,
+  `Also`, `In` but not `In re`) are stripped before assignment.
+- **`resolveShortFormCase`** collects all backward in-scope candidates that
+  match volume + reporter. When `partyNameNormalized` is set, it prefers
+  the candidate whose plaintiff or defendant normalized name overlaps
+  (substring containment in either direction tolerates abbreviation
+  patterns); recency breaks ties. Bare short-forms (no party name) continue
+  to fall back to recency — no regression.
+
+Disambiguated short-forms get confidence 0.98 (vs. 0.95 for vol+reporter-only
+matches) because the additional party-name constraint tightens the match.
+
+### Tests
+
+6 new tests under `short-form case party-name back-reference (#278)`:
+
+- **Regex captures** (4): bare form, `Smith,`, `See Smith,` (signal strip),
+  `Smith v. Jones,`.
+- **Resolver disambiguation** (2): two cases share vol+reporter →
+  party-named short-form picks the right one; bare short-form falls back to
+  recency.
+
+Pattern-level tests in `tests/patterns/shortForm.test.ts` were updated to
+the new group order; one new test confirms the optional partyName group.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -309,8 +309,8 @@ export function extractShortFormCase(
 ): ShortFormCaseCitation {
   const { text, span } = token
 
-  // Parse volume-reporter-[,]-at-page.
-  // Pattern: number space abbreviation [, ] at space number.
+  // Parse [Party,] volume-reporter-[,]-at-page.
+  // Pattern: optional Party name then number space abbreviation [, ] at space number.
   // Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
   // Handles comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
   // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
@@ -318,25 +318,45 @@ export function extractShortFormCase(
   // suffix " n.14" / " nn.14-15" (#202), an optional `p.` / `pp.` prefix for
   // CSM form (`18 Cal.4th at p. 717`; see #236), and `¶` / `¶¶` / `para.` /
   // `paras.` paragraph markers (#204).
+  // Optional leading party-name group (#278) captures Bluebook back-references
+  // (`Smith, 500 F.2d at 125`). Group order:
+  //   1: party name (optional, undefined for bare form)
+  //   2: volume
+  //   3: reporter
+  //   4: pincite
   const shortFormRegex =
-    /(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
+    /(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
   const match = shortFormRegex.exec(text)
 
   if (!match) {
     throw new Error(`Failed to parse short-form case citation: ${text}`)
   }
 
-  const rawVolume = match[1]
+  const rawPartyName = match[1]
+  const rawVolume = match[2]
   const volume = /^\d+$/.test(rawVolume) ? Number.parseInt(rawVolume, 10) : rawVolume
-  const reporter = match[2].trim() // Remove trailing spaces
-  const pinciteInfo: PinciteInfo | undefined = parsePincite(match[3]) ?? undefined
+  const reporter = match[3].trim() // Remove trailing spaces
+  const pinciteInfo: PinciteInfo | undefined = parsePincite(match[4]) ?? undefined
   const pincite = pinciteInfo?.page
+
+  // Strip leading citation signals from the captured party name (#216 helper).
+  // The optional party-name group itself doesn't include signal prefixes —
+  // the outer SHORT_FORM_CASE_PATTERN's `\b` anchor lands at the signal word
+  // (e.g., `See` is matched as the first capitalized token, then `Smith` as
+  // the second). `stripSupraPartyPrefix` peels off any leading signal /
+  // sentence-initial connector, mirroring the supra handling.
+  let partyName: string | undefined
+  let partyNameNormalized: string | undefined
+  if (rawPartyName) {
+    partyName = stripSupraPartyPrefix(rawPartyName)
+    partyNameNormalized = partyName.toLowerCase().replace(/\s+/g, " ").trim()
+  }
 
   // Component span for pincite (#210)
   let spans: ShortFormCaseComponentSpans | undefined
-  if (match.indices?.[3]) {
+  if (match.indices?.[4]) {
     spans = {
-      pincite: spanFromGroupIndex(span.cleanStart, match.indices[3], transformationMap),
+      pincite: spanFromGroupIndex(span.cleanStart, match.indices[4], transformationMap),
     }
   }
 
@@ -366,6 +386,8 @@ export function extractShortFormCase(
     reporter,
     pincite,
     pinciteInfo,
+    partyName,
+    partyNameNormalized,
     spans,
   }
 }

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -54,8 +54,8 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
   /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)|\s+(?:§+|Part|p\.)\s*\S+)/g
 
 /**
- * Short-form case: volume reporter [,] at page
- * Pattern: number space abbreviation [, ] at space number
+ * Short-form case: [Party,] volume reporter [,] at page
+ * Pattern: optional Party name, then number space abbreviation [, ] at space number.
  * Simplified detection; full parsing in extraction layer.
  * Supports reporters with 1-2 letter ordinal suffixes (e.g., F.4th, Cal.4th).
  * Handles SCOTUS/federal comma-before-at: "597 U.S., at 721", "116 F.4th, at 1193".
@@ -64,9 +64,17 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
  * " n.14" / " nn.14-15" (#202), an optional `p.` / `pp.` prefix for
  * California Style Manual form (`18 Cal.4th at p. 717`; see #236), and `¶` /
  * `¶¶` / `para.` / `paras.` paragraph markers (#204).
+ *
+ * Optional leading party-name group captures Bluebook back-references like
+ * `Smith, 500 F.2d at 125` so the resolver can disambiguate when multiple
+ * full citations share the same volume+reporter (#278). Group order:
+ *   1: party name (optional)
+ *   2: volume
+ *   3: reporter
+ *   4: pincite
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
+  /\b(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -262,39 +262,72 @@ export class DocumentResolver {
   }
 
   /**
-   * Resolves short-form case citation by matching volume/reporter.
+   * Resolves short-form case citation by matching volume/reporter, with
+   * party-name disambiguation when the short-form includes a back-reference
+   * name (#278).
+   *
+   * Algorithm:
+   *   1. Collect all backward candidates with matching volume + normalized
+   *      reporter that are in-scope.
+   *   2. If the short-form has `partyNameNormalized`: prefer the candidate
+   *      whose plaintiff/defendant matches (substring containment in either
+   *      direction handles abbreviations: `"Smith" ⊂ "Smith"` or
+   *      `"Smith"` in `"Smith, Inc."`). Tie-break by recency.
+   *   3. If no candidate matches the party name (or no party name on the
+   *      short-form): fall back to recency.
    */
   private resolveShortFormCase(citation: ShortFormCaseCitation): ResolutionResult | undefined {
     const currentIndex = this.context.citationIndex
+    const targetReporter = this.normalizeReporter(citation.reporter)
+    const targetParty = citation.partyNameNormalized
 
-    // Search backwards for matching full case citation
+    // Collect all backward candidates (most recent first) that match
+    // vol+reporter AND are in-scope.
+    const candidates: number[] = []
     for (let i = currentIndex - 1; i >= 0; i--) {
       const candidate = this.citations[i]
+      if (candidate.type !== "case") continue
+      if (candidate.volume !== citation.volume) continue
+      if (this.normalizeReporter(candidate.reporter) !== targetReporter) continue
+      if (!this.isWithinScope(i, currentIndex, true)) continue
+      candidates.push(i)
+    }
 
-      // Only match against full case citations
-      if (candidate.type !== "case") {
-        continue
-      }
+    if (candidates.length === 0) {
+      return this.createFailureResult("No matching full case citation found")
+    }
 
-      // Check if volume and reporter match
-      if (
-        candidate.volume === citation.volume &&
-        this.normalizeReporter(candidate.reporter) === this.normalizeReporter(citation.reporter)
-      ) {
-        // Check scope boundary (short-form case allows cross-zone: footnote -> body)
-        if (!this.isWithinScope(i, currentIndex, true)) {
-          return this.createFailureResult("Matching citation outside scope boundary")
-        }
-
-        // Found a match
+    // With a party name, prefer the candidate whose plaintiff or defendant
+    // normalized name contains (or is contained by) the short-form's party
+    // name. Substring containment in either direction tolerates common
+    // abbreviation patterns: short-form `Smith` matches full `Smith, Inc.`
+    // and vice versa. Recency breaks ties.
+    if (targetParty) {
+      const namedMatch = candidates.find((idx) => {
+        const c = this.citations[idx]
+        if (c.type !== "case") return false
+        const plaintiff = c.plaintiffNormalized
+        const defendant = c.defendantNormalized
+        const hit = (name: string | undefined) =>
+          name !== undefined &&
+          (name === targetParty ||
+            name.includes(targetParty) ||
+            targetParty.includes(name))
+        return hit(plaintiff) || hit(defendant)
+      })
+      if (namedMatch !== undefined) {
         return {
-          resolvedTo: i,
-          confidence: 0.95, // High confidence but not perfect (multiple cases could have same volume/reporter)
+          resolvedTo: namedMatch,
+          confidence: 0.98, // Higher than bare vol+reporter — party-name disambiguation tightens.
         }
       }
     }
 
-    return this.createFailureResult("No matching full case citation found")
+    // No party name (or no name match): pick most recent candidate.
+    return {
+      resolvedTo: candidates[0],
+      confidence: 0.95,
+    }
   }
 
   /**

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -715,6 +715,17 @@ export interface ShortFormCaseCitation extends CitationBase {
   pinciteInfo?: import("../extract/pincite").PinciteInfo
   /** Component-level spans (currently just `pincite`; extend when needed). */
   spans?: import("./componentSpans").ShortFormCaseComponentSpans
+  /** Back-reference party name when the short-form includes one (Bluebook
+   *  form: `Smith, 500 F.2d at 125`). Citation signals (`See`, `Cf.`, etc.)
+   *  and sentence-initial connectors (`Then`, `Also`, `In` not-`In re`) are
+   *  stripped via the same helper as supra (#216). Undefined when the
+   *  short-form is bare `500 F.2d at 125`. Used by the resolver to
+   *  disambiguate when multiple full citations share the same vol+reporter. */
+  partyName?: string
+  /** Normalized party name for resolver matching (lowercased, whitespace
+   *  collapsed). Mirrors `defendantNormalized` / `plaintiffNormalized` on
+   *  `FullCaseCitation`. */
+  partyNameNormalized?: string
 }
 
 /**

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -1211,3 +1211,119 @@ describe("paragraph-marker pincites on short-forms (#204)", () => {
     })
   })
 })
+
+/**
+ * Short-form case back-reference party name (#278).
+ *
+ * Bluebook short-forms commonly include a leading back-reference name
+ * (`Smith, 500 F.2d at 125`). Previously the tokenizer recognized only
+ * `vol reporter at page`, dropping the disambiguating name entirely — the
+ * resolver then matched purely on volume + reporter, so two cases sharing
+ * those values silently lost the distinguishing signal.
+ *
+ * Coverage:
+ *   - Bare `500 F.2d at 125` still works (regression).
+ *   - `Smith, 500 F.2d at 125` captures `partyName: "Smith"`.
+ *   - Signal-stripped: `See Smith, 500 F.2d at 125` → `Smith` (reuses
+ *     `stripSupraPartyPrefix` from #216).
+ *   - Multi-word: `Smith v. Jones, 500 F.2d at 125` → `Smith v. Jones`.
+ *   - Resolver: when two earlier full cites share vol+reporter, the short-
+ *     form with `partyName` resolves to the matching antecedent (not the
+ *     most-recent one).
+ */
+describe("short-form case party-name back-reference (#278)", () => {
+  describe("regex captures leading party name", () => {
+    it("`Smith, 500 F.2d at 125` → partyName='Smith'", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 100 (9th Cir. 1990). Smith, 500 F.2d at 125."
+      const cits = extractCitations(text)
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.partyName).toBe("Smith")
+        expect(sf.volume).toBe(500)
+        expect(sf.reporter).toBe("F.2d")
+        expect(sf.pincite).toBe(125)
+      }
+    })
+
+    it("`See Smith, 500 F.2d at 125` strips `See` from partyName", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 100 (9th Cir. 1990). See Smith, 500 F.2d at 125."
+      const cits = extractCitations(text)
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.partyName).toBe("Smith")
+      }
+    })
+
+    it("`Smith v. Jones, 500 F.2d at 125` captures both parties", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 100 (9th Cir. 1990). Smith v. Jones, 500 F.2d at 125."
+      const cits = extractCitations(text)
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.partyName).toBe("Smith v. Jones")
+      }
+    })
+
+    it("bare `500 F.2d at 125` has no partyName (regression)", () => {
+      const text = "Smith v. Jones, 500 F.2d 100 (9th Cir. 1990). 500 F.2d at 125."
+      const cits = extractCitations(text)
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.partyName).toBeUndefined()
+        expect(sf.volume).toBe(500)
+        expect(sf.pincite).toBe(125)
+      }
+    })
+  })
+
+  describe("resolver uses partyName for disambiguation", () => {
+    it("two cases share vol+reporter — partyName picks the right antecedent", () => {
+      const text = [
+        "Smith v. Jones, 500 F.2d 100 (9th Cir. 1990).",
+        "Then we cited Brown v. Doe, 500 F.2d 100 (2d Cir. 1995).",
+        "But in Smith, 500 F.2d at 125, the rule was settled.",
+      ].join(" ")
+      const cits = extractCitations(text, { resolve: true })
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        // Find the Smith v. Jones full-cite index
+        const smithIdx = cits.findIndex(
+          (c) =>
+            c.type === "case" &&
+            c.plaintiff === "Smith" &&
+            c.defendant === "Jones",
+        )
+        expect(smithIdx).toBeGreaterThanOrEqual(0)
+        expect(sf.resolution?.resolvedTo).toBe(smithIdx)
+      }
+    })
+
+    it("no partyName → falls back to recency (most recent vol+reporter wins)", () => {
+      const text = [
+        "Smith v. Jones, 500 F.2d 100 (9th Cir. 1990).",
+        "Then we cited Brown v. Doe, 500 F.2d 100 (2d Cir. 1995).",
+        "But 500 F.2d at 125 settled the rule.",
+      ].join(" ")
+      const cits = extractCitations(text, { resolve: true })
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        // No partyName → recency: most recent matching full is Brown v. Doe
+        const brownIdx = cits.findIndex(
+          (c) =>
+            c.type === "case" &&
+            c.plaintiff === "Brown" &&
+            c.defendant === "Doe",
+        )
+        expect(sf.resolution?.resolvedTo).toBe(brownIdx)
+      }
+    })
+  })
+})

--- a/tests/patterns/shortForm.test.ts
+++ b/tests/patterns/shortForm.test.ts
@@ -196,14 +196,16 @@ describe("SUPRA_PATTERN", () => {
 })
 
 describe("SHORT_FORM_CASE_PATTERN", () => {
+  // Group order (#278): 1=partyName (optional), 2=volume, 3=reporter, 4=pincite
   it("should match short-form case citation", () => {
     const text = "500 F.2d at 125"
     const match = SHORT_FORM_CASE_PATTERN.exec(text)
     expect(match).not.toBeNull()
     expect(match?.[0]).toBe("500 F.2d at 125")
-    expect(match?.[1]).toBe("500") // Volume
-    expect(match?.[2]).toBe("F.2d") // Reporter
-    expect(match?.[3]).toBe("125") // Page
+    expect(match?.[1]).toBeUndefined() // No party name
+    expect(match?.[2]).toBe("500") // Volume
+    expect(match?.[3]).toBe("F.2d") // Reporter
+    expect(match?.[4]).toBe("125") // Page
   })
 
   it("should match U.S. short-form", () => {
@@ -211,9 +213,9 @@ describe("SHORT_FORM_CASE_PATTERN", () => {
     const text = "410 U.S. at 113"
     const match = SHORT_FORM_CASE_PATTERN.exec(text)
     expect(match).not.toBeNull()
-    expect(match?.[1]).toBe("410")
-    expect(match?.[2]).toBe("U.S.")
-    expect(match?.[3]).toBe("113")
+    expect(match?.[2]).toBe("410")
+    expect(match?.[3]).toBe("U.S.")
+    expect(match?.[4]).toBe("113")
   })
 
   it("should match state reporter short-form", () => {
@@ -221,9 +223,9 @@ describe("SHORT_FORM_CASE_PATTERN", () => {
     const text = "123 Cal.Rptr. at 456"
     const match = SHORT_FORM_CASE_PATTERN.exec(text)
     expect(match).not.toBeNull()
-    expect(match?.[1]).toBe("123")
-    expect(match?.[2]).toBe("Cal.Rptr.")
-    expect(match?.[3]).toBe("456")
+    expect(match?.[2]).toBe("123")
+    expect(match?.[3]).toBe("Cal.Rptr.")
+    expect(match?.[4]).toBe("456")
   })
 
   it("should match F.4th reporter (two-letter ordinal suffix)", () => {
@@ -231,9 +233,9 @@ describe("SHORT_FORM_CASE_PATTERN", () => {
     const text = "74 F.4th at 30"
     const match = SHORT_FORM_CASE_PATTERN.exec(text)
     expect(match).not.toBeNull()
-    expect(match?.[1]).toBe("74")
-    expect(match?.[2]).toBe("F.4th")
-    expect(match?.[3]).toBe("30")
+    expect(match?.[2]).toBe("74")
+    expect(match?.[3]).toBe("F.4th")
+    expect(match?.[4]).toBe("30")
   })
 
   it("should match Cal.4th reporter", () => {
@@ -241,9 +243,21 @@ describe("SHORT_FORM_CASE_PATTERN", () => {
     const text = "500 Cal.4th at 120"
     const match = SHORT_FORM_CASE_PATTERN.exec(text)
     expect(match).not.toBeNull()
-    expect(match?.[1]).toBe("500")
-    expect(match?.[2]).toBe("Cal.4th")
-    expect(match?.[3]).toBe("120")
+    expect(match?.[2]).toBe("500")
+    expect(match?.[3]).toBe("Cal.4th")
+    expect(match?.[4]).toBe("120")
+  })
+
+  it("should match short-form with leading party name (#278)", () => {
+    SHORT_FORM_CASE_PATTERN.lastIndex = 0
+    const text = "Smith, 500 F.2d at 125"
+    const match = SHORT_FORM_CASE_PATTERN.exec(text)
+    expect(match).not.toBeNull()
+    expect(match?.[0]).toBe("Smith, 500 F.2d at 125")
+    expect(match?.[1]).toBe("Smith")
+    expect(match?.[2]).toBe("500")
+    expect(match?.[3]).toBe("F.2d")
+    expect(match?.[4]).toBe("125")
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #278.

Bluebook short-forms commonly include a leading back-reference name (\`Smith, 500 F.2d at 125\`). Previously the tokenizer recognized only the bare \`vol reporter at page\` form, dropping the disambiguating name. The resolver then matched purely on volume + reporter, so when two earlier full citations shared those values the short-form silently resolved to the wrong antecedent.

### Changes

- **\`ShortFormCaseCitation\`** gains \`partyName?: string\` and \`partyNameNormalized?: string\` mirroring \`SupraCitation.partyName\`.
- **\`SHORT_FORM_CASE_PATTERN\`** (tokenizer) and the local \`shortFormRegex\` (extractor) now accept an optional leading party-name segment before the volume. Group order shifts to \`1 = partyName? | 2 = volume | 3 = reporter | 4 = pincite\`.
- **\`extractShortFormCase\`** runs the captured raw party name through \`stripSupraPartyPrefix\` (#216 helper) so leading citation signals (\`See\`, \`Cf.\`, \`Compare\`, etc.) and sentence-initial connectors (\`Then\`, \`Also\`, \`In\` but not \`In re\`) are stripped before assignment.
- **\`resolveShortFormCase\`** collects all backward in-scope candidates that match volume + reporter. When \`partyNameNormalized\` is set, it prefers the candidate whose plaintiff or defendant normalized name overlaps (substring containment in either direction tolerates abbreviation patterns); recency breaks ties. Bare short-forms (no party name) continue to fall back to recency.

Disambiguated short-forms get confidence \`0.98\` (vs. \`0.95\` for vol+reporter-only matches) because the additional constraint tightens the match.

### Tests

6 new tests under \`short-form case party-name back-reference (#278)\`:

- **Regex captures** (4): bare form, \`Smith,\`, \`See Smith,\` (signal strip), \`Smith v. Jones,\`.
- **Resolver disambiguation** (2): two cases share vol+reporter → party-named short-form picks the right one; bare short-form falls back to recency.

Pattern-level tests in \`tests/patterns/shortForm.test.ts\` were updated to the new group order; one new test confirms the optional partyName group.

## Test plan

- [x] 6/6 new tests pass
- [x] Pattern-level tests updated to new group indices (5 updated + 1 new)
- [x] Full suite: 2337/2337 (was 2330)
- [x] \`pnpm typecheck\` clean
- [x] No new lint warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)