### PR TITLE
fix: suppress phantom case citation for Illinois Supreme Court Rules (#332)

### DIFF
--- a/.changeset/issue-332-ill-rule-misclassification.md
+++ b/.changeset/issue-332-ill-rule-misclassification.md
@@ -1,0 +1,54 @@
+---
+"eyecite-ts": patch
+---
+
+fix: suppress phantom case citation for `vol Ill. 2d R. ruleNum` (#332)
+
+Illinois Supreme Court Rules are cited as `177 Ill. 2d R. 234`
+(volume + reporter + `R.` + rule number). The state-reporter
+tokenizer pattern's lazy reporter capture was absorbing ` R.` into
+the reporter (yielding `reporter: "Ill.2d R."`, `page: 234`) and
+emitting a phantom case citation for a non-existent case.
+
+### Fix
+
+Add a negative lookahead `(?! R\.\s+\d)` to the inner loop of the
+`state-reporter` pattern in `src/patterns/casePatterns.ts`. When the
+lazy reporter expansion would consume ` R.` followed by a digit, the
+lookahead fires, the whole match fails, and the input is left
+untokenized.
+
+Resulting behavior on `177 Ill. 2d R. 234`:
+
+```
+before: { type: "case", volume: 177, reporter: "Ill.2d R.", page: 234 }
+after:  (no citation emitted)
+```
+
+### Scope
+
+This is the minimum fix that removes the wrong output. Producing a
+typed rule citation (`type: "rule"` with `ruleSet` / `rule` fields) is
+a larger feature — it requires a new citation type in the discriminated
+union and isn't done here. Suppressing the false positive is strictly
+better than emitting a wrong one downstream.
+
+Other Illinois rule forms outside the canonical `vol Ill. (2d )?R. num`
+shape (`Ill. R. Evid. 403`, `Ill. R. App. P. 5`, `Sup. Ct. R. 137`) are
+left for a follow-up — they either don't tokenize as cases today or
+need their own pattern.
+
+### Tests
+
+7 new tests under `Illinois rule-marker boundary in state-reporter
+pattern (#332)` in `tests/extract/extractCase.test.ts`:
+
+- `177 Ill. 2d R. 234` → 0 case citations
+- Normalized `177 Ill.2d R. 234` → 0
+- Trailing year-paren `177 Ill. 2d R. 431 (1997)` → 0
+- Older `100 Ill. R. 5` → 0
+- Mixed text: rule suppressed, real `234 Ill. 2d 5` case preserved
+- Regression: real `177 Ill. 2d 1` still emits a case citation
+- Regression: `123 Ill. App. 3d 456` reporter unaffected
+
+Full 2492-test suite passes; no regressions.

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -55,10 +55,18 @@ export const casePatterns: Pattern[] = [
     // reporter body rejects ` at ` so `18 Cal.4th at p. 717` (CSM short-form,
     // #236) doesn't absorb `at p.` into the reporter; the short-form pattern
     // handles it instead.
+    //
+    // ` R.\s+\d` guard (#332): Illinois Supreme Court Rules cite as
+    // `177 Ill. 2d R. 234` (volume + reporter + `R. ruleNum`), which the lazy
+    // reporter capture used to absorb as `Ill. 2d R.` with `page=234`,
+    // emitting a phantom case citation. The lookahead stops the lazy match
+    // before it consumes ` R.` when a digit follows — leaving the input
+    // untokenized rather than misclassified. A typed rule citation is out
+    // of scope; the goal here is to suppress the false positive.
     regex:
-      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?!\s+vs?\.\s)(?!\s+at\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[|\])/g,
+      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?! R\.\s+\d)(?!\s+vs?\.\s)(?!\s+at\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[|\])/g,
     description:
-      'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev", phantom matches across " v. "/" vs. ", and CSM " at " short-form boundaries, validated against reporters-db in Phase 3)',
+      'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev", phantom matches across " v. "/" vs. ", CSM " at " short-form boundaries, and Illinois " R. N" rule-marker boundaries, validated against reporters-db in Phase 3)',
     type: "case",
   },
 ]

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5894,4 +5894,67 @@ describe("`v` punctuation fidelity in caseName (#326)", () => {
   })
 })
 
