### PR TITLE
feat: capture trailing parentheticals on Id./supra/short-form cites (#303)

### DIFF
--- a/.changeset/issue-303-trailing-paren-shortform.md
+++ b/.changeset/issue-303-trailing-paren-shortform.md
@@ -1,0 +1,72 @@
+---
+"eyecite-ts": patch
+---
+
+feat: capture trailing parentheticals on `Id.`, `supra`, and short-form case citations (#303)
+
+`Id. at 770 (Marsh)`, `Id. at 770 (citation omitted)`,
+`Smith, supra, at 200 (holding that ...)`, and
+`100 F.3d at 770 (citations omitted)` previously dropped the trailing
+parenthetical content silently. The short-form extractors now capture
+the parenthetical text on a new `parenthetical?: string` field,
+mirroring how `extractCase` handles trailing parens on full citations.
+
+Surfaced as 80+ findings in the 200-opinion modern-era sweep — the
+third-largest field-issue bucket after caseName and court.
+
+### Fix
+
+Added a lightweight `extractTrailingParenthetical(cleanedText, cleanEnd)`
+helper in `src/extract/extractShortForms.ts`. It scans the cleaned text
+starting at the citation's `span.cleanEnd` for `^[\s,]*\(([^()]*)\)` and
+returns the inner text. Wired into all three short-form extractors:
+
+- `extractId(token, transformationMap, cleanedText)` — already received
+  `cleanedText` for context validation (#216); reuse it.
+- `extractSupra` — new third parameter.
+- `extractShortFormCase` — new third parameter.
+
+`extractCitations` now passes `cleaned` to all three call sites.
+
+### Fields added
+
+- `IdCitation.parenthetical?: string`
+- `SupraCitation.parenthetical?: string`
+- `ShortFormCaseCitation.parenthetical?: string`
+
+The captured value is the raw text between the parens. Consumers can
+post-classify it as a short-form identifier (`Marsh`), drop-citation
+marker (`citation omitted`), or explanatory holding by inspecting the
+content — the lightweight extractor intentionally doesn't classify, since
+short-form parens are rarely chained and classification adds value
+mostly on full case cites.
+
+### Scope notes
+
+- **Single paren only.** The extractor captures the first `(...)` that
+  immediately follows the citation. Chained parens on short-form cites
+  are rare and not in scope.
+- **No `parentheticals[]` array.** The full-cite `parentheticals`
+  array with structured `Parenthetical` objects (including signal-word
+  classification, span, and kind) remains case-cite-only. Adding it to
+  short-forms would require porting the full `collectParentheticals`
+  pipeline, which is heavier than the gap this PR addresses.
+- **No new `shortFormIdentifier` / `dropCitation` kinds.** The issue
+  suggested adding these to `ParentheticalType`, but with the raw
+  `parenthetical: string` field consumers can do their own classification
+  cheaply; adding union variants would expand the public type without
+  much practical benefit.
+
+### Tests
+
+6 new tests under `trailing parenthetical capture on short-form cites
+(#303)` in `tests/extract/extractShortForms.test.ts`:
+
+- `Id. at 770 (Marsh)` → `parenthetical: "Marsh"`
+- `Id. at 770 (citation omitted)` → `parenthetical: "citation omitted"`
+- `Id. at 100` (no paren) → no `parenthetical` field
+- `Smith, supra, at 200 (holding ...)` → `parenthetical: "holding that the rule applies"`
+- `Smith, supra, at 460` (no paren) → no `parenthetical` field
+- `100 F.3d at 770 (citations omitted)` → `parenthetical: "citations omitted"`
+
+Full 2427-test suite passes; no regressions.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -325,9 +325,9 @@ export function extractCitations(
         if (token.patternId === "id" || token.patternId === "ibid") {
           citation = extractId(token, transformationMap, cleaned)
         } else if (token.patternId === "supra") {
-          citation = extractSupra(token, transformationMap)
+          citation = extractSupra(token, transformationMap, cleaned)
         } else if (token.patternId === "shortFormCase") {
-          citation = extractShortFormCase(token, transformationMap)
+          citation = extractShortFormCase(token, transformationMap, cleaned)
         } else {
           citation = extractCase(
             token,

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -42,6 +42,34 @@ function stripSupraPartyPrefix(raw: string): string {
 }
 
 /**
+ * Trailing-parenthetical lookahead for short-form citations (#303).
+ *
+ * Captures content of a single `(...)` parenthetical immediately after the
+ * citation core, allowing optional whitespace/comma between. The body uses
+ * `[^()]*` (no nesting) — `parenthetical` is the raw text inside one set of
+ * parens. Suitable for `Id. at N (Marsh)`, `Id. (citation omitted)`,
+ * `Smith, supra (holding that ...)`, `Smith, 500 F.2d at 125 (citations omitted)`.
+ */
+const TRAILING_PAREN_REGEX = /^[\s,]*\(([^()]*)\)/
+
+/**
+ * Scan the cleaned text after a short-form citation's span end for an
+ * immediately-trailing `(...)` parenthetical. Returns the inner text
+ * (excluding the parens) or `undefined` if none found. #303
+ */
+function extractTrailingParenthetical(
+  cleanedText: string | undefined,
+  cleanEnd: number,
+): string | undefined {
+  if (!cleanedText) return undefined
+  const after = cleanedText.slice(cleanEnd)
+  const m = TRAILING_PAREN_REGEX.exec(after)
+  if (!m) return undefined
+  const content = m[1].trim()
+  return content.length > 0 ? content : undefined
+}
+
+/**
  * Extracts Id. citation metadata from a tokenized citation.
  *
  * Parses token text to extract:
@@ -134,6 +162,9 @@ export function extractId(
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
+  // Trailing parenthetical (#303): `Id. at 770 (Marsh)`, `Id. (citation omitted)`.
+  const parenthetical = extractTrailingParenthetical(cleanedText, span.cleanEnd)
+
   return {
     type: "id",
     text,
@@ -149,6 +180,7 @@ export function extractId(
     patternsChecked: 1,
     pincite,
     pinciteInfo,
+    ...(parenthetical ? { parenthetical } : {}),
     spans,
   }
 }
@@ -185,7 +217,11 @@ export function extractId(
  * // }
  * ```
  */
-export function extractSupra(token: Token, transformationMap: TransformationMap): SupraCitation {
+export function extractSupra(
+  token: Token,
+  transformationMap: TransformationMap,
+  cleanedText?: string,
+): SupraCitation {
   const { text, span } = token
 
   // Try party-name pattern first: "Smith, supra [note N] [, at page]".
@@ -255,6 +291,9 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
+  // Trailing parenthetical (#303): `Smith, supra (holding ...)`.
+  const parenthetical = extractTrailingParenthetical(cleanedText, span.cleanEnd)
+
   return {
     type: "supra",
     text,
@@ -271,6 +310,7 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
     partyName,
     pincite,
     pinciteInfo,
+    ...(parenthetical ? { parenthetical } : {}),
     spans,
   }
 }
@@ -312,6 +352,7 @@ export function extractSupra(token: Token, transformationMap: TransformationMap)
 export function extractShortFormCase(
   token: Token,
   transformationMap: TransformationMap,
+  cleanedText?: string,
 ): ShortFormCaseCitation {
   const { text, span } = token
 
@@ -378,6 +419,9 @@ export function extractShortFormCase(
     confidence += 0.3
   }
 
+  // Trailing parenthetical (#303): `Smith, 500 F.2d at 125 (citations omitted)`.
+  const parenthetical = extractTrailingParenthetical(cleanedText, span.cleanEnd)
+
   return {
     type: "shortFormCase",
     text,
@@ -397,6 +441,7 @@ export function extractShortFormCase(
     pinciteInfo,
     partyName,
     partyNameNormalized,
+    ...(parenthetical ? { parenthetical } : {}),
     spans,
   }
 }

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -704,6 +704,15 @@ export interface IdCitation extends CitationBase {
   pincite?: number
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
+  /**
+   * Trailing parenthetical content (text between the parens, excluding the
+   * parens themselves) captured from `Id. at N (...)` forms. Common values
+   * include drop-citation markers (`citation omitted`, `internal quotation
+   * marks omitted`), short-form case identifiers (`Marsh`, `Serrano III`),
+   * and explanatory holdings (`holding that ...`). Unclassified — consumers
+   * can post-classify if needed. #303
+   */
+  parenthetical?: string
   /** Component-level spans (currently just `pincite`; extend when needed). */
   spans?: import("./componentSpans").IdComponentSpans
 }
@@ -722,6 +731,12 @@ export interface SupraCitation extends CitationBase {
   pincite?: number
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
+  /**
+   * Trailing parenthetical content (text between the parens, excluding the
+   * parens themselves). See `IdCitation.parenthetical` for common shapes
+   * and rationale. #303
+   */
+  parenthetical?: string
   /** Component-level spans (currently just `pincite`; extend when needed). */
   spans?: import("./componentSpans").SupraComponentSpans
 }
@@ -753,6 +768,12 @@ export interface ShortFormCaseCitation extends CitationBase {
    *  collapsed). Mirrors `defendantNormalized` / `plaintiffNormalized` on
    *  `FullCaseCitation`. */
   partyNameNormalized?: string
+  /**
+   * Trailing parenthetical content (text between the parens, excluding the
+   * parens themselves). See `IdCitation.parenthetical` for common shapes
+   * and rationale. #303
+   */
+  parenthetical?: string
 }
 
 /**

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -1386,3 +1386,74 @@ describe("short-form case party-name back-reference (#278)", () => {
     })
   })
 })
+
+describe("trailing parenthetical capture on short-form cites (#303)", () => {
+  describe("Id.", () => {
+    it("captures `Id. at 770 (Marsh)` — short-form case identifier", () => {
+      const text =
+        "We followed In re Marriage Cases (Marsh), 43 Cal.4th 757. Id. at 770 (Marsh)."
+      const cites = extractCitations(text)
+      const id = cites.find((c) => c.type === "id")
+      expect(id?.type).toBe("id")
+      if (id?.type === "id") {
+        expect(id.pincite).toBe(770)
+        expect(id.parenthetical).toBe("Marsh")
+      }
+    })
+
+    it("captures `Id. at 770 (citation omitted)` — drop-citation marker", () => {
+      const cites = extractCitations("The court agreed. Id. at 770 (citation omitted).")
+      const id = cites.find((c) => c.type === "id")
+      expect(id?.type).toBe("id")
+      if (id?.type === "id") {
+        expect(id.parenthetical).toBe("citation omitted")
+      }
+    })
+
+    it("regression: `Id. at 100` (no paren) has no parenthetical field", () => {
+      const cites = extractCitations("See Smith v. Jones, 100 F.3d 200. Id. at 100.")
+      const id = cites.find((c) => c.type === "id")
+      expect(id?.type).toBe("id")
+      if (id?.type === "id") {
+        expect(id.parenthetical).toBeUndefined()
+      }
+    })
+  })
+
+  describe("supra", () => {
+    it("captures `Smith, supra, at 200 (holding ...)` — explanatory paren", () => {
+      const text =
+        "We followed Smith v. Doe, 100 F.3d 200. Smith, supra, at 200 (holding that the rule applies)."
+      const cites = extractCitations(text)
+      const supra = cites.find((c) => c.type === "supra")
+      expect(supra?.type).toBe("supra")
+      if (supra?.type === "supra") {
+        expect(supra.parenthetical).toBe("holding that the rule applies")
+      }
+    })
+
+    it("regression: `Smith, supra, at 460` (no paren) has no parenthetical field", () => {
+      const cites = extractCitations(
+        "See Smith v. Jones, 100 F.3d 200. Smith, supra, at 460.",
+      )
+      const supra = cites.find((c) => c.type === "supra")
+      expect(supra?.type).toBe("supra")
+      if (supra?.type === "supra") {
+        expect(supra.parenthetical).toBeUndefined()
+      }
+    })
+  })
+
+  describe("short-form case", () => {
+    it("captures `100 F.3d at 770 (citations omitted)`", () => {
+      const text =
+        "See Smith v. Jones, 100 F.3d 200. Plaintiff relies on the 100 F.3d at 770 (citations omitted)."
+      const cites = extractCitations(text)
+      const sf = cites.find((c) => c.type === "shortFormCase")
+      expect(sf?.type).toBe("shortFormCase")
+      if (sf?.type === "shortFormCase") {
+        expect(sf.parenthetical).toBe("citations omitted")
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes #303 — `Id. at 770 (Marsh)`, `Id. (citation omitted)`, `Smith, supra (holding ...)`, `100 F.3d at 770 (citations omitted)` now capture the parenthetical text
- New optional `parenthetical?: string` on `IdCitation`, `SupraCitation`, `ShortFormCaseCitation`
- 6 new tests; 140 net source/test lines
- 80+ findings in the 200-opinion modern sweep (3rd-largest field-issue bucket)

## Root cause

Trailing parens contain critical metadata — short-form case identifiers (`Marsh`, `Serrano III`), drop-citation markers (`citation omitted`, `internal quotation marks omitted`), and substantive explanatory holdings — and `extractCase` captures them for full citations via `collectParentheticals`. The short-form extractors had no equivalent.

| Input | Before | After |
|---|---|---|
| `Id. at 770 (Marsh)` | no parenthetical field | `parenthetical: \"Marsh\"` |
| `Id. at 770 (citation omitted)` | no parenthetical field | `parenthetical: \"citation omitted\"` |
| `Smith, supra, at 200 (holding ...)` | no parenthetical field | `parenthetical: \"holding that the rule applies\"` |
| `100 F.3d at 770 (citations omitted)` | no parenthetical field | `parenthetical: \"citations omitted\"` |
| `Id. at 100` (no paren) | unchanged | unchanged — no `parenthetical` field |

## Fix

A lightweight `extractTrailingParenthetical(cleanedText, cleanEnd)` helper added to `extractShortForms.ts`. Scans the cleaned text from `span.cleanEnd` for `^[\s,]*\(([^()]*)\)` and returns the inner text. Wired into all three short-form extractors:

- `extractId(token, transformationMap, cleanedText)` — already received `cleanedText`
- `extractSupra` — new third parameter
- `extractShortFormCase` — new third parameter
- `extractCitations` passes `cleaned` to all three

## Scope notes — intentionally NOT in this PR

- **Chained parens.** Single trailing `(...)` only. Multiple chained parens on short-form cites are rare; if needed they can be added by porting `collectParentheticals`.
- **`parentheticals[]` structured array.** Full-cite citations carry a `parentheticals[]` array of `Parenthetical` objects with signal-word classification and span. Adding that to short-forms would require porting `collectParentheticals` (~100 lines, more invasive). Raw string captures the data; consumers can classify cheaply.
- **No new `shortFormIdentifier` / `dropCitation` union variants** on `ParentheticalType`. The raw `parenthetical: string` lets consumers post-classify without expanding the public type union.

## Files changed

- `src/extract/extractShortForms.ts` — `TRAILING_PAREN_REGEX` + `extractTrailingParenthetical` helper + wired into all 3 extractors
- `src/extract/extractCitations.ts` — pass `cleaned` text to `extractSupra` and `extractShortFormCase`
- `src/types/citation.ts` — 3 new optional fields
- `tests/extract/extractShortForms.test.ts` — 6 new tests
- `.changeset/issue-303-trailing-paren-shortform.md` — patch changeset

## Test plan

- [x] 6 new tests under `trailing parenthetical capture on short-form cites (#303)`:
  - `Id. at 770 (Marsh)` and `Id. at 770 (citation omitted)` for short-form case ID + drop-citation
  - `Smith, supra, at 200 (holding ...)` for supra+explanatory
  - `100 F.3d at 770 (citations omitted)` for short-form case+drop-citation
  - Regression baselines: `Id. at 100` and `Smith, supra, at 460` (no paren) have no `parenthetical` field
- [x] Full suite — 2427/2436 pass, 0 regressions
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)