### PR TITLE
feat: Montana Code Annotated postfix form (\§ N, MCA) (#372)

### DIFF
--- a/.changeset/issue-372-montana-postfix.md
+++ b/.changeset/issue-372-montana-postfix.md
@@ -1,0 +1,53 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Montana Code Annotated postfix form (`§ N, MCA`) and edition-year parentheticals (#372)
+
+Montana's canonical court style places the section before the code
+name, with the code name `MCA` after a comma — same shape as
+Florida's `§ N, Florida Statutes` and Idaho's `§ N, Idaho Code`. A
+22-opinion Montana sweep produced 30+ MCA misses; every modern
+Montana Supreme Court opinion uses this form.
+
+### Fix
+
+New `mca-postfix` tokenizer pattern in `src/patterns/statutePatterns.ts`
+and dedicated `extractMcaPostfix` extractor at
+`src/extract/statutes/extractMcaPostfix.ts`. Listed BEFORE
+`abbreviated-code` so the container-shape wins span dedup. Emits
+`code: "MCA"`, `jurisdiction: "MT"`, `section`, and optional
+`subsection`.
+
+The trailing edition-year parenthetical (`MCA (1983)`) is attached
+by the generic year-paren absorber in `extractCitations.ts` — no
+extractor change needed.
+
+### Scope notes
+
+The following pieces of #372 are intentionally deferred:
+
+- **Abbreviated section continuation** (`§61-4-205 and -206, MCA`)
+  — the second section `-206` carries forward title/article from
+  the first (`61-4-`); deferred alongside the other multi-section
+  patterns.
+- **Multi-section lists** in general — same deferral.
+
+### Tests
+
+5 new tests under `Montana Code Annotated postfix form (#372)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `§ 77-6-205(2), MCA`
+- `Section 40-4-121(7)(a), MCA` (word "section")
+- `§ 39-71-703, MCA (1983)` (edition year)
+- Regression: `Mont. Code Ann. § 77-6-205`
+- Regression: `MCA § 77-6-205`
+
+Full 2597-test suite passes; no regressions.
+
+### Related
+
+Third state-postfix pattern after Florida (#356) and Idaho (#360).
+The pattern shape is now reusable: every state with a postfix
+citation style follows the same template.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -26,6 +26,7 @@ import { extractFederal } from "./statutes/extractFederal"
 import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
 import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
+import { extractMcaPostfix } from "./statutes/extractMcaPostfix"
 import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
@@ -136,6 +137,8 @@ export function extractStatute(
       return extractFloridaStatute(token, transformationMap)
     case "idaho-postfix":
       return extractIdahoPostfix(token, transformationMap)
+    case "mca-postfix":
+      return extractMcaPostfix(token, transformationMap)
     case "minn-st-year-edition":
       return extractMinnStYearEdition(token, transformationMap)
     case "rlh":

--- a/src/extract/statutes/extractMcaPostfix.ts
+++ b/src/extract/statutes/extractMcaPostfix.ts
@@ -1,0 +1,76 @@
+/**
+ * Montana Code Annotated postfix form — `§ 77-6-205(2), MCA`
+ *
+ * Canonical Montana court style places the section first, with the code name
+ * `MCA` after a comma — same shape as Florida's `§ N, Florida Statutes` and
+ * Idaho's `§ N, Idaho Code`. The trailing edition-year parenthetical (e.g.
+ * `MCA (1983)`) is attached by the generic year-paren absorber in
+ * `extractCitations.ts`. #372
+ *
+ * @module extract/statutes/extractMcaPostfix
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const MCA_POSTFIX_RE =
+  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+MCA$/d
+
+export function extractMcaPostfix(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = MCA_POSTFIX_RE.exec(text)!
+  const rawBody = match[1]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "MCA",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "MT",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -188,6 +188,20 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Montana postfix form: `§ 77-6-205(2), MCA` or `Section 40-4-121(7)(a),
+    // MCA` — the dominant Montana citation style (every modern Montana opinion
+    // uses this form). Sibling to florida-postfix and idaho-postfix. The
+    // trailing edition-year parenthetical (`MCA (1983)`) is left to the
+    // generic year-paren absorber in extractCitations.ts to attach. #372
+    //
+    // Captures: (1) section body.
+    id: "mca-postfix",
+    regex:
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+MCA/g,
+    description: 'Montana Code Annotated postfix form: "§ 77-6-205(2), MCA" — #372',
+    type: "statute",
+  },
+  {
     // Minnesota Statutes year-edition form: `Minn. St. 1971, § 176.66`.
     // The year (1971/1974/etc.) is the edition of Minnesota Statutes, not
     // the section number — abbreviated-code would mis-capture the year as

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1592,4 +1592,65 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Montana Code Annotated postfix form (#372)", () => {
+    it("extracts `§ 77-6-205(2), MCA`", () => {
+      const cites = extractCitations("See § 77-6-205(2), MCA.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MCA")
+        expect(cites[0].jurisdiction).toBe("MT")
+        expect(cites[0].section).toBe("77-6-205")
+        expect(cites[0].subsection).toBe("(2)")
+      }
+    })
+
+    it("extracts `Section 40-4-121(7)(a), MCA` (word section)", () => {
+      const cites = extractCitations("See Section 40-4-121(7)(a), MCA.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MCA")
+        expect(cites[0].section).toBe("40-4-121")
+        expect(cites[0].subsection).toBe("(7)(a)")
+      }
+    })
+
+    it("extracts edition year: `§ 39-71-703, MCA (1983)`", () => {
+      const cites = extractCitations("See § 39-71-703, MCA (1983).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MCA")
+        expect(cites[0].section).toBe("39-71-703")
+        expect(cites[0].year).toBe(1983)
+      }
+    })
+
+    it("regression: prefix `Mont. Code Ann. § 77-6-205` continues to work", () => {
+      const cites = extractCitations("See Mont. Code Ann. § 77-6-205.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MT")
+        expect(cites[0].section).toBe("77-6-205")
+      }
+    })
+
+    it("regression: prefix `MCA § 77-6-205` continues to work", () => {
+      const cites = extractCitations("See MCA § 77-6-205.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MCA")
+        expect(cites[0].jurisdiction).toBe("MT")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #372. Montana's canonical court style places the section BEFORE the code name with `MCA` after a comma — same shape as Florida (#356) and Idaho (#360). A 22-opinion sweep produced 30+ MCA misses.

New `mca-postfix` tokenizer + extractor. Emits `code: "MCA"`, `jurisdiction: "MT"`. Edition-year parenthetical (`MCA (1983)`) is attached automatically by the generic year-paren absorber — no extractor change needed.

### Behavior

| Input | Result |
|---|---|
| `§ 77-6-205(2), MCA` | code=MCA, jur=MT, section=77-6-205, sub=(2) |
| `Section 40-4-121(7)(a), MCA` | section=40-4-121, sub=(7)(a) |
| `§ 39-71-703, MCA (1983)` | section=39-71-703, year=1983 |
| `Mont. Code Ann. § 77-6-205`, `MCA § 77-6-205` | unchanged |

### Deferred

- Abbreviated section continuation (`§61-4-205 and -206, MCA`) — multi-section family
- Multi-section lists in general

## Test plan

- [x] 5 new tests under `Montana Code Annotated postfix form (#372)` (including 2 regressions)
- [x] Full 2597-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)