### PR TITLE
fix: Connecticut comma-pincite for Id./Ibid./supra (#353)

### DIFF
--- a/.changeset/issue-353-ct-comma-pincite.md
+++ b/.changeset/issue-353-ct-comma-pincite.md
@@ -1,0 +1,89 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Connecticut comma-pincite for Id./Ibid./supra back-references (#353)
+
+Connecticut courts use a distinctive citation style where the page
+follows a comma rather than the Bluebook `at`:
+
+```
+Id., 822          (vs. Bluebook `Id. at 822`)
+Smith, supra, 522 (vs. Bluebook `Smith, supra, at 822`)
+Ibid., 250
+```
+
+This convention is mandated by Connecticut Practice Book Rule 67-11
+and the Connecticut Style Manual. In a 28-opinion Connecticut sample,
+56 pincites were silently dropped because the existing `Id.`/`Ibid.`/
+`supra` patterns required the word `at` (or a paragraph marker)
+between the back-reference and the page.
+
+### Fix
+
+Extended the pincite-connector alternation in `ID_PATTERN`,
+`IBID_PATTERN`, and `SUPRA_PATTERN` (`src/patterns/shortForm.ts`) and
+the corresponding `idRegex` / `partySupraRegex` in
+`src/extract/extractShortForms.ts` from
+
+```
+(,?)\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))
+```
+
+to
+
+```
+(?:,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))
+```
+
+The new `,\s+` branch requires a literal comma, so it doesn't conflict
+with the existing typo-guard at the head of the pattern
+(`Id, at` is still only matched by `Id\s*,(?=\s+at\s)`).
+
+Group numbering in the extractor changed: the previous group 4
+(optional post-period comma) became group 4 (connector capture). The
+extractor now detects the "post-period comma" signal via
+`match[4]?.startsWith(",")` to preserve the existing confidence
+penalty for non-canonical forms.
+
+### Confidence policy
+
+- `Id. at 822` (canonical Bluebook) → confidence 1.0 unchanged
+- `Id., 822` (Connecticut comma-pincite) → confidence 0.9 (regional
+  convention; not a typo, but non-Bluebook)
+- `Id., at 253` (period-then-comma, Bluebook-tolerant) → confidence
+  0.9 unchanged
+- `Id, at 1483` (typo: comma instead of period) → confidence 0.7
+  unchanged
+
+### Scope
+
+The bracketed-reporter `supra, [24 Conn. App.] 554` and the
+section-comment-page `supra, § 2.09, comment 3, p. 375` forms are
+more complex pincite shapes and are deferred. Multi-page lists
+(`Id., 380, 383`) capture the first pincite only — same as existing
+hyphen-range behavior.
+
+### Tests
+
+9 new tests under `Connecticut comma-pincite for Id./Ibid./supra
+(#353)` in `tests/extract/extractShortForms.test.ts`:
+
+- `Id., 6` → pincite=6
+- `Id., 14-15` → pincite=14, endPage=15, isRange=true
+- `Id., 380, 383` → first pincite captured (list scope deferred)
+- `Smith, supra, 522` → pincite=522
+- `Ibid., 250` → pincite=250
+- Regression: `Id. at 822` → confidence=1.0
+- Regression: `Smith, supra, at 822`
+- Regression: `Id., at 253` (post-period comma)
+- Regression: `Id, at 1483` (typo comma) — confidence ≤ 0.7
+
+Full 2560-test suite passes; no regressions.
+
+### Related
+
+Surfaced by 28-opinion Connecticut sweep. Same family as #305 (Id./
+Ibid. punctuation variants), #281 / #247 (pincite forms), #344
+(short-form `at page N` word). Each is a pincite-prefix tolerance fix
+for back-reference shapes outside strict Bluebook.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -116,15 +116,20 @@ export function extractId(
   //     so bare `Id,` in prose ("his Id, but ...") is not misread.
   //
   // Group layout: 1=initial char ("I"/"i"), 2=`.` when canonical form,
-  // 3=`,` when typo form (mutually exclusive with 2), 4=optional post-period
-  // comma (canonical-only), 5=pincite.
+  // 3=`,` when typo form (mutually exclusive with 2), 4=connector before
+  // pincite (`, ` Connecticut-style, `,? at`, or `,? (?=¶)`), 5=pincite.
+  //
+  // Connector alternation accepts three forms (#353):
+  //   a) `, <pincite>` — Connecticut comma-pincite (`Id., 253`)
+  //   b) `[, ]?at <pincite>` — Bluebook at-form, optional leading comma
+  //   c) `[, ]?(?=¶|para)` — paragraph marker
   //
   // Pincite accepts optional "*" prefix for star-pagination (#191), an optional
   // trailing footnote suffix " n.14" / " nn.14-15" (#202), an optional
   // `p.` / `pp.` prefix for CSM form (`Id. at p. 125`; see #236), and
   // `¶` / `¶¶` / `para.` / `paras.` paragraph markers (#204). When the
   // pincite is a paragraph form, `at` is optional (`Id. ¶ 12`).
-  const idRegex = /([Ii])(?:d|bid)\s*(?:(\.)|(,)(?=\s+at\s))(,?)\s*(?:(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
+  const idRegex = /([Ii])(?:d|bid)\s*(?:(\.)|(,)(?=\s+at\s))(?:(,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const match = idRegex.exec(text)
 
   if (!match) {
@@ -132,10 +137,14 @@ export function extractId(
   }
 
   const firstChar = match[1]
-  // Non-standard punctuation: either a typo comma instead of period (group 3)
-  // or a post-period comma (group 4). Both lower confidence.
+  // Non-standard punctuation signals:
+  //   - `isTypoComma`: comma replacing the period (`Id, at 1483`) — lower confidence
+  //   - `hasComma`: post-period comma (`Id., at 253` or `Id., 253`) — slightly
+  //     lower confidence than canonical. Connector capture (group 4) starts
+  //     with `,` for both the post-period-comma-at form and the Connecticut
+  //     comma-pincite form.
   const isTypoComma = match[3] === ","
-  const hasComma = isTypoComma || match[4] === ","
+  const hasComma = isTypoComma || match[4]?.startsWith(",") === true
   const pinciteInfo: PinciteInfo | undefined = match[5]
     ? (parsePincite(match[5]) ?? undefined)
     : undefined
@@ -259,8 +268,11 @@ export function extractSupra(
   // range end / `p.` / `pp.` prefix for CSM form (#236), an optional trailing
   // footnote suffix (#202), and `¶` / `¶¶` / `para.` / `paras.` paragraph
   // markers (#204). When the pincite is a paragraph form, `at` is optional.
+  // Connector before pincite accepts the Connecticut comma-pincite form
+  // (`Smith, supra, 522`) alongside the Bluebook `, at` and paragraph
+  // forms (#353).
   const partySupraRegex =
-    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
+    /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:(?:,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const partyMatch = bracketedMatch ? null : partySupraRegex.exec(text)
 
   // Fallback: standalone supra — "supra note N", "supra at N", "supra § N".

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -29,12 +29,12 @@ import type { Pattern } from "./casePatterns"
  *  `paras.` paragraph markers (#204). When the pincite is a paragraph form,
  *  `at` is optional — `Id. ¶ 12` and `Id. at ¶ 12` both match. */
 export const ID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d(?:\s*\.|\s*,(?=\s+at\s))(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d(?:\s*\.|\s*,(?=\s+at\s))(?:(?:,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /** Ibid. with optional pincite (less common variant). Paragraph forms (#204)
  *  follow the same convention as Id. Optional space before the period (#305). */
 export const IBID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\s*\.(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\s*\.(?:(?:,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /**
  * Supra with party name and optional pincite.
@@ -59,7 +59,7 @@ export const IBID_PATTERN: RegExp =
  * paragraph form, `at` is optional.
  */
 export const SUPRA_PATTERN: RegExp =
-  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:(?:,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /**
  * Standalone supra without party name (common in footnotes).

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -1695,3 +1695,99 @@ describe("trailing parenthetical capture on short-form cites (#303)", () => {
     })
   })
 })
+
+describe("Connecticut comma-pincite for Id./Ibid./supra (#353)", () => {
+  it("extracts pincite from `Id., 6`", () => {
+    const text = "See Smith v. Jones, 100 Conn. 1, 5 (1980). Id., 6."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    expect(id?.type).toBe("id")
+    if (id?.type === "id") {
+      expect(id.pincite).toBe(6)
+    }
+  })
+
+  it("extracts pincite from `Id., 14-15` (range)", () => {
+    const text = "See Smith v. Jones, 100 Conn. 1, 5 (1980). Id., 14-15."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    expect(id?.type).toBe("id")
+    if (id?.type === "id") {
+      expect(id.pincite).toBe(14)
+      expect(id.pinciteInfo?.endPage).toBe(15)
+      expect(id.pinciteInfo?.isRange).toBe(true)
+    }
+  })
+
+  it("captures first pincite from `Id., 380, 383` (multi-page list out of scope)", () => {
+    const text = "See Smith v. Jones, 100 Conn. 1, 5 (1980). Id., 380, 383."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    expect(id?.type).toBe("id")
+    if (id?.type === "id") {
+      expect(id.pincite).toBe(380)
+    }
+  })
+
+  it("extracts pincite from `Smith, supra, 522`", () => {
+    const text = "We followed Smith v. Jones, 100 Conn. 1, 5 (1980). Smith, supra, 522."
+    const cites = extractCitations(text)
+    const supra = cites.find((c) => c.type === "supra")
+    expect(supra?.type).toBe("supra")
+    if (supra?.type === "supra") {
+      expect(supra.pincite).toBe(522)
+    }
+  })
+
+  it("extracts pincite from `Ibid., 250`", () => {
+    const text = "See Smith v. Jones, 100 Conn. 1, 5 (1980). Ibid., 250."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    expect(id?.type).toBe("id")
+    if (id?.type === "id") {
+      expect(id.pincite).toBe(250)
+    }
+  })
+
+  it("regression: `Id. at 822` (Bluebook form) — full confidence", () => {
+    const text = "See Smith, 100 Conn. 1 (1980). Id. at 822."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    expect(id?.type).toBe("id")
+    if (id?.type === "id") {
+      expect(id.pincite).toBe(822)
+      expect(id.confidence).toBe(1.0)
+    }
+  })
+
+  it("regression: `Smith, supra, at 822` (Bluebook form)", () => {
+    const text = "We cited Smith, 100 F.3d 1. Smith, supra, at 822."
+    const cites = extractCitations(text)
+    const supra = cites.find((c) => c.type === "supra")
+    expect(supra?.type).toBe("supra")
+    if (supra?.type === "supra") {
+      expect(supra.pincite).toBe(822)
+    }
+  })
+
+  it("regression: `Id., at 253` (post-period comma) still works", () => {
+    const text = "See Smith, 100 F.3d 1. Id., at 253."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    expect(id?.type).toBe("id")
+    if (id?.type === "id") {
+      expect(id.pincite).toBe(253)
+    }
+  })
+
+  it("regression: `Id, at 1483` (typo comma instead of period) still works", () => {
+    const text = "See Smith, 100 F.3d 1. Id, at 1483."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id")
+    expect(id?.type).toBe("id")
+    if (id?.type === "id") {
+      expect(id.pincite).toBe(1483)
+      expect(id.confidence).toBeLessThanOrEqual(0.7)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #353. Connecticut courts use a distinctive citation style with a comma directly followed by the page number — no `at`. The existing `Id.`/`Ibid.`/`supra` patterns required `at` (or a paragraph marker) before the pincite, dropping 56 pincites in a 28-opinion Connecticut sample.

Examples:
- `Id., 822` (Bluebook: `Id. at 822`)
- `Smith, supra, 522` (Bluebook: `Smith, supra, at 522`)
- `Ibid., 250`

### Fix

Extended the pincite-connector alternation in `ID_PATTERN`, `IBID_PATTERN`, and `SUPRA_PATTERN` (`src/patterns/shortForm.ts`) and the corresponding extractor regexes (`src/extract/extractShortForms.ts`) with a new `,\s+` branch:

```
(,?)\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))
                ↓
(?:,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))
```

The required comma on the new branch keeps it from conflicting with the existing typo-guard at the head of the pattern. Group numbering in the Id-extractor changed: previous group 4 (optional post-period comma) became the connector capture; the `hasComma` confidence signal is now detected via `match[4]?.startsWith(",")`.

### Confidence policy

- `Id. at 822` (Bluebook) — 1.0 unchanged
- `Id., 822` (CT comma-pincite) — **0.9** (regional convention, non-Bluebook)
- `Id., at 253` (post-period comma) — 0.9 unchanged
- `Id, at 1483` (typo) — 0.7 unchanged

### Scope

The bracketed-reporter `supra, [24 Conn. App.] 554` and section-comment-page `supra, § 2.09, comment 3, p. 375` forms are more complex pincite shapes and are deferred to follow-ups. Multi-page lists (`Id., 380, 383`) capture the first pincite only.

## Test plan

- [x] `Id., 6` → pincite=6
- [x] `Id., 14-15` (range) → pincite=14, endPage=15, isRange=true
- [x] `Id., 380, 383` → first pincite captured
- [x] `Smith, supra, 522` → pincite=522
- [x] `Ibid., 250` → pincite=250
- [x] Regression: `Id. at 822` — confidence=1.0
- [x] Regression: `Smith, supra, at 822`
- [x] Regression: `Id., at 253` (post-period comma)
- [x] Regression: `Id, at 1483` (typo) — confidence ≤ 0.7
- [x] Full vitest suite — 2560 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)