### PR TITLE
fix: Michigan MSA mis-classified as Minnesota; bracket-subscript sections (#370)

### DIFF
--- a/.changeset/issue-370-michigan-msa.md
+++ b/.changeset/issue-370-michigan-msa.md
@@ -1,0 +1,85 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Michigan `MSA` no longer mis-classified as Minnesota; bracket-subscript sections (`MSA 23.710[252]`) preserved (#370)
+
+A 32-opinion Michigan sweep showed 100% (53/53) of `MSA` citations
+mis-classified as Minnesota — `MSA` matched Minnesota's
+`M\.?S\.?A\.?` regex fragment (which made dots optional). The
+dotless `MSA` is in fact **Michigan Statutes Annotated** (Callaghan),
+the historical companion to MCL; the dotted `M.S.A.` is the Bluebook
+abbreviation for Minnesota Statutes Annotated.
+
+### Fixes
+
+- **MSA disambiguation**: Minnesota's regex fragment in
+  `src/data/stateStatutes.ts` tightened from `M\.?S\.?A\.?`
+  to literal `M\.S\.A\.` (dots required). A new Michigan entry
+  for Michigan Statutes Annotated (`abbreviations: ["Mich. Stat.
+  Ann.", "MSA"]`) lives alongside the existing MCL entry, so
+  the canonical `code` for `MSA` citations stays `MSA` rather
+  than being normalized to `MCL`.
+
+- **Bracket-subscript sections**: section body in
+  `buildAbbreviatedCodeRegex` and `ABBREVIATED_RE`
+  (`extractAbbreviated.ts`) now accepts either `(...)` or
+  `[...]` as trailing subscript groups. MSA cites bracket
+  subscripts (`23.710[252]`) interchangeably with parens. The
+  `SUBSECTION_RE` in `parseBody.ts` was extended to split on
+  the first `[` as well, so `23.710[252]` parses as
+  `section="23.710"`, `subsection="[252]"`.
+
+### Behavior changes
+
+- `MSA 23.710(254)` now emits `code: "MSA"`, `jurisdiction:
+  "MI"` (was `code: "M.S.A."`, `jurisdiction: "MN"`).
+- `MSA 23.710[252]` now extracts (was: dropped at tokenize
+  time because section body rejected brackets).
+- `M.S.A. § 480A.06` continues to emit `jurisdiction: "MN"`
+  — the dotted form is the Bluebook standard for Minnesota.
+- `Minn. Stat.` / `Minn. Stat. Ann.` continue to emit
+  `jurisdiction: "MN"`.
+- `MCL` / `MCLA` / `M.C.L.` / `Mich. Comp. Laws` continue to
+  emit `jurisdiction: "MI"` with their respective canonical
+  code names.
+
+### Scope notes
+
+The following pieces of #370 are intentionally deferred:
+
+- **`Stat Ann 1963 Rev § 21.96`** — year-edition variant
+  format, sibling to the deferred `IC YYYY` (#363), `C.R.S.
+  1963` (#352), `K.S.A. Supp.` (#367) family. Needs a unified
+  edition-year data model decision.
+- **`PA 1901, No 206`** — Public Acts session laws.
+  Deferred alongside the other session-law formats (`Ga. L.`,
+  `Stats.`, `Laws of Florida`, etc.) pending a unified
+  `sessionLaw` citation type.
+- **Prose forms** like `section 3110(3) of the Michigan
+  no-fault statute` — needs document-level context to attach
+  a jurisdiction.
+
+### Tests
+
+6 new tests under `Michigan MSA jurisdiction + bracket
+subscripts (#370)` in `tests/extract/extractStatute.test.ts`:
+
+- `MSA 23.710(254)` → `code="MSA"`, `jurisdiction="MI"`
+- `MSA 23.710[252]` → `subsection="[252]"`
+- `Mich. Stat. Ann. § 23.710` → `jurisdiction="MI"`
+- Regression: `M.S.A. § 480A.06` → `jurisdiction="MN"`
+- Regression: `Minn. Stat. § 290.16` → `jurisdiction="MN"`
+- Regression: `MCL 801.258` → `code="MCL"`,
+  `jurisdiction="MI"`
+
+Full 2589-test suite passes; no regressions.
+
+### Related
+
+Same disambiguation pattern as #360 (Idaho `I.C.` vs Indiana
+`IC`): when two states share an abbreviated form, prefer the
+formally-distinct surface (dots vs. no-dots, spacing) to
+route to the more common modern usage. The Michigan side
+follows the published source — Callaghan's MSA was the
+modern Michigan abbreviation through the 1990s.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -80,7 +80,9 @@ export function buildAbbreviatedCodeRegex(): RegExp {
     // `A.R.S. section 14-2804(A)` interchangeably with `A.R.S. § 14-2804(A)`.
     // Optional comma between code name and connector (`Idaho Code, § N`) is
     // common in Idaho practice (#360) and harmless elsewhere.
-    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:\\s*et\\s+seq\\.?)?)`,
+    // Trailing subscript groups accept either parens or brackets — MSA uses
+    // `[N]` for subdivisions (`MSA 23.710[252]`) #370.
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\)|\\[[^\\]]*\\])*(?:\\s*et\\s+seq\\.?)?)`,
     "g",
   )
 }
