### PR TITLE
fix: Arkansas Code Annotated + `(Repl. YYYY)` / `(YYYY Supp.)` parentheticals (#349)

### DIFF
--- a/.changeset/issue-349-ark-code-ann.md
+++ b/.changeset/issue-349-ark-code-ann.md
@@ -1,0 +1,79 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Arkansas Code Annotated + `(Repl. YYYY)` / `(YYYY Supp.)` edition parentheticals (#349)
+
+Arkansas's primary statute code is **Arkansas Code Annotated** (post-1987)
+or **Arkansas Statutes Annotated** (pre-1987). Three failures combined
+to drop almost every Arkansas statute citation in a 50-opinion sample
+(20+ misses):
+
+1. The spelled-out `Arkansas Code Annotated` form wasn't accepted
+   (the regex required `Ann.` rather than `Annotated`).
+2. `Ark. Stat. Ann.` (the pre-1987 code) had no entry at all.
+3. `(Repl. YYYY)`, `(YYYY Supp.)`, `(Cum. Supp. YYYY)` edition
+   parentheticals were dropped even when the citation tokenized —
+   the existing year-paren regex (#285) only recognized
+   `(Publisher? YYYY)`-shaped bodies.
+
+### Fix
+
+Four coordinated changes:
+
+1. **`src/data/stateStatutes.ts`** — extended the Arkansas Code
+   Annotated entry to accept the spelled-out `Annotated` form
+   (`Ann(?:otated)?\.?`); added `"Arkansas Code Annotated"` to the
+   abbreviations array.
+
+2. **`src/data/stateStatutes.ts`** — added a second Arkansas entry
+   for the pre-1987 **Arkansas Statutes Annotated** code family
+   (`Ark. Stat. Ann.`, `Ark. Stat.`, `Arkansas Statutes Annotated`).
+
+3. **`src/extract/extractCitations.ts`** — extended
+   `STATUTE_YEAR_PAREN_REGEX` so the parenthetical body accepts a
+   trailing dot on the publisher/label word (`Repl.`, `Supp.`,
+   `Cum. Supp.`) and a year-first variant (`(1969 Supp.)`,
+   `(1985 Cum. Supp.)`). `attachStatuteYearParen` routes the
+   non-year token to the new `editionLabel` field when it matches
+   `Repl. | Supp. | Cum. Supp.` (case-insensitive); otherwise the
+   token continues to populate `publisher` as before.
+
+4. **`src/types/citation.ts`** — added an optional
+   `editionLabel?: string` field to `StatuteCitation`. Distinct from
+   `publisher` (West/Lexis) — captures replacement/supplement
+   volume markers. Non-breaking additive change.
+
+### Side fix
+
+`src/extract/statutes/extractAbbreviated.ts` — mirrored the
+tokenizer's word-`section` tolerance from #348 in the internal
+`ABBREVIATED_RE`, so the abbreviation capture no longer absorbs the
+word `section` when it appears between the code name and the section
+body. Without this, `Arkansas Code Annotated section 11-9-102` would
+produce `abbrevText="Arkansas Code Annotated section"` and fall
+through to canonical-form normalization.
+
+### Tests
+
+7 new tests under `Arkansas Code Annotated + edition parenthetical
+(#349)` in `tests/extract/statutes/extractAbbreviated.test.ts`:
+
+- `Ark. Code Ann. § 11-9-514(a)(1) (Repl. 1996)` → all fields
+  populated, `editionLabel: "Repl."`
+- `Arkansas Code Annotated § 16-89-111(e)(1) (1987)` — spelled-out
+  form, bare year (no edition label)
+- `Arkansas Code Annotated section 11-9-102(5)(A)(i) (Repl. 1996)` —
+  spelled-out + word `section`, code preserved verbatim
+- `Ark. Stat. Ann. § 41-1201 (Repl. 1964)` — pre-1987 code
+- `(1969 Supp.)` year-first edition label
+- Regression: `(West 2018)` continues to populate `publisher`
+- Regression: bare `(1976)` continues to populate `year` only
+
+Full 2542-test suite passes; no regressions.
+
+### Scope
+
+Bare-section context propagation (`§ 41-1201` resolving to
+`Ark. Stat. Ann.` via earlier-in-document context) is tracked
+separately under the general per-document statute context proposal.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -201,10 +201,26 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Ariz\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|A\\.?\\s*R\\.?\\s*S\\.?",
   },
   // ── Arkansas ──────────────────────────────────────────────────────────────
+  // Modern Arkansas Code Annotated (post-1987). Fragment accepts both the
+  // abbreviated `Ann.` form and the spelled-out `Annotated` form (#349).
   {
     jurisdiction: "AR",
-    abbreviations: ["Ark. Code Ann.", "Arkansas Code", "A.C.A."],
-    regexFragment: "Ark(?:ansas)?\\.?\\s+Code(?:\\s+Ann\\.?)?|A\\.?C\\.?A\\.?",
+    abbreviations: [
+      "Arkansas Code Annotated",
+      "Ark. Code Ann.",
+      "Arkansas Code",
+      "A.C.A.",
+    ],
+    regexFragment:
+      "Ark(?:ansas)?\\.?\\s+Code(?:\\s+Ann(?:otated)?\\.?)?|A\\.?C\\.?A\\.?",
+  },
+  // Pre-1987 Arkansas Statutes Annotated. Modern Arkansas opinions still cite
+  // this when referencing pre-1987 statutory text (#349).
+  {
+    jurisdiction: "AR",
+    abbreviations: ["Arkansas Statutes Annotated", "Ark. Stat. Ann.", "Ark. Stat."],
+    regexFragment:
+      "Ark(?:ansas)?\\.?\\s+Stat(?:utes)?\\.?(?:\\s+Ann(?:otated)?\\.?)?",
   },
   // ── Connecticut ───────────────────────────────────────────────────────────
   {

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -653,31 +653,49 @@ function inheritSubsequentHistoryCaseName(citations: Citation[]): void {
  * Closes #282.
  */
 /**
- * Statute year-of-edition parenthetical regex (#285).
+ * Statute year-of-edition parenthetical regex (#285 + #349).
  *
  * Matches a parenthetical that follows a statute citation core. Anchored at
  * the start of the lookahead text (we substring from `span.cleanEnd`) and
- * allows whitespace, an optional comma + whitespace, and an optional ", at
- * <pincite>" intervening text. The parenthetical body is `(Publisher? YYYY)`:
- * a 4-digit year, optionally preceded by a capitalized publisher word
- * (`West`, `Lexis`, `Lexis Nexis`, etc.). Subsection parens like `(a)` and
- * `(1)` don't match — the body must end in a 4-digit run.
+ * allows whitespace, an optional comma + whitespace, and an optional
+ * `, at <pincite>` intervening text. The parenthetical body is one of:
+ *
+ *   - `(YYYY)`                  — bare year
+ *   - `(Publisher YYYY)`        — publisher-first (`(West 2018)`,
+ *                                  `(Lexis Nexis 2019)`)
+ *   - `(Label. YYYY)`           — edition-label-first (`(Repl. 1996)`,
+ *                                  `(Supp. 1985)`, `(Cum. Supp. 1985)`)
+ *   - `(YYYY Label.)`           — year-first edition label (`(1969 Supp.)`,
+ *                                  `(1985 Cum. Supp.)`)
+ *
+ * Subsection parens like `(a)` and `(1)` don't match — the body must contain
+ * a 4-digit year. The pre/post token (group 1 / group 3) admits a trailing
+ * `.` and an optional second capitalized word so `Cum. Supp.` and
+ * `Lexis Nexis` both flow through the same regex.
  */
 const STATUTE_YEAR_PAREN_REGEX =
-  /^\s*(?:,\s*(?:at\s+)?\d+(?:-\d+)?\s*)?\(\s*([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)?)?\s*(\d{4})\s*\)/
+  /^\s*(?:,\s*(?:at\s+)?\d+(?:-\d+)?\s*)?\(\s*([A-Z][A-Za-z]+\.?(?:\s+[A-Z][A-Za-z]+\.?)?)?\s*(\d{4})\s*([A-Z][A-Za-z]+\.?(?:\s+[A-Z][A-Za-z]+\.?)?)?\s*\)/
 
 /**
- * Attach `year` (and optional `publisher`) to statute citations whose
- * citation core is immediately followed by a year-of-edition parenthetical.
+ * Edition-label set — captured tokens that should populate `editionLabel`
+ * rather than `publisher`. `Repl.` = replacement volume, `Supp.` = supplement,
+ * `Cum. Supp.` = cumulative supplement. #349
+ */
+const EDITION_LABEL_REGEX = /^(?:Repl|Supp|Cum\.?\s*Supp)\.?$/i
+
+/**
+ * Attach `year` (and optional `publisher` / `editionLabel`) to statute
+ * citations whose citation core is immediately followed by a year-of-edition
+ * parenthetical.
  *
- * `HRS § 91-14(a) (1985)`, `42 U.S.C. § 1983 (1976)`, and
- * `28 U.S.C. § 1331 (West 2018)` are all common code-edition forms. The
- * tokenizer captures only the citation core; this post-pass scans forward
- * from `span.cleanEnd` for an optional `\s*\((?:Publisher\s+)?YYYY\)`. The
- * regex deliberately requires a literal 4-digit run inside the parens so a
- * trailing subsection paren (`(a)`, `(1)`) is never confused for a year.
+ * `HRS § 91-14(a) (1985)`, `42 U.S.C. § 1983 (1976)`,
+ * `28 U.S.C. § 1331 (West 2018)`, and `Ark. Code Ann. § 11-9-514(a)(1)
+ * (Repl. 1996)` are all common code-edition forms. The tokenizer captures
+ * only the citation core; this post-pass scans forward from `span.cleanEnd`
+ * for the year-paren and routes the non-year token to `publisher` or
+ * `editionLabel` depending on whether it's a replacement/supplement marker.
  *
- * Closes #285.
+ * Closes #285. Extended for `Repl.` / `Supp.` / `Cum. Supp.` in #349.
  */
 function attachStatuteYearParen(citations: Citation[], cleaned: string): void {
   for (const cite of citations) {
@@ -686,9 +704,19 @@ function attachStatuteYearParen(citations: Citation[], cleaned: string): void {
     const after = cleaned.slice(cite.span.cleanEnd)
     const match = STATUTE_YEAR_PAREN_REGEX.exec(after)
     if (!match) continue
-    const [, publisher, yearStr] = match
+    const [, prefixToken, yearStr, suffixToken] = match
     cite.year = Number.parseInt(yearStr, 10)
-    if (publisher) cite.publisher = publisher
+    // Route the non-year token: edition label vs publisher. Either slot may
+    // carry it (publisher conventionally precedes the year; edition labels
+    // appear on either side).
+    const token = prefixToken ?? suffixToken
+    if (!token) continue
+    if (EDITION_LABEL_REGEX.test(token)) {
+      // Normalize spacing inside `Cum. Supp.` to a single space.
+      cite.editionLabel = token.replace(/\s+/g, " ").trim()
+    } else {
+      cite.publisher = token
+    }
   }
 }
 

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -19,8 +19,13 @@ import { parseBody } from "./parseBody"
 
 // Section body: period only allowed when followed by alphanumeric so a
 // trailing sentence period is never captured (#283).
+// Section connector mirrors the tokenizer pattern: `§`, `§§`, or the
+// spelled-out word `section(s)` / `Section(s)` (#348). Without this, the
+// lazy abbreviation capture would absorb the word `section` and break
+// `findAbbreviatedCode` lookups (e.g., `Arkansas Code Annotated section
+// 11-9-102` would emit abbrevText="Arkansas Code Annotated section").
 const ABBREVIATED_RE =
-  /^(?:(\d+)\s+)?(.+?)\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
+  /^(?:(\d+)\s+)?(.+?)\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
 
 export function extractAbbreviated(
   token: Token,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -488,6 +488,15 @@ export interface StatuteCitation extends CitationBase {
    * (the original edition year, e.g. 1940). #343
    */
   recompiledYear?: number
+  /**
+   * Edition-volume label for codes that distinguish replacement and
+   * supplement volumes from the main code edition (`(Repl. 1996)`,
+   * `(1969 Supp.)`, `(Cum. Supp. 1985)`). The `year` field carries the
+   * year; `editionLabel` carries the normalized label
+   * (`"Repl."` / `"Supp."` / `"Cum. Supp."`). Common in Arkansas,
+   * Mississippi, Tennessee, and other state codes. #349
+   */
+  editionLabel?: string
 
   /** Precise text positions for each parsed component of this citation. */
   spans?: StatuteComponentSpans

--- a/tests/extract/statutes/extractAbbreviated.test.ts
+++ b/tests/extract/statutes/extractAbbreviated.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
 import { extractAbbreviated } from "@/extract/statutes/extractAbbreviated"
 import type { Token } from "@/tokenize"
 import { createIdentityMap } from "../../helpers/transformationMap"
@@ -239,6 +240,100 @@ describe("extractAbbreviated", () => {
       const c = extractAbbreviated(makeToken("Ariz. Rev. Stat. Ann. § 14-1234"), map)
       expect(c.jurisdiction).toBe("AZ")
       expect(c.code).toBe("Ariz. Rev. Stat. Ann.")
+    })
+  })
+
+  describe("Arkansas Code Annotated + edition parenthetical (#349)", () => {
+    // The edition-parenthetical post-pass runs in `extractCitations`, not in
+    // `extractAbbreviated`, so these tests use `extractCitations` end-to-end.
+    it("`Ark. Code Ann. § 11-9-514(a)(1) (Repl. 1996)` → year + editionLabel", () => {
+      const cs = extractCitations(
+        "violates Ark. Code Ann. § 11-9-514(a)(1) (Repl. 1996).",
+      ).filter((x) => x.type === "statute")
+      expect(cs).toHaveLength(1)
+      if (cs[0]?.type === "statute") {
+        expect(cs[0].code).toBe("Ark. Code Ann.")
+        expect(cs[0].section).toBe("11-9-514")
+        expect(cs[0].subsection).toBe("(a)(1)")
+        expect(cs[0].year).toBe(1996)
+        expect(cs[0].editionLabel).toBe("Repl.")
+        expect(cs[0].jurisdiction).toBe("AR")
+      }
+    })
+
+    it("`Arkansas Code Annotated § 16-89-111(e)(1) (1987)` (spelled-out form)", () => {
+      const cs = extractCitations(
+        "Per Arkansas Code Annotated § 16-89-111(e)(1) (1987).",
+      ).filter((x) => x.type === "statute")
+      expect(cs).toHaveLength(1)
+      if (cs[0]?.type === "statute") {
+        expect(cs[0].code).toBe("Arkansas Code Annotated")
+        expect(cs[0].year).toBe(1987)
+        expect(cs[0].editionLabel).toBeUndefined()
+      }
+    })
+
+    it("`Arkansas Code Annotated section ...` (spelled-out + word section)", () => {
+      const cs = extractCitations(
+        "see Arkansas Code Annotated section 11-9-102(5)(A)(i) (Repl. 1996).",
+      ).filter((x) => x.type === "statute")
+      expect(cs).toHaveLength(1)
+      if (cs[0]?.type === "statute") {
+        expect(cs[0].code).toBe("Arkansas Code Annotated")
+        expect(cs[0].section).toBe("11-9-102")
+        expect(cs[0].subsection).toBe("(5)(A)(i)")
+        expect(cs[0].year).toBe(1996)
+        expect(cs[0].editionLabel).toBe("Repl.")
+      }
+    })
+
+    it("`Ark. Stat. Ann. § 41-1201 (Repl. 1964)` (pre-1987 form)", () => {
+      const cs = extractCitations("under Ark. Stat. Ann. § 41-1201 (Repl. 1964).").filter(
+        (x) => x.type === "statute",
+      )
+      expect(cs).toHaveLength(1)
+      if (cs[0]?.type === "statute") {
+        expect(cs[0].code).toBe("Ark. Stat. Ann.")
+        expect(cs[0].section).toBe("41-1201")
+        expect(cs[0].year).toBe(1964)
+        expect(cs[0].editionLabel).toBe("Repl.")
+        expect(cs[0].jurisdiction).toBe("AR")
+      }
+    })
+
+    it("`(1969 Supp.)` year-first edition label", () => {
+      const cs = extractCitations("Ark. Stat. Ann. § 80-1304 (1969 Supp.).").filter(
+        (x) => x.type === "statute",
+      )
+      expect(cs).toHaveLength(1)
+      if (cs[0]?.type === "statute") {
+        expect(cs[0].year).toBe(1969)
+        expect(cs[0].editionLabel).toBe("Supp.")
+      }
+    })
+
+    it("regression: `(West 2018)` publisher still populates `publisher`, not `editionLabel`", () => {
+      const cs = extractCitations("28 U.S.C. § 1331 (West 2018).").filter(
+        (x) => x.type === "statute",
+      )
+      expect(cs).toHaveLength(1)
+      if (cs[0]?.type === "statute") {
+        expect(cs[0].year).toBe(2018)
+        expect(cs[0].publisher).toBe("West")
+        expect(cs[0].editionLabel).toBeUndefined()
+      }
+    })
+
+    it("regression: bare `(1976)` year still works", () => {
+      const cs = extractCitations("42 U.S.C. § 1983 (1976).").filter(
+        (x) => x.type === "statute",
+      )
+      expect(cs).toHaveLength(1)
+      if (cs[0]?.type === "statute") {
+        expect(cs[0].year).toBe(1976)
+        expect(cs[0].publisher).toBeUndefined()
+        expect(cs[0].editionLabel).toBeUndefined()
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

Fixes #349. Three combined failures dropped almost every Arkansas statute citation in a 50-opinion sample (20+ misses): the spelled-out `Arkansas Code Annotated` form wasn't accepted, the pre-1987 `Ark. Stat. Ann.` code had no entry, and `(Repl. YYYY)` / `(YYYY Supp.)` / `(Cum. Supp. YYYY)` edition parentheticals were dropped even when the citation tokenized.

### Four coordinated changes

1. **`stateStatutes.ts`** — extended the Arkansas Code Annotated regex to accept `Ann(?:otated)?\.?` and added `"Arkansas Code Annotated"` to the abbreviations array.
2. **`stateStatutes.ts`** — added a new entry for the pre-1987 `Ark. Stat. Ann.` / `Arkansas Statutes Annotated` code family.
3. **`extractCitations.ts`** — extended `STATUTE_YEAR_PAREN_REGEX` to accept publisher/label tokens with trailing dots (`Repl.`, `Supp.`, `Cum. Supp.`) and a year-first variant (`(1969 Supp.)`). `attachStatuteYearParen` routes `Repl./Supp./Cum. Supp.` to a new `editionLabel` field; `publisher` is preserved for `West`/`Lexis`/etc.
4. **`citation.ts`** — added optional `editionLabel?: string` to `StatuteCitation`. Non-breaking additive change.

### Side fix

`extractAbbreviated.ts` — mirrored the word-`section` tolerance from #348 in the internal `ABBREVIATED_RE` so `Arkansas Code Annotated section 11-9-102` doesn't absorb the word `section` into `abbrevText` and trigger canonical-form normalization.

## Test plan

- [x] `Ark. Code Ann. § 11-9-514(a)(1) (Repl. 1996)` → code, subsection, year, editionLabel="Repl."
- [x] `Arkansas Code Annotated § 16-89-111(e)(1) (1987)` — spelled-out form, bare year
- [x] `Arkansas Code Annotated section 11-9-102(5)(A)(i) (Repl. 1996)` — code preserved verbatim
- [x] `Ark. Stat. Ann. § 41-1201 (Repl. 1964)` — pre-1987 code
- [x] `(1969 Supp.)` year-first edition label
- [x] Regression: `(West 2018)` populates `publisher` (not `editionLabel`)
- [x] Regression: bare `(1976)` populates `year` only
- [x] 7 new tests under `Arkansas Code Annotated + edition parenthetical (#349)`
- [x] Full vitest suite — 2542 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

### Scope

Bare-section context propagation (`§ 41-1201` resolving to `Ark. Stat. Ann.` via earlier-in-document context) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)