### PR TITLE
fix: Massachusetts G.L. c. spacing/sec./chapter-only variants (#364)

### DIFF
--- a/.changeset/issue-364-massachusetts.md
+++ b/.changeset/issue-364-massachusetts.md
@@ -1,0 +1,70 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Massachusetts `G.L. c.` spacing variants, `sec.` connector, chapter-only, and spelled-out `General Laws` (#364)
+
+A 50-opinion Massachusetts sample showed 15+ misses dominated by
+the bare `G.L. c.` form — the canonical Massachusetts court style
+since 1932. The `mass-chapter` pattern only matched the strict
+`G.L. c. NNN, § NN` form, missing the common variants:
+
+- `G.L.c. NNN` (no space between `G.L.` and `c.`)
+- `G. L. c. NNN` (spaced abbreviation)
+- `G.L. c. NNN, sec. NN` (`sec.` instead of `§`)
+- `G.L. c. NNN` (chapter-only, no section)
+- `General Laws c. NNN, § NN` (spelled-out without `Mass.`)
+
+Beyond losing the statutory citation, the unrecognized text spilled
+forward and corrupted case-name extraction for the **next**
+citation (`G.L.c. 93A. Begelfer v. Najarian` →
+`caseName="G.L.c. 93A. Begelfer v. Najarian"`).
+
+### Fixes
+
+Two regexes updated in tandem — the `mass-chapter` tokenizer
+pattern in `src/patterns/statutePatterns.ts` and the mirroring
+`MASS_CHAPTER_RE` in `src/extract/statutes/extractNamedCode.ts`:
+
+1. Spacing between corpus prefix and `c.` made optional
+   (`\s+(?:ch\.?|c\.?)` → `\s*(?:ch\.?|c\.?)`) so `G.L.c.`
+   matches.
+2. Section connector accepts `§` / `§§` / `sec.` / `Sec.` /
+   `section` / `Section` alongside the canonical `§`.
+3. Section portion now optional (chapter-only citations like
+   `G.L. c. 93A` are valid by themselves and need to extract
+   so the unrecognized text doesn't pollute the next citation's
+   case-name).
+4. Corpus alternation extended with `General Laws` (spelled-out
+   without the `Mass.` prefix — common in Massachusetts
+   opinions which omit the home-state qualifier).
+
+The extractor in `extractNamedCode.ts` defaults the section body
+to empty string when missing — `code` (chapter), `jurisdiction:
+"MA"`, and `section: ""` for chapter-only citations.
+
+### Scope notes
+
+The following pieces of #364 are intentionally deferred:
+
+- **`St. YYYY, c. NNN, § N`** session laws (Acts/Statutes of
+  Massachusetts) — pending unified `sessionLaw` citation type.
+- **`NNN CMR § N.NN`** (Code of Massachusetts Regulations) —
+  administrative regulations broadly deferred per #320.
+- **`§ N.NN`** short-form regulation follow-on — short-form
+  citation problem, not extraction.
+
+### Tests
+
+7 new tests under `Massachusetts G.L. c. spacing/sec./chapter-only
+variants (#364)` in `tests/extract/extractStatute.test.ts`:
+
+- `G.L. c. 268A, sec. 25` (sec. connector)
+- `G.L.c. 93A` (no space)
+- `G. L. c. 93A` (spaced abbreviation, chapter-only)
+- `G.L.c. 90, §34M`
+- `G.L.c. 272, §99E(3)` (with subsection)
+- `General Laws c. 94C, § 32A(a)` (spelled-out)
+- Regression: `Mass. Gen. Laws c. 93A, § 2`
+
+Full 2620-test suite passes; no regressions.

--- a/src/extract/statutes/extractNamedCode.ts
+++ b/src/extract/statutes/extractNamedCode.ts
@@ -24,8 +24,11 @@ import { parseBody } from "./parseBody"
 const NAMED_CODE_RE =
   /^(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|Va\.?|Ala(?:bama)?\.?)\s+(.*?)\s*§§?\s*(.+)$/sd
 
-/** Match mass-chapter token: corpus abbreviation + ch./c. + chapter + § + section */
-const MASS_CHAPTER_RE = /^(.*?)\s+(?:ch\.?|c\.?)\s*(\w+),?\s*§\s*(.+)$/d
+/** Match mass-chapter token: corpus abbreviation + ch./c. + chapter + optional (§|sec.) + section.
+ *  Section connector and section body are optional — `G.L. c. 93A`
+ *  chapter-only citations are valid (#364). Spacing before `c.` is optional
+ *  so `G.L.c.` matches (also #364). */
+const MASS_CHAPTER_RE = /^(.*?)\s*(?:ch\.?|c\.?)\s*(\w+)(?:,?\s*(?:§§?|[Ss]ec\.?|[Ss]ection)\s*(.+))?$/d
 
 /** Map normalized jurisdiction prefixes to 2-letter state codes */
 const PREFIX_MAP: Record<string, string> = {
@@ -111,7 +114,9 @@ export function extractNamedCode(
     if (massMatch) {
       jurisdiction = "MA"
       code = massMatch[2] // chapter number (e.g., "93A")
-      rawBody = massMatch[3]
+      // Section body is optional — chapter-only citations like `G.L. c. 93A`
+      // are valid. When absent, leave the section empty. (#364)
+      rawBody = massMatch[3] ?? ""
     } else {
       code = text
       rawBody = ""

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -62,10 +62,16 @@ export const statutePatterns: Pattern[] = [
   {
     id: "mass-chapter",
     // Matches: Mass. Gen. Laws ch. X, § Y / M.G.L.A. c. X, § Y / G.L. c. X, § Y / A.L.M. c. X, § Y
+    // Spacing between corpus prefix and `c.` is optional (`G.L.c.` is common
+    // Massachusetts court style). The section connector accepts both `§` and
+    // `sec.` / `Sec.` (Massachusetts opinions use both). The section portion
+    // itself is optional — chapter-only citations like `G.L. c. 93A`
+    // refer to the entire chapter and are valid by themselves. #364
+    //
     // Section body: period only allowed when followed by alphanumeric, so a
     // trailing sentence period is not absorbed (#283).
     regex:
-      /\b(Mass\.?\s*Gen\.?\s*Laws|M\.?G\.?L\.?A?\.?|A\.?L\.?M\.?|G\.?\s*L\.?)\s+(?:ch\.?|c\.?)\s*(\w+),?\s*§\s*(\w+(?:[\w/-]|\.(?=\w))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(Mass\.?\s*Gen\.?\s*Laws|General\s+Laws|M\.?G\.?L\.?A?\.?|A\.?L\.?M\.?|G\.?\s*L\.?)\s*(?:ch\.?|c\.?)\s*(\w+)(?:,?\s*(?:§§?|[Ss]ec\.?|[Ss]ection)\s*(\w+(?:[\w/-]|\.(?=\w))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?))?/g,
     description: 'Massachusetts chapter-based citations (e.g., "Mass. Gen. Laws ch. 93A, § 2")',
     type: "statute",
   },

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1835,4 +1835,88 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Massachusetts G.L. c. spacing/sec./chapter-only variants (#364)", () => {
+    it("extracts `G.L. c. 268A, sec. 25` (sec. instead of §)", () => {
+      const cites = extractCitations("See G.L. c. 268A, sec. 25.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("268A")
+        expect(cites[0].jurisdiction).toBe("MA")
+        expect(cites[0].section).toBe("25")
+      }
+    })
+
+    it("extracts `G.L.c. 93A` (no space between G.L. and c.)", () => {
+      const cites = extractCitations("See G.L.c. 93A.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("93A")
+        expect(cites[0].jurisdiction).toBe("MA")
+      }
+    })
+
+    it("extracts `G. L. c. 93A` chapter-only (spaced abbreviation, no section)", () => {
+      const cites = extractCitations("See G. L. c. 93A.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("93A")
+        expect(cites[0].jurisdiction).toBe("MA")
+        expect(cites[0].section).toBe("")
+      }
+    })
+
+    it("extracts `G.L.c. 90, §34M` (combined no-space + § + section)", () => {
+      const cites = extractCitations("See G.L.c. 90, §34M.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("90")
+        expect(cites[0].section).toBe("34M")
+      }
+    })
+
+    it("extracts `G.L.c. 272, §99E(3)` with subsection", () => {
+      const cites = extractCitations("See G.L.c. 272, §99E(3).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("272")
+        expect(cites[0].section).toBe("99E")
+        expect(cites[0].subsection).toBe("(3)")
+      }
+    })
+
+    it("extracts spelled-out `General Laws c. 94C, § 32A(a)`", () => {
+      const cites = extractCitations("See General Laws c. 94C, § 32A(a).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("94C")
+        expect(cites[0].section).toBe("32A")
+        expect(cites[0].subsection).toBe("(a)")
+      }
+    })
+
+    it("regression: `Mass. Gen. Laws c. 93A, § 2` continues to work", () => {
+      const cites = extractCitations("See Mass. Gen. Laws c. 93A, § 2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("93A")
+        expect(cites[0].jurisdiction).toBe("MA")
+        expect(cites[0].section).toBe("2")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #364. 50-opinion Massachusetts sample showed 15+ misses dominated by the bare \`G.L. c.\` form — the canonical Massachusetts court style since 1932. The unrecognized text also corrupted case-name extraction for the **next** citation.

The \`mass-chapter\` tokenizer pattern and mirroring \`MASS_CHAPTER_RE\` extractor regex updated in tandem:

1. Whitespace between corpus prefix and \`c.\` made optional (\`G.L.c.\` now matches)
2. Section connector accepts \`sec.\`/\`Sec.\`/\`section\`/\`Section\` alongside \`§\`
3. Section portion now optional (\`G.L. c. 93A\` chapter-only citations are valid)
4. \`General Laws\` (spelled-out without \`Mass.\` prefix) added to corpus alternation

### Behavior

| Input | Before | After |
|---|---|---|
| \`G.L.c. 93A\` | not extracted | code=93A, jur=MA, section=\"\" |
| \`G.L. c. 268A, sec. 25\` | not extracted | code=268A, section=25 |
| \`G. L. c. 93A\` | not extracted | code=93A, section=\"\" |
| \`G.L.c. 272, §99E(3)\` | not extracted | code=272, section=99E, sub=(3) |
| \`General Laws c. 94C, § 32A(a)\` | not extracted | code=94C, section=32A, sub=(a) |
| \`Mass. Gen. Laws c. 93A, § 2\` | unchanged | unchanged |

### Deferred

- \`St. YYYY, c. NNN, § N\` session laws (pending unified sessionLaw type)
- \`NNN CMR § N.NN\` regulations (admin regs deferred per #320)
- \`§ N.NN\` short-form regulation follow-on (short-form citation problem)

## Test plan

- [x] 7 new tests under \`Massachusetts G.L. c. spacing/sec./chapter-only variants (#364)\`
- [x] Full 2620-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)