### PR TITLE
fix: short-form case pincite accepts spelled-out `at page` / `at pages` (#344)

### DIFF
--- a/.changeset/issue-344-shortform-at-page.md
+++ b/.changeset/issue-344-shortform-at-page.md
@@ -1,0 +1,57 @@
+---
+"eyecite-ts": patch
+---
+
+fix: short-form case pincite accepts spelled-out `at page` / `at pages` (#344)
+
+Short-form back-references using the full word `at page NNN` (rather
+than the abbreviated `at NNN` or CSM `at p. NNN`) were tokenized as
+`journal` citations instead of `shortFormCase`:
+
+```
+"281 Ala. at page 322" → type: "journal"     (was; should be shortFormCase)
+"38 Ala.App. at page 186" → type: "journal"   (was; should be shortFormCase)
+```
+
+This is an Alabama-style writing convention but appears in other state
+corpora as well. Downstream consumers filtering for `shortFormCase`
+missed the citations entirely; the short-form resolver couldn't link
+them to their full-cite antecedents.
+
+### Fix
+
+Extended the pincite-prefix alternation in both the tokenizer pattern
+and the extractor's anchored re-match regex from `(?:pp?\.\s*)?` to
+`(?:pp?\.\s*|pages?\s+)?`:
+
+- `src/patterns/shortForm.ts` — `SHORT_FORM_CASE_PATTERN`
+- `src/extract/extractShortForms.ts` — internal `shortFormRegex`
+
+Both forms (`page`, `pages`) are now accepted before the digit pincite.
+
+### Scope
+
+Multi-pincite lists (`at pages 261 and 262`) capture the first pincite
+only; the `and 262` is left for the surrounding text. Same as existing
+behavior on hyphen-range pincites. A separate multi-pincite extension
+(beyond `#247`) could pick up the second endpoint as a follow-up.
+
+The same prefix tolerance for `Id. at page` / `Ibid. at page` is
+explicitly out of scope — the issue points to a separate tracking
+ticket for those.
+
+### Tests
+
+6 new tests under `spelled-out at page / at pages pincite prefix
+(#344)` in `tests/extract/extractShortForms.test.ts`:
+
+- `281 Ala. at page 322` → shortFormCase, `pincite: 322`, no journal
+  misclassification
+- `38 Ala.App. at page 186` → shortFormCase, `pincite: 186`
+- `261 Ala. at pages 494` → shortFormCase, `pincite: 494`
+- `252 Ala. at pages 261 and 262` → first pincite captured (list scope
+  out of scope)
+- Regression: abbreviated `at 322` still works
+- Regression: CSM `at p. 717` still works
+
+Full 2516-test suite passes; no regressions.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -405,9 +405,10 @@ export function extractShortFormCase(
   //   4: pincite
   // Party-name capture mirrors SHORT_FORM_CASE_PATTERN: `v.` / `&` / `,`
   // continuations (#301). `In re` prefix intentionally omitted (see
-  // partySupraRegex above for rationale).
+  // partySupraRegex above for rationale). Pincite-prefix alternation also
+  // accepts spelled-out `page` / `pages` (#344).
   const shortFormRegex =
-    /(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
+    /(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*|pages?\s+)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
   const match = shortFormRegex.exec(text)
 
   if (!match) {

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -106,9 +106,15 @@ export const BRACKETED_SUPRA_PATTERN: RegExp =
  *   2: volume
  *   3: reporter
  *   4: pincite
+ *
+ * Pincite prefix also tolerates the spelled-out `page` / `pages` form
+ * (`281 Ala. at page 322`, `38 Ala.App. at pages 186`) common in Alabama
+ * appellate writing (#344). Without this, the input slipped past the
+ * short-form-case pattern and was misclassified as a journal citation by
+ * a later pattern.
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
+  /\b(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*|pages?\s+)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -1216,6 +1216,70 @@ describe("star-pagination pincite (#191)", () => {
       })
     })
   })
+
+  describe("spelled-out `at page` / `at pages` pincite prefix (#344)", () => {
+    it("classifies `281 Ala. at page 322` as short-form case (was misclassified as journal)", () => {
+      const cits = extractCitations("See 281 Ala. at page 322 for the rule.")
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.volume).toBe(281)
+        expect(sf.reporter).toBe("Ala.")
+        expect(sf.pincite).toBe(322)
+      }
+      // No journal misclassification on this input
+      expect(cits.some((c) => c.type === "journal")).toBe(false)
+    })
+
+    it("classifies `38 Ala.App. at page 186` as short-form case", () => {
+      const cits = extractCitations("See 38 Ala.App. at page 186.")
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.volume).toBe(38)
+        expect(sf.reporter).toBe("Ala.App.")
+        expect(sf.pincite).toBe(186)
+      }
+    })
+
+    it("classifies plural `261 Ala. at pages 494` as short-form case", () => {
+      const cits = extractCitations("See 261 Ala. at pages 494.")
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.volume).toBe(261)
+        expect(sf.reporter).toBe("Ala.")
+        expect(sf.pincite).toBe(494)
+      }
+    })
+
+    it("captures first pincite in `at pages 261 and 262` list (multi-pincite list out of scope)", () => {
+      const cits = extractCitations("See 252 Ala. at pages 261 and 262.")
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.pincite).toBe(261)
+      }
+    })
+
+    it("regression: abbreviated `at 322` still works", () => {
+      const cits = extractCitations("See 281 Ala. at 322 for the rule.")
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.pincite).toBe(322)
+      }
+    })
+
+    it("regression: CSM `at p. 717` still works", () => {
+      const cits = extractCitations("See 18 Cal.4th at p. 717.")
+      const sf = cits.find((c) => c.type === "shortFormCase")
+      expect(sf).toBeDefined()
+      if (sf?.type === "shortFormCase") {
+        expect(sf.pincite).toBe(717)
+      }
+    })
+  })
 })
 
 /**


### PR DESCRIPTION
## Summary

Fixes #344. Short-form back-references using `at page NNN` / `at pages NNN` (rather than abbreviated `at NNN` or CSM `at p. NNN`) were tokenized as `journal` citations instead of `shortFormCase`. Downstream consumers filtering for `shortFormCase` missed them entirely; the short-form resolver couldn't link them back to full-cite antecedents.

### Fix

Extended the pincite-prefix alternation in both the tokenizer pattern and the extractor regex from `(?:pp?\.\s*)?` to `(?:pp?\.\s*|pages?\s+)?`:

- `src/patterns/shortForm.ts` — `SHORT_FORM_CASE_PATTERN`
- `src/extract/extractShortForms.ts` — internal `shortFormRegex`

### Scope

Multi-pincite lists (`at pages 261 and 262`) capture the first pincite only — same as existing hyphen-range behavior; broader multi-pincite scope is tracked separately. `Id. at page` / `Ibid. at page` are out of scope per the issue body.

## Test plan

- [x] `281 Ala. at page 322` → `shortFormCase` (was `journal`), `pincite: 322`
- [x] `38 Ala.App. at page 186` → `shortFormCase`, `pincite: 186`
- [x] `261 Ala. at pages 494` → `shortFormCase`, `pincite: 494`
- [x] `252 Ala. at pages 261 and 262` → first pincite captured
- [x] Regression: abbreviated `at 322` still works
- [x] Regression: CSM `at p. 717` still works
- [x] Full vitest suite — 2516 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)