### PR TITLE
fix: statute section field strips sentence-ending period (#283)

### DIFF
--- a/.changeset/issue-283-statute-trailing-period.md
+++ b/.changeset/issue-283-statute-trailing-period.md
@@ -1,0 +1,46 @@
+---
+"eyecite-ts": patch
+---
+
+fix: statute `section` field no longer absorbs the sentence-ending period (#283)
+
+When a statute citation was the last token of a sentence — `17 P.S. § 91.`,
+`Ariz. Rev. Stat. Ann. § 16-141.`, `N.Y. Election Law § 131.`, `M.G.L. c. 93A, § 2.`
+— the section-body regex greedily consumed the trailing period, producing
+`section: "91."` / `"16-141."` / `"131."` / `"2."`. The contamination also
+extended into `matchedText`, breaking exact-match equality, deduplication
+against canonical statute references, and offset-based annotation.
+
+### Root cause
+
+Three tokenizer regexes used a section-body character class that included
+`.` directly (`[A-Za-z0-9.:/-]*` and `[\w./-]+`):
+
+- `abbreviated-code` in `src/data/stateStatutes.ts` (most states)
+- `named-code` in `src/patterns/statutePatterns.ts` (NY/CA/TX/MD/VA/AL)
+- `mass-chapter` in `src/patterns/statutePatterns.ts` (MA)
+
+USC and CFR patterns were unaffected because their classes already
+excluded `.` (CFR uses the safer `\d+(?:\.\d+)?[A-Za-z0-9-]*` shape).
+
+### Fix
+
+Replaced the period-permissive class with a guarded alternation:
+
+```
+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*
+```
+
+A period is only consumed when followed by an alphanumeric character
+(positive lookahead). Internal decimals (`226.5`, `17.46`, `1.5(a)`) and
+hyphenated sections (`16-141`, `39-13-101`) are preserved unchanged;
+a terminal period followed by end-of-string or whitespace is left for the
+sentence to keep. Same fix applied to `ABBREVIATED_RE` in
+`extractAbbreviated.ts` as defense in depth at the secondary parser.
+
+### Tests
+
+7 new tests under `sentence-ending period boundary (#283)` in
+`tests/extract/extractStatute.test.ts` covering the four pattern families,
+internal-decimal preservation, and mid-sentence regression baselines. Full
+2353-test suite passes with no regressions.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -5,15 +5,15 @@
 
 export interface StateStatuteEntry {
   /** Two-letter jurisdiction code (e.g., "AK", "AZ") */
-  jurisdiction: string;
+  jurisdiction: string
   /** All recognized abbreviation forms — used for lookup by findAbbreviatedCode */
-  abbreviations: string[];
+  abbreviations: string[]
   /**
    * Regex fragment for tokenizer alternation. If omitted, auto-generated
    * from abbreviations via escapeForRegex. Provide explicitly when the
    * pattern needs optional components (e.g., "Stat(?:utes)?").
    */
-  regexFragment?: string;
+  regexFragment?: string
 }
 
 /**
@@ -39,7 +39,7 @@ export function escapeForRegex(abbreviation: string): string {
       .replace(/\.$/g, "\\.?")
       // Remaining spaces → flexible whitespace
       .replace(/ +/g, "\\s+")
-  );
+  )
 }
 
 /**
@@ -53,27 +53,30 @@ export function escapeForRegex(abbreviation: string): string {
  * Fragments are sorted longest-first for PEG-style ordered choice.
  */
 export function buildAbbreviatedCodeRegex(): RegExp {
-  const allFragments: string[] = [];
+  const allFragments: string[] = []
 
   for (const entry of stateStatuteEntries) {
     if (entry.regexFragment) {
-      allFragments.push(entry.regexFragment);
+      allFragments.push(entry.regexFragment)
     } else {
       for (const abbrev of entry.abbreviations) {
-        allFragments.push(escapeForRegex(abbrev));
+        allFragments.push(escapeForRegex(abbrev))
       }
     }
   }
 
   // Sort longest-first so more specific patterns match before shorter ones
-  allFragments.sort((a, b) => b.length - a.length);
+  allFragments.sort((a, b) => b.length - a.length)
 
-  const alternation = allFragments.join("|");
+  const alternation = allFragments.join("|")
 
   return new RegExp(
-    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*§?\\s*(\\d+[A-Za-z0-9.:/-]*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
+    // Section body: digits prefix, then alphanumeric/colon/slash/hyphen OR
+    // period-followed-by-alphanumeric (lookahead). Period guard prevents
+    // sentence-ending punctuation from being absorbed into the section.
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*§?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
     "g",
-  );
+  )
 }
 
 /**
@@ -129,7 +132,8 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
   {
     jurisdiction: "NC",
     abbreviations: ["N.C. Gen. Stat. Ann.", "N.C. Gen. Stat.", "N.C.G.S.", "NCGS", "G.S.", "GS"],
-    regexFragment: "N\\.?C\\.?\\s*Gen\\.?\\s*Stat\\.?(?:\\s+Ann\\.?)?|N\\.?C\\.?G\\.?S\\.?|G\\.?S\\.?",
+    regexFragment:
+      "N\\.?C\\.?\\s*Gen\\.?\\s*Stat\\.?(?:\\s+Ann\\.?)?|N\\.?C\\.?G\\.?S\\.?|G\\.?S\\.?",
   },
   // ── Georgia ────────────────────────────────────────────────────────────────
   {
@@ -162,7 +166,8 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
       "I.C.",
       "IC",
     ],
-    regexFragment: "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?",
+    regexFragment:
+      "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?",
   },
   // ── New Jersey ─────────────────────────────────────────────────────────────
   {
@@ -240,7 +245,8 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
   {
     jurisdiction: "LA",
     abbreviations: ["La. Rev. Stat. Ann.", "La. R.S.", "LSA-R.S."],
-    regexFragment: "La\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|La\\.?\\s+R\\.?S\\.?|LSA-R\\.?S\\.?",
+    regexFragment:
+      "La\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|La\\.?\\s+R\\.?S\\.?|LSA-R\\.?S\\.?",
   },
   // ── Maine ─────────────────────────────────────────────────────────────────
   {
@@ -362,4 +368,4 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     abbreviations: ["Wyo. Stat. Ann.", "Wyo. Stat.", "W.S."],
     regexFragment: "Wyo\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|W\\.?S\\.?",
   },
-];
+]

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -17,8 +17,10 @@ import type { StatuteComponentSpans } from "@/types/componentSpans"
 import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
 import { parseBody } from "./parseBody"
 
+// Section body: period only allowed when followed by alphanumeric so a
+// trailing sentence period is never captured (#283).
 const ABBREVIATED_RE =
-  /^(?:(\d+)\s+)?(.+?)\s*§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
+  /^(?:(\d+)\s+)?(.+?)\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
 
 export function extractAbbreviated(
   token: Token,
@@ -51,8 +53,10 @@ export function extractAbbreviated(
   let spans: StatuteComponentSpans | undefined
   if (match?.indices) {
     spans = {}
-    if (match.indices[1]) spans.title = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
-    if (match.indices[2]) spans.code = spanFromGroupIndex(span.cleanStart, match.indices[2], transformationMap)
+    if (match.indices[1])
+      spans.title = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+    if (match.indices[2])
+      spans.code = spanFromGroupIndex(span.cleanStart, match.indices[2], transformationMap)
     if (match.indices[3] && section) {
       const bodyStart = match.indices[3][0]
       // Use section without trailing sentence punctuation for span boundary.

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -42,8 +42,10 @@ export const statutePatterns: Pattern[] = [
     id: "named-code",
     // Matches: [State abbrev]. [Code/Law Name] § [section]
     // Captures: (1) jurisdiction prefix, (2) code name text, (3) section+subsections+et seq
+    // Section body: period only allowed when followed by alphanumeric, so a
+    // trailing sentence period is not absorbed (#283).
     regex:
-      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s?)Va\.?|Ala(?:bama)?\.?)\s+((?:[A-Za-z.&',\s]+?))\s*§§?\s*(\d+[A-Za-z0-9.:/-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s?)Va\.?|Ala(?:bama)?\.?)\s+((?:[A-Za-z.&',\s]+?))\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
     description:
       "Named-code state citations (NY, CA, TX, MD, VA, AL) with jurisdiction prefix + code name + §",
     type: "statute",
@@ -51,8 +53,10 @@ export const statutePatterns: Pattern[] = [
   {
     id: "mass-chapter",
     // Matches: Mass. Gen. Laws ch. X, § Y / M.G.L.A. c. X, § Y / G.L. c. X, § Y / A.L.M. c. X, § Y
+    // Section body: period only allowed when followed by alphanumeric, so a
+    // trailing sentence period is not absorbed (#283).
     regex:
-      /\b(Mass\.?\s*Gen\.?\s*Laws|M\.?G\.?L\.?A?\.?|A\.?L\.?M\.?|G\.?\s*L\.?)\s+(?:ch\.?|c\.?)\s*(\w+),?\s*§\s*([\w./-]+(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(Mass\.?\s*Gen\.?\s*Laws|M\.?G\.?L\.?A?\.?|A\.?L\.?M\.?|G\.?\s*L\.?)\s+(?:ch\.?|c\.?)\s*(\w+),?\s*§\s*(\w+(?:[\w/-]|\.(?=\w))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
     description: 'Massachusetts chapter-based citations (e.g., "Mass. Gen. Laws ch. 93A, § 2")',
     type: "statute",
   },

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -194,6 +194,69 @@ describe("extractStatute", () => {
     })
   })
 
+  describe("sentence-ending period boundary (#283)", () => {
+    it("should strip trailing sentence period from abbreviated-code section", () => {
+      const citations = extractCitations("The defendant violated 17 P.S. § 91. The court agreed.")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].section).toBe("91")
+        expect(citations[0].matchedText).toBe("17 P.S. § 91")
+      }
+    })
+
+    it("should strip trailing period from hyphenated state section", () => {
+      const citations = extractCitations(
+        "Failure to comply violates Ariz. Rev. Stat. Ann. § 16-141.",
+      )
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].section).toBe("16-141")
+      }
+    })
+
+    it("should strip trailing period from named-code section", () => {
+      const citations = extractCitations("See N. Y. Election Law § 131.")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].section).toBe("131")
+      }
+    })
+
+    it("should strip trailing period from mass-chapter section", () => {
+      const citations = extractCitations("Plaintiffs invoke M.G.L. c. 93A, § 2.")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].section).toBe("2")
+      }
+    })
+
+    it("should preserve internal decimal period followed by digits", () => {
+      const citations = extractCitations("Cal. Civ. Code § 1.5(a). The plaintiff disagreed.")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].section).toBe("1.5")
+        expect(citations[0].subsection).toBe("(a)")
+      }
+    })
+
+    it("should not regress mid-sentence sections (no trailing period)", () => {
+      const citations = extractCitations("17 P.S. § 91 governs the action.")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].section).toBe("91")
+      }
+    })
+
+    it("should not regress decimal section without trailing period", () => {
+      const citations = extractCitations("12 C.F.R. § 226.5(b) controls.")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].section).toBe("226.5")
+        expect(citations[0].subsection).toBe("(b)")
+      }
+    })
+  })
+
   describe("metadata fields", () => {
     it("should include all required CitationBase fields", () => {
       const token: Token = {


### PR DESCRIPTION
## Summary

- Fixes #283 — statute `section` field (and `matchedText`) no longer absorb a sentence-ending period
- Three tokenizer regexes share the fix (`abbreviated-code`, `named-code`, `mass-chapter`); `ABBREVIATED_RE` patched as defense in depth
- 7 new tests cover all four reported variants, internal-decimal preservation, and mid-sentence regression baselines

## Root cause

The section-body character class included `.` directly (`[A-Za-z0-9.:/-]*` / `[\w./-]+`), so the regex greedily consumed a trailing period when a citation ended a sentence:

| Input | Before | After |
|---|---|---|
| `17 P.S. § 91.` | `section: "91."` | `section: "91"` |
| `Ariz. Rev. Stat. Ann. § 16-141.` | `section: "16-141."` | `section: "16-141"` |
| `N.Y. Election Law § 131.` | `section: "131."` | `section: "131"` |
| `M.G.L. c. 93A, § 2.` | `section: "2."` | `section: "2"` |

USC and CFR patterns were immune because their classes already excluded `.` (CFR uses the safer `\d+(?:\.\d+)?[A-Za-z0-9-]*` shape).

## Fix

Replaced the period-permissive class with a guarded alternation:

```regex
(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*
```

A period is only consumed when followed by an alphanumeric character (positive lookahead). Internal decimals (`226.5`, `17.46`, `1.5(a)`) and hyphenated sections (`16-141`, `39-13-101`) are preserved unchanged.

Files changed:
- `src/data/stateStatutes.ts` — `buildAbbreviatedCodeRegex`
- `src/patterns/statutePatterns.ts` — `named-code` and `mass-chapter`
- `src/extract/statutes/extractAbbreviated.ts` — `ABBREVIATED_RE` (defense in depth)
- `tests/extract/extractStatute.test.ts` — 7 new tests
- `.changeset/issue-283-statute-trailing-period.md` — patch changeset

## Test plan

- [x] 7 new tests under `sentence-ending period boundary (#283)` pass
- [x] Full suite — 2353/2353 pass, 0 regressions
- [x] `pnpm typecheck` clean
- [x] biome formatted
- [x] Mid-sentence baselines verified unchanged (`17 P.S. § 91 governs.` → `section: "91"`, `12 C.F.R. § 226.5(b) controls.` → `section: "226.5"`, subsection `"(b)"`)
- [x] Internal-decimal preservation verified (`Cal. Civ. Code § 1.5(a).` → `section: "1.5"`, `subsection: "(a)"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)