### PR TITLE
fix: Kansas K.S.A. year-edition mis-parse + comma-section (#367)

### DIFF
--- a/.changeset/issue-367-kansas.md
+++ b/.changeset/issue-367-kansas.md
@@ -1,0 +1,68 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Kansas `K.S.A. YYYY Supp.` year-edition mis-parse + comma-section format (#367)
+
+A 43-opinion Kansas sweep showed the same mis-parse 30+ times:
+every `K.S.A. YYYY Supp. NN-NNN` cite had the year mis-captured as
+the section number, silently substituting (e.g.) `2009` for the
+actual section `44-501(d)(2)`. Separately, Kansas's
+comma-section format `NN-N,NNN` (e.g. `K.S.A. 23-9,101`) was being
+truncated at the comma, dropping `,101`.
+
+### Fixes
+
+- **Year-edition pattern**: new `ksa-year-edition` tokenizer
+  pattern + dedicated `extractKsaYearEdition` extractor. Captures
+  `K.S.A. 2009 Supp. 44-501(d)(2)` as `code: "K.S.A."`,
+  `year: 2009`, `editionLabel: "Supp."`, `section: "44-501"`,
+  `subsection: "(d)(2)"`. The `Supp.` marker is optional —
+  bound-volume cites (`K.S.A. YYYY NN-NNN` without `Supp.`) also
+  match. Listed BEFORE `abbreviated-code` so this shape wins.
+
+- **Comma-section format**: the universal section-body regex (in
+  `buildAbbreviatedCodeRegex` and `ABBREVIATED_RE`) now accepts
+  `,(?=\d)` — comma followed by digit — alongside the existing
+  alphanumeric/colon/slash/hyphen character class. So `K.S.A.
+  23-9,101` parses as `section: "23-9,101"` rather than
+  truncating to `"23-9"`. The lookahead guard prevents a sentence
+  comma from being absorbed.
+
+### Behavior changes
+
+- `K.S.A. 2009 Supp. 44-501(d)(2)` → `section="44-501"`,
+  `year=2009`, `editionLabel="Supp."` (was: `section="2009"`,
+  everything else dropped)
+- `K.S.A. 23-9,101` → `section="23-9,101"` (was: `"23-9"`)
+- `K.S.A. 44-501` → unchanged
+
+### Scope notes
+
+The following pieces of #367 are intentionally deferred:
+
+- **Kansas session laws** (`L. 1985, ch. 176, § 2`) — deferred
+  alongside the other session-law formats (`Ga. L.`, `Stats.`,
+  `Laws of Florida`, `Ind. Acts`, `PA YYYY`, `Sess. L.`) pending a
+  unified `sessionLaw` citation type.
+
+### Tests
+
+5 new tests under `Kansas K.S.A. year-edition + comma-section
+(#367)` in `tests/extract/extractStatute.test.ts`:
+
+- `K.S.A. 2009 Supp. 44-501(d)(2)` (year-edition + subsection)
+- `K.S.A. 1988 Supp. 44-556` (year-edition without subsection)
+- `K.S.A. 23-9,101` (comma-section)
+- `K.S.A. 23-9,316`
+- Regression: bare `K.S.A. 44-501`
+
+Full 2608-test suite passes; no regressions.
+
+### Related
+
+Year-edition is sibling to Minnesota `Minn. St. YYYY, § N` (#371
+landed), Colorado `C.R.S. 1963` (#352 landed), and Nebraska
+`R.R.S. 1943, Reissue YYYY` (#373 landed). The comma-section
+character-class change is universal but Kansas-driven: no other
+state uses the `NN-N,NNN` form so the impact is bounded.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -72,8 +72,10 @@ export function buildAbbreviatedCodeRegex(): RegExp {
 
   return new RegExp(
     // Section body: digits prefix, then alphanumeric/colon/slash/hyphen OR
-    // period-followed-by-alphanumeric (lookahead). Period guard prevents
-    // sentence-ending punctuation from being absorbed into the section.
+    // period-followed-by-alphanumeric (lookahead) OR comma-followed-by-digit
+    // (Kansas comma-section format `NN-N,NNN` like `K.S.A. 23-9,101`, #367).
+    // Period and comma guards prevent sentence punctuation from being
+    // absorbed into the section.
     //
     // Section connector: `§`, `§§`, or the spelled-out word `section(s)` /
     // `Section(s)` (#348). Arizona and several other state corpora cite as
@@ -82,7 +84,7 @@ export function buildAbbreviatedCodeRegex(): RegExp {
     // common in Idaho practice (#360) and harmless elsewhere.
     // Trailing subscript groups accept either parens or brackets — MSA uses
     // `[N]` for subdivisions (`MSA 23.710[252]`) #370.
-    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\)|\\[[^\\]]*\\])*(?:\\s*et\\s+seq\\.?)?)`,
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9])|,(?=\\d))*(?:\\([^)]*\\)|\\[[^\\]]*\\])*(?:\\s*et\\s+seq\\.?)?)`,
     "g",
   )
 }

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -26,6 +26,7 @@ import { extractFederal } from "./statutes/extractFederal"
 import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
 import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
+import { extractKsaYearEdition } from "./statutes/extractKsaYearEdition"
 import { extractMcaPostfix } from "./statutes/extractMcaPostfix"
 import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
@@ -138,6 +139,8 @@ export function extractStatute(
       return extractFloridaStatute(token, transformationMap)
     case "idaho-postfix":
       return extractIdahoPostfix(token, transformationMap)
+    case "ksa-year-edition":
+      return extractKsaYearEdition(token, transformationMap)
     case "mca-postfix":
       return extractMcaPostfix(token, transformationMap)
     case "minn-st-year-edition":

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -26,8 +26,9 @@ import { parseBody } from "./parseBody"
 // 11-9-102` would emit abbrevText="Arkansas Code Annotated section").
 // Optional comma between code and connector (`Idaho Code, § N`) #360.
 // Trailing subscript groups accept either parens or brackets — MSA #370.
+// Internal comma allowed when followed by digit — Kansas `23-9,101` #367.
 const ABBREVIATED_RE =
-  /^(?:(\d+)\s+)?(.+?)\s*,?\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s*et\s+seq\.?)?)$/d
+  /^(?:(\d+)\s+)?(.+?)\s*,?\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9])|,(?=\d))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s*et\s+seq\.?)?)$/d
 
 export function extractAbbreviated(
   token: Token,

--- a/src/extract/statutes/extractKsaYearEdition.ts
+++ b/src/extract/statutes/extractKsaYearEdition.ts
@@ -1,0 +1,83 @@
+/**
+ * Kansas Statutes Annotated year-edition form — `K.S.A. 2009 Supp. 44-501(d)(2)`
+ *
+ * Kansas opinions cite a specific compilation year to indicate which
+ * version of the statute was in effect at the time of the events. The
+ * `Supp.` marker is optional — bound-volume citations omit it. The
+ * abbreviated-code pattern would otherwise capture the year as section,
+ * silently substituting the year for the actual section number.
+ *
+ * Same family as Minnesota `Minn. St. YYYY, § N` (#371), Colorado
+ * `C.R.S. YYYY § N` (#352), Indiana `IC YYYY` (#363 deferred).
+ *
+ * @module extract/statutes/extractKsaYearEdition
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const KSA_YEAR_RE =
+  /^K\.?\s*S\.?\s*A\.?\s+(\d{4})(?:\s+(Supp\.?))?\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9])|,(?=\d))*(?:\([^)]*\))*)$/d
+
+export function extractKsaYearEdition(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = KSA_YEAR_RE.exec(text)!
+  const year = Number.parseInt(match[1], 10)
+  const hasSupp = match[2] !== undefined
+  const rawBody = match[3]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[3]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "K.S.A.",
+    section,
+    subsection,
+    pincite: subsection,
+    year,
+    editionLabel: hasSupp ? "Supp." : undefined,
+    jurisdiction: "KS",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -235,6 +235,24 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Kansas Statutes Annotated year-edition / Supp. form: `K.S.A. 2009
+    // Supp. 44-501(d)(2)`. The year between K.S.A. and the section number
+    // is the compilation/supplement year, not the section — abbreviated-code
+    // would mis-capture the year. The Supp. token is optional (some Kansas
+    // courts write `K.S.A. YYYY NN-NNN` without `Supp.` to mean the bound
+    // volume of that year). Listed BEFORE `abbreviated-code` so this shape
+    // wins. The internal comma (`23-9,101`) is the Kansas comma-section
+    // form, also supported. #367
+    //
+    // Captures: (1) edition year, (2) optional Supp. marker, (3) section.
+    id: "ksa-year-edition",
+    regex:
+      /\bK\.?\s*S\.?\s*A\.?\s+(\d{4})(?:\s+(Supp\.?))?\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9])|,(?=\d))*(?:\([^)]*\))*)/g,
+    description:
+      'Kansas Statutes Annotated year-edition: "K.S.A. 2009 Supp. 44-501(d)(2)" — #367',
+    type: "statute",
+  },
+  {
     id: "abbreviated-code",
     regex: buildAbbreviatedCodeRegex(),
     description: "Abbreviated state code citations for all US jurisdictions",

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1705,4 +1705,65 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Kansas K.S.A. year-edition + comma-section (#367)", () => {
+    it("year-edition: `K.S.A. 2009 Supp. 44-501(d)(2)` → year=2009, section=44-501", () => {
+      const cites = extractCitations("See K.S.A. 2009 Supp. 44-501(d)(2).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("K.S.A.")
+        expect(cites[0].jurisdiction).toBe("KS")
+        expect(cites[0].section).toBe("44-501")
+        expect(cites[0].subsection).toBe("(d)(2)")
+        expect(cites[0].year).toBe(2009)
+        expect(cites[0].editionLabel).toBe("Supp.")
+      }
+    })
+
+    it("year-edition: `K.S.A. 1988 Supp. 44-556`", () => {
+      const cites = extractCitations("See K.S.A. 1988 Supp. 44-556.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("44-556")
+        expect(cites[0].year).toBe(1988)
+      }
+    })
+
+    it("comma-section: `K.S.A. 23-9,101` preserves internal comma", () => {
+      const cites = extractCitations("See K.S.A. 23-9,101.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("K.S.A.")
+        expect(cites[0].section).toBe("23-9,101")
+      }
+    })
+
+    it("comma-section: `K.S.A. 23-9,316`", () => {
+      const cites = extractCitations("See K.S.A. 23-9,316.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("23-9,316")
+      }
+    })
+
+    it("regression: bare `K.S.A. 44-501` continues to work", () => {
+      const cites = extractCitations("See K.S.A. 44-501.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("K.S.A.")
+        expect(cites[0].jurisdiction).toBe("KS")
+        expect(cites[0].section).toBe("44-501")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #367. A 43-opinion Kansas sweep showed the same mis-parse 30+ times: every \`K.S.A. YYYY Supp. NN-NNN\` cite had the year mis-captured as section, silently substituting (e.g.) \`2009\` for the actual section \`44-501(d)(2)\`. Separately, Kansas's comma-section format \`NN-N,NNN\` was being truncated at the comma.

### Fixes

- **New \`ksa-year-edition\` tokenizer + extractor**: captures \`K.S.A. 2009 Supp. 44-501(d)(2)\` as \`code: \"K.S.A.\"\`, \`year: 2009\`, \`editionLabel: \"Supp.\"\`, \`section: \"44-501\"\`, \`subsection: \"(d)(2)\"\`. The \`Supp.\` marker is optional (bound-volume cites without \`Supp.\` also match).
- **Comma-section character class**: section body regex (\`buildAbbreviatedCodeRegex\` + \`ABBREVIATED_RE\`) now accepts \`,(?=\d)\` — comma followed by digit — so \`K.S.A. 23-9,101\` preserves the comma. Lookahead guard prevents sentence-comma absorption.

### Behavior

| Input | Before | After |
|---|---|---|
| \`K.S.A. 2009 Supp. 44-501(d)(2)\` | section=2009, rest dropped | section=44-501, sub=(d)(2), year=2009, label=Supp. |
| \`K.S.A. 23-9,101\` | section=23-9 | section=23-9,101 |
| \`K.S.A. 44-501\` | unchanged | unchanged |

### Deferred

- Kansas session laws (\`L. 1985, ch. 176, § 2\`) — pending unified \`sessionLaw\` type

## Test plan

- [x] 5 new tests under \`Kansas K.S.A. year-edition + comma-section (#367)\`
- [x] Full 2608-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)