### PR TITLE
feat: Nebraska R.R.S. 1943 + Reissue edition label (#373)

### DIFF
--- a/.changeset/issue-373-nebraska.md
+++ b/.changeset/issue-373-nebraska.md
@@ -1,0 +1,67 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Nebraska R.R.S. 1943 historical form + `Reissue YYYY` edition label (#373)
+
+A 23-opinion Nebraska sweep produced 15+ Nebraska statute misses.
+The modern `Neb. Rev. Stat. § N-NNNN` form worked, but two pieces
+were broken:
+
+1. The historical `R.R.S. 1943` form (Reissue Revised Statutes of
+   Nebraska, 1943) was completely unrecognized — Nebraska compiled
+   its statutes in 1943 and re-issues volumes on a rolling basis, so
+   pre-1990 Nebraska opinions cite this form heavily and modern
+   opinions still cite it when referencing statutory history.
+2. The Nebraska-specific `(Reissue YYYY)` parenthetical was being
+   captured as a `year` but not labeled — it should populate
+   `editionLabel: "Reissue"` alongside the year (parallel to the
+   `Repl.` / `Supp.` / `Cum. Supp.` labels added in #349).
+
+### Fixes
+
+- **R.R.S. 1943 pattern**: new `rrs-1943` tokenizer pattern in
+  `src/patterns/statutePatterns.ts` + dedicated `extractRrs1943`
+  extractor. Handles `section 38-901, R. R. S. 1943` (no Reissue)
+  and `§ 30-2806, R. R. S. 1943, Reissue 1975` (with Reissue).
+  Accepts inter-letter spacing in `R.R.S.` (common OCR variant).
+  Emits `code: "R.R.S. 1943"`, `jurisdiction: "NE"`, `section`,
+  and — when present — `year` (the Reissue year) plus
+  `editionLabel: "Reissue"`.
+
+- **Reissue edition label**: `EDITION_LABEL_REGEX` in
+  `extractCitations.ts` extended to recognize `Reissue` as an
+  edition label (joining `Repl.`, `Supp.`, `Cum. Supp.`). The
+  generic year-paren absorber now correctly routes
+  `Neb. Rev. Stat. § 71-5016 (Reissue 2003)` to
+  `editionLabel: "Reissue"`, `year: 2003`.
+
+### Scope notes
+
+The following pieces of #373 are intentionally deferred:
+
+- **Section ranges** (`§§ 71-5016 to 71-5041 (Reissue 2003)`) —
+  multi-section deferred across all states.
+- **Bare-section follow-on with Cum. Supp.** (`43-253 (Cum. Supp.
+  2002)`) — this is a short-form citation problem (resolves to the
+  parent full-form citation), not an extraction problem.
+
+### Tests
+
+4 new tests under `Nebraska R.R.S. 1943 + Reissue edition label
+(#373)` in `tests/extract/extractStatute.test.ts`:
+
+- `section 38-901, R. R. S. 1943` (no Reissue)
+- `§ 30-2806, R. R. S. 1943, Reissue 1975` (with Reissue year)
+- `Neb. Rev. Stat. § 71-5016 (Reissue 2003)` (Reissue paren)
+- Regression: bare modern `Neb. Rev. Stat. § 71-5016`
+
+Full 2603-test suite passes; no regressions.
+
+### Related
+
+Companion to #330 (pre-1993 Illinois Revised Statutes), #343 (Code
+of Alabama 1940), and #359 (Revised Laws of Hawaii pre-1955) —
+historical state-statute compilations that remain in active
+citation. The Reissue edition label joins the family established
+by #349 (Arkansas `Repl.` / `Supp.` / `Cum. Supp.`).

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -679,9 +679,10 @@ const STATUTE_YEAR_PAREN_REGEX =
 /**
  * Edition-label set — captured tokens that should populate `editionLabel`
  * rather than `publisher`. `Repl.` = replacement volume, `Supp.` = supplement,
- * `Cum. Supp.` = cumulative supplement. #349
+ * `Cum. Supp.` = cumulative supplement. `Reissue` = reissued volume
+ * (Nebraska's rolling-reissue convention) #349 #373
  */
-const EDITION_LABEL_REGEX = /^(?:Repl|Supp|Cum\.?\s*Supp)\.?$/i
+const EDITION_LABEL_REGEX = /^(?:Repl|Supp|Cum\.?\s*Supp|Reissue)\.?$/i
 
 /**
  * Attach `year` (and optional `publisher` / `editionLabel`) to statute

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -31,6 +31,7 @@ import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
+import { extractRrs1943 } from "./statutes/extractRrs1943"
 
 /**
  * Legacy inline parser for unknown patterns.
@@ -143,6 +144,8 @@ export function extractStatute(
       return extractMinnStYearEdition(token, transformationMap)
     case "rlh":
       return extractRlh(token, transformationMap)
+    case "rrs-1943":
+      return extractRrs1943(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractRrs1943.ts
+++ b/src/extract/statutes/extractRrs1943.ts
@@ -1,0 +1,82 @@
+/**
+ * Nebraska Reissue Revised Statutes 1943 (R.R.S. 1943) — historical form
+ *
+ *   section 38-901, R. R. S. 1943
+ *   § 30-2806, R.R.S. 1943, Reissue 1975
+ *
+ * Nebraska compiled its statutes in 1943 and re-issues individual volumes
+ * on a rolling basis. The trailing `Reissue YYYY` clause gives the volume
+ * year — when present it goes into `year` (and `editionLabel` is set to
+ * `"Reissue"`). When absent, the citation refers to the original 1943
+ * compilation. #373
+ *
+ * @module extract/statutes/extractRrs1943
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const RRS_1943_RE =
+  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+R\.?\s*R\.?\s*S\.?\s+1943(?:,\s+Reissue\s+(\d{4}))?$/d
+
+export function extractRrs1943(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = RRS_1943_RE.exec(text)!
+  const rawBody = match[1]
+  const reissueYear = match[2] ? Number.parseInt(match[2], 10) : undefined
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "R.R.S. 1943",
+    section,
+    subsection,
+    pincite: subsection,
+    year: reissueYear,
+    editionLabel: reissueYear !== undefined ? "Reissue" : undefined,
+    jurisdiction: "NE",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -202,6 +202,23 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Nebraska Reissue Revised Statutes 1943 (R.R.S. 1943) — historical
+    // form: `section 38-901, R. R. S. 1943` or `§ 30-2806, R.R.S. 1943,
+    // Reissue 1975`. Nebraska compiled its statutes in 1943 and re-issues
+    // volumes on a rolling basis, so the trailing `Reissue YYYY` clause
+    // gives the volume year. The `R.R.S.` token admits inter-letter
+    // spacing (`R. R. S.`) — common OCR variant. Listed BEFORE
+    // `abbreviated-code` so the container shape wins. #373
+    //
+    // Captures: (1) section body, (2) optional Reissue year.
+    id: "rrs-1943",
+    regex:
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+R\.?\s*R\.?\s*S\.?\s+1943(?:,\s+Reissue\s+(\d{4}))?/g,
+    description:
+      'Nebraska Reissue Revised Statutes 1943: "§ 30-2806, R.R.S. 1943, Reissue 1975" — #373',
+    type: "statute",
+  },
+  {
     // Minnesota Statutes year-edition form: `Minn. St. 1971, § 176.66`.
     // The year (1971/1974/etc.) is the edition of Minnesota Statutes, not
     // the section number — abbreviated-code would mis-capture the year as

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1653,4 +1653,56 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Nebraska R.R.S. 1943 + Reissue edition label (#373)", () => {
+    it("extracts `section 38-901, R. R. S. 1943` (no Reissue)", () => {
+      const cites = extractCitations("See section 38-901, R. R. S. 1943.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.R.S. 1943")
+        expect(cites[0].jurisdiction).toBe("NE")
+        expect(cites[0].section).toBe("38-901")
+        expect(cites[0].year).toBeUndefined()
+      }
+    })
+
+    it("extracts `§ 30-2806, R. R. S. 1943, Reissue 1975`", () => {
+      const cites = extractCitations("See § 30-2806, R. R. S. 1943, Reissue 1975.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.R.S. 1943")
+        expect(cites[0].jurisdiction).toBe("NE")
+        expect(cites[0].section).toBe("30-2806")
+        expect(cites[0].year).toBe(1975)
+        expect(cites[0].editionLabel).toBe("Reissue")
+      }
+    })
+
+    it("attaches `Reissue YYYY` parenthetical to modern Neb. Rev. Stat.", () => {
+      const cites = extractCitations("Neb. Rev. Stat. § 71-5016 (Reissue 2003).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Neb. Rev. Stat.")
+        expect(cites[0].year).toBe(2003)
+        expect(cites[0].editionLabel).toBe("Reissue")
+      }
+    })
+
+    it("regression: bare modern `Neb. Rev. Stat. § 71-5016` continues to work", () => {
+      const cites = extractCitations("See Neb. Rev. Stat. § 71-5016.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("NE")
+        expect(cites[0].section).toBe("71-5016")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #373. A 23-opinion Nebraska sweep showed 15+ Nebraska statute misses. Modern \`Neb. Rev. Stat.\` worked but two pieces were broken:

1. The historical \`R.R.S. 1943\` form (Reissue Revised Statutes 1943) was completely unrecognized
2. The Nebraska-specific \`(Reissue YYYY)\` parenthetical was captured as \`year\` but missing the \`editionLabel\`

### Fixes

- **New \`rrs-1943\` tokenizer + extractor** for both \`section N, R. R. S. 1943\` and \`§ N, R. R. S. 1943, Reissue YYYY\`. Accepts inter-letter spacing in \`R.R.S.\`. Emits \`code: \"R.R.S. 1943\"\`, \`jurisdiction: \"NE\"\`, \`year\` (Reissue year if present), \`editionLabel: \"Reissue\"\`.
- **\`Reissue\` added to \`EDITION_LABEL_REGEX\`** in \`extractCitations.ts\` — joining \`Repl.\`, \`Supp.\`, \`Cum. Supp.\` (from #349). The generic year-paren absorber now correctly labels \`Neb. Rev. Stat. § N (Reissue 2003)\`.

### Behavior

| Input | Result |
|---|---|
| \`section 38-901, R. R. S. 1943\` | code=R.R.S. 1943, jur=NE, section=38-901 |
| \`§ 30-2806, R. R. S. 1943, Reissue 1975\` | year=1975, editionLabel=Reissue |
| \`Neb. Rev. Stat. § 71-5016 (Reissue 2003)\` | year=2003, editionLabel=Reissue |
| \`Neb. Rev. Stat. § 71-5016\` | unchanged |

### Deferred

- Section ranges (\`§§ 71-5016 to 71-5041\`) — multi-section family
- Bare-section follow-on with Cum. Supp. (\`43-253 (Cum. Supp. 2002)\`) — short-form citation problem, not extraction

## Test plan

- [x] 4 new tests under \`Nebraska R.R.S. 1943 + Reissue edition label (#373)\`
- [x] Full 2603-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)