### PR TITLE
feat: Minnesota Minn. St. short form, year-edition, spelled-out Minnesota Statutes (#371)

### DIFF
--- a/.changeset/issue-371-minnesota.md
+++ b/.changeset/issue-371-minnesota.md
@@ -1,0 +1,89 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Minnesota `Minn. St.` short form, year-edition (`Minn. St. YYYY, § N`), and spelled-out `Minnesota Statutes` extraction (#371)
+
+A 35-opinion Minnesota sweep produced 30+ Minnesota statute misses.
+`Minn. St.` (without the `at`) is the canonical Minnesota court style
+— distinct from the federal Bluebook's `Minn. Stat.` Modern Minnesota
+opinions and pre-1980 historical opinions use the year-edition form
+`Minn. St. 1971, § 176.66` to indicate which compilation was in
+effect at the time of the events.
+
+### Fixes
+
+- **Modern `Minn. St. N.NN`**: Minnesota regex fragment in
+  `src/data/stateStatutes.ts` extended to accept `Minn. St.` (short
+  form) alongside `Minn. Stat.` (Bluebook). The abbreviations array
+  adds `Minn. St.` so the canonical `code` field preserves the
+  surface form when extracted.
+
+- **Spelled-out `Minnesota Statutes`**: fragment also matches the
+  spelled-out short title plus optional `Ann.` / `Annotated`
+  trailer. Pairs with the universal optional-comma + word "Section"
+  connector (added in #348/#360) to handle prose forms like
+  `Minnesota Statutes, Section 120.10`.
+
+- **Year-edition `Minn. St. YYYY, § N`**: new `minn-st-year-edition`
+  tokenizer pattern (listed BEFORE `abbreviated-code` so it wins for
+  the year-edition shape) routed to dedicated extractor
+  `extractMinnStYearEdition`. Captures the edition year (1971 /
+  1974 / 1967 / etc.) into the `year` field and the actual section
+  into `section`. Emits `code: "Minn. Stat."` (normalized canonical).
+  The `, § N` separator is REQUIRED so we don't false-positive on
+  bare years that happen to follow `Minn. St.`
+
+### Behavior changes
+
+- `Minn. St. 48.30` → `code="Minn. St."`, `jurisdiction="MN"`,
+  `section="48.30"` (was: not extracted)
+- `Minn. St. 1971, § 176.66` → `code="Minn. Stat."`, `year=1971`,
+  `section="176.66"`, `jurisdiction="MN"` (was: section
+  mis-captured as "1971" by abbreviated-code, then not extracted at
+  all since `Minn. St.` wasn't in the fragment)
+- `Minnesota Statutes, Section 120.10` → `code="Minnesota Statutes"`,
+  `section="120.10"`, `jurisdiction="MN"` (was: not extracted)
+- `Minn. Stat. § 480A.06` continues to work (Bluebook form
+  unchanged)
+
+### Scope notes
+
+The following pieces of #371 are intentionally deferred:
+
+- **Subdivision parsing** (`, subd. 5`, `subds. 1 and 2`,
+  `Subdivision 2`): the section extracts correctly but the trailing
+  `subd.` text is dropped. Requires either a `subdivision` field on
+  `StatuteCitation` or an extension to the subsection chain
+  grammar.
+- **Laws of Minnesota session laws** (`L. 1969, c. 570`): deferred
+  alongside the other session-law formats (`Ga. L.`, `Stats.`,
+  `Laws of Florida`, `Ind. Acts`, `PA YYYY`) pending a unified
+  `sessionLaw` citation type.
+
+### Tests
+
+6 new tests under `Minnesota \`Minn. St.\` short form and
+year-edition (#371)` in `tests/extract/extractStatute.test.ts`:
+
+- Modern `Minn. St. 48.30`
+- Criminal `Minn. St. 609.035`
+- Year-edition `Minn. St. 1971, § 176.66`
+- Year-edition with subsection `Minn. St. 1974, § 80A.14(n)`
+- Spelled-out `Minnesota Statutes, Section 120.10`
+- Regression: Bluebook `Minn. Stat. § 480A.06`
+
+Full 2596-test suite passes; no regressions.
+
+### Related
+
+Year-edition form is sibling to Colorado `C.R.S. 1963` (#352
+landed), Indiana `IC 1971` (#363 deferred), Kansas `K.S.A. Supp.
+YYYY` (#367 deferred), and Stat Ann year-edition (#370 deferred).
+Each state with a year-edition variant needs its own tokenizer
+pattern because the year semantics differ: Colorado names the
+compilation year in the abbreviation (`C.R.S. 1963` is the
+compilation, not an edition of `C.R.S.`); Minnesota uses the
+year-edition to mark which compilation was in force when the events
+occurred (more like a parenthetical edition than a code-name
+component).

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -323,10 +323,15 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
   // The dotted `M.S.A.` form (literal dots required) routes to Minnesota
   // Statutes Annotated; the dotless `MSA` belongs to Michigan (Mich. Stat.
   // Ann.) via array order — see Michigan entry above. #370
+  // The short form `Minn. St.` (without the `at`) is the canonical Minnesota
+  // court style — distinct from the federal Bluebook's `Minn. Stat.` (#371).
+  // `Minnesota Statutes` (spelled out) is the official short title used in
+  // postfix prose forms.
   {
     jurisdiction: "MN",
-    abbreviations: ["Minn. Stat. Ann.", "Minn. Stat.", "M.S.A."],
-    regexFragment: "Minn\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|M\\.S\\.A\\.",
+    abbreviations: ["Minnesota Statutes", "Minn. Stat. Ann.", "Minn. Stat.", "Minn. St.", "M.S.A."],
+    regexFragment:
+      "Minnesota\\s+Statutes(?:\\s+Ann(?:otated)?\\.?)?|Minn\\.?\\s+(?:Stat|St)\\.?(?:\\s+Ann\\.?)?|M\\.S\\.A\\.",
   },
   // ── Mississippi ───────────────────────────────────────────────────────────
   {

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -26,6 +26,7 @@ import { extractFederal } from "./statutes/extractFederal"
 import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
 import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
+import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
@@ -135,6 +136,8 @@ export function extractStatute(
       return extractFloridaStatute(token, transformationMap)
     case "idaho-postfix":
       return extractIdahoPostfix(token, transformationMap)
+    case "minn-st-year-edition":
+      return extractMinnStYearEdition(token, transformationMap)
     case "rlh":
       return extractRlh(token, transformationMap)
     default:

--- a/src/extract/statutes/extractMinnStYearEdition.ts
+++ b/src/extract/statutes/extractMinnStYearEdition.ts
@@ -1,0 +1,81 @@
+/**
+ * Minnesota Statutes year-edition form — `Minn. St. 1971, § 176.66`
+ *
+ * The year (1971 / 1974 / 1967 / etc.) is the EDITION of Minnesota Statutes
+ * that was in effect when the underlying events occurred, not the section
+ * number. The default abbreviated-code pattern would capture the year as
+ * the section; this dedicated pattern preserves the year-as-edition
+ * semantics. #371
+ *
+ * Same family as Colorado `C.R.S. 1963` (#352), Indiana `IC 1971` (#363
+ * deferred), Kansas `K.S.A. Supp. YYYY` (#367 deferred).
+ *
+ * @module extract/statutes/extractMinnStYearEdition
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const MINN_ST_YEAR_RE =
+  /^Minn\.?\s+(?:Stat|St)\.?\s+(19\d{2}),\s*§\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*)$/d
+
+export function extractMinnStYearEdition(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = MINN_ST_YEAR_RE.exec(text)!
+  const year = Number.parseInt(match[1], 10)
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "Minn. Stat.",
+    section,
+    subsection,
+    pincite: subsection,
+    year,
+    jurisdiction: "MN",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -188,6 +188,22 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Minnesota Statutes year-edition form: `Minn. St. 1971, § 176.66`.
+    // The year (1971/1974/etc.) is the edition of Minnesota Statutes, not
+    // the section number — abbreviated-code would mis-capture the year as
+    // section. Listed BEFORE `abbreviated-code` so the year-edition shape
+    // wins. The trailing `, § N` is REQUIRED so we don't false-positive on
+    // bare years that happen to follow `Minn. St.`. #371
+    //
+    // Captures: (1) edition year, (2) section body.
+    id: "minn-st-year-edition",
+    regex:
+      /\bMinn\.?\s+(?:Stat|St)\.?\s+(19\d{2}),\s*§\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*)/g,
+    description:
+      'Minnesota Statutes year-edition form: "Minn. St. 1971, § 176.66" — #371',
+    type: "statute",
+  },
+  {
     id: "abbreviated-code",
     regex: buildAbbreviatedCodeRegex(),
     description: "Abbreviated state code citations for all US jurisdictions",

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1520,4 +1520,76 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Minnesota `Minn. St.` short form and year-edition (#371)", () => {
+    it("extracts modern `Minn. St. 48.30`", () => {
+      const cites = extractCitations("See Minn. St. 48.30.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Minn. St.")
+        expect(cites[0].jurisdiction).toBe("MN")
+        expect(cites[0].section).toBe("48.30")
+      }
+    })
+
+    it("extracts `Minn. St. 609.035` (criminal section)", () => {
+      const cites = extractCitations("See Minn. St. 609.035.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MN")
+        expect(cites[0].section).toBe("609.035")
+      }
+    })
+
+    it("year-edition: `Minn. St. 1971, § 176.66` → year=1971, section=176.66", () => {
+      const cites = extractCitations("See Minn. St. 1971, § 176.66.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Minn. Stat.")
+        expect(cites[0].jurisdiction).toBe("MN")
+        expect(cites[0].section).toBe("176.66")
+        expect(cites[0].year).toBe(1971)
+      }
+    })
+
+    it("year-edition: `Minn. St. 1974, § 80A.14(n)` preserves subsection", () => {
+      const cites = extractCitations("See Minn. St. 1974, § 80A.14(n).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("80A.14")
+        expect(cites[0].subsection).toBe("(n)")
+        expect(cites[0].year).toBe(1974)
+      }
+    })
+
+    it("extracts spelled-out `Minnesota Statutes, Section 120.10`", () => {
+      const cites = extractCitations("See Minnesota Statutes, Section 120.10.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MN")
+        expect(cites[0].section).toBe("120.10")
+      }
+    })
+
+    it("regression: Bluebook `Minn. Stat. § 480A.06` continues to work", () => {
+      const cites = extractCitations("See Minn. Stat. § 480A.06.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Minn. Stat.")
+        expect(cites[0].jurisdiction).toBe("MN")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #371. A 35-opinion Minnesota sweep showed 30+ Minnesota statute misses. \`Minn. St.\` (without the \`at\`) is the canonical Minnesota court style — distinct from the federal Bluebook's \`Minn. Stat.\` — and the year-edition form (\`Minn. St. YYYY, § N\`) is the standard way Minnesota cites pre-1974 compilations.

- **Modern \`Minn. St. N.NN\`** — Minnesota regex fragment accepts the short form alongside \`Minn. Stat.\`
- **Spelled-out \`Minnesota Statutes\`** — fragment matches the spelled-out short title; pairs with the universal optional-comma + word-Section connector to handle \`Minnesota Statutes, Section 120.10\` prose form
- **Year-edition** — new \`minn-st-year-edition\` tokenizer pattern + dedicated extractor. Captures \`Minn. St. 1971, § 176.66\` as \`year=1971, section=176.66\` (was: section mis-captured as \"1971\"). Requires \`, § N\` to avoid false-positives on bare years

### Behavior

| Input | Before | After |
|---|---|---|
| \`Minn. St. 48.30\` | not extracted | code=Minn. St., jur=MN, section=48.30 |
| \`Minn. St. 1971, § 176.66\` | not extracted | code=Minn. Stat., year=1971, section=176.66 |
| \`Minn. St. 1974, § 80A.14(n)\` | not extracted | year=1974, section=80A.14, sub=(n) |
| \`Minnesota Statutes, Section 120.10\` | not extracted | jur=MN, section=120.10 |
| \`Minn. Stat. § 480A.06\` | unchanged | unchanged |

### Deferred

- Subdivision parsing (\`, subd. 5\`, \`Subdivision 2\`) — needs data-model change
- Laws of Minnesota session laws (\`L. YYYY, c. NNN\`) — pending unified \`sessionLaw\` type

## Test plan

- [x] 6 new tests under \`Minnesota \`Minn. St.\` short form and year-edition (#371)\`
- [x] Full 2596-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)