+describe("Illinois rule-marker boundary in state-reporter pattern (#332)", () => {
+  it("suppresses phantom case citation for `177 Ill. 2d R. 234`", () => {
+    const cases = extractCitations("Per 177 Ill. 2d R. 234, the rule provides.").filter(
+      (c) => c.type === "case",
+    )
+    expect(cases).toHaveLength(0)
+  })
+
+  it("suppresses phantom case citation for normalized `Ill.2d R.` form", () => {
+    const cases = extractCitations("See 177 Ill.2d R. 234.").filter((c) => c.type === "case")
+    expect(cases).toHaveLength(0)
+  })
+
+  it("suppresses phantom even with trailing parenthetical year", () => {
+    const cases = extractCitations("See 177 Ill. 2d R. 431 (1997).").filter(
+      (c) => c.type === "case",
+    )
+    expect(cases).toHaveLength(0)
+  })
+
+  it("suppresses phantom for older `Ill. R. N` form", () => {
+    const cases = extractCitations("Pre-2d edition: 100 Ill. R. 5.").filter(
+      (c) => c.type === "case",
+    )
+    expect(cases).toHaveLength(0)
+  })
+
+  it("regression: real `177 Ill. 2d 1` still extracts as a case", () => {
+    const cases = extractCitations("Smith v. Jones, 177 Ill. 2d 1 (1997).").filter(
+      (c) => c.type === "case",
+    )
+    expect(cases).toHaveLength(1)
+    if (cases[0]?.type === "case") {
+      expect(cases[0].volume).toBe(177)
+      expect(cases[0].reporter).toBe("Ill.2d")
+      expect(cases[0].page).toBe(1)
+    }
+  })
+
+  it("mixed text: rule citation suppressed, real case preserved", () => {
+    const cases = extractCitations(
+      "She cited 177 Ill. 2d R. 137 and Doe v. Roe, 234 Ill. 2d 5.",
+    ).filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    if (cases[0]?.type === "case") {
+      expect(cases[0].volume).toBe(234)
+      expect(cases[0].page).toBe(5)
+    }
+  })
+
+  it("regression: `Ill. App.` reporter unaffected", () => {
+    const cases = extractCitations("123 Ill. App. 3d 456 (1984)").filter(
+      (c) => c.type === "case",
+    )
+    expect(cases).toHaveLength(1)
+    if (cases[0]?.type === "case") {
+      expect(cases[0].volume).toBe(123)
+      // Reporter is post-normalization (`Ill. App. 3d` → `Ill. App.3d`)
+      expect(cases[0].reporter).toBe("Ill. App.3d")
+      expect(cases[0].page).toBe(456)
+    }
+  })
+})
 


### PR DESCRIPTION
## Summary

Fixes #332. Illinois Supreme Court Rules are cited as `177 Ill. 2d R. 234` (volume + reporter + `R.` + rule number). The `state-reporter` tokenizer pattern's lazy reporter capture was absorbing ` R.` into the reporter, yielding a phantom case citation for a non-existent case.

- Adds `(?! R\.\s+\d)` negative lookahead to the inner loop of the state-reporter pattern in `src/patterns/casePatterns.ts`.
- When the lazy reporter expansion would consume ` R.` followed by a digit, the lookahead fires, the match fails, and the input is left untokenized.

### Scope

This is the minimum fix that removes the wrong output. Producing a typed rule citation (`type: "rule"` with `ruleSet` / `rule` fields) is a larger feature — it requires a new citation type in the discriminated union and isn't done here. Suppressing the false positive is strictly better than emitting a wrong one downstream.

Other Illinois rule forms outside the canonical `vol Ill. (2d )?R. num` shape (`Ill. R. Evid. 403`, `Ill. R. App. P. 5`, `Sup. Ct. R. 137`) are left for a follow-up — they either don't tokenize as cases today or would need their own pattern.

## Test plan

- [x] `pnpm exec tsx scripts/repro_332.ts` — all `Ill. 2d R.` cases now emit no citation; real `177 Ill. 2d 1` still works
- [x] 7 new tests under `Illinois rule-marker boundary in state-reporter pattern (#332)`
- [x] Full vitest suite — 2492 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)