### PR TITLE
fix: in-word em-dashes normalize to a single hyphen (#333)

### DIFF
--- a/.changeset/issue-333-emdash-normalization.md
+++ b/.changeset/issue-333-emdash-normalization.md
@@ -1,0 +1,63 @@
+---
+"eyecite-ts": patch
+---
+
+fix: in-word em-dashes normalize to a single hyphen (#333)
+
+Illinois opinions (and OCR'd reporter text more generally) use the
+em-dash character `—` (U+2014) where most jurisdictions use a hyphen.
+The `normalizeDashes` cleaner was rewriting every em-dash to triple
+hyphen (`---`), the blank-page placeholder form. As a result, citations
+like `par. 13—214(a)`, `pars. 8—102, 8—103`, and `at 875—877` were
+contaminated with `---` in the section/pincite body, blocking
+extraction or polluting downstream output.
+
+### Fix
+
+Context-aware substitution in `src/clean/cleaners.ts:normalizeDashes`.
+A new in-word rule runs first:
+
+```
+text.replace(/(?<=\w)[—―](?=\w)/g, "-")
+```
+
+- Between word characters → single hyphen (`13—214` → `13-214`,
+  `84—C—4508` → `84-C-4508` — both em-dashes converted in one pass via
+  zero-width lookbehind/lookahead).
+- Standalone (whitespace on either side) → triple hyphen, preserving
+  the `500 F.4th — (2024)` blank-page placeholder behavior.
+
+Em-dash-to-hyphen is length-preserving (1 codepoint each), so the
+existing transformation map continues to map `originalStart` /
+`originalEnd` 1:1 to the em-dash position in the source text.
+
+### Tests
+
+11 new tests:
+
+`tests/clean/cleanText.test.ts` (6):
+- In-word em-dash between digits → single hyphen
+- In-word em-dash in page range → single hyphen
+- Adjacent em-dashes in docket separators handled in one pass
+- Standalone em-dash → triple hyphen (regression for blank-page form)
+- Mixed input (in-word vs standalone)
+- In-word horizontal bar (U+2015) → hyphen
+
+`tests/extract/extractStatute.test.ts` (5):
+- End-to-end: `par. 13—214(a)` now extracts as `section: "13-214"`,
+  `subsection: "(a)"`
+- Em-dash and hyphen variants produce equivalent statute output
+- Multi-paragraph em-dash form (first paragraph matched)
+- Blank-page em-dash still tokenizes as case with `---`
+- Span check: `originalStart`/`originalEnd` map back to the em-dash
+  position in the source
+
+Full 2503-test suite passes; no regressions.
+
+### Related
+
+Surfaced by a 16-opinion Illinois sample. Companion to #330 (the ILRS
+pattern itself); fixing #330 alone wouldn't help inputs that used the
+canonical Illinois em-dash subdivision form. Page-range pincite capture
+(`at 875—877` extracting both endpoints as a range, not just the first)
+is a separate issue.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -113,13 +113,31 @@ export function removeOcrArtifacts(text: string): string {
 /**
  * Normalize Unicode dashes to ASCII equivalents.
  *
- * En-dash (U+2013) → single hyphen (used in page ranges like 105–107).
- * Em-dash (U+2014) → triple hyphen (used as blank page placeholder in citations
- * like "500 F.4th — (2024)", matching the existing `-{3,}` blank page pattern).
+ * En-dash (U+2013) maps to a single hyphen (page ranges like 105–107).
+ *
+ * Em-dash (U+2014) is context-aware: between word characters (Illinois
+ * Revised Statutes paragraph subdivisions like `par. 13—214`,
+ * docket-number separators like `No. 84—C—4508`, page-range pincites
+ * like `875—877`) it maps to a single hyphen; standalone (the
+ * `500 F.4th — (2024)` blank-page placeholder) it maps to triple
+ * hyphen so the existing `-{3,}` blank-page pattern still matches.
+ *
+ * The in-word substitution runs first with zero-width
+ * lookbehind/lookahead so adjacent em-dashes (`84—C—4508`) are both
+ * rewritten in one pass and don't fall through to the blank-page rule
+ * (#333).
  *
  * @example
  * normalizeDashes("500 F.2d 123, 125–130")  // en-dash in range
  * // => "500 F.2d 123, 125-130"
+ *
+ * @example
+ * normalizeDashes("par. 13—214(a)")  // in-word em-dash (#333)
+ * // => "par. 13-214(a)"
+ *
+ * @example
+ * normalizeDashes("No. 84—C—4508")  // docket separator (#333)
+ * // => "No. 84-C-4508"
  *
  * @example
  * normalizeDashes("500 F.4th — (2024)")  // em-dash blank page
@@ -127,7 +145,8 @@ export function removeOcrArtifacts(text: string): string {
  */
 export function normalizeDashes(text: string): string {
   return text
-    .replace(/[\u2014\u2015]/g, "---") // em-dash, horizontal bar → triple hyphen
+    .replace(/(?<=\w)[\u2014\u2015](?=\w)/g, "-") // in-word em-dash \u2192 hyphen (#333)
+    .replace(/[\u2014\u2015]/g, "---") // standalone em-dash, horizontal bar → triple hyphen
     .replace(/[\u2010\u2012\u2013]/g, "-") // hyphen, figure dash, en-dash → hyphen
 }
 

--- a/tests/clean/cleanText.test.ts
+++ b/tests/clean/cleanText.test.ts
@@ -282,6 +282,34 @@ describe("normalizeDashes (issue #54)", () => {
   it("converts figure dash (U+2012) to ASCII hyphen", () => {
     expect(normalizeDashes("105\u2012107")).toBe("105-107")
   })
+
+  // #333 \u2014 in-word em-dash \u2192 single hyphen (Illinois Revised Statutes
+  // paragraph subdivisions, docket-number separators, page-range pincites)
+  it("converts in-word em-dash between digits to a single hyphen", () => {
+    expect(normalizeDashes("par. 13\u2014214(a)")).toBe("par. 13-214(a)")
+  })
+
+  it("converts in-word em-dash in page range to a single hyphen", () => {
+    expect(normalizeDashes("at 875\u2014877")).toBe("at 875-877")
+  })
+
+  it("converts adjacent em-dashes in docket separators (one pass)", () => {
+    expect(normalizeDashes("No. 84\u2014C\u20144508")).toBe("No. 84-C-4508")
+  })
+
+  it("preserves standalone em-dash (blank-page placeholder) as triple hyphen", () => {
+    expect(normalizeDashes("500 F.4th \u2014 (2024)")).toBe("500 F.4th --- (2024)")
+  })
+
+  it("mixed input: in-word em-dash hyphenated, standalone preserved", () => {
+    expect(
+      normalizeDashes("par. 13\u2014214 and 500 F.4th \u2014 (2024)"),
+    ).toBe("par. 13-214 and 500 F.4th --- (2024)")
+  })
+
+  it("in-word horizontal bar (U+2015) also converts to hyphen", () => {
+    expect(normalizeDashes("13\u2015214")).toBe("13-214")
+  })
 })
 
 describe("normalizeWhitespace — Unicode whitespace (issue #11)", () => {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -959,4 +959,71 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("em-dash subdivision in paragraph numbers (#333)", () => {
+    it("extracts Ill. Rev. Stat. paragraph with in-word em-dash subdivision", () => {
+      const cites = extractCitations(
+        "violates Ill. Rev. Stat. 1983, ch. 110, par. 13—214(a).",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(110)
+        expect(cites[0].section).toBe("13-214")
+        expect(cites[0].subsection).toBe("(a)")
+        expect(cites[0].year).toBe(1983)
+      }
+    })
+
+    it("extracts equivalent output for em-dash and hyphen variants", () => {
+      const emDash = extractCitations(
+        "Ill. Rev. Stat. 1983, ch. 110, par. 13—214(a).",
+      ).filter((c) => c.type === "statute")
+      const hyphen = extractCitations(
+        "Ill. Rev. Stat. 1983, ch. 110, par. 13-214(a).",
+      ).filter((c) => c.type === "statute")
+      expect(emDash).toHaveLength(1)
+      expect(hyphen).toHaveLength(1)
+      if (emDash[0]?.type === "statute" && hyphen[0]?.type === "statute") {
+        expect(emDash[0].section).toBe(hyphen[0].section)
+        expect(emDash[0].subsection).toBe(hyphen[0].subsection)
+        expect(emDash[0].title).toBe(hyphen[0].title)
+      }
+    })
+
+    it("extracts multi-paragraph em-dash form (first paragraph only)", () => {
+      const cites = extractCitations(
+        "See Ill. Rev. Stat. 1987, ch. 85, pars. 8—102, 8—103.",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(85)
+        expect(cites[0].section).toBe("8-102")
+      }
+    })
+
+    it("regression: blank-page em-dash still tokenizes as case with `---`", () => {
+      const cites = extractCitations("See Jones v. Doe, 500 F.4th — (2024).").filter(
+        (c) => c.type === "case",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "case") {
+        expect(cites[0].matchedText).toContain("---")
+      }
+    })
+
+    it("originalStart/originalEnd map back to the em-dash position in the source", () => {
+      const text = "violates Ill. Rev. Stat. 1983, ch. 110, par. 13—214(a)."
+      const cites = extractCitations(text).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        const slice = text.slice(cites[0].span.originalStart, cites[0].span.originalEnd)
+        // Source still contains em-dash; matchedText is the cleaned hyphen form.
+        expect(slice).toContain("—")
+        expect(cites[0].matchedText).toContain("13-214")
+        // Em-dash → hyphen is length-preserving, so clean/original spans match.
+        expect(cites[0].span.originalStart).toBe(cites[0].span.cleanStart)
+        expect(cites[0].span.originalEnd).toBe(cites[0].span.cleanEnd)
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #333. The `normalizeDashes` cleaner was rewriting every em-dash (`—`, U+2014) to triple hyphen (`---`), the blank-page placeholder shape. This contaminated Illinois statute paragraph subdivisions (`par. 13—214`), docket-number separators (`No. 84—C—4508`), and page-range pincites (`at 875—877`), so the extracted `section`/`pincite` fields carried `---` instead of `-` or didn't extract at all.

### Fix

Context-aware substitution in `src/clean/cleaners.ts:normalizeDashes`. A new in-word rule runs first:

```
text.replace(/(?<=\w)[—―](?=\w)/g, "-")
```

- Between word characters → single hyphen (`13—214` → `13-214`, `84—C—4508` → `84-C-4508` — both em-dashes converted in one pass via zero-width lookbehind/lookahead).
- Standalone (whitespace on either side) → triple hyphen, preserving the `500 F.4th — (2024)` blank-page placeholder.

Em-dash → hyphen is length-preserving, so `originalStart`/`originalEnd` continue to map 1:1 back to the em-dash position in the source text.

## Test plan

- [x] `pnpm exec tsx scripts/repro_333.ts` — ILRS w/ em-dash extracts as `section: "13-214"`; blank-page form still produces `---`
- [x] 6 new `normalizeDashes` unit tests + 5 new end-to-end statute tests
- [x] Span check confirms `originalStart`/`originalEnd` map to the em-dash position in the source
- [x] Full vitest suite — 2503 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)