### PR TITLE
fix: Florida postfix and spelled-out-prefix statute forms (#356)

### DIFF
--- a/.changeset/issue-356-fla-postfix.md
+++ b/.changeset/issue-356-fla-postfix.md
@@ -1,0 +1,75 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Florida postfix and spelled-out-prefix statute forms (#356)
+
+Florida courts use a distinctive postfix citation syntax where the
+code name appears AFTER the section number — opposite the typical
+Bluebook prefix order. eyecite-ts handled the canonical Bluebook
+`Fla. Stat. § N` form but missed every Florida-specific variant. A
+50-opinion Florida sample produced 15+ statute misses dominated by
+these forms:
+
+- `section 812.035(7), Florida Statutes`
+- `§83.15, Florida Statutes`
+- `§120.68, Fla. Stat.`
+- `Florida Statute 679.504(3)` (singular code name, no `section`/`§`)
+- `Florida Statutes §73.071(3)(b)`
+
+### Fix
+
+Two new tokenizer patterns + one new extractor:
+
+- **`florida-postfix`** — section first, then code name
+  (`section <body>, Florida Statutes|Fla. Stat.` /
+  `§<body>, Florida Statutes|Fla. Stat.`). Uses a lookbehind
+  `(?<![A-Za-z])` boundary so the pattern can start at `§` (a `\b`
+  anchor doesn't match before a non-word char).
+- **`florida-prefix-spelled`** — spelled-out code name first
+  (`Florida Statute(s) [§] <body>`). Distinct from the canonical
+  Bluebook `Fla. Stat. §` prefix already handled by `abbreviated-code`.
+
+Both patternIds dispatch to a new
+`src/extract/statutes/extractFloridaStatute.ts`, which emits
+`code: "Fla. Stat."` (normalized) and `jurisdiction: "FL"`.
+
+The patterns are listed BEFORE `abbreviated-code` in `statutePatterns.ts`
+so the container shapes win span dedup over the trailing `Florida
+Statutes` token (which would otherwise tokenize on its own with a
+phantom section).
+
+### Scope notes
+
+Two pieces of #356 are intentionally deferred:
+
+- **Chapter-only references** (`Chapter 78, Florida Statutes`,
+  `Chapters 74-310 and 75-191, Florida Statutes`) — needs a data
+  model change (separate `chapter` field, or a chapter-only marker)
+  that's larger than a tight regex fix.
+- **Florida session laws** (`Chapters 74-310 and 75-191, Laws of
+  Florida`) — needs a new `sessionLaw` citation type. Tracked
+  separately alongside California `Stats.`, Colorado `Sess. Laws`,
+  and Arkansas equivalents.
+
+### Tests
+
+7 new tests under `Florida postfix + spelled-out-prefix statute forms
+(#356)` in `tests/extract/extractStatute.test.ts`:
+
+- Postfix word-section: `section 812.035(7), Florida Statutes`
+- Postfix §-section (no space): `§83.15, Florida Statutes`
+- Postfix §-section with `Fla. Stat.`: `§120.68, Fla. Stat.`
+- Spelled-out singular prefix: `Florida Statute 679.504(3)`
+- Spelled-out plural prefix + §: `Florida Statutes §73.071(3)(b)`
+- Regression: canonical `Fla. Stat. § 812.035(7)`
+- Regression: abbreviated `F.S. § 812.035`
+
+Full 2569-test suite passes; no regressions.
+
+### Related
+
+Same family as #348 (Arizona), #349 (Arkansas), #352 (Colorado), #330
+(Illinois pre-1993), #343 (Alabama 1940). Each state's statute code
+has its own ordering, abbreviation, and connector conventions that
+need explicit pattern coverage.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -23,6 +23,7 @@ import { extractCaBareCode } from "./statutes/extractCaBareCode"
 import { extractChapterAct } from "./statutes/extractChapterAct"
 import { extractColoradoProse } from "./statutes/extractColoradoProse"
 import { extractFederal } from "./statutes/extractFederal"
+import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
@@ -127,6 +128,9 @@ export function extractStatute(
       return extractAlaCode1940(token, transformationMap)
     case "colorado-prose":
       return extractColoradoProse(token, transformationMap)
+    case "florida-postfix":
+    case "florida-prefix-spelled":
+      return extractFloridaStatute(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractFloridaStatute.ts
+++ b/src/extract/statutes/extractFloridaStatute.ts
@@ -1,0 +1,95 @@
+/**
+ * Florida statute citations — postfix and spelled-out-prefix forms (#356)
+ *
+ * Florida courts use a distinctive postfix syntax where the code name
+ * appears AFTER the section number. The canonical Bluebook prefix form
+ * (`Fla. Stat. § 812.035`) is handled by `extractAbbreviated`; this
+ * extractor handles two Florida-specific shapes:
+ *
+ *   - postfix: `section 812.035(7), Florida Statutes` /
+ *              `§83.15, Florida Statutes` (patternId `florida-postfix`)
+ *   - spelled-out prefix: `Florida Statute 679.504(3)` /
+ *              `Florida Statutes §73.071(3)(b)` (patternId
+ *              `florida-prefix-spelled`)
+ *
+ * Both shapes emit `code: "Fla. Stat."` (normalized) and
+ * `jurisdiction: "FL"`.
+ *
+ * @module extract/statutes/extractFloridaStatute
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+// `^` anchor is fine here — the extractor receives only the matched span,
+// so the leading position is always the start of the captured token text.
+const FLORIDA_POSTFIX_RE =
+  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)$/d
+
+const FLORIDA_PREFIX_SPELLED_RE =
+  /^Florida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)$/d
+
+export function extractFloridaStatute(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+
+  const re =
+    token.patternId === "florida-postfix" ? FLORIDA_POSTFIX_RE : FLORIDA_PREFIX_SPELLED_RE
+  const match = re.exec(text)!
+
+  const rawBody = match[1]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  // Confidence: 0.95 for both shapes (closed Florida-specific patterns
+  // are unambiguous). +0.05 with a subsection.
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "Fla. Stat.",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "FL",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -124,6 +124,42 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Florida postfix form: `section 812.035(7), Florida Statutes` or
+    // `§83.15, Florida Statutes`. The code name appears AFTER the section
+    // — canonical Florida court style since at least the 1970s. Listed
+    // BEFORE `abbreviated-code` so the container-shape wins span dedup
+    // (otherwise the trailing `Florida Statutes` could tokenize as a
+    // separate abbreviated-code match). #356
+    //
+    // Captures: (1) section body.
+    id: "florida-postfix",
+    // Use a lookbehind boundary (`(?<![A-Za-z])`) instead of `\b` so the
+    // pattern can start at `§` — `\b` requires a word/non-word transition
+    // and `§` is a non-word char, so `\b` fails when `§` is the first char.
+    // No trailing `\b` because `Fla. Stat.` ends with `.` (non-word) and
+    // `\b` wouldn't anchor at end-of-string. The closed alternation
+    // (`Florida Statutes | Fla. Stat.`) is specific enough on its own.
+    regex:
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)/g,
+    description:
+      'Florida postfix statute form: "section 812.035(7), Florida Statutes" / "§83.15, Florida Statutes" — #356',
+    type: "statute",
+  },
+  {
+    // Florida spelled-out-prefix form: `Florida Statute 679.504(3)` or
+    // `Florida Statutes §73.071(3)(b)`. Spelled-out (singular or plural)
+    // code name with optional `§` connector — distinct from the canonical
+    // Bluebook `Fla. Stat. §` prefix handled by `abbreviated-code`.
+    //
+    // Captures: (1) section body.
+    id: "florida-prefix-spelled",
+    regex:
+      /\bFlorida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+    description:
+      'Florida spelled-out prefix form: "Florida Statute 679.504(3)" / "Florida Statutes §73.071" — #356',
+    type: "statute",
+  },
+  {
     id: "abbreviated-code",
     regex: buildAbbreviatedCodeRegex(),
     description: "Abbreviated state code citations for all US jurisdictions",

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1219,4 +1219,86 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Florida postfix + spelled-out-prefix statute forms (#356)", () => {
+    it("postfix word-section: `section 812.035(7), Florida Statutes`", () => {
+      const cites = extractCitations(
+        "violates section 812.035(7), Florida Statutes.",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Fla. Stat.")
+        expect(cites[0].section).toBe("812.035")
+        expect(cites[0].subsection).toBe("(7)")
+        expect(cites[0].jurisdiction).toBe("FL")
+      }
+    })
+
+    it("postfix §-section: `§83.15, Florida Statutes`", () => {
+      const cites = extractCitations("under §83.15, Florida Statutes.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Fla. Stat.")
+        expect(cites[0].section).toBe("83.15")
+      }
+    })
+
+    it("postfix §-section with `Fla. Stat.`: `§120.68, Fla. Stat.`", () => {
+      const cites = extractCitations("under §120.68, Fla. Stat.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Fla. Stat.")
+        expect(cites[0].section).toBe("120.68")
+      }
+    })
+
+    it("spelled-out singular prefix: `Florida Statute 679.504(3)`", () => {
+      const cites = extractCitations("Florida Statute 679.504(3) governs.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Fla. Stat.")
+        expect(cites[0].section).toBe("679.504")
+        expect(cites[0].subsection).toBe("(3)")
+      }
+    })
+
+    it("spelled-out plural prefix + §: `Florida Statutes §73.071(3)(b)`", () => {
+      const cites = extractCitations("under Florida Statutes §73.071(3)(b).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Fla. Stat.")
+        expect(cites[0].section).toBe("73.071")
+        expect(cites[0].subsection).toBe("(3)(b)")
+      }
+    })
+
+    it("regression: canonical Bluebook `Fla. Stat. § 812.035(7)` unaffected", () => {
+      const cites = extractCitations("Fla. Stat. § 812.035(7).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Fla. Stat.")
+        expect(cites[0].section).toBe("812.035")
+      }
+    })
+
+    it("regression: `F.S. § 812.035` abbreviated form unaffected", () => {
+      const cites = extractCitations("F.S. § 812.035 governs.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("FL")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #356. Florida courts use a distinctive postfix syntax where the code name appears AFTER the section. eyecite-ts handled the canonical Bluebook `Fla. Stat. § N` form but missed every Florida-specific variant. A 50-opinion Florida sample produced 15+ statute misses dominated by these forms.

### Two new patterns + new extractor

- **`florida-postfix`** — `section 812.035(7), Florida Statutes` / `§83.15, Florida Statutes` / `§120.68, Fla. Stat.`. Uses lookbehind `(?<![A-Za-z])` boundary so the pattern can start at `§` (a `\b` anchor doesn't match before a non-word char).
- **`florida-prefix-spelled`** — `Florida Statute 679.504(3)` / `Florida Statutes §73.071(3)(b)`. Spelled-out code name (singular or plural) — distinct from the abbreviated `Fla. Stat. §` prefix.

Both route to `src/extract/statutes/extractFloridaStatute.ts` and emit `code: \"Fla. Stat.\"` (normalized), `jurisdiction: \"FL\"`. Listed BEFORE `abbreviated-code` so the container shapes win span dedup.

### Deferred (out of scope for this patch)

- Chapter-only references (`Chapter 78, Florida Statutes`) — needs data-model change for a `chapter` field.
- Florida session laws (`Chapters 74-310 and 75-191, Laws of Florida`) — needs a new `sessionLaw` citation type.

## Test plan

- [x] `section 812.035(7), Florida Statutes`
- [x] `§83.15, Florida Statutes`
- [x] `§120.68, Fla. Stat.`
- [x] `Florida Statute 679.504(3)` (singular code, no §)
- [x] `Florida Statutes §73.071(3)(b)` (plural code, with §)
- [x] Regression: canonical `Fla. Stat. § 812.035(7)`
- [x] Regression: abbreviated `F.S. § 812.035`
- [x] 7 new tests
- [x] Full vitest suite — 2569 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)