### PR TITLE
fix: preserve v punctuation fidelity in caseName — NY style v, vs. variant (#326)

### DIFF
--- a/.changeset/issue-326-v-punctuation-fidelity.md
+++ b/.changeset/issue-326-v-punctuation-fidelity.md
@@ -1,0 +1,59 @@
+---
+"eyecite-ts": patch
+---
+
+fix: preserve `v` punctuation fidelity in `caseName` — NY-style `v` (no period) and `vs.` variant (#326)
+
+`Rocovich v Consolidated Edison Co., 78 N.Y.2d 509` previously produced
+`caseName: "Rocovich v. Consolidated Edison Co."` — the extractor was
+silently adding a period to the NY-court `v` separator. The same
+happened to `Romano v Hotel Carlyle Owners Corp.`. New York courts use
+`v` without a period as the canonical form; rewriting it as `v.` breaks
+round-trip fidelity and NY court records search compatibility.
+
+### Fix
+
+Two changes in `src/extract/extractCase.ts`:
+
+1. **`extractCaseName` (`v.` capture site, line 1335)** — replaced the
+   hardcoded `${plaintiff} v. ${defendantText}` with a captured
+   separator from the regex match:
+
+   ```
+   const sepMatch = /\bvs?\.?(?=\s)/.exec(vMatch[0])
+   const sep = sepMatch?.[0] ?? "v."
+   ```
+
+   The matched separator (`v`, `v.`, `vs`, or `vs.`) is whichever form
+   appeared in the source.
+
+2. **`extractCase`'s caseName rebuild site (line ~2688)** — when
+   `extractPartyNames` modifies the plaintiff (signal-strip, transition-
+   word-strip, etc.), the rebuilt caseName now preserves whichever `v`
+   form was already in the existing caseName, detected via
+   `/\s+(vs?\.?)\s+/.exec(caseName)`.
+
+### Companion fix — internal `vRegex` consistency
+
+The `extractPartyNames` internal regex for splitting plaintiff/defendant
+on `v` (`/\s+v\.?\s+/i`) didn't accept the `vs?` variant. Before #326,
+the case-name rebuild always normalized to `v.`, so the inconsistency
+was masked. With `vs.` and `v` now preserved in `caseName`, the
+internal regex needed updating to match the same alternation
+(`/\s+vs?\.?\s+/i`). Applied to all five internal regex sites in the
+file. Without this, `Smith vs. Jones, 500 F.2d 123` would extract
+`caseName: "Smith vs. Jones"` correctly but leave `plaintiff` and
+`defendant` undefined.
+
+### Tests
+
+5 new tests under `\`v\` punctuation fidelity in caseName (#326)` in
+`tests/extract/extractCase.test.ts`:
+
+- `Rocovich v Consolidated Edison Co.` → NY `v` preserved
+- `Romano v Hotel Carlyle Owners Corp.` → NY `v` preserved
+- `Smith v. Jones` → federal `v.` preserved
+- `Smith vs. Jones` → `vs.` preserved; plaintiff/defendant captured
+- `In re K.F.` → no `v` at all, unchanged
+
+Full 2468-test suite passes; no regressions.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1324,7 +1324,15 @@ export function extractCaseName(
         }
       }
 
-      const caseName = `${plaintiff} v. ${defendantText}`
+      // Preserve the source's `v` punctuation form in `caseName`. New York
+      // courts use `v` (no period); federal/most state courts use `v.`. The
+      // existing V_CASE_NAME_REGEX accepts both via `v(?:s)?\.?` — extract
+      // whichever form actually appears in the matched text so the
+      // assembled caseName is faithful to the source. #326
+      const sepMatch = /\bvs?\.?(?=\s)/.exec(vMatch[0])
+      const sep = sepMatch?.[0] ?? "v."
+
+      const caseName = `${plaintiff} ${sep} ${defendantText}`
       const nameStart = adjustedSearchStart + vMatch.index + trimOffset
       // vMatch[3] = optional court text from the CSM year-first paren
       // (`Smith v. Jones (2d Cir. 2005)` — #293); vMatch[4] = the year
@@ -1971,10 +1979,10 @@ export function extractPartyNames(caseName: string): {
       const subject = match[2]
 
       // Check if there's a "v." after the prefix (adversarial case)
-      if (/\s+v\.?\s+/i.test(subject)) {
+      if (/\s+vs?\.?\s+/i.test(subject)) {
         // Adversarial case with procedural-looking plaintiff (e.g., "Estate of X v. Y")
         // Split on "v."
-        const vMatch = /^(.+?)\s+v\.?\s+(.+)$/i.exec(caseName)
+        const vMatch = /^(.+?)\s+vs?\.?\s+(.+)$/i.exec(caseName)
         if (vMatch) {
           const plaintiff = vMatch[1].trim()
           const defendant = vMatch[2].trim()
@@ -1997,7 +2005,7 @@ export function extractPartyNames(caseName: string): {
   }
 
   // Split on "v." for adversarial cases
-  const vRegex = /^(.+?)\s+v\.?\s+(.+)$/i
+  const vRegex = /^(.+?)\s+vs?\.?\s+(.+)$/i
   const vMatch = vRegex.exec(caseName)
   if (vMatch) {
     let plaintiff = vMatch[1].trim()
@@ -2677,13 +2685,18 @@ export function extractCase(
     // visible to consumers even though it's stripped off the `defendant` field.
     if (plaintiff && defendant) {
       const adminSuffix = adminParenthetical ? ` (${adminParenthetical})` : ""
-      const rebuiltName = `${plaintiff} v. ${defendant}${adminSuffix}`
+      // Preserve the source's `v` punctuation form when rebuilding (#326).
+      // The existing caseName already carries the right separator (set by
+      // extractCaseName / V_CASE_NAME_REGEX); detect it and reuse.
+      const existingSepMatch = caseName ? /\s+(vs?\.?)\s+/.exec(caseName) : null
+      const rebuildSep = existingSepMatch?.[1] ?? "v."
+      const rebuiltName = `${plaintiff} ${rebuildSep} ${defendant}${adminSuffix}`
       if (rebuiltName !== caseName && fullSpan && cleanedText) {
         caseName = rebuiltName
 
         // Advance fullSpan.cleanStart to where the plaintiff actually starts
         const prefixRegion = cleanedText.substring(fullSpan.cleanStart, span.cleanStart)
-        const vSep = /\s+v\.?\s+/i.exec(prefixRegion)
+        const vSep = /\s+vs?\.?\s+/i.exec(prefixRegion)
         if (vSep) {
           const beforeV = prefixRegion.substring(0, vSep.index)
           const pIdx = beforeV.lastIndexOf(plaintiff)
@@ -2719,7 +2732,7 @@ export function extractCase(
     if (plaintiff && caseNameResult && cleanedText) {
       const nameAnchor = fullSpan?.cleanStart ?? caseNameResult.nameStart
       const searchRegion = cleanedText.substring(nameAnchor, span.cleanStart)
-      const vSepMatch = /\s+v\.?\s+/i.exec(searchRegion)
+      const vSepMatch = /\s+vs?\.?\s+/i.exec(searchRegion)
       if (vSepMatch) {
         // Plaintiff: search only in the region before "v."
         const plaintiffRegion = searchRegion.substring(0, vSepMatch.index)

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5845,4 +5845,53 @@ describe("plaintiff field over-capture — transition words + sentence-paren bou
   })
 })
 
+describe("`v` punctuation fidelity in caseName (#326)", () => {
+  it("preserves NY-style `v` (no period) in caseName", () => {
+    const cases = extractCitations("Rocovich v Consolidated Edison Co., 78 N.Y.2d 509").filter(
+      (c) => c.type === "case",
+    )
+    if (cases[0]?.type === "case") {
+      expect(cases[0].caseName).toBe("Rocovich v Consolidated Edison Co.")
+    }
+  })
+
+  it("preserves NY-style `v` on second example", () => {
+    const cases = extractCitations(
+      "Romano v Hotel Carlyle Owners Corp., 19 N.Y.2d 1",
+    ).filter((c) => c.type === "case")
+    if (cases[0]?.type === "case") {
+      expect(cases[0].caseName).toBe("Romano v Hotel Carlyle Owners Corp.")
+    }
+  })
+
+  it("regression: federal `v.` (with period) still preserved", () => {
+    const cases = extractCitations("Smith v. Jones, 100 F.3d 1 (1990)").filter(
+      (c) => c.type === "case",
+    )
+    if (cases[0]?.type === "case") {
+      expect(cases[0].caseName).toBe("Smith v. Jones")
+    }
+  })
+
+  it("regression: `vs.` variant preserved in caseName", () => {
+    const cases = extractCitations("Smith vs. Jones, 500 F.2d 123 (2020)").filter(
+      (c) => c.type === "case",
+    )
+    if (cases[0]?.type === "case") {
+      expect(cases[0].plaintiff).toBe("Smith")
+      expect(cases[0].defendant).toBe("Jones")
+      expect(cases[0].caseName).toBe("Smith vs. Jones")
+    }
+  })
+
+  it("regression: `In re K.F.` (no v at all) unchanged", () => {
+    const cases = extractCitations("In re K.F., 173 Cal.App.4th 655 (2009).").filter(
+      (c) => c.type === "case",
+    )
+    if (cases[0]?.type === "case") {
+      expect(cases[0].caseName).toBe("In re K.F.")
+    }
+  })
+})
+
 


### PR DESCRIPTION
## Summary

- Fixes #326 — `caseName` now preserves the source's `v` punctuation: NY-court `v` (no period), federal/most state `v.`, and `vs.` variant all kept verbatim instead of normalized
- 5 new tests; 128 net source/test lines; 0 regressions

## Root cause

Two hardcoded `v.` strings in caseName construction:

1. `extractCaseName` assembled `caseName` as `\${plaintiff} v. \${defendantText}` (line 1335), ignoring what was actually in the source.
2. `extractCase`'s rebuild path (line ~2688), which fires when `extractPartyNames` strips signal words from the plaintiff, also hardcoded `v.`.

| Input | Before | After |
|---|---|---|
| `Rocovich v Consolidated Edison Co., 78 N.Y.2d 509` | `caseName: \"Rocovich v. Consolidated Edison Co.\"` | `caseName: \"Rocovich v Consolidated Edison Co.\"` |
| `Romano v Hotel Carlyle Owners Corp.` | normalized to `v.` | preserved as `v` |
| `Smith v. Jones, 100 F.3d 1` (federal) | unchanged | unchanged |
| `Smith vs. Jones, 500 F.2d 123` | `caseName: \"Smith vs. Jones\"` but plaintiff/defendant undefined | full extraction works |
| `In re K.F.` (no `v`) | unchanged | unchanged |

## Fix

In `src/extract/extractCase.ts`:

- **`extractCaseName`** now extracts the separator from `vMatch[0]` with `/\bvs?\.?(?=\s)/` and uses the captured literal (`v`, `v.`, `vs`, `vs.`) in the assembled caseName.
- **`extractCase` rebuild** now detects the existing separator in `caseName` via `/\s+(vs?\.?)\s+/` and reuses it.

### Companion fix — internal regex consistency

The `extractPartyNames` internal regex for splitting plaintiff/defendant on `v` (`/\s+v\.?\s+/i`) didn't accept the `vs?` variant. Before this PR, the rebuild always normalized to `v.`, masking the inconsistency. With `vs.` and `v` now preserved in `caseName`, the internal regex needed updating to match the same alternation. Applied to **all five** internal `\s+v\.?\s+` sites in the file → `\s+vs?\.?\s+`. Without this, `Smith vs. Jones, 500 F.2d 123` would have `caseName: \"Smith vs. Jones\"` correct but leave `plaintiff` / `defendant` undefined.

## Files changed

- `src/extract/extractCase.ts` — 2 caseName construction sites + 5 internal-regex sites
- `tests/extract/extractCase.test.ts` — 5 new tests
- `.changeset/issue-326-v-punctuation-fidelity.md`

## Test plan

- [x] 5 new tests under `\`v\` punctuation fidelity in caseName (#326)`:
  - 2 NY `v` (Rocovich, Romano)
  - Federal `v.` regression
  - `Smith vs. Jones` — `caseName` + plaintiff/defendant all captured correctly
  - `In re K.F.` regression
- [x] Full suite — 2468/2477 pass, 0 regressions
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)