@@ -115,6 +117,16 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
       "MCL",
     ],
     regexFragment: "Mich\\.?\\s+Comp\\.?\\s+Laws(?:\\s+(?:Ann|Serv)\\.?)?|M\\.?C\\.?L\\.?|MCL[AS]?",
+  },
+  // Michigan Statutes Annotated (MSA) — historical Callaghan-published
+  // companion to MCL. Bare `MSA` (no dots) is Michigan; the dotted `M.S.A.`
+  // is reserved for Minnesota Statutes Annotated (Bluebook standard).
+  // Separate entry from MCL so the canonical `code` field stays `MSA` rather
+  // than being normalized to `MCL`. #370
+  {
+    jurisdiction: "MI",
+    abbreviations: ["Mich. Stat. Ann.", "MSA"],
+    regexFragment: "Mich\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|MSA",
   },
   // ── Utah ───────────────────────────────────────────────────────────────────
   {
@@ -308,10 +320,13 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Me\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.?R\\.?S\\.?A?\\.?",
   },
   // ── Minnesota ─────────────────────────────────────────────────────────────
+  // The dotted `M.S.A.` form (literal dots required) routes to Minnesota
+  // Statutes Annotated; the dotless `MSA` belongs to Michigan (Mich. Stat.
+  // Ann.) via array order — see Michigan entry above. #370
   {
     jurisdiction: "MN",
     abbreviations: ["Minn. Stat. Ann.", "Minn. Stat.", "M.S.A."],
-    regexFragment: "Minn\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.?S\\.?A\\.?",
+    regexFragment: "Minn\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.S\\.A\\.",
   },
   // ── Mississippi ───────────────────────────────────────────────────────────
   {

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -25,8 +25,9 @@ import { parseBody } from "./parseBody"
 // `findAbbreviatedCode` lookups (e.g., `Arkansas Code Annotated section
 // 11-9-102` would emit abbrevText="Arkansas Code Annotated section").
 // Optional comma between code and connector (`Idaho Code, § N`) #360.
+// Trailing subscript groups accept either parens or brackets — MSA #370.
 const ABBREVIATED_RE =
-  /^(?:(\d+)\s+)?(.+?)\s*,?\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
+  /^(?:(\d+)\s+)?(.+?)\s*,?\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s*et\s+seq\.?)?)$/d
 
 export function extractAbbreviated(
   token: Token,

--- a/src/extract/statutes/parseBody.ts
+++ b/src/extract/statutes/parseBody.ts
@@ -7,8 +7,10 @@
  * @module extract/statutes/parseBody
  */
 
-/** Separate subsection chain from section number */
-const SUBSECTION_RE = /^([^(]+?)\s*((?:\([^)]*\))*)$/
+/** Separate subsection chain from section number.
+ * Accepts both `(...)` and `[...]` — MSA uses bracket subscripts
+ * (`23.710[252]`) interchangeably with parens (`23.710(252)`). #370 */
+const SUBSECTION_RE = /^([^([]+?)\s*((?:\([^)]*\)|\[[^\]]*\])*)$/
 
 /** Et seq. at end of string */
 const ET_SEQ_RE = /\s*et\s+seq\.?\s*$/i

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1448,4 +1448,76 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Michigan MSA jurisdiction + bracket subscripts (#370)", () => {
+    it("extracts `MSA 23.710(254)` as Michigan (not Minnesota)", () => {
+      const cites = extractCitations("See MSA 23.710(254).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MSA")
+        expect(cites[0].jurisdiction).toBe("MI")
+        expect(cites[0].section).toBe("23.710")
+        expect(cites[0].subsection).toBe("(254)")
+      }
+    })
+
+    it("extracts `MSA 23.710[252]` with bracket subscript", () => {
+      const cites = extractCitations("See MSA 23.710[252].").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MSA")
+        expect(cites[0].jurisdiction).toBe("MI")
+        expect(cites[0].section).toBe("23.710")
+        expect(cites[0].subsection).toBe("[252]")
+      }
+    })
+
+    it("extracts `Mich. Stat. Ann. § 23.710` as Michigan", () => {
+      const cites = extractCitations("See Mich. Stat. Ann. § 23.710.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MI")
+      }
+    })
+
+    it("regression: dotted `M.S.A. § 480A.06` still routes to Minnesota", () => {
+      const cites = extractCitations("See M.S.A. § 480A.06.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("M.S.A.")
+        expect(cites[0].jurisdiction).toBe("MN")
+      }
+    })
+
+    it("regression: `Minn. Stat. § 290.16` still routes to Minnesota", () => {
+      const cites = extractCitations("See Minn. Stat. § 290.16.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MN")
+        expect(cites[0].section).toBe("290.16")
+      }
+    })
+
+    it("regression: `MCL 801.258` still routes to Michigan with code=MCL", () => {
+      const cites = extractCitations("See MCL 801.258.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MCL")
+        expect(cites[0].jurisdiction).toBe("MI")
+        expect(cites[0].section).toBe("801.258")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #370. A 32-opinion Michigan sweep showed 100% (53/53) of `MSA` citations were mis-classified as Minnesota. The dotless `MSA` is **Michigan Statutes Annotated** (Callaghan); the dotted `M.S.A.` is the Bluebook form for Minnesota Statutes Annotated.

- **Disambiguate `MSA`**: Minnesota fragment tightened to literal `M\\.S\\.A\\.` (dots required). New separate Michigan entry for `Mich. Stat. Ann.` / `MSA` lives alongside the MCL entry, so canonical `code` stays `MSA` rather than being normalized to `MCL`.
- **Bracket-subscript sections**: section-body regex in tokenizer + extractor + `parseBody` now accepts `[...]` alongside `(...)` so `MSA 23.710[252]` parses with `subsection="[252]"` (was: bracket dropped at tokenize time).

### Behavior

| Input | Before | After |
|---|---|---|
| `MSA 23.710(254)` | code=M.S.A., jur=MN | code=MSA, jur=MI |
| `MSA 23.710[252]` | code=M.S.A., jur=MN, sub=undefined | code=MSA, jur=MI, sub=[252] |
| `M.S.A. § 480A.06` | jur=MN | jur=MN (unchanged) |
| `Minn. Stat. § N`, `MCL N`, `MCLA N`, etc. | unchanged | unchanged |

### Deferred

- `Stat Ann 1963 Rev § 21.96` — year-edition variant; pending unified edition-year handling
- `PA 1901, No 206` — Public Acts session laws; pending unified `sessionLaw` type
- Prose `section N of the Michigan no-fault statute` — needs document context

## Test plan

- [x] 6 new tests under `Michigan MSA jurisdiction + bracket subscripts (#370)`
- [x] Full 2589-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)