### PR TITLE
feat: Maryland article-letter codes (HG, CP, R.P., ...) (#368)

### DIFF
--- a/.changeset/issue-368-md-article-letter.md
+++ b/.changeset/issue-368-md-article-letter.md
@@ -1,0 +1,74 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Maryland article-letter codes (`HG § 19-906`, `CP § 10-105`, `R.P. § 8-211`, ...) (#368)
+
+Maryland reorganized its statutory code in 2002 into ~30 named
+articles, each cited by a 2- or 3-letter prefix (`HG` for
+Health-General, `CP` for Criminal Procedure, `R.P.` for Real
+Property, etc.). This is the dominant Maryland court style for
+every modern Maryland appellate opinion. A 38-opinion Maryland
+sweep showed 25+ Maryland statute misses, dominated by these
+article-letter forms — none were extracted.
+
+### Fix
+
+New `md-article-letter` tokenizer pattern in
+`src/patterns/statutePatterns.ts` + dedicated
+`extractMdArticleLetter` extractor at
+`src/extract/statutes/extractMdArticleLetter.ts`. The letter
+prefixes are a closed enumeration matching the published
+Maryland-Code article list:
+
+```
+AB AG BO BR CJ CL CP CR CS EC ED EL EN ET FI FL GP HG HO HS
+HU IN LE LG LU NR PS PUC R.P. RP SF SG TA TG TP TR
+```
+
+Both dotted (`R.P.`) and dotless (`RP`) variants of Real Property
+are accepted. The mandatory `§` connector disambiguates the
+letter prefix from ordinary prose tokens that happen to appear at
+sentence-initial position. Emits `code: <surface form>`,
+`jurisdiction: "MD"`, `section`, `subsection` (preserves the
+deep-subsection chains common in Maryland statutes:
+`CP § 10-105(e)(4)(ii)(2)`).
+
+### Scope notes
+
+The following pieces of #368 are intentionally deferred:
+
+- **Long-form Bluebook** (`Md. Code Ann., Health-Gen. § 19-906`)
+  — the existing `named-code` regex breaks on the hyphen in
+  `Health-Gen.`; a one-character regex change there is sufficient
+  but deferred to a follow-up PR.
+- **Pre-2002 numbered articles** (`Article 27, § 36`,
+  `Article 101, § 56(e)`) — requires a different pattern; some
+  collision risk with `Article` in other prose contexts.
+- **Postfix prose** (`Section X of the Y Article`) — requires
+  enumerating the article-name forms.
+- **Maryland session laws** (`1987 Md. Laws, ch. 670`,
+  `2001 Md. Laws, Chap. 10, § 2`) — pending unified
+  `sessionLaw` type.
+
+### Tests
+
+6 new tests under `Maryland article-letter codes (#368)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `HG § 19-906` (Health-General)
+- `CP § 10-105(e)(4)(ii)(2)` (deep-subsection chain)
+- `R.P. § 8-211` (dotted variant)
+- `BR § 1-101` (Business Regulation)
+- `FL § 5-1027` (Family Law — doesn't collide with Florida)
+- Regression: `Fla. Stat. § 119.07` continues to route to Florida
+
+Full 2614-test suite passes; no regressions.
+
+### Related
+
+The Maryland article-letter code system is unique among U.S.
+states — no other jurisdiction uses 2-letter prefixes as the
+bare citation form. The pattern complements the existing
+`named-code` family that handles `N.Y. Penal Law § N`,
+`Cal. Civ. Code § N`, etc.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -28,6 +28,7 @@ import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
 import { extractKsaYearEdition } from "./statutes/extractKsaYearEdition"
 import { extractMcaPostfix } from "./statutes/extractMcaPostfix"
+import { extractMdArticleLetter } from "./statutes/extractMdArticleLetter"
 import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
@@ -143,6 +144,8 @@ export function extractStatute(
       return extractKsaYearEdition(token, transformationMap)
     case "mca-postfix":
       return extractMcaPostfix(token, transformationMap)
+    case "md-article-letter":
+      return extractMdArticleLetter(token, transformationMap)
     case "minn-st-year-edition":
       return extractMinnStYearEdition(token, transformationMap)
     case "rlh":

--- a/src/extract/statutes/extractMdArticleLetter.ts
+++ b/src/extract/statutes/extractMdArticleLetter.ts
@@ -1,0 +1,82 @@
+/**
+ * Maryland article-letter codes — post-2002 Maryland Code
+ *
+ *   HG § 19-906             (Health-General)
+ *   CP § 10-105(e)(4)(ii)   (Criminal Procedure)
+ *   R.P. § 8-211            (Real Property — dotted variant)
+ *   BR § 1-101              (Business Regulation)
+ *
+ * Maryland reorganized its code in 2002 into ~30 named articles, each
+ * cited by a 2- or 3-letter prefix. This is the dominant Maryland court
+ * style for every modern Maryland appellate opinion. #368
+ *
+ * @module extract/statutes/extractMdArticleLetter
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const MD_ARTICLE_LETTER_RE =
+  /^(AB|AG|BO|BR|CJ|CL|CP|CR|CS|EC|ED|EL|EN|ET|FI|FL|GP|HG|HO|HS|HU|IN|LE|LG|LU|NR|PS|PUC|R\.?P\.?|RP|SF|SG|TA|TG|TP|TR)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
+
+export function extractMdArticleLetter(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = MD_ARTICLE_LETTER_RE.exec(text)!
+  const codePrefix = match[1]
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.code = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: codePrefix,
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "MD",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -219,6 +219,27 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Maryland article-letter codes — post-2002 the Maryland Code is
+    // organized into named articles, each with a 2- or 3-letter prefix
+    // used as the bare citation form (no `Md.` prefix): `HG § 19-906`,
+    // `CP § 10-105(e)(4)`, `R.P. § 8-211`. This is the dominant Maryland
+    // citation style for any Maryland appellate opinion since 2002. The
+    // letter prefixes are a closed enumeration; matching is restricted to
+    // that set to keep the false-positive risk bounded. #368
+    //
+    // The mandatory `§` connector disambiguates the letter prefix from
+    // ordinary prose tokens like `IN` or `TR` that happen to appear at
+    // the start of a sentence.
+    //
+    // Captures: (1) code-letter prefix, (2) section body.
+    id: "md-article-letter",
+    regex:
+      /\b(AB|AG|BO|BR|CJ|CL|CP|CR|CS|EC|ED|EL|EN|ET|FI|FL|GP|HG|HO|HS|HU|IN|LE|LG|LU|NR|PS|PUC|R\.?P\.?|RP|SF|SG|TA|TG|TP|TR)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+    description:
+      'Maryland article-letter codes: "HG § 19-906", "CP § 10-105", "R.P. § 8-211" — #368',
+    type: "statute",
+  },
+  {
     // Minnesota Statutes year-edition form: `Minn. St. 1971, § 176.66`.
     // The year (1971/1974/etc.) is the edition of Minnesota Statutes, not
     // the section number — abbreviated-code would mis-capture the year as

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1766,4 +1766,73 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Maryland article-letter codes (#368)", () => {
+    it("extracts `HG § 19-906` (Health-General)", () => {
+      const cites = extractCitations("See HG § 19-906.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("HG")
+        expect(cites[0].jurisdiction).toBe("MD")
+        expect(cites[0].section).toBe("19-906")
+      }
+    })
+
+    it("extracts `CP § 10-105(e)(4)(ii)(2)` with deep subsection", () => {
+      const cites = extractCitations("See CP § 10-105(e)(4)(ii)(2).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("CP")
+        expect(cites[0].section).toBe("10-105")
+        expect(cites[0].subsection).toBe("(e)(4)(ii)(2)")
+      }
+    })
+
+    it("extracts `R.P. § 8-211` (dotted variant)", () => {
+      const cites = extractCitations("See R.P. § 8-211.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.P.")
+        expect(cites[0].jurisdiction).toBe("MD")
+      }
+    })
+
+    it("extracts `BR § 1-101` (Business Regulation)", () => {
+      const cites = extractCitations("See BR § 1-101.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("BR")
+        expect(cites[0].jurisdiction).toBe("MD")
+      }
+    })
+
+    it("extracts `FL § 5-1027` (Family Law) — doesn't collide with Florida", () => {
+      const cites = extractCitations("See FL § 5-1027.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("FL")
+        expect(cites[0].jurisdiction).toBe("MD")
+      }
+    })
+
+    it("regression: Florida `Fla. Stat. § 119.07` continues to route to Florida", () => {
+      const cites = extractCitations("See Fla. Stat. § 119.07.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("FL")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #368. Maryland reorganized its statutory code in 2002 into ~30 named articles, each cited by a 2- or 3-letter prefix (\`HG\` Health-General, \`CP\` Criminal Procedure, \`R.P.\` Real Property, etc.). This is the **dominant Maryland court style** for every modern Maryland appellate opinion. A 38-opinion sweep showed 25+ misses dominated by these — none were extracted.

New \`md-article-letter\` tokenizer + extractor. Closed enumeration of 36 valid Maryland code prefixes. Mandatory \`§\` connector disambiguates from prose tokens. Both dotted (\`R.P.\`) and dotless (\`RP\`) variants accepted. Preserves deep-subsection chains.

### Behavior

| Input | Result |
|---|---|
| \`HG § 19-906\` | code=HG, jur=MD, section=19-906 |
| \`CP § 10-105(e)(4)(ii)(2)\` | code=CP, section=10-105, sub=(e)(4)(ii)(2) |
| \`R.P. § 8-211\` | code=R.P., jur=MD |
| \`FL § 5-1027\` | code=FL, jur=MD (doesn't collide with Florida) |
| \`Fla. Stat. § 119.07\` | unchanged (still FL) |

### Deferred

- Long-form Bluebook (\`Md. Code Ann., Health-Gen. § 19-906\`) — needs hyphen support in \`named-code\` regex (one-char fix, follow-up)
- Pre-2002 numbered articles (\`Article 27, § 36\`) — different pattern
- Postfix prose (\`Section X of the Y Article\`)
- Maryland session laws (\`1987 Md. Laws, ch. 670\`) — pending unified sessionLaw type

## Test plan

- [x] 6 new tests under \`Maryland article-letter codes (#368)\`
- [x] Full 2614-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)