### PR TITLE
fix: Idaho Code variants — comma, postfix, I.C./I. C. (#360)

### DIFF
--- a/.changeset/issue-360-idaho-code.md
+++ b/.changeset/issue-360-idaho-code.md
@@ -1,0 +1,73 @@
+---
+"eyecite-ts": patch
+---
+
+feat: extract Idaho Code variants — `Idaho Code, § N`, postfix `Section N, Idaho Code`, and `I.C.` / `I. C.` abbreviations (#360)
+
+Idaho courts cite the Idaho Code in five interchangeable forms within a
+single opinion. Only the canonical `Idaho Code § N` and the universal
+`Idaho Code section N` (#348) variants were extracted. A 50-opinion
+Idaho sample produced 20+ Idaho Code misses — the dominant statutory
+citation form.
+
+### Fixes
+
+- **Comma form** (`Idaho Code, § 19-4906(c)`) — added optional comma
+  between code name and section connector in the `abbreviated-code`
+  tokenizer regex (`buildAbbreviatedCodeRegex` in
+  `src/data/stateStatutes.ts`) and the mirroring extractor regex
+  (`ABBREVIATED_RE` in `src/extract/statutes/extractAbbreviated.ts`).
+  Universal change; harmless to other states.
+- **Postfix form** (`Section 23-908(4), Idaho Code`) — new
+  `idaho-postfix` tokenizer pattern (sibling to `florida-postfix`),
+  routed to dedicated `extractIdahoPostfix` extractor. Emits
+  `code: "Idaho Code"`, `jurisdiction: "ID"`.
+- **`I.C. § N`** / **`I. C. § N`** — Idaho regex fragment now admits
+  `I\.?\s*C\.?` (canonical dotted + inter-letter spacing variants).
+  The stripped-form fallback in `findAbbreviatedCode` resolves
+  spacing variants to the canonical `I.C.` abbreviation.
+
+### Indiana / Idaho disambiguation
+
+Bare `I.C.` (with dots) is the Idaho abbreviation; Indiana opinions
+use the dotless `IC` or the spelled-out `Ind. Code` forms instead.
+The Indiana regex fragment in `src/data/stateStatutes.ts` was
+tightened from `I\.?C\.?` (which matched both `IC` and `I.C.`) to
+literal `IC`, freeing the dotted form for Idaho. Indiana coverage of
+`IC`, `Ind. Code`, `Indiana Code`, and `Burns Ind. Code Ann.` is
+unchanged.
+
+### Scope notes
+
+The following pieces of #360 are intentionally deferred:
+
+- **Multi-section lists** (`I.C. §§ 61-624, 61-629`,
+  `Idaho Code §§ 19-4904 and 19-852`) — deferred across all states
+  pending a unified multi-section data-model decision.
+- **Section ranges** (`I.C. §§ 16-1605-1607`) — ambiguous parse
+  (range vs. weird single section); deferred with the multi-section
+  work.
+
+### Tests
+
+8 new tests under `Idaho Code variants (#360)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `Idaho Code section 15-5-209`
+- `Idaho Code section 19-2715(5)` with subsection
+- `Idaho Code, § 19-4906(c)` (comma form)
+- `Section 23-908(4), Idaho Code` (postfix form)
+- `I.C. § 61-623` (canonical dotted)
+- `I. C. § 61-623` (spaced)
+- Regression: `IC 35-42-1-1` still routes to Indiana
+- Regression: `Ind. Code § 35-42-1-1` still routes to Indiana
+
+Full 2583-test suite passes; no regressions.
+
+### Related
+
+Sibling to #356 (Florida postfix), #348 (universal word-section
+connector), and #349 (Arkansas inter-letter spacing). Every state
+with a dotted-abbreviation code (A.R.S., C.R.S., I.C., etc.) needs
+both spacing tolerance and an audit against neighboring states that
+might collide on the stripped form.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -78,7 +78,9 @@ export function buildAbbreviatedCodeRegex(): RegExp {
     // Section connector: `§`, `§§`, or the spelled-out word `section(s)` /
     // `Section(s)` (#348). Arizona and several other state corpora cite as
     // `A.R.S. section 14-2804(A)` interchangeably with `A.R.S. § 14-2804(A)`.
-    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
+    // Optional comma between code name and connector (`Idaho Code, § N`) is
+    // common in Idaho practice (#360) and harmless elsewhere.
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
     "g",
   )
 }
@@ -178,6 +180,10 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "P\\.?S\\.?",
   },
   // ── Indiana ────────────────────────────────────────────────────────────────
+  // The bare dotted `I.C.` form is reserved for Idaho (#360) — Indiana
+  // opinions use either the spelled-out `Ind. Code` / `Indiana Code` or the
+  // dotless `IC` shorthand. Restricting Indiana to the dotless `IC` lets
+  // Idaho own `I.C.` / `I. C.` without losing Indiana coverage.
   {
     jurisdiction: "IN",
     abbreviations: [
@@ -187,11 +193,10 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
       "Indiana Code",
       "Ind. Code Ann.",
       "Ind. Code",
-      "I.C.",
       "IC",
     ],
     regexFragment:
-      "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?",
+      "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|IC",
   },
   // ── New Jersey ─────────────────────────────────────────────────────────────
   {
@@ -267,10 +272,15 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Iowa\\s+Code(?:\\s+Ann\\.?)?|I\\.?C\\.?A\\.?",
   },
   // ── Idaho ─────────────────────────────────────────────────────────────────
+  // Idaho fragment admits the dotted `I.C.` abbreviation plus inter-letter
+  // spacing variants (`I. C.`, OCR `I.  C.`) and the no-dots form (`IC` is
+  // owned by Indiana via array order). The extractor normalizes all variants
+  // to the canonical `Idaho Code` via the stripped-form fallback in
+  // `findAbbreviatedCode`. #360
   {
     jurisdiction: "ID",
-    abbreviations: ["Idaho Code Ann.", "Idaho Code"],
-    regexFragment: "Idaho\\s+Code(?:\\s+Ann\\.?)?",
+    abbreviations: ["Idaho Code Ann.", "Idaho Code", "I.C."],
+    regexFragment: "Idaho\\s+Code(?:\\s+Ann\\.?)?|I\\.?\\s*C\\.?",
   },
   // ── Kansas ────────────────────────────────────────────────────────────────
   {

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -24,6 +24,7 @@ import { extractChapterAct } from "./statutes/extractChapterAct"
 import { extractColoradoProse } from "./statutes/extractColoradoProse"
 import { extractFederal } from "./statutes/extractFederal"
 import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
+import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
@@ -132,6 +133,8 @@ export function extractStatute(
     case "florida-postfix":
     case "florida-prefix-spelled":
       return extractFloridaStatute(token, transformationMap)
+    case "idaho-postfix":
+      return extractIdahoPostfix(token, transformationMap)
     case "rlh":
       return extractRlh(token, transformationMap)
     default:

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -24,8 +24,9 @@ import { parseBody } from "./parseBody"
 // lazy abbreviation capture would absorb the word `section` and break
 // `findAbbreviatedCode` lookups (e.g., `Arkansas Code Annotated section
 // 11-9-102` would emit abbrevText="Arkansas Code Annotated section").
+// Optional comma between code and connector (`Idaho Code, § N`) #360.
 const ABBREVIATED_RE =
-  /^(?:(\d+)\s+)?(.+?)\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
+  /^(?:(\d+)\s+)?(.+?)\s*,?\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
 
 export function extractAbbreviated(
   token: Token,

--- a/src/extract/statutes/extractIdahoPostfix.ts
+++ b/src/extract/statutes/extractIdahoPostfix.ts
@@ -1,0 +1,75 @@
+/**
+ * Idaho Code postfix form — `Section 23-908(4), Idaho Code`
+ *
+ * Canonical Idaho court style places the code name AFTER the section, just
+ * like Florida's `section N, Florida Statutes` form. The leading word
+ * "section" / "§" is optional in some Idaho variants but typically present.
+ * #360
+ *
+ * @module extract/statutes/extractIdahoPostfix
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const IDAHO_POSTFIX_RE =
+  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Idaho\s+Code(?:\s+Ann\.?)?$/d
+
+export function extractIdahoPostfix(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = IDAHO_POSTFIX_RE.exec(text)!
+  const rawBody = match[1]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "Idaho Code",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "ID",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -173,6 +173,21 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Idaho postfix form: `Section 23-908(4), Idaho Code` — the code name
+    // appears AFTER the section. Sibling to florida-postfix. Listed BEFORE
+    // `abbreviated-code` so the container-shape wins span dedup (otherwise
+    // the trailing `Idaho Code` could tokenize as a separate abbreviated-code
+    // match). #360
+    //
+    // Captures: (1) section body.
+    id: "idaho-postfix",
+    regex:
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Idaho\s+Code(?:\s+Ann\.?)?/g,
+    description:
+      'Idaho postfix statute form: "Section 23-908(4), Idaho Code" — #360',
+    type: "statute",
+  },
+  {
     id: "abbreviated-code",
     regex: buildAbbreviatedCodeRegex(),
     description: "Abbreviated state code citations for all US jurisdictions",

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1351,4 +1351,101 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Idaho Code variants (#360)", () => {
+    it("extracts `Idaho Code section 15-5-209` (word section)", () => {
+      const cites = extractCitations("See Idaho Code section 15-5-209.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Idaho Code")
+        expect(cites[0].section).toBe("15-5-209")
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("extracts `Idaho Code section 19-2715(5)` with subsection", () => {
+      const cites = extractCitations("See Idaho Code section 19-2715(5).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Idaho Code")
+        expect(cites[0].section).toBe("19-2715")
+        expect(cites[0].subsection).toBe("(5)")
+      }
+    })
+
+    it("extracts `Idaho Code, § 19-4906(c)` (comma form)", () => {
+      const cites = extractCitations("Idaho Code, § 19-4906(c).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Idaho Code")
+        expect(cites[0].section).toBe("19-4906")
+        expect(cites[0].subsection).toBe("(c)")
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("extracts `Section 23-908(4), Idaho Code` (postfix form)", () => {
+      const cites = extractCitations("Section 23-908(4), Idaho Code.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Idaho Code")
+        expect(cites[0].section).toBe("23-908")
+        expect(cites[0].subsection).toBe("(4)")
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("extracts `I.C. § 61-623` (canonical dotted abbreviation)", () => {
+      const cites = extractCitations("See I.C. § 61-623.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("I.C.")
+        expect(cites[0].section).toBe("61-623")
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("extracts `I. C. § 61-623` (inter-letter spaced abbreviation)", () => {
+      const cites = extractCitations("See I. C. § 61-623.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("I.C.")
+        expect(cites[0].section).toBe("61-623")
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("regression: Indiana `IC 35-42-1-1` still routes to Indiana", () => {
+      const cites = extractCitations("See IC 35-42-1-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("IN")
+      }
+    })
+
+    it("regression: Indiana `Ind. Code § 35-42-1-1` still routes to Indiana", () => {
+      const cites = extractCitations("See Ind. Code § 35-42-1-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("35-42-1-1")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #360. Idaho courts cite the Idaho Code in five interchangeable forms within a single opinion. Only the canonical `Idaho Code § N` and word-section variants were extracted. This PR adds the remaining four forms:

- **Comma form**: `Idaho Code, § 19-4906(c)` — optional comma allowed in `abbreviated-code` regex (universal change, harmless to other states).
- **Postfix form**: `Section 23-908(4), Idaho Code` — new `idaho-postfix` tokenizer + `extractIdahoPostfix` extractor, sibling to `florida-postfix`.
- **`I.C. § N`**: dotted abbreviation — Idaho regex fragment now admits `I\.?\s*C\.?`.
- **`I. C. § N`**: spaced abbreviation — same fragment + stripped-form fallback normalizes to canonical `I.C.`.

### Indiana / Idaho disambiguation

Bare `I.C.` (dotted) is the Idaho abbreviation; Indiana opinions use `IC` (dotless) or spelled-out `Ind. Code`. The Indiana regex fragment was tightened from `I\.?C\.?` (which matched both forms) to literal `IC`, freeing `I.C.` for Idaho. Indiana coverage of `IC`, `Ind. Code`, `Indiana Code`, and `Burns Ind. Code Ann.` is unchanged.

### Scope notes (deferred)

- Multi-section lists (`I.C. §§ 61-624, 61-629`) — pending unified multi-section data model.
- Section ranges (`I.C. §§ 16-1605-1607`) — same.

## Test plan

- [x] 8 new tests under `Idaho Code variants (#360)` including Indiana regressions
- [x] Full 2583-test suite passes locally
- [x] Typecheck + lint clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)