### PR TITLE
fix: parallel-cite volume absorbed as pincite + year/caseName recovery

### DIFF
--- a/.changeset/fix-parallel-cite-pincite-disambiguation.md
+++ b/.changeset/fix-parallel-cite-pincite-disambiguation.md
@@ -1,0 +1,63 @@
+---
+"eyecite-ts": patch
+---
+
+fix: parallel-cite volume mistakenly consumed as pincite + lost year/caseName on parallel chains
+
+When a primary cite was followed by a comma-separated parallel cite —
+e.g., `Nixon v. Nixon, 329 Pa. 256, 198 A. 154 (1938)` or Roe's three-reporter
+`410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)` — the volume of the
+parallel cite (`198`, `93`, `35`) was greedily matched by
+`LOOKAHEAD_PINCITE_REGEX` as a pincite for the first cite. Downstream effects:
+
+- The first cite's trailing year parenthetical was unreachable (hidden behind
+  the parallel cite), leaving `year` undefined.
+- The case-name backward walk for a parallel cite started at its own position
+  and walked unbounded, scooping the prior reporter cite into its `caseName`
+  (e.g., `Nixon v. Nixon, 329 Pa. 256`).
+
+### Fix (two layers)
+
+**(A) Pincite regex disambiguation.** `LOOKAHEAD_PINCITE_REGEX` and
+`ADDITIONAL_PINCITE_REGEX` now require the captured pincite to terminate at
+end-of-string, sentence punctuation, paren/bracket close, or whitespace NOT
+followed by a capital letter. `, 198 A.` no longer matches (capital `A`
+starts a parallel reporter); `, 117 (1973)` still does; bracketed pincites
+`[266 Cal.Rptr. 569, 575]` still terminate cleanly on `]`.
+
+**(B) Span-aware extraction.** `extractCase` now receives the spans of
+sibling case-citation tokens and uses them to:
+
+- Skip past a contiguous parallel-cite chain (separated only by commas,
+  whitespace, and digit/dash runs for intervening pincites) when searching
+  for the shared trailing year parenthetical — both in the look-ahead paren
+  scan and in `collectParentheticals` so `fullSpan` extends through the
+  shared paren.
+- Bound the case-name backward walk by the prior sibling's end so a parallel
+  cite cannot absorb the preceding reporter cite's text into its caseName.
+- Populate `fullSpan` on secondary parallel cites (which have no captured
+  caseName) when a close preceding sibling indicates a parallel chain, so
+  string-citation grouping and downstream span consumers see the full
+  citation extent through the shared trailing paren.
+
+### Tests
+
+9 new tests under `parallel-cite pincite disambiguation (regression)` in
+`tests/extract/extractCase.test.ts`:
+
+- **Two-reporter parallel** (`329 Pa. 256, 198 A. 154 (1938)`): no false
+  pincite on the first cite; both cites get `year=1938`; the second cite's
+  `caseName` does not leak the first reporter cite.
+- **Three-reporter parallel** (Roe v. Wade): no false pincites on any of
+  the three cites; all three get `year=1973`.
+- **Pincite WITH following parallel** (`410 U.S. 113, 117, 93 S. Ct. 705
+  (1973)`): the real pincite `117` is captured; no additional false pincite
+  from the parallel volume; the first cite still gets `year=1973`.
+- **Multi-discrete pincite regression** (`410 U.S. 113, 115, 153 (1973)`):
+  the #247 feature continues to work — `pincite=115`,
+  `additionalPincites=[{page: 153}]`, `year=1973`.
+
+Full 2346-test suite passes including the existing California bracketed
+parallel pincite test (`[266 Cal.Rptr. 569, 575]`) and the string-citation
+grouping integration test that depends on `fullSpan` extending through the
+shared trailing paren.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -177,8 +177,13 @@ const LOOKAHEAD_PAREN_REGEX =
  *  " nn.14-15" footnote suffix is captured when present (#202). Paragraph
  *  forms (`¶ N` / `¶¶ N-M` / `para. N` / `paras. N-M`) are accepted in the
  *  capture; `parsePincite` routes them to the `paragraph` field (#204). */
+// Parallel-cite disambiguation: a real pincite is bounded by end-of-string,
+// sentence punctuation, a paren or bracket close, or whitespace NOT followed
+// by a capital letter (which would start a parallel cite's reporter token,
+// e.g., `, 198 A. 154` or `, 93 S. Ct. 705`). The anchored positive lookahead
+// prevents regex backtracking into shorter digit prefixes.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
+  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,;)(\]]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -193,8 +198,11 @@ const PAREN_SKIP_REGEX = /[\s,]/
  *
  *  Excludes paragraph forms (`¶ 12` mixed with page numbers is exceedingly
  *  rare and would conflict with the citation core's lookahead boundary). */
+// Parallel-cite disambiguation: tighten the trailing whitespace branch to
+// reject `\s+[A-Z]` (a parallel-cite reporter token). Allow bracket close
+// `]` as a terminator so bracketed parallel pincites still capture.
 const ADDITIONAL_PINCITE_REGEX =
-  /^,\s*(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)(?=\s|$|\(|,|;|\.)/
+  /^,\s*(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)(?=$|[.,;)(\]]|\s(?![A-Z]))/
 
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.
@@ -2031,6 +2039,13 @@ export function extractCase(
   transformationMap: TransformationMap,
   cleanedText?: string,
   originalText?: string,
+  /** Clean-coordinate spans of sibling tokens. Used to:
+   *  - bound the case-name backward walk so a parallel cite's caption is
+   *    not absorbed into this cite's caseName,
+   *  - skip past a contiguous parallel-cite chain (`, 198 A. 154, 35 L.Ed.2d 147`)
+   *    when searching for the shared trailing year parenthetical so each
+   *    cite in the chain gets year/court populated. */
+  siblings?: ReadonlyArray<{ cleanStart: number; cleanEnd: number }>,
 ): FullCaseCitation {
   const { text, span } = token
 
@@ -2144,17 +2159,48 @@ export function extractCase(
     }
   }
 
+  // Parallel-cite chain skip: when this cite is followed by another citation
+  // separated only by parallel-chain junk (commas, whitespace, digit/dash
+  // runs for intervening pincites), the shared trailing parenthetical sits
+  // AFTER the last cite in the chain — e.g., `329 Pa. 256, 198 A. 154 (1938)`
+  // or `410 U.S. 113, 117, 93 S. Ct. 705 (1973)` where the `, 117,` is the
+  // first cite's pincite. Compute the post-chain start position once and
+  // share it between the look-ahead paren scan and `collectParentheticals`
+  // so the trailing year paren is found AND fullSpan extends through it.
+  let postChainStart = span.cleanEnd
+  if (cleanedText && siblings && siblings.length > 0) {
+    const CHAIN_BRIDGE_REGEX = /^[\s,\d\-–—]*$/
+    while (true) {
+      const next = siblings.find(
+        (s) =>
+          s.cleanStart > postChainStart &&
+          CHAIN_BRIDGE_REGEX.test(
+            cleanedText.substring(postChainStart, s.cleanStart),
+          ),
+      )
+      if (!next) break
+      postChainStart = next.cleanEnd
+    }
+  }
+
   // Look ahead in cleaned text for parenthetical after the token
   // Tokenization patterns only capture volume-reporter-page, so parentheticals
   // like "(1989)" or "(9th Cir. 2020)" are not in the token text.
   if (cleanedText && !parentheticalContent) {
-    let afterToken = cleanedText.substring(span.cleanEnd)
+    // The pincite scan below must still operate on the original afterToken
+    // (starting at span.cleanEnd) so `, 117` is parseable as this cite's
+    // pincite; the paren scan uses the post-chain window instead.
+    const afterToken = cleanedText.substring(span.cleanEnd)
+    let parenAfterToken =
+      postChainStart === span.cleanEnd
+        ? afterToken
+        : cleanedText.substring(postChainStart)
     // Consume any leading (U)/[U] marker so the real court paren is found.
-    const unpubMatch = /^\s*(?:\(U\)|\[U\])/.exec(afterToken)
+    const unpubMatch = /^\s*(?:\(U\)|\[U\])/.exec(parenAfterToken)
     if (unpubMatch) {
-      afterToken = afterToken.substring(unpubMatch[0].length)
+      parenAfterToken = parenAfterToken.substring(unpubMatch[0].length)
     }
-    const lookAheadMatch = LOOKAHEAD_PAREN_REGEX.exec(afterToken)
+    const lookAheadMatch = LOOKAHEAD_PAREN_REGEX.exec(parenAfterToken)
     if (lookAheadMatch) {
       parentheticalContent = lookAheadMatch[1]
       // Parse parenthetical using unified parser
@@ -2220,7 +2266,9 @@ export function extractCase(
   let allParens: RawParenthetical[] | undefined
   let collected: CollectedParentheticals | undefined
   if (cleanedText) {
-    collected = collectParentheticals(cleanedText, span.cleanEnd)
+    // Use postChainStart so fullSpan / chained-paren classification can see
+    // the shared trailing paren that sits past a parallel-cite chain.
+    collected = collectParentheticals(cleanedText, postChainStart)
     allParens = collected.parens
     // Skip first paren (already parsed above as court/year)
     const remaining = parentheticalContent ? allParens.slice(1) : allParens
@@ -2381,13 +2429,35 @@ export function extractCase(
     court = "scotus"
   }
 
-  // Phase 6: Extract case name via backward search
+  // Phase 6: Extract case name via backward search.
+  // Bound the lookback by the previous sibling token's end (if any) so the
+  // backward walk for a parallel cite (e.g., the `198 A. 154` half of
+  // `Nixon v. Nixon, 329 Pa. 256, 198 A. 154`) does not absorb the earlier
+  // reporter cite into the case name.
+  let caseNameLookback: number | undefined
+  if (siblings && siblings.length > 0) {
+    const prev = siblings
+      .filter((s) => s.cleanEnd <= span.cleanStart)
+      .reduce<{ cleanEnd: number } | undefined>(
+        (best, s) =>
+          !best || s.cleanEnd > best.cleanEnd ? s : best,
+        undefined,
+      )
+    if (prev) {
+      caseNameLookback = span.cleanStart - prev.cleanEnd
+    }
+  }
   let caseNameResult: ReturnType<typeof extractCaseName> | undefined
   if (cleanedText) {
-    caseNameResult = extractCaseName(cleanedText, span.cleanStart, undefined, {
-      originalText,
-      transformationMap,
-    })
+    caseNameResult = extractCaseName(
+      cleanedText,
+      span.cleanStart,
+      caseNameLookback,
+      {
+        originalText,
+        transformationMap,
+      },
+    )
     if (caseNameResult) {
       caseName = caseNameResult.caseName
 
@@ -2462,6 +2532,39 @@ export function extractCase(
         cleanEnd: caseNameCleanEnd,
         originalStart: caseNameOrig.originalStart,
         originalEnd: caseNameOrig.originalEnd,
+      }
+    }
+  }
+
+  // Parallel-cite fullSpan fallback: when this cite is a secondary parallel
+  // (no case-name extracted because the bounded lookback hits the prior
+  // cite's end) AND there is a close preceding sibling indicating a parallel
+  // chain, still extend fullSpan through the shared trailing paren so
+  // string-citation grouping and downstream span consumers see the full
+  // citation extent. The bare cite's own cleanStart anchors the lower bound.
+  // Cites without a preceding sibling (e.g., a standalone `500 F.2d 123 (2020)`
+  // with no caption) intentionally do not get a fullSpan — that's existing
+  // contract: "no case name → no fullSpan".
+  const hasCloseParallelPrev =
+    caseNameLookback !== undefined && caseNameLookback < 30
+  if (
+    !fullSpan &&
+    hasCloseParallelPrev &&
+    allParens &&
+    allParens.length > 0
+  ) {
+    const lastParen = allParens[allParens.length - 1]
+    if (lastParen.end > span.cleanEnd) {
+      const fullCleanStart = span.cleanStart
+      const fullCleanEnd = lastParen.end
+      fullSpan = {
+        cleanStart: fullCleanStart,
+        cleanEnd: fullCleanEnd,
+        originalStart:
+          transformationMap.cleanToOriginal.get(fullCleanStart) ??
+          fullCleanStart,
+        originalEnd:
+          transformationMap.cleanToOriginal.get(fullCleanEnd) ?? fullCleanEnd,
       }
     }
   }

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -304,6 +304,15 @@ export function extractCitations(
     for (const s of secondaries) secondaryToGroup.set(s, primary)
   }
 
+  // Span list for all case-shape tokens. Passed to extractCase so the per-cite
+  // pincite/year/caseName logic can see what's adjacent and avoid scanning
+  // INTO neighbor citations (parallel-cite chains share a trailing year paren
+  // and the case-name backward walk for a parallel cite must stop at the
+  // prior cite's end).
+  const caseTokenSpans = deduplicatedTokens
+    .filter((t) => t.type === "case")
+    .map((t) => ({ cleanStart: t.span.cleanStart, cleanEnd: t.span.cleanEnd }))
+
   // Step 4: Extract citations from deduplicated tokens
   const citations: Citation[] = []
   for (let i = 0; i < deduplicatedTokens.length; i++) {
@@ -320,7 +329,13 @@ export function extractCitations(
         } else if (token.patternId === "shortFormCase") {
           citation = extractShortFormCase(token, transformationMap)
         } else {
-          citation = extractCase(token, transformationMap, cleaned, text)
+          citation = extractCase(
+            token,
+            transformationMap,
+            cleaned,
+            text,
+            caseTokenSpans,
+          )
         }
         break
       case "docket": {

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5471,4 +5471,120 @@ describe("Louisiana date-in-number citations (#232)", () => {
   })
 })
 
+/**
+ * Parallel-citation pincite disambiguation.
+ *
+ * Bug: when a primary cite is followed by a comma-separated parallel cite —
+ * `329 Pa. 256, 198 A. 154 (1938)` — the volume of the parallel cite (`198`)
+ * was consumed by `LOOKAHEAD_PINCITE_REGEX` as a pincite for the first cite.
+ * Cascading effects: the first cite then could not find its trailing year
+ * parenthetical (hidden behind the parallel cite), and the case-name backward
+ * walk for the second cite over-included the first cite's reporter text.
+ *
+ * Fix path:
+ *   (A) Regex guard — refuse `, NUM` when NUM looks like a parallel-cite
+ *       volume (i.e., followed by whitespace + a capital letter that begins
+ *       a reporter token).
+ *   (B) Span-aware extraction — refuse to consume pincite or parenthetical
+ *       bytes that overlap another tokenized citation, and continue the
+ *       parenthetical search past intervening citations so the shared
+ *       trailing year is found.
+ */
+describe("parallel-cite pincite disambiguation (regression)", () => {
+  describe("two-reporter parallel cite — `329 Pa. 256, 198 A. 154 (1938)`", () => {
+    const text = "See Nixon v. Nixon, 329 Pa. 256, 198 A. 154 (1938)."
+
+    it("first cite has no pincite (parallel volume is not a pincite)", () => {
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      expect(cases).toHaveLength(2)
+      if (cases[0].type === "case") {
+        expect(cases[0].pincite).toBeUndefined()
+      }
+    })
+
+    it("first cite gets year=1938 from the shared trailing parenthetical", () => {
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      if (cases[0].type === "case") {
+        expect(cases[0].year).toBe(1938)
+      }
+    })
+
+    it("second (parallel) cite's caseName does not leak the first reporter cite", () => {
+      // Fix B's job: the case-name backward walk for the parallel cite is
+      // bounded by the prior cite's end, so it cannot absorb `329 Pa. 256`.
+      // (Propagating the caption from the primary cite to its parallels is a
+      // separate concern — handled by parallel-cite linking, not extractCase.)
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      if (cases[1]?.type === "case") {
+        expect(cases[1].caseName ?? "").not.toContain("Pa.")
+        expect(cases[1].caseName ?? "").not.toContain("329")
+      }
+    })
+  })
+
+  describe("three-reporter parallel cite — Roe v. Wade", () => {
+    const text =
+      "Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)."
+
+    it("none of the three cites have a (false) pincite", () => {
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      expect(cases).toHaveLength(3)
+      for (const c of cases) {
+        if (c.type === "case") {
+          expect(c.pincite).toBeUndefined()
+        }
+      }
+    })
+
+    it("all three cites get year=1973 from the shared trailing parenthetical", () => {
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      for (const c of cases) {
+        if (c.type === "case") {
+          expect(c.year).toBe(1973)
+        }
+      }
+    })
+  })
+
+  describe("pincite WITH a following parallel cite — `410 U.S. 113, 117, 93 S. Ct. 705 (1973)`", () => {
+    const text =
+      "Roe v. Wade, 410 U.S. 113, 117, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)."
+
+    it("first cite has pincite=117 (real pincite before the parallel)", () => {
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      if (cases[0]?.type === "case") {
+        expect(cases[0].pincite).toBe(117)
+      }
+    })
+
+    it("first cite does not pick up parallel-cite volume as additional pincite", () => {
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      if (cases[0]?.type === "case") {
+        expect(cases[0].pinciteInfo?.additionalPincites ?? []).toEqual([])
+      }
+    })
+
+    it("first cite still gets year=1973 from the shared trailing parenthetical", () => {
+      const cases = extractCitations(text).filter((c) => c.type === "case")
+      if (cases[0]?.type === "case") {
+        expect(cases[0].year).toBe(1973)
+      }
+    })
+  })
+
+  describe("regression: discrete multi-pincite chains still work (no parallel cite)", () => {
+    it("`410 U.S. 113, 115, 153 (1973)` — pincite=115, additionalPincites=[153]", () => {
+      const cases = extractCitations(
+        "Smith, 410 U.S. 113, 115, 153 (1973).",
+      ).filter((c) => c.type === "case")
+      if (cases[0]?.type === "case") {
+        expect(cases[0].pincite).toBe(115)
+        expect(cases[0].pinciteInfo?.additionalPincites).toHaveLength(1)
+        expect(cases[0].pinciteInfo?.additionalPincites?.[0]?.page).toBe(153)
+        expect(cases[0].year).toBe(1973)
+      }
+    })
+  })
+})
+
 


### PR DESCRIPTION
## Summary

- Parallel cites no longer corrupt the primary cite's pincite (`329 Pa. 256, 198 A. 154 (1938)` no longer gives the Pa. cite `pincite=198`).
- All cites in a parallel chain now recover the shared trailing year (`Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)` — every reporter cite now carries `year=1973`).
- A parallel-secondary cite's case-name backward walk is bounded by the prior cite's end, so it can't absorb the preceding reporter cite (`198 A. 154`'s `caseName` no longer over-reports as `"Nixon v. Nixon, 329 Pa. 256"`).
- Secondary parallel cites also get a `fullSpan` covering the shared trailing paren, so string-citation grouping and downstream span consumers see the full citation extent.

## Background

Surfaced by an LLM-judge sweep over a 22-opinion sample from real Pennsylvania case law — 41 instances of the same misparse pattern (parallel reporter volume captured as pincite) in just those 22 opinions. The bug is older than the multi-pincite feature (#247) but had been masked by hand-curated fixtures that didn't exercise comma-separated parallel cites with shared trailing years. Confirmed pre-existing by reproducing on `522c6a1~1`.

## Fix (two layers)

**(A) Regex disambiguation** in `LOOKAHEAD_PINCITE_REGEX` and `ADDITIONAL_PINCITE_REGEX` — the captured pincite must terminate at end-of-string, sentence punctuation, paren/bracket close, or whitespace NOT followed by a capital letter. `, 198 A.` (parallel reporter start) no longer matches; `, 117 (1973)` and `[266 Cal.Rptr. 569, 575]` (bracketed) still do.

**(B) Span-aware `extractCase`** receives sibling case-citation token spans and uses them to:
1. Skip past a contiguous parallel-cite chain when searching for the shared trailing year paren — applied to both the look-ahead paren scan and `collectParentheticals` so `fullSpan` extends through it.
2. Bound the case-name backward walk by the prior sibling's end.
3. Populate `fullSpan` on parallel-secondary cites (which have no captured caseName) when a close preceding sibling indicates a parallel chain.

The pincite scan still operates on the original `afterToken` (starting at `span.cleanEnd`) so `, 117` is parseable as the cite's own pincite in mixed forms like `410 U.S. 113, 117, 93 S. Ct. 705 (1973)`.

## Behavior matrix (before → after)

| Input | Field | Before | After |
|---|---|---|---|
| `329 Pa. 256, 198 A. 154 (1938)` | first.pincite | `198` ❌ | `undefined` ✅ |
| `329 Pa. 256, 198 A. 154 (1938)` | first.year | `undefined` ❌ | `1938` ✅ |
| `329 Pa. 256, 198 A. 154 (1938)` | parallel.caseName | `"Nixon v. Nixon, 329 Pa. 256"` ❌ | `undefined` (no leakage) ✅ |
| Roe v. Wade (3 parallels) `(1973)` | all.year | only last had `1973` ❌ | all three get `1973` ✅ |
| `410 U.S. 113, 117, 93 S. Ct. 705 (1973)` | first.pincite | `93` ❌ | `117` ✅ |
| `410 U.S. 113, 115, 153 (1973)` (#247) | first.pincite + additionalPincites | `115` / `[153]` ✅ | `115` / `[153]` ✅ (regression preserved) |

## Test plan

- [x] 9 new tests under `parallel-cite pincite disambiguation (regression)` in `tests/extract/extractCase.test.ts` covering 2- and 3-reporter parallels, pincite-with-parallel, and the discrete multi-pincite regression
- [x] Full 2346-test vitest suite passes (no regressions)
- [x] Existing California bracketed parallel pincite test (`[266 Cal.Rptr. 569, 575]`) still passes
- [x] Existing string-citation grouping integration test still passes
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` introduces 0 new errors (168 pre-existing warnings unchanged)

## Known follow-up (not in this PR)

Propagating the primary parallel's caption to its secondaries (so `198 A. 154`'s `caseName` resolves to `"Nixon v. Nixon"` rather than `undefined`) is a separate concern — it belongs in the parallel-cite linker (`detectParallel.ts` + the `parallelCitations` array on the primary), not in per-cite extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)