### PR TITLE
feat: recognize bracketed [supra] forms — Connecticut style (#306)

### DIFF
--- a/.changeset/issue-306-bracketed-supra.md
+++ b/.changeset/issue-306-bracketed-supra.md
@@ -1,0 +1,50 @@
+---
+"eyecite-ts": patch
+---
+
+feat: recognize bracketed `[supra]` forms — Connecticut style (#306)
+
+Connecticut Supreme/Appellate opinions enclose `supra` in square
+brackets when the supra reference is nested inside a string-cite or
+quotation: `State v. Jarzbek, [supra, 705]`, `State v. Jarzbek,
+[supra]`, `[supra at 78-82]`. None of these tokenized — all returned
+`[]`. Surfaced by the 200-opinion modern-era sweep as a systematic
+recall gap for Connecticut citation extraction.
+
+### Fix
+
+Added a new tokenizer pattern `BRACKETED_SUPRA_PATTERN` to
+`src/patterns/shortForm.ts`:
+
+```regex
+(?:\b([A-Z]...)\s*,?\s+)?\[supra(?:(?:,\s+|\s+at\s+(?:pp?\.\s*)?)(\d+(?:[-–—]\d+)?))?\]
+```
+
+Captures:
+- Group 1: party name (optional — undefined for the bare standalone
+  `[supra at N]` form)
+- Group 2: pincite (optional, accepts both Connecticut's `, N` form
+  and the canonical `at N` form, plus range `N-M`)
+
+The bracket-comma pincite shape `[supra, 705]` deliberately accepts
+no `at` before the page — that's the Connecticut convention.
+
+`extractSupra` adds a fast-path branch that recognizes bracketed
+token text (via `text.includes("[supra")`) and parses it through the
+new regex. Falls through to the canonical `partySupraRegex` for
+non-bracketed forms — zero impact on existing supra extraction.
+
+### Tests
+
+4 new tests under `bracketed [supra] forms (#306)` in
+`tests/extract/extractShortForms.test.ts`:
+
+- `State v. Jarzbek, [supra, 705]` → partyName + pincite
+- `State v. Jarzbek, [supra]` → partyName, no pincite
+- `[supra at 78-82]` → no partyName, pincite 78 (range start)
+- Regression: `Smith, supra, at 100` continues to work
+
+Updated the pattern-count test in `tests/patterns/shortForm.test.ts`
+from "all five patterns" → "all six patterns".
+
+Full 2448-test suite passes; no regressions.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -239,6 +239,15 @@ export function extractSupra(
 ): SupraCitation {
   const { text, span } = token
 
+  // Bracketed supra (#306): `State v. Jarzbek, [supra, 705]` /
+  // `[supra at 78-82]`. Connecticut Supreme/Appellate convention. The
+  // comma-pincite shape `[supra, 705]` accepts no `at` before the page.
+  // When the token text matches this shape, parse it via the bracketed
+  // regex; otherwise fall through to the canonical partySupraRegex.
+  const bracketedSupraRegex =
+    /(?:\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+)?\[supra(?:(?:,\s+|\s+at\s+(?:pp?\.\s*)?)(\d+(?:[-–—]\d+)?))?\]/d
+  const bracketedMatch = text.includes("[supra") ? bracketedSupraRegex.exec(text) : null
+
   // Try party-name pattern first: "Smith, supra [note N] [, at page]".
   // Party-name capture mirrors SUPRA_PATTERN in src/patterns/shortForm.ts:
   // `v.` / `&` / `,` continuations (#301) so multi-word names like
@@ -252,14 +261,14 @@ export function extractSupra(
   // markers (#204). When the pincite is a paragraph form, `at` is optional.
   const partySupraRegex =
     /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
-  const partyMatch = partySupraRegex.exec(text)
+  const partyMatch = bracketedMatch ? null : partySupraRegex.exec(text)
 
   // Fallback: standalone supra — "supra note N", "supra at N", "supra § N".
   // The `at` page accepts the same `p.` / `pp.` prefix and range form (#236)
   // plus paragraph markers (#204).
   const standaloneRegex =
     /supra(?:\s+note\s+(\d+)(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?|\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
-  const match = partyMatch || standaloneRegex.exec(text)
+  const match = bracketedMatch || partyMatch || standaloneRegex.exec(text)
 
   if (!match) {
     throw new Error(`Failed to parse supra citation: ${text}`)
@@ -270,7 +279,15 @@ export function extractSupra(
   let confidence: number
   let pinciteGroupIdx: number | undefined
 
-  if (partyMatch) {
+  if (bracketedMatch) {
+    // Bracketed form (#306): group 1 = optional party, group 2 = optional pincite.
+    partyName = bracketedMatch[1] ? stripSupraPartyPrefix(bracketedMatch[1]) : undefined
+    pinciteInfo = bracketedMatch[2]
+      ? (parsePincite(bracketedMatch[2]) ?? undefined)
+      : undefined
+    confidence = partyName ? 0.9 : 0.8
+    if (bracketedMatch[2]) pinciteGroupIdx = 2
+  } else if (partyMatch) {
     partyName = stripSupraPartyPrefix(partyMatch[1])
     pinciteInfo = partyMatch[3]
       ? (parsePincite(partyMatch[3]) ?? undefined)

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -74,6 +74,20 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
   /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)|\s+(?:§+|Part|p\.)\s*\S+)/g
 
 /**
+ * Bracketed supra forms (#306) — `[supra]`, `[supra, 705]`, `[supra at 78-82]`,
+ * and `State v. Jarzbek, [supra, 705]`. Connecticut Supreme/Appellate use
+ * brackets around the supra token when it appears inside a string-cite or
+ * quotation. The comma-pincite form `[supra, 705]` accepts NO `at` before
+ * the page — that's the Connecticut convention.
+ *
+ * Captures: (1) party name (optional; undefined for bare standalone form),
+ *   (2) pincite (optional, accepts comma-form `, N` or `at N` shape with
+ *   optional range `N-M`).
+ */
+export const BRACKETED_SUPRA_PATTERN: RegExp =
+  /(?:\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+)?\[supra(?:(?:,\s+|\s+at\s+(?:pp?\.\s*)?)(\d+(?:[-–—]\d+)?))?\]/g
+
+/**
  * Short-form case: [Party,] volume reporter [,] at page
  * Pattern: optional Party name, then number space abbreviation [, ] at space number.
  * Simplified detection; full parsing in extraction layer.
@@ -100,6 +114,7 @@ export const SHORT_FORM_CASE_PATTERN: RegExp =
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [
   ID_PATTERN,
   IBID_PATTERN,
+  BRACKETED_SUPRA_PATTERN,
   SUPRA_PATTERN,
   STANDALONE_SUPRA_PATTERN,
   SHORT_FORM_CASE_PATTERN,
@@ -118,6 +133,13 @@ export const shortFormPatterns: Pattern[] = [
     regex: IBID_PATTERN,
     description: 'Ibid. citations (e.g., "Ibid." or "Ibid. at 125")',
     type: "case", // Will be typed as 'id' in extraction layer
+  },
+  {
+    id: "supra",
+    regex: BRACKETED_SUPRA_PATTERN,
+    description:
+      'Bracketed supra citations (e.g., "State v. Jarzbek, [supra, 705]" — Connecticut style; #306)',
+    type: "case", // Will be typed as 'supra' in extraction layer
   },
   {
     id: "supra",

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -564,6 +564,52 @@ describe("extractShortForms", () => {
       expect(citation.confidence).toBe(0.9)
     })
 
+    describe("bracketed `[supra]` forms (#306)", () => {
+      it("extracts `State v. Jarzbek, [supra, 705]` (Connecticut style)", () => {
+        const cites = extractCitations(
+          "As stated in State v. Jarzbek, [supra, 705], the rule applies.",
+        )
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("State v. Jarzbek")
+          expect(supra.pincite).toBe(705)
+        }
+      })
+
+      it("extracts `State v. Jarzbek, [supra]` (no pincite)", () => {
+        const cites = extractCitations("State v. Jarzbek, [supra], the parties argued.")
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("State v. Jarzbek")
+          expect(supra.pincite).toBeUndefined()
+        }
+      })
+
+      it("extracts standalone `[supra at 78-82]` (range pincite)", () => {
+        const cites = extractCitations(
+          "The court applied [supra at 78-82] in its analysis.",
+        )
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBeUndefined()
+          expect(supra.pincite).toBe(78) // start of range
+        }
+      })
+
+      it("regression: canonical `Smith, supra, at 100` still works", () => {
+        const cites = extractCitations("See Smith, supra, at 100.")
+        const supra = cites.find((c) => c.type === "supra")
+        expect(supra?.type).toBe("supra")
+        if (supra?.type === "supra") {
+          expect(supra.partyName).toBe("Smith")
+          expect(supra.pincite).toBe(100)
+        }
+      })
+    })
+
     it("extractId penalizes mid-sentence `Id.` context (existing #182 behavior)", () => {
       // Pin the mid-sentence-context penalty path — `Id.` preceded by a
       // lowercase word in a sentence (e.g., "The Id. card") gets confidence

--- a/tests/patterns/shortForm.test.ts
+++ b/tests/patterns/shortForm.test.ts
@@ -262,8 +262,8 @@ describe("SHORT_FORM_CASE_PATTERN", () => {
 })
 
 describe("SHORT_FORM_PATTERNS array", () => {
-  it("should export all five patterns", () => {
-    expect(SHORT_FORM_PATTERNS).toHaveLength(5)
+  it("should export all six patterns", () => {
+    expect(SHORT_FORM_PATTERNS).toHaveLength(6)
     expect(SHORT_FORM_PATTERNS).toContain(ID_PATTERN)
     expect(SHORT_FORM_PATTERNS).toContain(IBID_PATTERN)
     expect(SHORT_FORM_PATTERNS).toContain(SUPRA_PATTERN)


### PR DESCRIPTION
## Summary

- Fixes #306 — `[supra]`, `[supra, 705]`, `[supra at 78-82]`, and `State v. Jarzbek, [supra, 705]` now tokenize
- New `BRACKETED_SUPRA_PATTERN` + `extractSupra` fast-path branch
- 4 new tests; 90 net source/test lines
- Connecticut Supreme/Appellate uses this convention; systematic recall gap

## Root cause

The existing `SUPRA_PATTERN` requires bare `supra` with no surrounding brackets. Connecticut state opinions enclose `supra` in square brackets when nested in a string-cite or quotation. All bracketed forms were silently dropped.

| Input | Before | After |
|---|---|---|
| `State v. Jarzbek, [supra, 705]` | `[]` | `partyName: \"State v. Jarzbek\", pincite: 705` |
| `State v. Jarzbek, [supra]` | `[]` | `partyName: \"State v. Jarzbek\"`, no pincite |
| `[supra at 78-82]` | `[]` | `pincite: 78` (range start) |
| `Smith, supra, at 100` (canonical) | unchanged | unchanged |

## Fix

Added new tokenizer pattern in `src/patterns/shortForm.ts`:

```regex
(?:\b([A-Z]...)\s*,?\s+)?\[supra(?:(?:,\s+|\s+at\s+(?:pp?\.\s*)?)(\d+(?:[-–—]\d+)?))?\]
```

- Group 1: party name (optional — undefined for the bare standalone form)
- Group 2: pincite (optional, accepts both `, N` and ` at N` forms plus range `N-M`)

The comma-pincite shape `[supra, 705]` deliberately accepts no `at` before the page — that's the Connecticut convention.

`extractSupra` adds a fast-path branch that recognizes bracketed token text (`text.includes(\"[supra\")`) and parses it through the new regex. Falls through to the canonical `partySupraRegex` for non-bracketed forms — zero impact on existing supra extraction.

## Files changed

- `src/patterns/shortForm.ts` — `BRACKETED_SUPRA_PATTERN` + added to `SHORT_FORM_PATTERNS` array + new entry in `shortFormPatterns` Pattern[] array
- `src/extract/extractShortForms.ts` — `bracketedSupraRegex` + new branch in result-construction
- `tests/extract/extractShortForms.test.ts` — 4 new tests
- `tests/patterns/shortForm.test.ts` — pattern-count test updated 5 → 6
- `.changeset/issue-306-bracketed-supra.md`

## Test plan

- [x] 4 new tests under `bracketed [supra] forms (#306)`:
  - `State v. Jarzbek, [supra, 705]` → party + pincite
  - `State v. Jarzbek, [supra]` → party only
  - `[supra at 78-82]` → range pincite
  - Regression: canonical `Smith, supra, at 100` still works
- [x] Pattern-count test in `tests/patterns/shortForm.test.ts` updated 5 → 6
- [x] Full suite — 2448/2457 pass, 0 regressions
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)