### PR TITLE
feat: extract Revised Laws of Hawaii (pre-1955) `RLH YYYY § N` citations (#359)

### DIFF
--- a/.changeset/issue-359-rlh-hawaii.md
+++ b/.changeset/issue-359-rlh-hawaii.md
@@ -1,0 +1,62 @@
+---
+"eyecite-ts": patch
+---
+
+feat: extract Revised Laws of Hawaii (pre-1955) `RLH YYYY § N` citations (#359)
+
+Hawaii compiled its statutes as `RLH 1935`, `RLH 1945`, and `RLH 1955`
+before adopting the modern Hawaii Revised Statutes (HRS) in 1968.
+Modern Hawaii opinions still cite RLH when referencing pre-1955
+statutory history. A 50-opinion Hawaii sample showed these forms
+weren't extracted.
+
+### Fix
+
+New `rlh` tokenizer pattern in `src/patterns/statutePatterns.ts` and
+dedicated `extractRlh` extractor at
+`src/extract/statutes/extractRlh.ts`.
+
+Tokenizer regex:
+
+```
+\bRLH\s+(\d{4})\s+§\s+(<section-body>)
+```
+
+The `RLH` abbreviation is distinctively Hawaii-only, so no
+jurisdiction disambiguation is needed. Output:
+`code: "RLH"`, `jurisdiction: "HI"`, `year` = edition (1935/1945/1955),
+`section` (and `subsection` if present).
+
+### Scope notes
+
+The dominant Hawaii citation form `HRS § N` already worked (handled by
+the abbreviated-code pattern). This PR adds only the historical RLH
+compilation. The following pieces of #359 are intentionally deferred:
+
+- **HRS Chapter-only references** (`HRS Chapter 353E`) — needs a
+  `chapter`/section-less data model.
+- **HRS multi-section lists** (`HRS §§ 705-500, 707-701(1) (1985)`)
+  — same multi-section scope deferred for other states.
+- **Hawaii Session Laws** (`1927 Sess. L., Act 206, § 4, at 209`) —
+  needs a new `sessionLaw` citation type, tracked alongside the
+  unified-session-law work for CA / FL / CO / AR / GA.
+- **Prose form with okina** (`Section X of the Hawai'i Revised
+  Statutes`) — sibling to `extractColoradoProse` (#352); deferred.
+
+### Tests
+
+4 new tests under `Revised Laws of Hawaii (pre-1955) (#359)` in
+`tests/extract/extractStatute.test.ts`:
+
+- Canonical `RLH 1935 § 2545`
+- `RLH 1945 § 7186`
+- Hyphenated section `RLH 1955 § 100-1`
+- Regression: modern `HRS § 658-8 (1976)` continues to work
+
+Full 2574-test suite passes; no regressions.
+
+### Related
+
+Companion to #330 (pre-1993 Illinois Revised Statutes) and #343
+(Code of Alabama 1940) — historical state-statute formats that
+remain in active citation.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -27,6 +27,7 @@ import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
+import { extractRlh } from "./statutes/extractRlh"
 
 /**
  * Legacy inline parser for unknown patterns.
@@ -131,6 +132,8 @@ export function extractStatute(
     case "florida-postfix":
     case "florida-prefix-spelled":
       return extractFloridaStatute(token, transformationMap)
+    case "rlh":
+      return extractRlh(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractRlh.ts
+++ b/src/extract/statutes/extractRlh.ts
@@ -1,0 +1,84 @@
+/**
+ * Revised Laws of Hawaii (pre-1955) — historical compilation citations
+ *
+ * Hawaii compiled its statutes as RLH 1935, RLH 1945, and RLH 1955 before
+ * adopting the modern Hawaii Revised Statutes (HRS) in 1968. Modern Hawaii
+ * opinions still cite RLH when referencing pre-1955 statutory text. #359
+ *
+ *   RLH 1935 § 2545
+ *   RLH 1945 § 7186
+ *   RLH 1955 § 7186
+ *
+ * The `RLH` token is distinctively Hawaii-only, so no jurisdiction
+ * disambiguation is needed.
+ *
+ * @module extract/statutes/extractRlh
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const RLH_RE =
+  /^RLH\s+(\d{4})\s+§\s+(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
+
+export function extractRlh(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = RLH_RE.exec(text)!
+  const year = Number.parseInt(match[1], 10)
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  // Confidence: 0.95 baseline; +0.05 with subsection.
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "RLH",
+    section,
+    subsection,
+    pincite: subsection,
+    year,
+    jurisdiction: "HI",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -103,6 +103,19 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Revised Laws of Hawaii — pre-1955 Hawaii statutory compilations
+    // (`RLH 1935 § 2545`, `RLH 1945 § 7186`, `RLH 1955 § 7186`). Modern
+    // Hawaii opinions still cite RLH when discussing pre-1955 statutory
+    // history. The `RLH` token is distinctively Hawaii-only. #359
+    //
+    // Captures: (1) edition year, (2) section body.
+    id: "rlh",
+    regex:
+      /\bRLH\s+(\d{4})\s+§\s+(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+    description: 'Revised Laws of Hawaii (pre-1955): "RLH 1935 § 2545" — #359',
+    type: "statute",
+  },
+  {
     // Pre-1973 Colorado Revised Statutes (prose form): `Section 148-21-34,
     // Colorado Revised Statutes 1963` / `Section 13-25-126, Colo. Rev. Stat.
     // 1973`. Pre-1973 Colorado used a chapter-article-section numbering

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1301,4 +1301,54 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Revised Laws of Hawaii (pre-1955) (#359)", () => {
+    it("extracts `RLH 1935 § 2545`", () => {
+      const cites = extractCitations("Per RLH 1935 § 2545.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RLH")
+        expect(cites[0].section).toBe("2545")
+        expect(cites[0].year).toBe(1935)
+        expect(cites[0].jurisdiction).toBe("HI")
+      }
+    })
+
+    it("extracts `RLH 1945 § 7186`", () => {
+      const cites = extractCitations("Per RLH 1945 § 7186.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RLH")
+        expect(cites[0].section).toBe("7186")
+        expect(cites[0].year).toBe(1945)
+      }
+    })
+
+    it("extracts hyphenated section: `RLH 1955 § 100-1`", () => {
+      const cites = extractCitations("Per RLH 1955 § 100-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("100-1")
+        expect(cites[0].year).toBe(1955)
+      }
+    })
+
+    it("regression: modern `HRS § 658-8 (1976)` continues to work", () => {
+      const cites = extractCitations("HRS § 658-8 (1976).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("HRS")
+        expect(cites[0].section).toBe("658-8")
+        expect(cites[0].year).toBe(1976)
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #359 (narrow scope). Hawaii compiled its statutes as `RLH 1935`, `RLH 1945`, and `RLH 1955` before adopting HRS in 1968. Modern Hawaii opinions still cite RLH for pre-1955 statutory history. A 50-opinion Hawaii sample showed these forms weren't extracted.

### Fix

New `rlh` tokenizer pattern + dedicated `extractRlh` extractor. `RLH` is Hawaii-only, so jurisdiction is hardcoded to `\"HI\"`, code is normalized to `\"RLH\"`, and `year` captures the edition (1935/1945/1955).

### Out of scope (deferred)

The dominant `HRS § N` form already works. Other parts of #359:

- **HRS Chapter-only refs** (`HRS Chapter 353E`) — needs section-less data model.
- **HRS multi-section lists** (`HRS §§ 705-500, 707-701(1)`) — same as other state multi-section deferrals.
- **Hawaii Session Laws** (`1927 Sess. L., Act 206, § 4, at 209`) — needs a new `sessionLaw` citation type.
- **Prose form with okina** (`Section X of the Hawai'i Revised Statutes`) — sibling to `extractColoradoProse`.

## Test plan

- [x] `RLH 1935 § 2545` → code=\"RLH\", section=\"2545\", year=1935
- [x] `RLH 1945 § 7186` → year=1945
- [x] Hyphenated section: `RLH 1955 § 100-1`
- [x] Regression: modern `HRS § 658-8 (1976)` continues to work
- [x] 4 new tests
- [x] Full vitest suite — 2574 passed, 0 failed (9 skipped, pre-existing)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)