### PR TITLE
fix: extract court from CSM year-first parenthetical (#293)

### DIFF
--- a/.changeset/issue-293-csm-court.md
+++ b/.changeset/issue-293-csm-court.md
@@ -1,0 +1,53 @@
+---
+"eyecite-ts": patch
+---
+
+fix: extract court from CSM year-first parenthetical `(court year)` (#293)
+
+California Style Manual citations place the court+year parenthetical
+**before** the volume-reporter-page rather than after:
+`Camden I Condominium Assn. v. Dunkle (11th Cir. 1991) 946 F.2d 768`.
+The existing year-first machinery (#19) captured the year but dropped
+the court — `court` ended up `undefined` even though `(11th Cir. ...)`
+explicitly states it.
+
+Surfaced by a 200-opinion modern-era sweep as the **largest** field-
+extraction gap (195 instances) — California opinions are the largest
+single-jurisdiction body of US case law and use CSM almost universally,
+so federal cites within California opinions show this pattern dozens of
+times per opinion.
+
+### Fix
+
+Two pieces:
+
+1. `V_CASE_NAME_REGEX` and `PROCEDURAL_PREFIX_REGEX` now accept an
+   optional court prefix inside the CSM trailing paren:
+   `\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\)`. The court text must contain
+   a period so loose forms like `(March 1991)` aren't mis-attributed as
+   courts — Bluebook T7 court abbreviations all contain at least one
+   period. Group 3 = court (optional), group 4 = year.
+2. Both consumer sites build a `precedingDocketMeta` payload when both
+   court and year are captured. The existing Louisiana-docket meta
+   handler at the consumer end (`extractCase.ts` line ~2502) already
+   propagates `precedingDocketMeta.court` onto the citation as
+   fallback when no trailing court paren is present.
+
+Year-only CSM (`In re K.F. (2009)`) continues to work via the dedicated
+`year`/`yearStart`/`yearEnd` fields — unchanged for that path. Trailing-
+paren form still wins when both forms are present (defensive — extremely
+rare in practice).
+
+### Tests
+
+5 new tests under `CSM year-first with court (#293)` in
+`tests/extract/extractCase.test.ts`:
+
+- `(11th Cir. 1991)` in v. form — court="11th Cir.", year=1991
+- `(2d Cir. 2005)` in v. form
+- `(9th Cir. 2014)` in procedural-prefix form
+- Year-only `(2013)` — court undefined, no regression
+- Year-only procedural prefix `In re K.F. (2009)` — court undefined,
+  no regression
+
+Full 2384-test suite passes; no regressions.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -359,13 +359,17 @@ const LEADING_WORD_REGEX = /^([a-z]+)\b/i
  *
  *  The trailing alternation accepts either a comma (Bluebook form:
  *  `Smith v. Jones, 50 Cal.3d 100 (Cal. 1990)`) or a year paren (California
- *  Style Manual year-first form: `Smith v. Jones (1990) 50 Cal.3d 100`). The
- *  optional `(\d{4})` capture surfaces the year so the CSM form doesn't drop
- *  it on the floor — there is no trailing court parenthetical from which to
- *  recover the year later. The `d` flag enables `match.indices` so the
- *  caller can compute a year span. See #19. */
+ *  Style Manual year-first form: `Smith v. Jones (2d Cir. 2005) 396 F.3d 96`
+ *  / `Smith v. Jones (1990) 50 Cal.3d 100`). The CSM paren may carry an
+ *  optional court abbreviation before the year — `(2d Cir. 2005)`,
+ *  `(N.Y. 1991)` — which the caller routes to `precedingDocketMeta.court`.
+ *  The court text must contain a period so loose forms like `(March 1991)`
+ *  don't get misread as courts (Bluebook T7 court abbreviations all contain
+ *  at least one period). Capture group 3 = court (optional), 4 = year.
+ *  The `d` flag enables `match.indices` so the caller can compute a year
+ *  span. See #19, #293. */
 const V_CASE_NAME_REGEX =
-  /([A-Z][A-Za-z0-9\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9\s.,'&()/-]+?)\s*(?:,|\((\d{4})\))\s*$/d
+  /([A-Z][A-Za-z0-9\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
 
 /** Procedural prefix case name format.
  *  Longer prefixes listed first so the alternation prefers the longer match
@@ -374,11 +378,13 @@ const V_CASE_NAME_REGEX =
  *  beats `Commonwealth ex rel.`). See #193, #242, and the six 2026-05-11
  *  procedural-prefix research dispatches in `docs/research/`.
  *
- *  The trailing alternation matches either `,` (Bluebook) or `(YYYY)` (CSM
- *  year-first form, #19). Year is captured as group 3; the `d` flag enables
- *  `match.indices` so the caller can compute a year span. */
+ *  The trailing alternation matches either `,` (Bluebook) or
+ *  `((<court>)? <year>)` (CSM year-first form, #19 / #293). Captures:
+ *    1: prefix word, 2: party body, 3: court (optional), 4: year.
+ *  The court text must contain a period so loose forms like `(March 1991)`
+ *  don't get misread as courts. The `d` flag enables `match.indices`. */
 const PROCEDURAL_PREFIX_REGEX =
-  /\b(In\s+the\s+Matter\s+of\s+the\s+Liquidation\s+of|In\s+the\s+Matter\s+of\s+the\s+Rehabilitation\s+of|In\s+the\s+Matter\s+of\s+the\s+Receivership\s+of|In\s+the\s+Matter\s+of\s+the\s+Extradition\s+of|In\s+the\s+Matter\s+of\s+the\s+Application\s+of|In\s+the\s+Matter\s+of\s+the\s+Welfare\s+of|In\s+the\s+Matter\s+of|In\s+re\s+Petition\s+for\s+Naturalization\s+of|In\s+re\s+Termination\s+of\s+Parental\s+Rights\s+as\s+to|In\s+re\s+Termination\s+of\s+Parental\s+Rights\s+to|In\s+re\s+Termination\s+of\s+Parental\s+Rights\s+of|In\s+re\s+Marriage\s+of|In\s+re\s+Liquidation\s+of|In\s+re\s+Rehabilitation\s+of|In\s+re\s+Receivership\s+of|In\s+re\s+Naturalization\s+of|In\s+re\s+Extradition\s+of|In\s+re\s+Application\s+of|In\s+re\s+Welfare\s+of|In\s+re\s+Dependency\s+of|In\s+re\s+Paternity\s+of|In\s+re\s+Parentage\s+of|In\s+re\s+Conservatorship\s+of|In\s+re\s+Guardianship\s+of|In\s+re\s+Adoption\s+of|In\s+the\s+Interest\s+of|Matter\s+of\s+Liquidation\s+of|Matter\s+of\s+Rehabilitation\s+of|Commonwealth\s+of\s+Puerto\s+Rico\s+ex\s+rel\.|Government\s+of\s+the\s+Virgin\s+Islands\s+ex\s+rel\.|Commonwealth\s+ex\s+rel\.|Petition\s+for\s+Naturalization\s+of|People\s+ex\s+rel\.|District\s+of\s+Columbia\s+ex\s+rel\.|Conservatorship\s+of\s+the\s+Person\s+and\s+Estate\s+of|Conservatorship\s+of\s+the\s+Person\s+of|Conservatorship\s+of\s+the\s+Estate\s+of|Inquiry\s+Concerning\s+Judge|Appeal\s+of|Care\s+and\s+Protection\s+of|Succession\s+of|In re|Ex parte|Matter of|Estate of|State ex rel\.|United States ex rel\.|Application of|On Petition of|Petition of|Adoption of|Conservatorship of|Guardianship of)\s+([A-Za-z0-9\s.,'&()/-]+?)\s*(?:,|\((\d{4})\))\s*$/id
+  /\b(In\s+the\s+Matter\s+of\s+the\s+Liquidation\s+of|In\s+the\s+Matter\s+of\s+the\s+Rehabilitation\s+of|In\s+the\s+Matter\s+of\s+the\s+Receivership\s+of|In\s+the\s+Matter\s+of\s+the\s+Extradition\s+of|In\s+the\s+Matter\s+of\s+the\s+Application\s+of|In\s+the\s+Matter\s+of\s+the\s+Welfare\s+of|In\s+the\s+Matter\s+of|In\s+re\s+Petition\s+for\s+Naturalization\s+of|In\s+re\s+Termination\s+of\s+Parental\s+Rights\s+as\s+to|In\s+re\s+Termination\s+of\s+Parental\s+Rights\s+to|In\s+re\s+Termination\s+of\s+Parental\s+Rights\s+of|In\s+re\s+Marriage\s+of|In\s+re\s+Liquidation\s+of|In\s+re\s+Rehabilitation\s+of|In\s+re\s+Receivership\s+of|In\s+re\s+Naturalization\s+of|In\s+re\s+Extradition\s+of|In\s+re\s+Application\s+of|In\s+re\s+Welfare\s+of|In\s+re\s+Dependency\s+of|In\s+re\s+Paternity\s+of|In\s+re\s+Parentage\s+of|In\s+re\s+Conservatorship\s+of|In\s+re\s+Guardianship\s+of|In\s+re\s+Adoption\s+of|In\s+the\s+Interest\s+of|Matter\s+of\s+Liquidation\s+of|Matter\s+of\s+Rehabilitation\s+of|Commonwealth\s+of\s+Puerto\s+Rico\s+ex\s+rel\.|Government\s+of\s+the\s+Virgin\s+Islands\s+ex\s+rel\.|Commonwealth\s+ex\s+rel\.|Petition\s+for\s+Naturalization\s+of|People\s+ex\s+rel\.|District\s+of\s+Columbia\s+ex\s+rel\.|Conservatorship\s+of\s+the\s+Person\s+and\s+Estate\s+of|Conservatorship\s+of\s+the\s+Person\s+of|Conservatorship\s+of\s+the\s+Estate\s+of|Inquiry\s+Concerning\s+Judge|Appeal\s+of|Care\s+and\s+Protection\s+of|Succession\s+of|In re|Ex parte|Matter of|Estate of|State ex rel\.|United States ex rel\.|Application of|On Petition of|Petition of|Adoption of|Conservatorship of|Guardianship of)\s+([A-Za-z0-9\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/id
 
 /**
  * Lowercase words that legitimately appear in legal party names.
@@ -1287,16 +1293,31 @@ export function extractCaseName(
 
       const caseName = `${plaintiff} v. ${defendantText}`
       const nameStart = adjustedSearchStart + vMatch.index + trimOffset
-      // vMatch[3] holds the year captured by the CSM year-first tail
-      // (`Smith v. Jones (1990)` — #19). Bluebook form leaves it undefined.
-      // vMatch.indices[3] (enabled by the `d` flag) gives the position within
-      // precedingText; translate to cleanedText coordinates.
-      const year = vMatch[3] ? Number.parseInt(vMatch[3], 10) : undefined
+      // vMatch[3] = optional court text from the CSM year-first paren
+      // (`Smith v. Jones (2d Cir. 2005)` — #293); vMatch[4] = the year
+      // (`Smith v. Jones (1990)` — #19). Bluebook form leaves both undefined.
+      // vMatch.indices[4] (enabled by `d` flag) gives the year position;
+      // translate to cleanedText coordinates.
+      const courtFromCsm = vMatch[3]?.trim()
+      const year = vMatch[4] ? Number.parseInt(vMatch[4], 10) : undefined
       let yearStart: number | undefined
       let yearEnd: number | undefined
-      if (year !== undefined && vMatch.indices?.[3]) {
-        yearStart = adjustedSearchStart + vMatch.indices[3][0]
-        yearEnd = adjustedSearchStart + vMatch.indices[3][1]
+      if (year !== undefined && vMatch.indices?.[4]) {
+        yearStart = adjustedSearchStart + vMatch.indices[4][0]
+        yearEnd = adjustedSearchStart + vMatch.indices[4][1]
+      }
+      // CSM `(court year)` form (#293): synthesize a precedingDocketMeta so
+      // the existing consumer at extractCase line ~2502 propagates court,
+      // year, and date onto the citation. Skip when only year is present
+      // (year-only handled by the dedicated `year`/`yearStart`/`yearEnd`
+      // fields above).
+      let csmDocketMeta = precedingDocketMeta
+      if (!csmDocketMeta && courtFromCsm && year !== undefined && vMatch[4]) {
+        csmDocketMeta = {
+          court: courtFromCsm,
+          year,
+          date: { iso: vMatch[4], parsed: { year } },
+        }
       }
       return {
         caseName,
@@ -1304,7 +1325,7 @@ export function extractCaseName(
         year,
         yearStart,
         yearEnd,
-        precedingDocketMeta,
+        precedingDocketMeta: csmDocketMeta,
       }
     }
   }
@@ -1316,14 +1337,24 @@ export function extractCaseName(
     if (!procMatch[0].includes(";")) {
       const caseName = `${procMatch[1]} ${procMatch[2].trim()}`
       const nameStart = adjustedSearchStart + procMatch.index
-      // procMatch[3] holds the year captured by the CSM year-first tail
-      // (`In re K.F. (2009)` — #19). Bluebook form leaves it undefined.
-      const year = procMatch[3] ? Number.parseInt(procMatch[3], 10) : undefined
+      // procMatch[3] = optional court text from the CSM year-first paren
+      // (`In re Cellphone (9th Cir. 2014)` — #293); procMatch[4] = the year
+      // (`In re K.F. (2009)` — #19). Bluebook form leaves both undefined.
+      const courtFromCsm = procMatch[3]?.trim()
+      const year = procMatch[4] ? Number.parseInt(procMatch[4], 10) : undefined
       let yearStart: number | undefined
       let yearEnd: number | undefined
-      if (year !== undefined && procMatch.indices?.[3]) {
-        yearStart = adjustedSearchStart + procMatch.indices[3][0]
-        yearEnd = adjustedSearchStart + procMatch.indices[3][1]
+      if (year !== undefined && procMatch.indices?.[4]) {
+        yearStart = adjustedSearchStart + procMatch.indices[4][0]
+        yearEnd = adjustedSearchStart + procMatch.indices[4][1]
+      }
+      let csmDocketMeta = precedingDocketMeta
+      if (!csmDocketMeta && courtFromCsm && year !== undefined && procMatch[4]) {
+        csmDocketMeta = {
+          court: courtFromCsm,
+          year,
+          date: { iso: procMatch[4], parsed: { year } },
+        }
       }
       return {
         caseName,
@@ -1331,7 +1362,7 @@ export function extractCaseName(
         year,
         yearStart,
         yearEnd,
-        precedingDocketMeta,
+        precedingDocketMeta: csmDocketMeta,
       }
     }
   }

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -4933,6 +4933,71 @@ describe("California year-first citation format (#19)", () => {
     })
   })
 
+  describe("CSM year-first with court (#293)", () => {
+    it("extracts court from `(11th Cir. 1991)` in v. form", () => {
+      const text =
+        "Camden I Condominium Assn. v. Dunkle (11th Cir. 1991) 946 F.2d 768, 774."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].caseName).toBe("Camden I Condominium Assn. v. Dunkle")
+        expect(cases[0].court).toBe("11th Cir.")
+        expect(cases[0].year).toBe(1991)
+        expect(cases[0].pincite).toBe(774)
+      }
+    })
+
+    it("extracts court from `(2d Cir. 2005)` in v. form", () => {
+      const text =
+        "Wal-Mart Stores, Inc. v. Visa U.S.A., Inc. (2d Cir. 2005) 396 F.3d 96, 103."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].court).toBe("2d Cir.")
+        expect(cases[0].year).toBe(2005)
+      }
+    })
+
+    it("extracts court from `(9th Cir. 2014)` in procedural-prefix form", () => {
+      const text =
+        "See In re Cellphone Termination Fee Cases (9th Cir. 2014) 731 F.3d 968."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].caseName).toBe("In re Cellphone Termination Fee Cases")
+        expect(cases[0].court).toBe("9th Cir.")
+        expect(cases[0].year).toBe(2014)
+      }
+    })
+
+    it("year-only CSM `(2013)` still works (no court, no regression)", () => {
+      const text = "Cf. People v. Rivas (2013) 214 Cal.App.4th 1410, 1430."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].caseName).toBe("People v. Rivas")
+        expect(cases[0].year).toBe(2013)
+        expect(cases[0].court).toBeUndefined()
+      }
+    })
+
+    it("year-only CSM with procedural prefix `In re K.F. (2009)` still works", () => {
+      const text = "See In re K.F. (2009) 173 Cal.App.4th 655 for the standard."
+      const cits = extractCitations(text)
+      const cases = cits.filter((c) => c.type === "case")
+      expect(cases).toHaveLength(1)
+      if (cases[0].type === "case") {
+        expect(cases[0].caseName).toBe("In re K.F.")
+        expect(cases[0].year).toBe(2009)
+        expect(cases[0].court).toBeUndefined()
+      }
+    })
+  })
+
   describe("regression controls — Bluebook form still works", () => {
     it("`Smith v. Jones, 50 Cal.3d 100 (Cal. 1990)` still parses court+year", () => {
       const text = "Smith v. Jones, 50 Cal.3d 100 (Cal. 1990) held that..."


### PR DESCRIPTION
## Summary

- Fixes #293 — CSM year-first form (`(11th Cir. 1991) 946 F.2d 768`) now extracts `court` alongside `year`
- Largest field-extraction gap in the 200-opinion modern-era sweep (195 instances)
- 5 new tests; 122 net source/test lines

## Root cause

CSM puts the court+year parenthetical **before** the volume-reporter-page. The existing #19 year-first machinery captured the year (via the trailing alternation in `V_CASE_NAME_REGEX` / `PROCEDURAL_PREFIX_REGEX`) but the regex only accepted `(\d{4})` — anything before the year killed the match. So `(2009)` worked, `(11th Cir. 1991)` failed entirely.

| Input | Before | After |
|---|---|---|
| `Camden I Condominium Assn. v. Dunkle (11th Cir. 1991) 946 F.2d 768, 774` | caseName undefined, year undefined, court undefined | + `court: \"11th Cir.\"`, `year: 1991`, caseName + year recovered |
| `Wal-Mart v. Visa (2d Cir. 2005) 396 F.3d 96` | all dropped | + `court: \"2d Cir.\"`, `year: 2005` |
| `In re Cellphone (9th Cir. 2014) 731 F.3d 968` | all dropped | + `court: \"9th Cir.\"`, `year: 2014` |
| `People v. Rivas (2013) 214 Cal.App.4th 1410` | year + caseName captured (#19) | unchanged — `court: undefined` (year-only) |
| `Smith v. Jones, 50 Cal.3d 100 (Cal. 1990)` (Bluebook) | court captured from trailing | unchanged |

## Fix

`V_CASE_NAME_REGEX` and `PROCEDURAL_PREFIX_REGEX` now accept an optional court prefix inside the CSM paren:

```regex
\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\)
```

Capture groups:
- 3 = court (optional, from CSM paren — requires at least one `.`)
- 4 = year (shifted from old group 3)

The `\.` constraint inside the court body prevents loose forms like `(March 1991)` from being mis-attributed as courts. Bluebook T7 court abbreviations all contain at least one period.

Both consumer sites build a `precedingDocketMeta` payload when both court and year are captured. The existing Louisiana-docket meta consumer at `extractCase.ts:~2502` already propagates `precedingDocketMeta.court` onto the citation as fallback when no trailing court paren is present — that handler is reused for free.

## Files changed

- `src/extract/extractCase.ts` — 2 regex edits + 2 consumer-site updates (year capture shifted to group 4, optional court built into `precedingDocketMeta`)
- `tests/extract/extractCase.test.ts` — 5 new tests
- `.changeset/issue-293-csm-court.md` — patch changeset

## Test plan

- [x] 5 new tests under `CSM year-first with court (#293)`:
  - `(11th Cir. 1991)`, `(2d Cir. 2005)`, `(9th Cir. 2014)` — court + year captured
  - `(2013)` and procedural-prefix `(2009)` — year-only baselines, court undefined
- [x] Full suite — 2384/2393 pass, 0 regressions
- [x] `pnpm typecheck` clean
- [x] Diff is minimal: 122 lines, no formatting churn on unrelated code

🤖 Generated with [Claude Code](https://claude.com/claude-code)