### PR TITLE
fix: Arizona A.R.S. — word `section`, spacing/OCR variants, code normalization (#348)

### DIFF
--- a/.changeset/issue-348-ars-variants.md
+++ b/.changeset/issue-348-ars-variants.md
@@ -1,0 +1,80 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Arizona A.R.S. accepts word `section`, spacing/OCR variants, and normalizes `code` (#348)
+
+Arizona statutes appear in many forms across published opinions —
+`A.R.S. § 25-331`, `A.R.S. section 14-2804(A)`, `ARS § 35-213`,
+`A. R.S. § 36-1002.02`, `AR.S. § 35-213`. The tokenizer recognized
+only the canonical fully-dotted-with-`§` form, and even the partially
+matching variants (`ARS`, `AR.S.`) emitted with `code` reflecting the
+raw match instead of the canonical `A.R.S.`. A 42-opinion Arizona
+sample showed 20+ statute misses on these variants alone.
+
+### Fix
+
+Three coordinated surface-level changes:
+
+1. **`src/data/stateStatutes.ts`** — the abbreviated-code section
+   connector accepts the spelled-out word `section(s)` /
+   `Section(s)` alongside `§` / `§§`:
+
+   ```
+   …\\s*(?:§§?|[Ss]ections?)?\\s*…
+   ```
+
+   This is a universal change benefiting all abbreviated-code
+   jurisdictions; Arizona is the immediate driver per #348.
+
+2. **`src/data/stateStatutes.ts`** — the Arizona `regexFragment`
+   admits inter-letter whitespace so spacing/OCR variants tokenize:
+
+   ```
+   A\\.?\\s*R\\.?\\s*S\\.?     (was: A\\.?R\\.?S\\.?)
+   ```
+
+   `A. R.S.`, `AR.S.`, `ARS` all match.
+
+3. **`src/data/knownCodes.ts` + `src/extract/statutes/extractAbbreviated.ts`**
+   — added a stripped-form fallback to `findAbbreviatedCode` (matches
+   on dots+spaces removed) and a normalization step in the extractor.
+   When the raw match doesn't appear in `entry.patterns` verbatim
+   (i.e., it's an OCR/spacing variant), `code` is set to the canonical
+   short abbreviation (`A.R.S.`). Exact-match inputs are left
+   unchanged, so `Ariz. Rev. Stat. § 14-1234` continues to emit
+   `code: "Ariz. Rev. Stat."` (no regression for Bluebook full forms).
+
+### Scope
+
+- **Multi-section ranges** (`A.R.S. §§ 23-941 through 23-952`) are
+  intentionally deferred — they require either a `sectionRange` field
+  or producing multiple citations from one match, neither of which
+  is a tight regex change.
+- **Bare-section context propagation** (`§ 36-3706` resolving to
+  A.R.S. via earlier context) is tracked separately under the
+  general per-document statute context proposal.
+
+### Tests
+
+8 new tests under `Arizona A.R.S. format variants (#348)` in
+`tests/extract/statutes/extractAbbreviated.test.ts`:
+
+- Canonical with subsection: `A.R.S. § 25-331(E)`
+- Word `section` lowercase: `A.R.S. section 14-2804(A)`
+- Word `Section` capital: `A.R.S. Section 22-318`
+- No-dots variant: `ARS § 35-213` → code normalized to `A.R.S.`
+- Extra-space variant: `A. R.S. § 36-1002.02` → code normalized
+- OCR variant: `AR.S. § 35-213` → code normalized
+- Regression: `Ariz. Rev. Stat. § 14-1234` → code preserved as-is
+- Regression: `Ariz. Rev. Stat. Ann. § 14-1234` → code preserved as-is
+
+Full 2535-test suite passes; no regressions.
+
+### Related
+
+Surfaced by 42-opinion Arizona sample. Same family as #12 (state
+bare-statute forms), #330 (pre-1993 Illinois Revised Statutes), #343
+(Code of Alabama 1940) — each state's most common statute family has
+its own abbreviation/spacing/subdivision quirks that have to be
+covered explicitly.

--- a/src/data/knownCodes.ts
+++ b/src/data/knownCodes.ts
@@ -848,6 +848,22 @@ for (const entry of abbreviatedCodes) {
 }
 
 /**
+ * Stripped-form index — pattern with all dots and whitespace removed.
+ * Used by `findAbbreviatedCode` to resolve OCR/spacing variants like
+ * `AR.S.`, `ARS`, `A. R.S.` to the canonical `A.R.S.` entry (#348).
+ */
+const _byStrippedPattern = new Map<string, CodeEntry>()
+for (const entry of abbreviatedCodes) {
+  for (const pattern of entry.patterns) {
+    const stripped = pattern.toLowerCase().replace(/[.\s]/g, "")
+    if (stripped.length === 0) continue
+    // Last-write-wins; abbreviated arrays are ordered longest-first within an
+    // entry, so the SHORTEST (canonical) form for a given stripped key wins.
+    _byStrippedPattern.set(stripped, entry)
+  }
+}
+
+/**
  * Find a CodeEntry by an abbreviated text token.
  *
  * Lookup order:
@@ -870,7 +886,15 @@ export function findAbbreviatedCode(abbrevText: string): CodeEntry | undefined {
   const exact = _byPattern.get(lower)
   if (exact) return exact
 
-  // 2. Prefix fallback — find the longest pattern that is a prefix of abbrevText
+  // 2. Stripped-form match — OCR variants like `AR.S.`, `ARS`, `A. R.S.`
+  //    all collapse to `ars` and resolve to the canonical `A.R.S.` entry. #348
+  const stripped = lower.replace(/[.\s]/g, "")
+  if (stripped.length > 0) {
+    const strippedHit = _byStrippedPattern.get(stripped)
+    if (strippedHit) return strippedHit
+  }
+
+  // 3. Prefix fallback — find the longest pattern that is a prefix of abbrevText
   let bestMatch: CodeEntry | undefined
   let bestLen = 0
   for (const [pattern, entry] of _byPattern) {

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -74,7 +74,11 @@ export function buildAbbreviatedCodeRegex(): RegExp {
     // Section body: digits prefix, then alphanumeric/colon/slash/hyphen OR
     // period-followed-by-alphanumeric (lookahead). Period guard prevents
     // sentence-ending punctuation from being absorbed into the section.
-    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*§?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
+    //
+    // Section connector: `§`, `§§`, or the spelled-out word `section(s)` /
+    // `Section(s)` (#348). Arizona and several other state corpora cite as
+    // `A.R.S. section 14-2804(A)` interchangeably with `A.R.S. § 14-2804(A)`.
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
     "g",
   )
 }
@@ -188,10 +192,13 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Alaska\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?S\\.?",
   },
   // ── Arizona ───────────────────────────────────────────────────────────────
+  // A.R.S. fragment admits inter-letter spaces (`A. R.S.`, OCR `AR.S.`) and
+  // no-dots (`ARS`) — see #348. The extractor normalizes all variants to the
+  // canonical `A.R.S.` via the stripped-form fallback in `findAbbreviatedCode`.
   {
     jurisdiction: "AZ",
     abbreviations: ["Ariz. Rev. Stat. Ann.", "Ariz. Rev. Stat.", "A.R.S."],
-    regexFragment: "Ariz\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?R\\.?S\\.?",
+    regexFragment: "Ariz\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?\\s*R\\.?\\s*S\\.?",
   },
   // ── Arkansas ──────────────────────────────────────────────────────────────
   {

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -44,7 +44,15 @@ export function extractAbbreviated(
 
   const codeEntry = findAbbreviatedCode(abbrevText)
   const jurisdiction = codeEntry?.jurisdiction
-  const code = abbrevText
+  // Normalize OCR/spacing variants (`AR.S.`, `ARS`, `A. R.S.`) to the canonical
+  // short abbreviation when the input doesn't already match a recognized
+  // pattern verbatim — the stripped-form fallback in `findAbbreviatedCode`
+  // returns the canonical entry, so `entry.abbreviation` is the right
+  // normalized `code`. Exact matches keep their original-form `code`. #348
+  const code =
+    codeEntry && !codeEntry.patterns.some((p) => p.toLowerCase() === abbrevText.toLowerCase())
+      ? codeEntry.abbreviation
+      : abbrevText
 
   const { section, subsection, hasEtSeq } = parseBody(rawBody)
 

--- a/tests/extract/statutes/extractAbbreviated.test.ts
+++ b/tests/extract/statutes/extractAbbreviated.test.ts
@@ -182,4 +182,63 @@ describe("extractAbbreviated", () => {
       expect(c.confidence).toBeLessThanOrEqual(0.4)
     })
   })
+
+  describe("Arizona A.R.S. format variants (#348)", () => {
+    it("canonical `A.R.S. § 25-331(E)` extracts with subsection", () => {
+      const c = extractAbbreviated(makeToken("A.R.S. § 25-331(E)"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("A.R.S.")
+      expect(c.section).toBe("25-331")
+      expect(c.subsection).toBe("(E)")
+    })
+
+    it("word `section` (lowercase) — `A.R.S. section 14-2804(A)`", () => {
+      const c = extractAbbreviated(makeToken("A.R.S. section 14-2804(A)"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("A.R.S.")
+      expect(c.section).toBe("14-2804")
+      expect(c.subsection).toBe("(A)")
+    })
+
+    it("word `Section` (capital S) — `A.R.S. Section 22-318`", () => {
+      const c = extractAbbreviated(makeToken("A.R.S. Section 22-318"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("A.R.S.")
+      expect(c.section).toBe("22-318")
+    })
+
+    it("no-dots variant `ARS § 35-213` normalizes code to `A.R.S.`", () => {
+      const c = extractAbbreviated(makeToken("ARS § 35-213"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("A.R.S.")
+      expect(c.section).toBe("35-213")
+    })
+
+    it("extra-space variant `A. R.S. § 36-1002.02` normalizes code to `A.R.S.`", () => {
+      const c = extractAbbreviated(makeToken("A. R.S. § 36-1002.02"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("A.R.S.")
+      expect(c.section).toBe("36-1002.02")
+    })
+
+    it("OCR variant `AR.S. § 35-213` normalizes code to `A.R.S.`", () => {
+      const c = extractAbbreviated(makeToken("AR.S. § 35-213"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("A.R.S.")
+      expect(c.section).toBe("35-213")
+    })
+
+    it("regression: Bluebook full form `Ariz. Rev. Stat.` preserved (not over-normalized)", () => {
+      const c = extractAbbreviated(makeToken("Ariz. Rev. Stat. § 14-1234"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("Ariz. Rev. Stat.")
+      expect(c.section).toBe("14-1234")
+    })
+
+    it("regression: Bluebook annotated form `Ariz. Rev. Stat. Ann.` preserved", () => {
+      const c = extractAbbreviated(makeToken("Ariz. Rev. Stat. Ann. § 14-1234"), map)
+      expect(c.jurisdiction).toBe("AZ")
+      expect(c.code).toBe("Ariz. Rev. Stat. Ann.")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #348 (scoped to tractable parts; range + bare-section context deferred). Arizona statutes appear in many forms; only the canonical fully-dotted `A.R.S. §` form was being recognized, and even partially matching variants emitted with `code` reflecting the raw match instead of the canonical `A.R.S.`. A 42-opinion Arizona sample showed 20+ statute misses on these variants.

### Three coordinated changes

1. **`src/data/stateStatutes.ts`** — abbreviated-code section connector accepts `(?:§§?|[Ss]ections?)?` (universal change benefiting all jurisdictions; Arizona is the immediate driver).
2. **`src/data/stateStatutes.ts`** — Arizona `regexFragment` admits inter-letter whitespace (`A\.?\s*R\.?\s*S\.?`) so `A. R.S.`, `AR.S.`, and `ARS` all tokenize.
3. **`src/data/knownCodes.ts` + `src/extract/statutes/extractAbbreviated.ts`** — stripped-form fallback in `findAbbreviatedCode` + canonical-code normalization in the extractor. Variants normalize to `A.R.S.`; exact Bluebook forms (`Ariz. Rev. Stat.`, `Ariz. Rev. Stat. Ann.`) are preserved as-is.

### Out of scope (deferred)

- Multi-section ranges (`A.R.S. §§ 23-941 through 23-952`) — needs a `sectionRange` field or multi-citation emission.
- Bare-section context propagation (`§ 36-3706` resolving to A.R.S. via earlier context) — tracked separately.

## Test plan

- [x] `A.R.S. § 25-331(E)` (canonical) — section + subsection extracted
- [x] `A.R.S. section 14-2804(A)` — word form, code normalized
- [x] `A.R.S. Section 22-318` — capital S
- [x] `ARS § 35-213` — code normalized from `ARS` to `A.R.S.`
- [x] `A. R.S. § 36-1002.02` — code normalized
- [x] `AR.S. § 35-213` — OCR variant, code normalized
- [x] Regression: `Ariz. Rev. Stat. § 14-1234` — code preserved
- [x] Regression: `Ariz. Rev. Stat. Ann. § 14-1234` — code preserved
- [x] 8 new tests under `Arizona A.R.S. format variants (#348)`
- [x] Full vitest suite — 2535 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)