### PR TITLE
fix: add Vil. and Enters. to case-name abbreviation set (#288)

### DIFF
--- a/.changeset/issue-288-vil-abbreviation.md
+++ b/.changeset/issue-288-vil-abbreviation.md
@@ -1,0 +1,46 @@
+---
+"eyecite-ts": patch
+---
+
+fix: add `Vil.` and `Enters.` to case-name abbreviation set (#288)
+
+`extractCitations` truncated `caseName` when a party name contained `Vil.`
+(the NY-court single-L variant of Bluebook `Vill.` for "Village"). The
+case-name scanback treated the `.` as a sentence terminator and restarted
+the case-name candidate after it — captions like
+`Bristol Harbour Vil. Assn., Inc.` (NY 4th Dep't) and
+`Smithtown Vil. Bd.` truncated to `"Assn., Inc."` and `"Bd."`
+respectively. The Bluebook double-L `Vill.` was already in the
+abbreviation set and worked correctly, confirming a missing-variant gap
+rather than a structural scanback issue.
+
+### Fix
+
+Added two entries to `CASE_NAME_ABBREVS` in `src/extract/extractCase.ts`:
+
+- **`vil`** — Bluebook T6 `Vill.` variant used by NY Reporter / Slip
+  Opinion captions, especially 4th Dep't. Placed alongside the existing
+  state-practice gap `"tp"` (NJ alternative to `Twp.` for "Township"),
+  with the same comment-block style.
+- **`enters`** — Bluebook T6 plural of `Enter.` (Enterprises). Surfaced
+  by the same issue's first repro case (`Fields Enters. Inc. v. Bristol
+  Harbour Vil. Assn., Inc.`) — once the `Vil.` gap was fixed, the
+  scanback still truncated at the `Enters.` boundary, revealing a
+  separate but identically-shaped missing-stem gap. Placed next to the
+  existing singular `"enter"`.
+
+No regex changes; both additions are single-stem entries in the existing
+set.
+
+### Tests
+
+Three new tests in `tests/extract/extractCase.test.ts` under the
+existing `case name boundary bugs` block:
+
+- `#288: handles Vil. in Bristol Harbour Vil. Assn., Inc. (4th Dep't)`
+  — full caption with both `Enters.` and `Vil.` abbreviations.
+- `#288: handles Smithtown Vil. Bd.` — `Vil.` in isolation.
+- `#288: regression — Bluebook Vill. still works` — guards against
+  accidental change to the canonical double-L form.
+
+Full 2368-test suite passes; no regressions.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -594,6 +594,7 @@ const CASE_NAME_ABBREVS: ReadonlySet<string> = new Set([
   "emp",
   "eng",
   "enter",
+  "enters", // Enters. (Enterprises, plural of Bluebook T6 "Enter.") — common in NY/4th Dep't captions ("Fields Enters. Inc."). #288 surfaced this gap.
   "ent",
   "equal",
   "equip",
@@ -898,10 +899,14 @@ const CASE_NAME_ABBREVS: ReadonlySet<string> = new Set([
   // Used in real case captions across multiple jurisdictions:
   //   - "Tp." (NJ alternative to Bluebook "Twp." Township) —
   //     "Parsippany-Troy Hills Tp. Council", "Bernards Tp. v. ..."
+  //   - "Vil." (NY single-L variant of Bluebook "Vill." Village) — #288
+  //     NY Reporter / Slip Opinion captions, esp. 4th Dep't:
+  //     "Bristol Harbour Vil. Assn., Inc.", "Smithtown Vil. Bd."
   //   - "Tax'n" (Taxation) — "Dep't of Tax'n v. ..."
   //   - "Enf't" (Enforcement) — "Drug Enf't Admin. v. ..."
   //   - "Rts." (Rights) — "Human Rts. Watch v. ...", "Civ. Rts. Div."
   "tp",
+  "vil",
   "taxn",
   "enft",
   "rts",

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -2263,6 +2263,39 @@ describe("nominative reporter support (#49, #16)", () => {
         expect(cite.caseName).toContain("Nw. Austin Mun. Util. Dist.")
       }
     })
+
+    // ── Issue #288: Vil. (NY single-L Village variant) ──
+
+    it("#288: handles Vil. in Bristol Harbour Vil. Assn., Inc. (4th Dep't)", () => {
+      const text =
+        "See Fields Enters. Inc. v. Bristol Harbour Vil. Assn., Inc., 2023 N.Y. Slip Op. 03165 (4th Dep't 2023)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe(
+          "Fields Enters. Inc. v. Bristol Harbour Vil. Assn., Inc.",
+        )
+      }
+    })
+
+    it("#288: handles Smithtown Vil. Bd.", () => {
+      const text =
+        "See Williams Mfg. Co. v. Smithtown Vil. Bd., 100 N.Y.2d 1 (2003)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Williams Mfg. Co. v. Smithtown Vil. Bd.")
+      }
+    })
+
+    it("#288: regression — Bluebook Vill. still works", () => {
+      const text = "See Smithtown Vill. Bd. v. Smith, 100 N.Y.2d 1 (2003)."
+      const [cite] = extractCitations(text)
+      expect(cite.type).toBe("case")
+      if (cite.type === "case") {
+        expect(cite.caseName).toBe("Smithtown Vill. Bd. v. Smith")
+      }
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- Fixes #288 — `Vil.` (NY single-L variant of Bluebook `Vill.` for "Village") no longer truncates caseName
- Also adds `Enters.` (plural of Bluebook T6 `Enter.` for "Enterprises") — adjacent gap surfaced by the issue's first repro case
- 3 new tests; 38 net lines of source/test change, 0 regex changes

## Root cause

The case-name scanback treats unrecognized `Word.` boundaries as sentence terminators and restarts the case-name candidate after them. `Vil.` was not in `CASE_NAME_ABBREVS`, even though the Bluebook double-L `Vill.` already was. Once `Vil.` was patched, the issue's first repro case (`Fields Enters. Inc. v. Bristol Harbour Vil. Assn., Inc.`) still truncated at `Enters.` — a second identically-shaped gap.

| Input | Before | After |
|---|---|---|
| `Williams Mfg. Co. v. Smithtown Vil. Bd.` | `"Bd."` | `"Williams Mfg. Co. v. Smithtown Vil. Bd."` |
| `Fields Enters. Inc. v. Bristol Harbour Vil. Assn., Inc.` | `"Assn., Inc."` | `"Fields Enters. Inc. v. Bristol Harbour Vil. Assn., Inc."` |
| `Smithtown Vill. Bd. v. Smith` (regression baseline) | `"Smithtown Vill. Bd. v. Smith"` | unchanged ✓ |

## Fix

Two single-stem additions to `CASE_NAME_ABBREVS` in `src/extract/extractCase.ts`:

- **`vil`** — placed next to existing `tp` (NJ-Township) in the explicitly-documented "state-practice gaps not in Bluebook T6 source" block, with a matching comment.
- **`enters`** — placed next to existing singular `enter` (Enter.). Bluebook T6 supports `Enters.` as the plural of `Enter.`; common in NY 4th Dep't and corporate-name captions.

No regex changes. No structural changes to the scanback algorithm.

## Files changed

- `src/extract/extractCase.ts` — 5 lines (2 entries + 3 comment lines)
- `tests/extract/extractCase.test.ts` — 33 lines (3 new tests)
- `.changeset/issue-288-vil-abbreviation.md` — patch changeset

## Test plan

- [x] 3 new tests under `case name boundary bugs (#182, #183, #184)` pass:
  - `#288: handles Vil. in Bristol Harbour Vil. Assn., Inc. (4th Dep't)` — exercises both new entries
  - `#288: handles Smithtown Vil. Bd.` — `Vil.` in isolation
  - `#288: regression — Bluebook Vill. still works`
- [x] Full suite — 2368/2377 pass, 0 regressions
- [x] `pnpm typecheck` clean
- [x] Diff is minimal: 38 net lines, no formatting churn on unrelated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)