### PR TITLE
fix: Colorado `C.R.S. 1963` / `C.R.S. 1973` year-edition + prose form (#352)

### DIFF
--- a/.changeset/issue-352-crs-year-edition.md
+++ b/.changeset/issue-352-crs-year-edition.md
@@ -1,0 +1,79 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Colorado `C.R.S. 1963` / `C.R.S. 1973` year-edition and prose form (#352)
+
+Colorado has two compilations: pre-1973 (`C.R.S. 1963`) and post-1973
+(`C.R.S.` / `C.R.S. 1973`). The year suffix is part of the **code
+name**, distinguishing the edition — not an edition parenthetical and
+not a section number. Three failures combined to mis-parse every
+pre-1973 Colorado statute reference in a 38-opinion sample:
+
+1. **Year suffix consumed as section number**: `C.R.S. 1963 §
+   148-21-34` extracted `section: "1963"` (the year), dropping the
+   real section number `148-21-34` entirely.
+2. **Code name truncated**: `code` was reported as `C.R.S.` rather
+   than `C.R.S. 1963`, losing the edition information.
+3. **Prose form not extracted**: `Section 148-21-34, Colorado Revised
+   Statutes 1963` (the dominant pre-1973 form, with section BEFORE
+   the code name) produced no citation.
+
+### Fix
+
+Two coordinated changes:
+
+1. **`src/data/stateStatutes.ts`** — extended the Colorado regex
+   fragment with an optional `\s+19\d{2}` tail that absorbs `1963` /
+   `1973` into the abbreviation capture. Added the canonical
+   year-suffixed forms (`C.R.S. 1963`, `C.R.S. 1973`, `Colorado
+   Revised Statutes 1963`, `Colorado Revised Statutes 1973`) and the
+   spelled-out base form (`Colorado Revised Statutes`,
+   `Colorado Revised Statutes Annotated`) to the abbreviations array.
+   With this `findAbbreviatedCode` resolves the year-suffixed forms
+   via exact match and `code` is preserved verbatim.
+
+2. **New `colorado-prose` tokenizer pattern + `extractColoradoProse`
+   extractor** — handles the section-first prose form
+   `Section 148-21-34, Colorado Revised Statutes 1963`. The pattern
+   is listed BEFORE `abbreviated-code` in `statutePatterns.ts` so
+   it wins span dedup over the abbreviated-code match (which would
+   otherwise still consume the trailing `Colorado Revised Statutes
+   1963` and emit a duplicate citation with `section: "1963"`).
+
+### Scope notes
+
+- **Chapter-article-section structured fields** (pre-1973 Colorado's
+  `148-21-34` = chapter 148, article 21, section 34) are deferred —
+  the full section body is preserved in `section`, and consumers can
+  split it themselves. Surfacing `chapter` / `article` as typed fields
+  would require new optional fields on `StatuteCitation`.
+- **`Article 18 of Chapter 148, Colorado Revised Statutes 1963`**
+  (article-of-chapter prose form) is deferred — separate pattern
+  shape from the section-first form covered here.
+- **Colorado session laws** (`Colo. Sess. Laws YYYY, ch. NNN, § N`)
+  are a separate citation family entirely and tracked separately.
+
+### Tests
+
+8 new tests under `Colorado pre-1973 and year-edition variants (#352)`
+in `tests/extract/extractStatute.test.ts`:
+
+- Inline `C.R.S. 1963 § 148-21-34` — code preserved with year suffix
+- Inline `C.R.S. 1973 § 13-25-126` — modern edition variant
+- Prose `Section 148-21-34, Colorado Revised Statutes 1963`
+- Prose + `(1965 Supp.)` trailing parenthetical → year + editionLabel
+- Prose with subsection: `Section 82-4-8(8)(f), Colo. Rev. Stat. 1963`
+- Regression: modern `C.R.S. § 13-25-126` (no year suffix) unchanged
+- Regression: `C.R.S. § 13-25-126 (1973)` — trailing year parenthetical
+  continues to populate `year`
+- Regression: federal `42 U.S.C. § 1983 (1976)` unaffected
+
+Full 2551-test suite passes; no regressions.
+
+### Related
+
+Surfaced by 38-opinion Colorado sweep. Companion to #348 (Arizona),
+#349 (Arkansas), #330 (Illinois pre-1993), #343 (Alabama 1940) — each
+state's pre-modern statute code has distinct conventions not in the
+default abbreviated-code pattern.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -121,10 +121,30 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Utah\\s+Code(?:\\s+Ann\\.?)?|U\\.?C\\.?A\\.?",
   },
   // ── Colorado ───────────────────────────────────────────────────────────────
+  // Colorado has two compilations: pre-1973 (`C.R.S. 1963`) and modern
+  // (`C.R.S.` / `C.R.S. 1973`). The year suffix is part of the code name,
+  // not an edition parenthetical — without absorbing it into the
+  // abbreviation capture the section body would swallow the year (`C.R.S.
+  // 1963 § 148-21-34` → section="1963"; #352). The optional `\s+19\d{2}`
+  // tail attaches `1963` / `1973` / etc. to the code, and the canonical
+  // year-suffixed forms are added to the abbreviations array so
+  // `findAbbreviatedCode` resolves them via exact match.
   {
     jurisdiction: "CO",
-    abbreviations: ["Colo. Rev. Stat. Ann.", "Colo. Rev. Stat.", "C.R.S.", "CRS"],
-    regexFragment: "Colo\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|C\\.?R\\.?S\\.?",
+    abbreviations: [
+      "Colorado Revised Statutes Annotated",
+      "Colo. Rev. Stat. Ann.",
+      "Colorado Revised Statutes 1963",
+      "Colorado Revised Statutes 1973",
+      "Colorado Revised Statutes",
+      "Colo. Rev. Stat.",
+      "C.R.S. 1963",
+      "C.R.S. 1973",
+      "C.R.S.",
+      "CRS",
+    ],
+    regexFragment:
+      "Colo(?:rado)?\\.?\\s+Rev(?:ised)?\\.?\\s+Stat(?:utes)?\\.?(?:\\s+Ann(?:otated)?\\.?)?(?:\\s+19\\d{2})?|C\\.?R\\.?S\\.?(?:\\s+19\\d{2})?",
   },
   // ── Washington ─────────────────────────────────────────────────────────────
   {

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -21,6 +21,7 @@ import { extractAbbreviated } from "./statutes/extractAbbreviated"
 import { extractAlaCode1940 } from "./statutes/extractAlaCode1940"
 import { extractCaBareCode } from "./statutes/extractCaBareCode"
 import { extractChapterAct } from "./statutes/extractChapterAct"
+import { extractColoradoProse } from "./statutes/extractColoradoProse"
 import { extractFederal } from "./statutes/extractFederal"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
 import { extractNamedCode } from "./statutes/extractNamedCode"
@@ -124,6 +125,8 @@ export function extractStatute(
     case "ala-title-trailer":
     case "ala-tit-bare":
       return extractAlaCode1940(token, transformationMap)
+    case "colorado-prose":
+      return extractColoradoProse(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractColoradoProse.ts
+++ b/src/extract/statutes/extractColoradoProse.ts
@@ -1,0 +1,93 @@
+/**
+ * Colorado Revised Statutes prose form (pre-1973 and modern)
+ *
+ * Parses citations in the form `Section 148-21-34, Colorado Revised Statutes
+ * 1963`, where the section comes BEFORE the code name. Pre-1973 Colorado
+ * used a chapter-article-section numbering scheme (`148-21-34` = chapter
+ * 148, article 21, section 34); the structured chapter/article fields are
+ * not surfaced separately — the full section body goes on `section`.
+ *
+ * `code` carries the full code name including the year suffix when present
+ * (`Colorado Revised Statutes 1963`), so consumers can distinguish editions
+ * without looking at `year` (which is reserved for trailing parenthetical
+ * edition years). #352
+ *
+ * @module extract/statutes/extractColoradoProse
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const COLORADO_PROSE_RE =
+  /^[Ss]ection\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+(Colo(?:rado)?\.?\s+Rev(?:ised)?\.?\s+Stat(?:utes)?\.?(?:\s+Ann(?:otated)?\.?)?)(?:\s+(19\d{2}))?$/d
+
+export function extractColoradoProse(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = COLORADO_PROSE_RE.exec(text)!
+
+  const rawBody = match[1]
+  const codeName = match[2].replace(/\s+/g, " ").trim()
+  const editionYear = match[3]
+  // `code` preserves the year suffix as part of the name: `Colorado Revised
+  // Statutes 1963`. The bare modern form remains `Colorado Revised Statutes`.
+  const code = editionYear ? `${codeName} ${editionYear}` : codeName
+
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const sectionIdx = match.indices[1]
+    if (sectionIdx && section) {
+      const bodyStart = sectionIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+    if (match.indices[2]) {
+      spans.code = spanFromGroupIndex(span.cleanStart, match.indices[2], transformationMap)
+    }
+  }
+
+  // Confidence: 0.9 baseline (the closed prose shape is unambiguous); +0.05
+  // when a subsection is captured.
+  let confidence = 0.9
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code,
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "CO",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -103,6 +103,27 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Pre-1973 Colorado Revised Statutes (prose form): `Section 148-21-34,
+    // Colorado Revised Statutes 1963` / `Section 13-25-126, Colo. Rev. Stat.
+    // 1973`. Pre-1973 Colorado used a chapter-article-section numbering
+    // scheme that surfaces here as the section body (`148-21-34`). The
+    // section comes BEFORE the code name — opposite of the canonical
+    // `<code> § <section>` shape — so this needs its own pattern.
+    //
+    // Listed BEFORE `abbreviated-code` so the prose-form container wins span
+    // dedup over the abbreviated-code match (which would otherwise consume
+    // the trailing `Colorado Revised Statutes 1963` and treat `1963` as the
+    // section, producing a duplicate citation). #352
+    //
+    // Captures: (1) section body, (2) optional edition year (1963/1973).
+    id: "colorado-prose",
+    regex:
+      /\b[Ss]ection\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Colo(?:rado)?\.?\s+Rev(?:ised)?\.?\s+Stat(?:utes)?\.?(?:\s+Ann(?:otated)?\.?)?(?:\s+(19\d{2}))?/g,
+    description:
+      'Pre-1973 Colorado prose form: "Section 148-21-34, Colorado Revised Statutes 1963" — #352',
+    type: "statute",
+  },
+  {
     id: "abbreviated-code",
     regex: buildAbbreviatedCodeRegex(),
     description: "Abbreviated state code citations for all US jurisdictions",

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1123,4 +1123,100 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Colorado pre-1973 and year-edition variants (#352)", () => {
+    it("inline `C.R.S. 1963 § 148-21-34` preserves edition in code, section is correct", () => {
+      const cites = extractCitations("Per C.R.S. 1963 § 148-21-34.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("C.R.S. 1963")
+        expect(cites[0].section).toBe("148-21-34")
+        expect(cites[0].jurisdiction).toBe("CO")
+      }
+    })
+
+    it("inline `C.R.S. 1973 § 13-25-126` works for modern edition variant", () => {
+      const cites = extractCitations("Per C.R.S. 1973 § 13-25-126.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("C.R.S. 1973")
+        expect(cites[0].section).toBe("13-25-126")
+      }
+    })
+
+    it("prose form `Section 148-21-34, Colorado Revised Statutes 1963`", () => {
+      const cites = extractCitations(
+        "violates Section 148-21-34, Colorado Revised Statutes 1963.",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Colorado Revised Statutes 1963")
+        expect(cites[0].section).toBe("148-21-34")
+        expect(cites[0].jurisdiction).toBe("CO")
+      }
+    })
+
+    it("prose form with `(YYYY Supp.)` trailing parenthetical", () => {
+      const cites = extractCitations(
+        "Section 148-11-22, Colorado Revised Statutes 1963 (1965 Supp.).",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Colorado Revised Statutes 1963")
+        expect(cites[0].section).toBe("148-11-22")
+        expect(cites[0].year).toBe(1965)
+        expect(cites[0].editionLabel).toBe("Supp.")
+      }
+    })
+
+    it("prose form with subsection: `Section 82-4-8(8)(f), Colo. Rev. Stat. 1963`", () => {
+      const cites = extractCitations(
+        "Per Section 82-4-8(8)(f), Colo. Rev. Stat. 1963.",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Colo. Rev. Stat. 1963")
+        expect(cites[0].section).toBe("82-4-8")
+        expect(cites[0].subsection).toBe("(8)(f)")
+      }
+    })
+
+    it("regression: modern `C.R.S. § 13-25-126` continues to work (no year)", () => {
+      const cites = extractCitations("under C.R.S. § 13-25-126.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("C.R.S.")
+        expect(cites[0].section).toBe("13-25-126")
+      }
+    })
+
+    it("regression: modern `C.R.S. § 13-25-126 (1973)` keeps 1973 in trailing year-parenthetical", () => {
+      const cites = extractCitations("under C.R.S. § 13-25-126 (1973).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("C.R.S.")
+        expect(cites[0].section).toBe("13-25-126")
+        expect(cites[0].year).toBe(1973)
+      }
+    })
+
+    it("regression: federal `42 U.S.C. § 1983 (1976)` unaffected", () => {
+      const cites = extractCitations("42 U.S.C. § 1983 (1976).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("1983")
+        expect(cites[0].year).toBe(1976)
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #352. Colorado has two compilations (`C.R.S. 1963` pre-1973 and `C.R.S.` / `C.R.S. 1973` post-1973). The year suffix is part of the code name, distinguishing the edition. Three combined failures dropped every pre-1973 Colorado statute citation in a 38-opinion sample:

1. **Year suffix consumed as section number**: `C.R.S. 1963 § 148-21-34` extracted `section: \"1963\"`, dropping `148-21-34`.
2. **Code name truncated**: `code` was `\"C.R.S.\"` instead of `\"C.R.S. 1963\"`.
3. **Prose form not extracted**: `Section 148-21-34, Colorado Revised Statutes 1963` (dominant pre-1973 form) produced no citation.

### Two coordinated changes

1. **`stateStatutes.ts`** — extended the Colorado regex fragment with an optional `\s+19\d{2}` tail so the year suffix attaches to the code name. Added year-suffixed canonical forms and the spelled-out base to the abbreviations array so `findAbbreviatedCode` resolves them via exact match.
2. **New `colorado-prose` tokenizer pattern + `extractColoradoProse` extractor** for the section-first prose form. Listed BEFORE `abbreviated-code` so the container shape wins span dedup over the trailing abbreviation match (otherwise both would emit citations with different sections).

### Scope notes

- Chapter-article-section structured fields, article-of-chapter prose form, and Colorado session laws are deferred — each is feature-shaped (new fields / new pattern families).

## Test plan

- [x] Inline `C.R.S. 1963 § 148-21-34` → `code: \"C.R.S. 1963\"`, `section: \"148-21-34\"`
- [x] Inline `C.R.S. 1973 § 13-25-126` → modern edition variant works
- [x] Prose `Section 148-21-34, Colorado Revised Statutes 1963` → single citation, correct section
- [x] Prose + `(1965 Supp.)` → year + editionLabel populated
- [x] Prose with subsection: `Section 82-4-8(8)(f), Colo. Rev. Stat. 1963`
- [x] Regression: `C.R.S. § 13-25-126` (no year) unchanged
- [x] Regression: `C.R.S. § 13-25-126 (1973)` — trailing year-parenthetical populates `year`
- [x] Regression: federal `42 U.S.C. § 1983 (1976)` unaffected
- [x] 8 new tests under `Colorado pre-1973 and year-edition variants (#352)`
- [x] Full vitest suite — 2551 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)