### PR TITLE
fix: spaced statute code abbreviations extract correctly (#284)

### DIFF
--- a/.changeset/issue-284-spaced-code-abbreviations.md
+++ b/.changeset/issue-284-spaced-code-abbreviations.md
@@ -1,0 +1,50 @@
+---
+"eyecite-ts": patch
+---
+
+fix: spaced statute code abbreviations (`42 U. S. C.`, `29 C. F. R.`) now extract correctly (#284)
+
+Historical and OCR'd legal text — pre-1990 Supreme Court opinions, scanned PACER
+PDFs, Harvard CAP corpus — writes federal code abbreviations with spaces
+between the letters: `42 U. S. C. § 1973`, `29 C. F. R. § 1604.11`. The
+clean-pipeline normalization handled 2-letter case-cite abbreviations
+(`U.S.`, `S.Ct.`, `L.Ed.`, `F.Supp.`) but had no rules for the 3-letter
+code abbreviations, so spaced statute citations were silently dropped by
+the tokenizer.
+
+### Root cause
+
+`normalizeReporterSpacing` in `src/clean/cleaners.ts` had only 2-letter
+rules. For `42 U. S. C. § 1983` the existing `U. S. → U.S.` rule fired
+but left a dangling `C.`: `42 U.S. C. § 1983`. The statute tokenizer
+expects the literal `U.S.C.` shape and could not match the
+partially-normalized form, so the citation was dropped entirely (no
+fallback, no signal that a citation existed).
+
+### Fix
+
+Added two targeted rules placed *before* the existing 2-letter ones so
+the full 3-letter shape collapses in one pass on every spacing variant:
+
+```
+\bU\.\s*S\.\s*C\.  →  U.S.C.
+\bC\.\s*F\.\s*R\.  →  C.F.R.
+```
+
+`\s*` (zero or more, not `\s+`) so the rules also act as idempotent
+canonicalizers on already-compact input and on partial forms like
+`U.S. C.` and `U. S.C.`. The lookahead bound is implicit — the trailing
+`C.` / `R.` literal prevents `U. S.` (case-cite) from being intercepted.
+
+### Tests
+
+- 7 new tests under `three-letter code abbreviations (#284)` in
+  `tests/clean/reporterSpacing.test.ts`: fully-spaced, partially-spaced
+  (both directions), canonical idempotency, and a non-interception check
+  for `410 U. S. 113` case cites.
+- 5 new tests under `spaced code abbreviations (#284)` in
+  `tests/extract/extractStatute.test.ts`: end-to-end extraction through
+  the full `extractCitations` pipeline, including subsection capture
+  (`29 U. S. C. § 158(a)(3)`).
+
+Full 2365-test suite passes; no regressions.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -72,9 +72,7 @@ export function collapseSpaces(text: string): string {
  * // => "Smith v. Doe, 500 F.2d 123"
  */
 export function normalizeWhitespace(text: string): string {
-  return text
-    .replace(/[\t\n\r\u00A0\u2000-\u200A\u202F\u205F\u3000]+/g, " ")
-    .replace(/ {2,}/g, " ")
+  return text.replace(/[\t\n\r\u00A0\u2000-\u200A\u202F\u205F\u3000]+/g, " ").replace(/ {2,}/g, " ")
 }
 
 /**
@@ -189,6 +187,12 @@ export function normalizeReporterSpacing(text: string): string {
   // then apply a general ordinal-suffix rule. This avoids affecting non-reporter
   // abbreviations like "L. Rev." or "L. J." in journal citations.
   let result = text
+
+  // Three-letter code abbreviations (U.S.C., C.F.R.) — must run BEFORE the
+  // two-letter rules below so the full 3-letter shape collapses in one pass
+  // regardless of spacing pattern (`U. S. C.` / `U.S. C.` / `U. S.C.`). #284
+  result = result.replace(/\bU\.\s*S\.\s*C\./g, "U.S.C.")
+  result = result.replace(/\bC\.\s*F\.\s*R\./g, "C.F.R.")
 
   // Specific reporter abbreviation collapses
   result = result.replace(/\bU\.\s+S\./g, "U.S.")

--- a/tests/clean/reporterSpacing.test.ts
+++ b/tests/clean/reporterSpacing.test.ts
@@ -34,4 +34,34 @@ describe("normalizeReporterSpacing", () => {
     const input = "550 U. S. 544, 127 S. Ct. 1955"
     expect(normalizeReporterSpacing(input)).toBe("550 U.S. 544, 127 S.Ct. 1955")
   })
+
+  describe("three-letter code abbreviations (#284)", () => {
+    it("normalizes fully spaced 'U. S. C.' to 'U.S.C.'", () => {
+      expect(normalizeReporterSpacing("42 U. S. C. § 1983")).toBe("42 U.S.C. § 1983")
+    })
+
+    it("normalizes partially spaced 'U.S. C.' to 'U.S.C.'", () => {
+      expect(normalizeReporterSpacing("42 U.S. C. § 1983")).toBe("42 U.S.C. § 1983")
+    })
+
+    it("normalizes partially spaced 'U. S.C.' to 'U.S.C.'", () => {
+      expect(normalizeReporterSpacing("42 U. S.C. § 1983")).toBe("42 U.S.C. § 1983")
+    })
+
+    it("normalizes fully spaced 'C. F. R.' to 'C.F.R.'", () => {
+      expect(normalizeReporterSpacing("29 C. F. R. § 1604.11")).toBe("29 C.F.R. § 1604.11")
+    })
+
+    it("leaves canonical 'U.S.C.' unchanged", () => {
+      expect(normalizeReporterSpacing("42 U.S.C. § 1983")).toBe("42 U.S.C. § 1983")
+    })
+
+    it("leaves canonical 'C.F.R.' unchanged", () => {
+      expect(normalizeReporterSpacing("29 C.F.R. § 1604.11")).toBe("29 C.F.R. § 1604.11")
+    })
+
+    it("does not intercept 'U. S.' standalone (case cite)", () => {
+      expect(normalizeReporterSpacing("410 U. S. 113")).toBe("410 U.S. 113")
+    })
+  })
 })

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -257,6 +257,57 @@ describe("extractStatute", () => {
     })
   })
 
+  describe("spaced code abbreviations (#284)", () => {
+    it("should extract fully-spaced U.S.C. statute", () => {
+      const citations = extractCitations("Plaintiff sued under 42 U. S. C. § 1983.")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].title).toBe(42)
+        expect(citations[0].code).toBe("U.S.C.")
+        expect(citations[0].section).toBe("1983")
+      }
+    })
+
+    it("should extract spaced U.S.C. with subsection", () => {
+      const citations = extractCitations("29 U. S. C. § 158(a)(3)")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].title).toBe(29)
+        expect(citations[0].code).toBe("U.S.C.")
+        expect(citations[0].section).toBe("158")
+        expect(citations[0].subsection).toBe("(a)(3)")
+      }
+    })
+
+    it("should extract partially-spaced 'U.S. C.' form", () => {
+      const citations = extractCitations("42 U.S. C. § 1983")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].code).toBe("U.S.C.")
+        expect(citations[0].section).toBe("1983")
+      }
+    })
+
+    it("should extract fully-spaced C.F.R. regulation", () => {
+      const citations = extractCitations("29 C. F. R. § 1604.11")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].title).toBe(29)
+        expect(citations[0].code).toBe("C.F.R.")
+        expect(citations[0].section).toBe("1604.11")
+      }
+    })
+
+    it("should not regress canonical compact form", () => {
+      const citations = extractCitations("28 U.S.C. § 1983")
+      expect(citations).toHaveLength(1)
+      if (citations[0].type === "statute") {
+        expect(citations[0].code).toBe("U.S.C.")
+        expect(citations[0].section).toBe("1983")
+      }
+    })
+  })
+
   describe("metadata fields", () => {
     it("should include all required CitationBase fields", () => {
       const token: Token = {


### PR DESCRIPTION
## Summary

- Fixes #284 — spaced statute code abbreviations like `42 U. S. C. § 1983` and `29 C. F. R. § 1604.11` are no longer silently dropped
- Fix is at the cleaning layer — single normalization pass benefits all downstream extractors
- 7 unit tests + 5 integration tests added

## Root cause

`normalizeReporterSpacing` in `src/clean/cleaners.ts` had only 2-letter rules (`U.S.`, `S.Ct.`, `L.Ed.`, `F.Supp.`). For `42 U. S. C. § 1983` the existing `U. S. → U.S.` rule fired and left a dangling `C.`:

| Input | After normalizeReporterSpacing | Tokenizer match? |
|---|---|---|
| `42 U. S. C. § 1983` | `42 U.S. C. § 1983` | ✗ — drops citation |
| `42 U.S. C. § 1983` | `42 U.S. C. § 1983` | ✗ — drops citation |
| `29 C. F. R. § 1604.11` | `29 C. F. R. § 1604.11` | ✗ — drops citation |
| `410 U. S. 113` (case) | `410 U.S. 113` | ✓ — 2-letter rule sufficient |

A silently dropped citation is worse than a wrong one — downstream sees no signal that a cite existed. Real-world impact: historical/OCR'd corpora (pre-1990 Supreme Court opinions, PACER scans, Harvard CAP) systematically under-report statutes.

## Fix

Two targeted rules added to `normalizeReporterSpacing`, placed **before** the existing 2-letter rules so the full 3-letter shape matches in one pass:

```regex
\bU\.\s*S\.\s*C\.  →  U.S.C.
\bC\.\s*F\.\s*R\.  →  C.F.R.
```

`\s*` (zero or more) handles every variant idempotently:
- Fully spaced: `U. S. C.` ✓
- Partial: `U.S. C.` ✓, `U. S.C.` ✓
- Canonical: `U.S.C.` unchanged ✓

The trailing `C.` / `R.` literal prevents interception of standalone `U. S.` in case cites — `410 U. S. 113` still uses only the 2-letter rule.

## Files changed

- `src/clean/cleaners.ts` — added 2 rules at the top of `normalizeReporterSpacing`
- `tests/clean/reporterSpacing.test.ts` — 7 new unit tests
- `tests/extract/extractStatute.test.ts` — 5 new integration tests (full pipeline)
- `.changeset/issue-284-spaced-code-abbreviations.md` — patch changeset

## Test plan

- [x] 7 unit tests under `three-letter code abbreviations (#284)` pass
- [x] 5 integration tests under `spaced code abbreviations (#284)` pass — including subsection capture (`29 U. S. C. § 158(a)(3)` → section `158`, subsection `(a)(3)`)
- [x] Full suite — 2365/2365 pass, 0 regressions
- [x] `pnpm typecheck` clean
- [x] biome formatted
- [x] Canonical compact form regression baseline (`28 U.S.C. § 1983`) verified
- [x] Case-cite non-interception (`410 U. S. 113`) verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)