### PR TITLE
fix: state constitution prefix preserved on no-space `Pa.Const.` form (#329)

### DIFF
--- a/.changeset/issue-329-const-state-prefix.md
+++ b/.changeset/issue-329-const-state-prefix.md
@@ -1,0 +1,55 @@
+---
+"eyecite-ts": patch
+---
+
+fix: state constitution prefix preserved on no-space `Pa.Const.` form (#329)
+
+When a state constitutional citation used the abbreviated form with no
+space between the state prefix and `Const.` — `Pa.Const. art. VIII, § 4`,
+`Cal.Const. art. I, § 6`, `N.Y.Const. art. III` — the `state-constitution`
+tokenizer pattern required a whitespace separator and didn't match. The
+input fell through to `bare-constitution`, producing `matchedText: "Const.
+art. VIII, § 4"` with `jurisdiction: undefined`. The jurisdictional
+attribution was silently dropped, even though it was present in the source.
+
+### Fix
+
+Two surface-level updates:
+
+1. **Pattern** (`src/patterns/constitutionalPatterns.ts`): the separator
+   between the state abbreviation and `Const.` is now `(?:\.\s*|\s+)` —
+   either `.` followed by 0+ whitespace, OR 1+ whitespace. Both forms
+   require a separator, so `PaConst.` (no `.` and no space) still does
+   not match, preventing word-glue false positives from any word
+   starting with a state-abbreviation stem.
+
+2. **Extractor** (`src/extract/extractConstitutional.ts`):
+   `STATE_PREFIX_RE` now uses `\.?\s*Const` instead of `\.?\s+Const`,
+   so the prefix is captured from `Pa.Const.` and `N.Y.Const.` the same
+   way as from `Pa. Const.` / `N.Y. Const.`. `resolveStateJurisdiction`
+   already strips spaces and dots before lookup, so jurisdiction
+   resolution is unchanged downstream.
+
+### Tests
+
+7 new tests:
+
+`tests/patterns/constitutionalPatterns.test.ts` (4):
+- `Pa.Const. art. VIII, § 4` matches state-constitution
+- `Cal.Const. art. I, § 6` matches state-constitution
+- `N.Y.Const. art. III` (multi-part) matches state-constitution
+- `PaConst.` (no separator at all) does NOT match — false-positive guard
+
+`tests/extract/extractConstitutional.test.ts` (3):
+- `Pa.Const.` → `jurisdiction: "PA"`, `article: 8`, `section: "4"`
+- `Cal.Const.` → `jurisdiction: "CA"`
+- `N.Y.Const.` → `jurisdiction: "NY"`, `article: 3`
+
+Full 2510-test suite passes; existing spaced and `U.S. Const.` forms
+unchanged.
+
+### Related
+
+Surfaced by a 200-opinion modern sweep. Other constitutional-citation
+coverage gaps (bare `Eighth Amendment` prose form, populated `document`
+field on the output) are tracked as separate issues.

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -121,8 +121,16 @@ const STATE_ABBREV_TO_CODE: Record<string, string> = {
 
 const IS_AMENDMENT_RE = /amend|amdt/i
 
-/** Regex to extract the state abbreviation prefix from state-constitution tokens */
-const STATE_PREFIX_RE = /^([A-Za-z]+(?:\.\s*[A-Za-z]+)?(?:\.\s*[A-Za-z]+)?)\.?\s+Const/i
+/**
+ * Regex to extract the state abbreviation prefix from state-constitution tokens.
+ *
+ * Trailing `\.?\s*Const` (rather than `\.?\s+Const`) accepts both the
+ * canonical spaced form (`Pa. Const.`) and the abbreviated no-space form
+ * (`Pa.Const.`, `N.Y.Const.`) introduced in #329. The greedy `[A-Za-z]+`
+ * still backtracks correctly so the prefix capture stops at the state
+ * abbreviation rather than swallowing `Const`.
+ */
+const STATE_PREFIX_RE = /^([A-Za-z]+(?:\.\s*[A-Za-z]+)?(?:\.\s*[A-Za-z]+)?)\.?\s*Const/i
 
 /**
  * Resolve state abbreviation from token text to 2-letter code.

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -37,12 +37,17 @@ export const constitutionalPatterns: Pattern[] = [
   },
   {
     id: "state-constitution",
+    // Separator between state abbrev and `Const.` uses `(?:\.\s*|\s+)`:
+    // accepts canonical `Pa. Const.`, abbreviated no-space `Pa.Const.`
+    // (#329), and bare-space `Pa Const.`. The `.` branch requires a dot
+    // (forces a separator), so `PaConst.` does not match — avoids false
+    // positives from words that happen to start with a state stem.
     regex: new RegExp(
-      String.raw`\b(?:Ala|Alaska|Ariz|Ark|Cal(?:if)?|Colo|Conn|Del|Fla|Ga|Haw|Idaho|Ill|Ind|Iowa|Kan|Ky|La|Me|Md|Mass|Mich|Minn|Miss|Mo|Mont|Neb|Nev|N\.?\s*H|N\.?\s*J|N\.?\s*M|N\.?\s*Y|N\.?\s*C|N\.?\s*D|Ohio|Okla|Or(?:e)?|Pa|R\.?\s*I|S\.?\s*C|S\.?\s*D|Tenn|Tex|Utah|Vt|W\.?\s*Va|Va|Wash|Wis|Wyo)\.?\s+Const\.?,?\s+${BODY_TAIL}`,
+      String.raw`\b(?:Ala|Alaska|Ariz|Ark|Cal(?:if)?|Colo|Conn|Del|Fla|Ga|Haw|Idaho|Ill|Ind|Iowa|Kan|Ky|La|Me|Md|Mass|Mich|Minn|Miss|Mo|Mont|Neb|Nev|N\.?\s*H|N\.?\s*J|N\.?\s*M|N\.?\s*Y|N\.?\s*C|N\.?\s*D|Ohio|Okla|Or(?:e)?|Pa|R\.?\s*I|S\.?\s*C|S\.?\s*D|Tenn|Tex|Utah|Vt|W\.?\s*Va|Va|Wash|Wis|Wyo)(?:\.\s*|\s+)Const\.?,?\s+${BODY_TAIL}`,
       "gi",
     ),
     description:
-      'State constitution citations (e.g., "Cal. Const. art. I, § 7", "N.Y. Const. art. VI, § 20")',
+      'State constitution citations (e.g., "Cal. Const. art. I, § 7", "N.Y. Const. art. VI, § 20", "Pa.Const. art. VIII, § 4")',
     type: "constitutional",
   },
   {

--- a/tests/extract/extractConstitutional.test.ts
+++ b/tests/extract/extractConstitutional.test.ts
@@ -216,6 +216,43 @@ describe("extractConstitutional", () => {
       expect(citation.article).toBe(1)
       expect(citation.section).toBe("1")
     })
+
+    // #329 — no-space variant: `Pa.Const.`, `Cal.Const.`, `N.Y.Const.`
+    it("extracts no-space `Pa.Const.` with jurisdiction", () => {
+      const token: Token = {
+        text: "Pa.Const. art. VIII, § 4",
+        span: { cleanStart: 0, cleanEnd: 24 },
+        type: "constitutional",
+        patternId: "state-constitution",
+      }
+      const citation = extractConstitutional(token, createIdentityMap())
+      expect(citation.jurisdiction).toBe("PA")
+      expect(citation.article).toBe(8)
+      expect(citation.section).toBe("4")
+    })
+
+    it("extracts no-space `Cal.Const.` with jurisdiction", () => {
+      const token: Token = {
+        text: "Cal.Const. art. I, § 6",
+        span: { cleanStart: 0, cleanEnd: 22 },
+        type: "constitutional",
+        patternId: "state-constitution",
+      }
+      const citation = extractConstitutional(token, createIdentityMap())
+      expect(citation.jurisdiction).toBe("CA")
+    })
+
+    it("extracts no-space `N.Y.Const.` (multi-part) with jurisdiction", () => {
+      const token: Token = {
+        text: "N.Y.Const. art. III",
+        span: { cleanStart: 0, cleanEnd: 19 },
+        type: "constitutional",
+        patternId: "state-constitution",
+      }
+      const citation = extractConstitutional(token, createIdentityMap())
+      expect(citation.jurisdiction).toBe("NY")
+      expect(citation.article).toBe(3)
+    })
   })
 
   describe("bare constitution", () => {

--- a/tests/patterns/constitutionalPatterns.test.ts
+++ b/tests/patterns/constitutionalPatterns.test.ts
@@ -103,6 +103,30 @@ describe("constitutionalPatterns", () => {
       const matches = findMatches("under Cal. Const. amend. II, § 3")
       expect(matches).toHaveLength(1)
     })
+
+    // #329 — no-space variant: `Pa.Const.`, `Cal.Const.`, `N.Y.Const.`
+    it("matches no-space variant `Pa.Const.`", () => {
+      const matches = findMatches("under Pa.Const. art. VIII, § 4 today")
+      expect(matches.some((m) => m.patternId === "state-constitution")).toBe(true)
+      const m = matches.find((x) => x.patternId === "state-constitution")
+      expect(m?.text).toBe("Pa.Const. art. VIII, § 4")
+    })
+
+    it("matches no-space variant `Cal.Const.`", () => {
+      const matches = findMatches("under Cal.Const. art. I, § 6 today")
+      expect(matches.some((m) => m.patternId === "state-constitution")).toBe(true)
+    })
+
+    it("matches no-space variant `N.Y.Const.` (multi-part abbreviation)", () => {
+      const matches = findMatches("under N.Y.Const. art. III today")
+      expect(matches.some((m) => m.patternId === "state-constitution")).toBe(true)
+    })
+
+    it("does NOT match `PaConst.` (no separator at all)", () => {
+      // Sanity check: requiring `.` or whitespace prevents word-glue false positives.
+      const matches = findMatches("under PaConst. art. VIII, § 4 today")
+      expect(matches.some((m) => m.patternId === "state-constitution")).toBe(false)
+    })
   })
 
   describe("bare-constitution", () => {


### PR DESCRIPTION
## Summary

Fixes #329. When a state constitutional citation used the abbreviated form with no space between the state prefix and `Const.` — `Pa.Const. art. VIII, § 4`, `Cal.Const. art. I, § 6`, `N.Y.Const. art. III` — the `state-constitution` tokenizer pattern required a whitespace separator and didn't match. The input fell through to `bare-constitution`, producing `matchedText: "Const. art. VIII, § 4"` with `jurisdiction: undefined`. The jurisdictional attribution was silently dropped.

### Fix

1. **Pattern** (`src/patterns/constitutionalPatterns.ts`): the separator between the state abbreviation and `Const.` is now `(?:\.\s*|\s+)` — `.` followed by 0+ whitespace, OR 1+ whitespace. Both branches require an actual separator, so `PaConst.` (no `.` and no space) still does not match (false-positive guard).
2. **Extractor** (`src/extract/extractConstitutional.ts`): `STATE_PREFIX_RE` uses `\.?\s*Const` instead of `\.?\s+Const`, so the prefix is captured from `Pa.Const.` / `N.Y.Const.` the same way as from `Pa. Const.` / `N.Y. Const.`.

## Test plan

- [x] Repro: `Pa.Const.` now yields `matchedText: "Pa.Const. art. VIII, § 4"` with `jurisdiction: "PA"`; same for `Cal.Const.` (CA) and `N.Y.Const.` (NY)
- [x] Spaced `Pa. Const.` / `U.S. Const.` forms still work (regression)
- [x] Bare `Const. art.` (no prefix in source) still produces `jurisdiction: undefined`
- [x] `PaConst.` (no separator at all) does NOT match (false-positive guard)
- [x] 7 new tests (4 pattern-level, 3 extractor-level)
- [x] Full vitest suite — 2510 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)