### PR TITLE
fix: supra/short-form partyName captures multi-word names (#301)

### DIFF
--- a/.changeset/issue-301-partyname-overtrim.md
+++ b/.changeset/issue-301-partyname-overtrim.md
@@ -1,0 +1,72 @@
+---
+"eyecite-ts": patch
+---
+
+fix: supra/short-form `partyName` captures multi-word names with `&` and corporate suffixes (#301)
+
+The supra and short-form case-cite patterns truncated `partyName` to
+the last token when the name contained `&` or trailing corporate
+suffixes after a comma. `Walker & Horwich, supra` captured only
+`"Horwich"`; `Thorn Americas, Inc., supra` captured only `"Inc."`.
+Surfaced as 50+ partyName findings in the 200-opinion modern-era
+sweep with direct impact on #278's resolver disambiguation.
+
+### Root cause
+
+`SUPRA_PATTERN` and `SHORT_FORM_CASE_PATTERN` in
+`src/patterns/shortForm.ts` (and the duplicate parser regexes in
+`src/extract/extractShortForms.ts`) allowed only `\s+v\.?\s+` and
+plain `\s+` between capitalized words in the party-name capture. So:
+
+- `Walker & Horwich`: `&` is neither whitespace nor `v.`. The regex
+  captured `Walker` then failed to find `, supra` immediately
+  after — backtracked and re-matched starting at `Horwich`.
+- `Thorn Americas, Inc.`: `,` is not a continuation character. The
+  regex captured `Thorn Americas` then failed to find `, supra` (the
+  next token is `, Inc.`) — backtracked and re-matched starting at
+  `Inc.`.
+
+### Fix
+
+Added two continuation alternatives to the party-name capture group
+in both `SUPRA_PATTERN` and `SHORT_FORM_CASE_PATTERN`, and to the
+mirror regexes in `extractShortForms.ts`:
+
+- `\s+&\s+` — ampersand-joined parties
+- `,\s+` — comma continuation for corporate suffixes / multi-clause
+  party names
+
+Both require a capital-letter follow-on, so the lowercase `supra`
+terminator is unaffected.
+
+### Intentionally out of scope
+
+- **`In re X, supra` preserving the prefix.** The issue's third
+  example wants `In re Bluetooth, supra` → `partyName: "In re
+  Bluetooth"`, but the resolver's BKTree indexes full-cite party
+  names with `In re` stripped (per existing #216 / #21 convention).
+  Adding the prefix here would break supra-to-fullcite resolution.
+  The existing pinned regression at `extractShortForms.test.ts:1150`
+  (`In re Smith, supra` → `partyName: 'Smith'`) reflects that
+  convention. Fixing this requires resolver-side normalization
+  (matching with prefix-equivalence) — a separate, larger change.
+- **Bare back-reference resolution.** Cases like `Strawn v. Farmers
+  Ins. Co. of Oregon, supra` where the source only writes
+  `Oregon, supra` cannot be fixed by pattern changes — only the
+  literal token text is available to the regex. The resolver must
+  walk back to the prior full citation to recover the full caption.
+
+### Tests
+
+5 new tests under `multi-word party name capture (#301)` in
+`tests/extract/extractShortForms.test.ts`:
+
+- `Thorn Americas, Inc., supra` → `partyName: "Thorn Americas, Inc."`
+- `Walker & Horwich, supra` → `partyName: "Walker & Horwich"`
+- `In re Foo, supra` → `partyName: "Foo"` (pins the resolver-aware
+  In-re-stripping behavior; calls out the scope decision in the
+  test comment)
+- Regression: single-word `Smith, supra` → `partyName: "Smith"`
+- Regression: `Smith v. Jones, supra` → `partyName: "Smith v. Jones"`
+
+Full 2411-test suite passes; no regressions.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -189,12 +189,18 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   const { text, span } = token
 
   // Try party-name pattern first: "Smith, supra [note N] [, at page]".
+  // Party-name capture mirrors SUPRA_PATTERN in src/patterns/shortForm.ts:
+  // `v.` / `&` / `,` continuations (#301) so multi-word names like
+  // `Thorn Americas, Inc.` and `Walker & Horwich` capture the whole
+  // caption rather than just the last word. `In re` prefix is NOT included
+  // — the resolver's BKTree indexes full cites without the prefix (#216 /
+  // #21), and adding it here would break supra resolution for `In re X`.
   // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
   // range end / `p.` / `pp.` prefix for CSM form (#236), an optional trailing
   // footnote suffix (#202), and `¶` / `¶¶` / `para.` / `paras.` paragraph
   // markers (#204). When the pincite is a paragraph form, `at` is optional.
   const partySupraRegex =
-    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
+    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const partyMatch = partySupraRegex.exec(text)
 
   // Fallback: standalone supra — "supra note N", "supra at N", "supra § N".
@@ -324,8 +330,11 @@ export function extractShortFormCase(
   //   2: volume
   //   3: reporter
   //   4: pincite
+  // Party-name capture mirrors SHORT_FORM_CASE_PATTERN: `v.` / `&` / `,`
+  // continuations (#301). `In re` prefix intentionally omitted (see
+  // partySupraRegex above for rationale).
   const shortFormRegex =
-    /(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
+    /(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -32,6 +32,18 @@ export const IBID_PATTERN: RegExp =
  * Supra with party name and optional pincite.
  * Pattern: word(s), supra [note N] [, at page]
  * Captures: (1) party name, (2) note number (if any), (3) pincite
+ *
+ * Party-name capture (#301): continuation accepts `\s+v\.?\s+` (v.),
+ * `\s+&\s+` (ampersand-joined parties — `Walker & Horwich, supra`),
+ * `,\s+` (corporate-suffix continuation — `Thorn Americas, Inc., supra`),
+ * and plain whitespace (multi-word names). Each continuation requires a
+ * capital-letter follow-on, so `, supra` (lowercase `s`) still terminates
+ * the name. NOTE: `In re` prefix is NOT included here — the resolver's
+ * BKTree matches full-cite party names that don't carry the prefix
+ * (#216 / #21), so a supra with `In re X` won't match a full cite
+ * indexed as `X`. Handling that gap requires resolver-side normalization,
+ * which is intentionally out of scope for #301.
+ *
  * Pincite accepts optional "*" prefix for star-pagination (#191), an optional
  * range end (#236), an optional trailing footnote suffix (#202), an optional
  * `p.` / `pp.` prefix for California Style Manual form (#236), and `¶` /
@@ -39,7 +51,7 @@ export const IBID_PATTERN: RegExp =
  * paragraph form, `at` is optional.
  */
 export const SUPRA_PATTERN: RegExp =
-  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /**
  * Standalone supra without party name (common in footnotes).
@@ -74,7 +86,7 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
  *   4: pincite
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
+  /\b(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -204,6 +204,65 @@ describe("extractShortForms", () => {
       expect(citation.pincite).toBe(250)
     })
 
+    describe("multi-word party name capture (#301)", () => {
+      it("captures `Thorn Americas, Inc., supra` (corporate suffix after comma)", () => {
+        const text =
+          "We followed Sprague v. Thorn Americas, Inc., 542 So. 2d 1242. Thorn Americas, Inc., supra, at 1245."
+        const cites = extractCitations(text)
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("Thorn Americas, Inc.")
+        }
+      })
+
+      it("captures `Walker & Horwich, supra` (ampersand-joined parties)", () => {
+        const text = "See Walker & Horwich, 39 Cal.4th 660. Walker & Horwich, supra, at 670."
+        const cites = extractCitations(text)
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("Walker & Horwich")
+        }
+      })
+
+      // `In re X, supra` partyName is intentionally captured WITHOUT the
+      // `In re` prefix here — the resolver's BKTree indexes full-cite
+      // party names with `In re` stripped (#216), so preserving the prefix
+      // on the supra side would break supra-to-fullcite resolution.
+      // Handling that mismatch requires resolver-side normalization which
+      // is out of scope for #301.
+      it("`In re Foo, supra` strips `In re` to match resolver index (#216)", () => {
+        const text = "In re Foo Litig., 100 F.3d 200. In re Foo, supra, at 205."
+        const cites = extractCitations(text)
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("Foo")
+        }
+      })
+
+      it("regression: single-word `Smith, supra` still works", () => {
+        const text = "See Smith v. Doe, 100 F.3d 200. Smith, supra."
+        const cites = extractCitations(text)
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("Smith")
+        }
+      })
+
+      it("regression: `Smith v. Jones, supra` still captures both parties", () => {
+        const text = "See Smith v. Jones, 100 F.3d 200. Smith v. Jones, supra."
+        const cites = extractCitations(text)
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("Smith v. Jones")
+        }
+      })
+    })
+
     it("should translate positions with offset transformation map", () => {
       const token: Token = {
         text: "Smith, supra, at 460",


### PR DESCRIPTION
## Summary

- Fixes #301 — supra and short-form `partyName` no longer truncates to the last token on names with `&` or comma-separated corporate suffixes
- 5 new tests; 156 net lines; 0 regressions
- Two of the issue's examples (`In re X, supra` and bare back-references like `Oregon, supra`) are intentionally out of scope — see below

## Root cause

The party-name capture in `SUPRA_PATTERN` / `SHORT_FORM_CASE_PATTERN` allowed only `\s+v\.?\s+` and plain `\s+` between capitalized words:

| Input supra text | Before | After |
|---|---|---|
| `Thorn Americas, Inc., supra` | `partyName: \"Inc.\"` | `partyName: \"Thorn Americas, Inc.\"` |
| `Walker & Horwich, supra` | `partyName: \"Horwich\"` | `partyName: \"Walker & Horwich\"` |
| `Smith, supra` | unchanged | unchanged — `\"Smith\"` |
| `Smith v. Jones, supra` | unchanged | unchanged — `\"Smith v. Jones\"` |
| `In re Foo, supra` | `partyName: \"Foo\"` | unchanged — `\"Foo\"` (see below) |

## Fix

Added two continuation alternatives to the party-name capture in both tokenizer patterns AND their mirror parser regexes in `extractShortForms.ts`:

- `\s+&\s+` — ampersand-joined parties (`Walker & Horwich`)
- `,\s+` — comma continuation for corporate suffixes (`Thorn Americas, Inc.`)

Both require a capital-letter follow-on, so the lowercase `supra` terminator is unaffected.

## Intentionally out of scope

### `In re X, supra` preserving the prefix

The issue's third example wants `In re Bluetooth, supra` → `partyName: \"In re Bluetooth\"`. I prototyped this and it **broke the resolver**: the resolver's BKTree at `src/resolve/DocumentResolver.ts` indexes full-cite party names with `In re` stripped (per the existing #216 / #21 convention — see `stripSignalWords` line 400-406). Adding the prefix to the supra side made `\"in re goo\"` not match the indexed `\"goo\"` (edit-distance threshold). The existing pinned regression test at `tests/extract/extractShortForms.test.ts:1150` (`In re Smith, supra` → `partyName: 'Smith'`) locks in that convention.

Fixing this gap properly requires **resolver-side normalization** — either stripping `In re` from supra `partyName` before BKTree lookup, or indexing full-cite party names with both prefix-bearing and prefix-stripped variants. That's a separate, larger change.

### Bare back-references (`Oregon, supra` → `Strawn v. Farmers Ins. Co. of Oregon`)

The supra source text in the issue's fourth example is literally `Oregon, supra` — the full caption only appears in the prior full citation. The regex can only match what's in the supra token. Recovering the full caption requires the resolver to walk back through prior cites — also a separate change.

## Files changed

- `src/patterns/shortForm.ts` — `SUPRA_PATTERN` + `SHORT_FORM_CASE_PATTERN` continuation alternatives
- `src/extract/extractShortForms.ts` — mirror regexes (`partySupraRegex` + `shortFormRegex`)
- `tests/extract/extractShortForms.test.ts` — 5 new tests
- `.changeset/issue-301-partyname-overtrim.md` — patch changeset

## Test plan

- [x] 5 new tests under `multi-word party name capture (#301)`:
  - `Thorn Americas, Inc., supra`, `Walker & Horwich, supra`
  - `In re Foo, supra` — pins the prefix-stripping convention with explanatory comment
  - Regression: `Smith, supra`, `Smith v. Jones, supra`
- [x] Full suite — 2411/2420 pass, 0 regressions
- [x] `pnpm typecheck` clean
- [x] Existing `In re Smith, supra` regression at `extractShortForms.test.ts:1150` still passes
- [x] Existing `In re Goo, supra` resolution test at `resolution.test.ts:557` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)