### PR TITLE
feat: extract pre-1975 Alabama Code (`Code of Alabama 1940`) citations (#343)

### DIFF
--- a/.changeset/issue-343-ala-code-1940.md
+++ b/.changeset/issue-343-ala-code-1940.md
@@ -1,0 +1,75 @@
+---
+"eyecite-ts": patch
+---
+
+feat: extract pre-1975 Alabama Code (`Code of Alabama 1940`) citations (#343)
+
+Alabama used a distinct Title/Section statutory format before adopting
+the modern `Ala. Code § N-NN-N` form. Pre-1975 statutes — and continuing
+back-references to them in modern opinions — use forms like
+`Code 1940, T. 15, § 389` or `Title 26, Section 214, Code of Alabama
+1940, as Recompiled 1958`. None of these tokenized — surfaced as the
+dominant statute miss pattern in a 50-opinion Alabama sample (15+
+misses).
+
+### Fix
+
+Three tokenizer patterns in `src/patterns/statutePatterns.ts`, one
+dedicated extractor at `src/extract/statutes/extractAlaCode1940.ts`:
+
+- **`ala-code-prefix`** — `Code 1940, T. NN, § NNN` / `Code of Alabama
+  1940, T. NN, § NNN` (Code-first form; year hardcoded to 1940)
+- **`ala-title-trailer`** — `Title NN, Section NNN, Code of Alabama
+  1940[, as Recompiled YYYY]` (Title-first, requires Code trailer)
+- **`ala-tit-bare`** — `Tit. NN, § NNN[, Code 1940...]` (abbreviated
+  `Tit.` form, optional Code trailer)
+
+Each pattern routes to `extractAlaCode1940`, which emits a
+`StatuteCitation` with `code: "Code of Alabama 1940"`, `jurisdiction:
+"AL"`, the parsed `title`, `section`, `subsection`, and optionally
+`year` (edition year, e.g. 1940) and `recompiledYear` (1958 when the
+recompilation clause is present).
+
+`recompiledYear?: number` is a new optional field on `StatuteCitation`
+— additive change, no breaking API impact. Distinct from `year` (the
+original edition year).
+
+### Scope notes
+
+- **Bare `Title 7, § 508` form (no Code clause, spelled-out `Title`)**
+  is intentionally NOT matched. The spelled-out form without an
+  Alabama-specific signal would false-positive on bare USC-style
+  `Title 18, § 1001` prose. The `Tit.` abbreviation is recognized
+  bare because the abbreviation is itself an Alabama-distinctive
+  signal (USC opinions spell out `Title`). A future enhancement
+  could pick up bare spelled-out `Title N, § N` when a contextual
+  jurisdiction marker is present.
+
+- **Multi-section lists** (`Title 52, Sections 486 and 487, ...`)
+  match the first section only; the `, 487` is left for downstream.
+  Same shape as the existing multi-paragraph match on Illinois ILRS.
+
+### Tests
+
+8 new tests under `Code of Alabama 1940 — pre-1975 statutes (#343)` in
+`tests/extract/extractStatute.test.ts`:
+
+- Code-prefix: `Code 1940, T. 15, § 389`
+- Title-first w/ recompiledYear: `Title 26, Section 214, Code of
+  Alabama 1940, as Recompiled 1958`
+- Title-first w/ comma-before-year: `Title 7, Section 273, Code of
+  Alabama, 1940`
+- Title-first w/ abbreviated trailer: `Title 7, § 21, Code 1940`
+- Title-first w/ §-then-trailer: `Title 43, § 30, Code 1940`
+- Abbreviated bare: `Tit. 52, § 361`
+- Negative: bare `Title 7, § 508` does not match (USC false-positive
+  guard)
+- Regression: modern `Ala. Code § 6-2-39` still extracts
+
+Full 2521-test suite passes; no regressions.
+
+### Related
+
+Surfaced by 50-opinion Alabama sample. Companion to #330 (pre-1993
+Illinois Revised Statutes) — both are pre-modern state code formats
+that remain in active citation.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -18,6 +18,7 @@ import type { Token } from "@/tokenize"
 import type { StatuteCitation } from "@/types/citation"
 import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
 import { extractAbbreviated } from "./statutes/extractAbbreviated"
+import { extractAlaCode1940 } from "./statutes/extractAlaCode1940"
 import { extractCaBareCode } from "./statutes/extractCaBareCode"
 import { extractChapterAct } from "./statutes/extractChapterAct"
 import { extractFederal } from "./statutes/extractFederal"
@@ -119,6 +120,10 @@ export function extractStatute(
       return extractChapterAct(token, transformationMap)
     case "ill-rev-stat":
       return extractIllRevStat(token, transformationMap)
+    case "ala-code-prefix":
+    case "ala-title-trailer":
+    case "ala-tit-bare":
+      return extractAlaCode1940(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractAlaCode1940.ts
+++ b/src/extract/statutes/extractAlaCode1940.ts
@@ -1,0 +1,143 @@
+/**
+ * Pre-1975 Alabama Code Extraction
+ *
+ * Parses citations to the Code of Alabama 1940 — the dominant pre-1975
+ * Alabama statutory citation form. Modern Alabama opinions still cite this
+ * version when referencing the historical text of a statute:
+ *
+ *   Code 1940, T. 15, § 389
+ *   Title 26, Section 214, Code of Alabama 1940, as Recompiled 1958
+ *   Tit. 52, § 361
+ *
+ * Three tokenizer patternIds route here:
+ *   - `ala-code-prefix`     → Code-first form (year hardcoded to 1940)
+ *   - `ala-title-trailer`   → Title-first with mandatory Code trailer
+ *   - `ala-tit-bare`        → abbreviated `Tit.` form (optional Code trailer)
+ *
+ * @module extract/statutes/extractAlaCode1940
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+// Anchored re-match regexes for each Alabama patternId — mirror the
+// tokenizer patterns in `src/patterns/statutePatterns.ts` so the extractor
+// re-parses the same span the tokenizer captured. `d` flag enables
+// `match.indices` for component spans.
+
+const ALA_CODE_PREFIX_RE =
+  /^Code(?:\s+of\s+Alabama)?,?\s+1940,?\s+T(?:itle|it)?\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)$/d
+
+const ALA_TITLE_TRAILER_RE =
+  /^Title\s+(\d+),?\s+(?:§|Sec(?:tion)?s?\.?)\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?$/d
+
+const ALA_TIT_BARE_RE =
+  /^Tit\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)(?:,?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?)?$/d
+
+export function extractAlaCode1940(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+
+  let titleRaw: string
+  let sectionRaw: string
+  let year: number | undefined
+  let recompiledYear: number | undefined
+  let titleGroupIdx: number
+  let sectionGroupIdx: number
+  let match: RegExpExecArray
+
+  switch (token.patternId) {
+    case "ala-code-prefix": {
+      match = ALA_CODE_PREFIX_RE.exec(text)!
+      titleRaw = match[1]
+      sectionRaw = match[2]
+      year = 1940 // prefix asserts the 1940 edition
+      titleGroupIdx = 1
+      sectionGroupIdx = 2
+      break
+    }
+    case "ala-title-trailer": {
+      match = ALA_TITLE_TRAILER_RE.exec(text)!
+      titleRaw = match[1]
+      sectionRaw = match[2]
+      year = Number.parseInt(match[3], 10)
+      if (match[4]) recompiledYear = Number.parseInt(match[4], 10)
+      titleGroupIdx = 1
+      sectionGroupIdx = 2
+      break
+    }
+    default: {
+      // ala-tit-bare
+      match = ALA_TIT_BARE_RE.exec(text)!
+      titleRaw = match[1]
+      sectionRaw = match[2]
+      if (match[3]) year = Number.parseInt(match[3], 10)
+      if (match[4]) recompiledYear = Number.parseInt(match[4], 10)
+      titleGroupIdx = 1
+      sectionGroupIdx = 2
+      break
+    }
+  }
+
+  const title = Number.parseInt(titleRaw, 10)
+  const { section, subsection, hasEtSeq } = parseBody(sectionRaw)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const titleIdx = match.indices[titleGroupIdx]
+    if (titleIdx) spans.title = spanFromGroupIndex(span.cleanStart, titleIdx, transformationMap)
+    const bodyIdx = match.indices[sectionGroupIdx]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  // Confidence: 0.95 baseline (closed-shape Alabama Code matches are
+  // unambiguous when the Code prefix / trailer or `Tit.` abbreviation is
+  // present, which all three patternIds enforce). +0.05 with a subsection.
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    title,
+    code: "Code of Alabama 1940",
+    section,
+    subsection,
+    pincite: subsection,
+    year,
+    recompiledYear,
+    jurisdiction: "AL",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -115,4 +115,45 @@ export const statutePatterns: Pattern[] = [
       'California bare-code citations (#296) — `Pen. Code § 148`, `Code Civ. Proc., § 1021.5`, `Bus. & Prof. Code § 17200` (no "Cal." prefix; common in single-jurisdiction California practice).',
     type: "statute",
   },
+  {
+    // Pre-1975 Alabama Code (Code-prefix form): `Code 1940, T. 15, § 389`.
+    // The leading `Code [of Alabama,] 1940` is an unambiguous Alabama signal,
+    // so the title body uses `T.` / `Tit.` / `Title` interchangeably. The
+    // section uses the period-followed-by-alphanumeric guard from #283.
+    // Captures: (1) chapter (title), (2) section body. Year is hardcoded to
+    // 1940 in the extractor (the prefix asserts 1940). #343
+    id: "ala-code-prefix",
+    regex:
+      /\bCode(?:\s+of\s+Alabama)?,?\s+1940,?\s+T(?:itle|it)?\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+    description:
+      'Alabama Code 1940 (Code-prefix form, pre-1975): "Code 1940, T. 15, § 389" / "Code of Alabama 1940, T. NN, § NNN" — #343',
+    type: "statute",
+  },
+  {
+    // Pre-1975 Alabama Code (Title-first with mandatory Code trailer):
+    // `Title 26, Section 214, Code of Alabama 1940, as Recompiled 1958`.
+    // Requires the trailing `Code [of Alabama] YYYY` clause so the spelled-out
+    // `Title NN` form doesn't false-positive on bare prose like USC's
+    // `Title 18, § 1001`. Captures: (1) title, (2) section, (3) edition year,
+    // (4) optional recompilation year.
+    id: "ala-title-trailer",
+    regex:
+      /\bTitle\s+(\d+),?\s+(?:§|Sec(?:tion)?s?\.?)\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?/g,
+    description:
+      'Alabama Code (Title-first with Code trailer): "Title 26, Section 214, Code of Alabama 1940, as Recompiled 1958" — #343',
+    type: "statute",
+  },
+  {
+    // Pre-1975 Alabama Code (abbreviated bare form): `Tit. 52, § 361`.
+    // The `Tit.` abbreviation is itself an Alabama signal — USC and other
+    // federal codes spell out `Title` instead. Optional Code trailer captures
+    // year and recompilation when present. Captures: (1) title, (2) section,
+    // (3) optional edition year, (4) optional recompilation year.
+    id: "ala-tit-bare",
+    regex:
+      /\bTit\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)(?:,?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?)?/g,
+    description:
+      'Alabama Code (abbreviated `Tit.` form): "Tit. 52, § 361" — #343',
+    type: "statute",
+  },
 ]

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -482,6 +482,12 @@ export interface StatuteCitation extends CitationBase {
    * `(Publisher YYYY)` parentheticals alongside `year`. #285
    */
   publisher?: string
+  /**
+   * Recompilation year for codes that were re-issued without renumbering
+   * (`Code of Alabama 1940, as Recompiled 1958`). Distinct from `year`
+   * (the original edition year, e.g. 1940). #343
+   */
+  recompiledYear?: number
 
   /** Precise text positions for each parsed component of this citation. */
   spans?: StatuteComponentSpans

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1026,4 +1026,101 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Code of Alabama 1940 — pre-1975 statutes (#343)", () => {
+    it("extracts Code-prefix form: `Code 1940, T. 15, § 389`", () => {
+      const cites = extractCitations("violates Code 1940, T. 15, § 389.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(15)
+        expect(cites[0].section).toBe("389")
+        expect(cites[0].code).toBe("Code of Alabama 1940")
+        expect(cites[0].year).toBe(1940)
+        expect(cites[0].jurisdiction).toBe("AL")
+      }
+    })
+
+    it("extracts Title-first with Code trailer + recompiledYear: `Title 26, Section 214, Code of Alabama 1940, as Recompiled 1958`", () => {
+      const cites = extractCitations(
+        "Per Title 26, Section 214, Code of Alabama 1940, as Recompiled 1958.",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(26)
+        expect(cites[0].section).toBe("214")
+        expect(cites[0].year).toBe(1940)
+        expect(cites[0].recompiledYear).toBe(1958)
+      }
+    })
+
+    it("extracts Title-first with comma before year: `Title 7, Section 273, Code of Alabama, 1940`", () => {
+      const cites = extractCitations("Per Title 7, Section 273, Code of Alabama, 1940.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(7)
+        expect(cites[0].section).toBe("273")
+        expect(cites[0].year).toBe(1940)
+        expect(cites[0].recompiledYear).toBeUndefined()
+      }
+    })
+
+    it("extracts Title-first with abbreviated Code trailer: `Title 7, § 21, Code 1940`", () => {
+      const cites = extractCitations("Per Title 7, § 21, Code 1940.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(7)
+        expect(cites[0].section).toBe("21")
+        expect(cites[0].year).toBe(1940)
+      }
+    })
+
+    it("extracts Title-first, §-after-title, trailing Code: `Title 43, § 30, Code 1940`", () => {
+      const cites = extractCitations("violates Title 43, § 30, Code 1940.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(43)
+        expect(cites[0].section).toBe("30")
+      }
+    })
+
+    it("extracts abbreviated bare form: `Tit. 52, § 361`", () => {
+      const cites = extractCitations("See Tit. 52, § 361.").filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(52)
+        expect(cites[0].section).toBe("361")
+        expect(cites[0].code).toBe("Code of Alabama 1940")
+        expect(cites[0].jurisdiction).toBe("AL")
+        // No Code trailer, so year is undefined
+        expect(cites[0].year).toBeUndefined()
+      }
+    })
+
+    it("does NOT match bare `Title 7, § 508` (no Alabama context signal)", () => {
+      // The spelled-out `Title N, § N` form without any Code clause is
+      // intentionally not matched — bare `Title 18, § 1001`-style strings
+      // would false-positive on USC and other federal codes. Deferred.
+      const cites = extractCitations("Title 7, § 508.").filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(0)
+    })
+
+    it("regression: modern `Ala. Code § 6-2-39` continues to route through the abbreviated extractor", () => {
+      const cites = extractCitations("Ala. Code § 6-2-39.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("6-2-39")
+        expect(cites[0].jurisdiction).toBe("AL")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #343. Three tokenizer patterns + one dedicated extractor for the pre-1975 Alabama Code — the dominant statutory citation form in pre-1975 Alabama opinions and in modern Alabama opinions referencing historical statute text. None of the forms tokenized before; a 50-opinion Alabama sample found 15+ misses.

### Pattern coverage

- **`ala-code-prefix`** — `Code 1940, T. 15, § 389` / `Code of Alabama 1940, T. NN, § NNN`
- **`ala-title-trailer`** — `Title 26, Section 214, Code of Alabama 1940, as Recompiled 1958`
- **`ala-tit-bare`** — `Tit. 52, § 361` (optionally with `, Code [of Alabama] YYYY[, as Recompiled YYYY]`)

All three route to `src/extract/statutes/extractAlaCode1940.ts` and emit `code: "Code of Alabama 1940"`, `jurisdiction: "AL"`, plus parsed `title` / `section` / `subsection` / optional `year` (edition) and `recompiledYear` (1958 etc.).

`recompiledYear?: number` is a new optional field on `StatuteCitation` — additive change, distinct from existing `year`. No breaking API impact.

### Scope notes

- Bare spelled-out `Title 7, § 508` (no Code clause, no `Tit.` abbreviation) is **intentionally NOT matched** — too easy to false-positive on USC-style `Title 18, § 1001` prose. The `Tit.` abbreviation alone is sufficient as a bare-form signal because USC always spells out `Title`. A contextual-jurisdiction enhancement could pick up bare spelled-out forms in a follow-up.
- Multi-section lists (`Sections 486 and 487`) match the first section only; trailing comma list is left for downstream. Same shape as ILRS multi-paragraph behavior.

## Test plan

- [x] All 7 wild-corpus forms from the issue body extract correctly (see `scripts/repro_343.ts`)
- [x] Bare `Title 7, § 508` (no Alabama signal) correctly yields nothing (USC false-positive guard)
- [x] Regression: modern `Ala. Code § 6-2-39` continues to route through the abbreviated extractor
- [x] 8 new tests under `Code of Alabama 1940 — pre-1975 statutes (#343)`
- [x] Full vitest suite — 2521 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)