### PR TITLE
fix: ILCS trailing sentence period no longer absorbed into section (#331)

### DIFF
--- a/.changeset/issue-331-ilcs-trailing-period.md
+++ b/.changeset/issue-331-ilcs-trailing-period.md
@@ -1,0 +1,54 @@
+---
+"eyecite-ts": patch
+---
+
+fix: ILCS trailing sentence period no longer absorbed into section (#331)
+
+Modern Illinois Compiled Statutes (ILCS) citations that end a sentence
+were leaving the period attached to the `section` field:
+
+```
+"See 5 ILCS 100/1-1." → section: "1-1."   (was; should be "1-1")
+"See 225 ILCS 60/22." → section: "22."    (was; should be "22")
+```
+
+This is the same anti-pattern fixed for other section bodies in #283,
+applied to the `chapter-act` family.
+
+### Fix
+
+Both the tokenizer pattern (`chapter-act` in
+`src/patterns/statutePatterns.ts`) and the extractor's anchored re-match
+regex (`CHAPTER_ACT_RE` in `src/extract/statutes/extractChapterAct.ts`)
+now use the period-followed-by-alphanumeric guard for the section body:
+
+```
+\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?
+```
+
+A period is consumed only when followed by an alphanumeric (preserving
+internal decimal sections such as `1-1.5`); a trailing sentence period
+is left for the surrounding prose.
+
+### Field mapping clarification
+
+The issue also reported that "chapter is lost." It is not — the chapter
+has always been emitted on the `title` field on the extracted
+`StatuteCitation` (e.g., `750 ILCS 36/305(b)` → `title: 750`,
+`code: "36"`, `section: "305"`, `subsection: "(b)"`). The act number
+sits in `code`. These field names predate the issue and are kept for
+backward compatibility.
+
+### Tests
+
+6 new tests under `ILCS trailing-period absorption (#331)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `5 ILCS 100/1-1.` — trailing period stripped from hyphenated section
+- `225 ILCS 60/22.` — trailing period stripped from bare-numeric section
+- `735 ILCS 5/2-1001.` — trailing period stripped from canonical-shape section
+- `750 ILCS 36/305(b).` — subsection preserved, trailing period stripped
+- `820 ILCS 405/1100 et seq.` — `hasEtSeq` set, trailing period not absorbed
+- `5 ILCS 100/1-1.5` — internal decimal period preserved (regression guard)
+
+Full 2485-test suite passes; no regressions.

--- a/src/extract/statutes/extractChapterAct.ts
+++ b/src/extract/statutes/extractChapterAct.ts
@@ -13,8 +13,17 @@ import type { StatuteComponentSpans } from "@/types/componentSpans"
 import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
 import { parseBody } from "./parseBody"
 
-/** Parse chapter-act token: chapter + ILCS + act/section */
-const CHAPTER_ACT_RE = /^(\d+)\s+(?:ILCS|Ill\.?\s*Comp\.?\s*Stat\.?)\s*(?:Ann\.?\s+)?(\d+)\/(.+)$/d
+/**
+ * Parse chapter-act token: chapter + ILCS + act/section.
+ *
+ * Section body uses the period-followed-by-alphanumeric guard from #283:
+ * a trailing sentence period is not absorbed (`5 ILCS 100/1-1.` → `1-1`,
+ * not `1-1.`; #331). The body must mirror the tokenizer regex in
+ * `statutePatterns.ts` so that the extractor's anchored re-match consumes
+ * the same span the tokenizer captured.
+ */
+const CHAPTER_ACT_RE =
+  /^(\d+)\s+(?:ILCS|Ill\.?\s*Comp\.?\s*Stat\.?)\s*(?:Ann\.?\s+)?(\d+)\/(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
 
 export function extractChapterAct(
   token: Token,

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -73,8 +73,14 @@ export const statutePatterns: Pattern[] = [
     id: "chapter-act",
     // IL: "735 ILCS 5/2-1001" or "735 Ill. Comp. Stat. 5/2-1001"
     // Captures: (1) chapter, (2) act, (3) section+subsections+et seq
+    //
+    // Section body: digits then alphanumeric/colon/slash/hyphen OR
+    // period-followed-by-alphanumeric (lookahead). The period guard
+    // prevents sentence-ending punctuation from being absorbed into
+    // the section field (`5 ILCS 100/1-1.` → section "1-1", not "1-1.";
+    // #283 / #331).
     regex:
-      /\b(\d+)\s+(?:ILCS|Ill\.?\s*Comp\.?\s*Stat\.?)\s*(?:Ann\.?\s+)?(\d+)\/([^\s(]+(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(\d+)\s+(?:ILCS|Ill\.?\s*Comp\.?\s*Stat\.?)\s*(?:Ann\.?\s+)?(\d+)\/(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
     description: 'Illinois Compiled Statutes chapter-act citations (e.g., "735 ILCS 5/2-1001")',
     type: "statute",
   },

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -888,4 +888,75 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("ILCS trailing-period absorption (#331)", () => {
+    it("strips trailing sentence period: `5 ILCS 100/1-1.`", () => {
+      const cites = extractCitations("See 5 ILCS 100/1-1.").filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(5)
+        expect(cites[0].code).toBe("100")
+        expect(cites[0].section).toBe("1-1")
+        expect(cites[0].matchedText).toBe("5 ILCS 100/1-1")
+        expect(cites[0].jurisdiction).toBe("IL")
+      }
+    })
+
+    it("strips trailing period from bare-numeric section: `225 ILCS 60/22.`", () => {
+      const cites = extractCitations("See 225 ILCS 60/22.").filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(225)
+        expect(cites[0].code).toBe("60")
+        expect(cites[0].section).toBe("22")
+      }
+    })
+
+    it("strips trailing period from hyphenated section: `735 ILCS 5/2-1001.`", () => {
+      const cites = extractCitations("See 735 ILCS 5/2-1001.").filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(735)
+        expect(cites[0].code).toBe("5")
+        expect(cites[0].section).toBe("2-1001")
+      }
+    })
+
+    it("preserves subsection while stripping sentence period: `750 ILCS 36/305(b).`", () => {
+      const cites = extractCitations("See 750 ILCS 36/305(b).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(750)
+        expect(cites[0].code).toBe("36")
+        expect(cites[0].section).toBe("305")
+        expect(cites[0].subsection).toBe("(b)")
+      }
+    })
+
+    it("captures et seq. without absorbing sentence period: `820 ILCS 405/1100 et seq.`", () => {
+      const cites = extractCitations("See 820 ILCS 405/1100 et seq.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(820)
+        expect(cites[0].code).toBe("405")
+        expect(cites[0].section).toBe("1100")
+        expect(cites[0].hasEtSeq).toBe(true)
+      }
+    })
+
+    it("retains internal period inside decimal section: `5 ILCS 100/1-1.5`", () => {
+      const cites = extractCitations("See 5 ILCS 100/1-1.5 governs.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(5)
+        expect(cites[0].section).toBe("1-1.5")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #331. Modern Illinois Compiled Statutes (ILCS) citations that end a sentence were leaving the trailing period attached to the `section` field — same anti-pattern as #283, applied to the `chapter-act` family.

- Tokenizer (`src/patterns/statutePatterns.ts`) and extractor (`src/extract/statutes/extractChapterAct.ts`) now use the `\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*` period-guard on the section body.
- A trailing sentence period is left for the surrounding prose; internal decimal sections (`1-1.5`) remain intact.
- The companion claim that the **chapter** was being dropped is **not** a real defect — the chapter has always been emitted on the `title` field on the extracted citation. Field-name reshuffling is deferred for backward compatibility (kept in the changeset notes).

## Test plan

- [x] `pnpm exec tsx scripts/repro_331.ts` — all five cases strip the trailing period and preserve subsections / `et seq.`
- [x] 6 new tests under `ILCS trailing-period absorption (#331)` in `tests/extract/extractStatute.test.ts`
- [x] Full vitest suite — 2485 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)