### PR TITLE
feat: Indiana pre-1976 Burns + IC year-edition mis-parse + IND. CODE (#363)

### DIFF
--- a/.changeset/issue-363-indiana.md
+++ b/.changeset/issue-363-indiana.md
@@ -1,0 +1,97 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Indiana pre-1976 Burns Statutes, `IC YYYY` year-edition mis-parse, uppercase `IND. CODE` (#363)
+
+A 50-opinion Indiana sweep produced 15+ Indiana statute misses
+covering three distinct failure modes:
+
+1. **Pre-1976 Burns Indiana Statutes Annotated** — modern
+   Indiana opinions still cite this when referencing pre-1976
+   statutory text (`Burns Ind. Stat. Ann.`, `Burns' Indiana
+   Statutes Annotated`, `Ind. Stat. Ann.`, `Ind. Ann. Stat.`).
+   All variants were entirely unrecognized.
+2. **`IC YYYY` year-edition mis-parse** — `IC 1971, 35-13-4-4`
+   captured the year as section (silently substituting `1971`
+   for the actual section `35-13-4-4`), same family as the
+   year-edition mis-parses fixed for Colorado #352, Minnesota
+   #371, and Kansas #367.
+3. **Uppercase `IND. CODE`** — Indiana case captions and some
+   treatises use the all-caps form, but the Indiana regex
+   fragment only matched the mixed-case `Ind. Code`.
+
+### Fixes
+
+- **Pre-1976 Burns entry**: new separate Indiana entry in
+  `src/data/stateStatutes.ts` for the historical Burns Indiana
+  Statutes Annotated compilation. Fragment matches
+  `Burns(?:'s|')?\s+Ind(?:iana)?\.?\s+Stat(?:utes)?\.?
+  (?:\s+Ann(?:otated)?\.?)?` plus the `Ind. Stat. Ann.` and
+  `Ind. Ann. Stat.` forms. Sibling to Arkansas's modern/pre-1987
+  split (#349).
+
+- **Apostrophe-aware stripped lookup**: `findAbbreviatedCode`
+  in `src/data/knownCodes.ts` now strips apostrophes (along
+  with dots and whitespace) when computing the canonical
+  stripped-form key. This lets `Burns' Indiana Statutes
+  Annotated` resolve to the apostrophe-less entry.
+
+- **IC year-edition pattern**: new `ic-year-edition` tokenizer
+  pattern + dedicated `extractIcYearEdition` extractor. Captures
+  `IC 1971, 35-13-4-4` as `code: "IC"`, `year: 1971`,
+  `section: "35-13-4-4"`, `jurisdiction: "IN"`. The trailing
+  `, NN-N-N` separator distinguishes year-edition from bare
+  `IC NN-N-N` modern cites. Listed BEFORE `abbreviated-code`.
+
+- **`IND. CODE` uppercase**: Indiana regex fragment extended
+  with `IND\.?\s+CODE` to accept the all-caps variant.
+
+### Behavior changes
+
+- `IC 1971, 35-13-4-4` → `section="35-13-4-4"`, `year=1971`
+  (was: `section="1971"`)
+- `Burns Ind. Stat. Ann., § 10-3401 (1956 Repl.)` →
+  `jurisdiction="IN"`, `year=1956`, `editionLabel="Repl."`
+  (was: not extracted)
+- `Burns' Indiana Statutes Annotated § 48-702` →
+  `jurisdiction="IN"` (was: jurisdiction undefined; apostrophe
+  blocked stripped-form lookup)
+- `IND. CODE 6-5-1-7` → `jurisdiction="IN"`, `section="6-5-1-7"`
+  (was: not extracted)
+- Modern `IC 35-42-1-1` → unchanged
+
+### Scope notes
+
+The following pieces of #363 are intentionally deferred:
+
+- **Indiana Acts session laws** (`Indiana Acts 1905, ch. 129,
+  § 243`, `Acts 1929, ch. 172, § 49, p. 536`) — pending
+  unified `sessionLaw` citation type alongside session-law
+  formats for other states.
+
+### Tests
+
+7 new tests under `Indiana pre-1976 Burns + IC year-edition +
+IND. CODE (#363)` in `tests/extract/extractStatute.test.ts`:
+
+- Year-edition `IC 1971, 35-13-4-4`
+- Uppercase `IND. CODE 6-5-1-7`
+- Pre-1976 `Burns Ind. Stat. Ann., § 10-3401 (1956 Repl.)`
+- Pre-1976 `Ind. Stat. Ann. § 28-1710 (Burns 1971)`
+- Pre-1976 `Burns' Indiana Statutes Annotated § 48-702`
+  (apostrophe form)
+- Pre-1976 `Ind. Ann. Stat. § 10-4709`
+- Regression: bare modern `IC 35-42-1-1`
+
+Full 2628-test suite passes; no regressions.
+
+### Related
+
+Companion to #330 (pre-1993 Illinois Revised Statutes), #343
+(Code of Alabama 1940), #359 (Revised Laws of Hawaii pre-1955),
+#349 (Arkansas pre-1987 Statutes Annotated), and #373 (Nebraska
+R.R.S. 1943) — historical state-statute compilations that
+remain in active citation. The `IC YYYY` mis-parse fix joins
+Colorado #352, Minnesota #371, and Kansas #367 in the
+year-edition pattern family.

--- a/src/data/knownCodes.ts
+++ b/src/data/knownCodes.ts
@@ -848,14 +848,15 @@ for (const entry of abbreviatedCodes) {
 }
 
 /**
- * Stripped-form index — pattern with all dots and whitespace removed.
- * Used by `findAbbreviatedCode` to resolve OCR/spacing variants like
- * `AR.S.`, `ARS`, `A. R.S.` to the canonical `A.R.S.` entry (#348).
+ * Stripped-form index — pattern with all dots, whitespace, and apostrophes
+ * removed. Used by `findAbbreviatedCode` to resolve OCR/spacing variants
+ * like `AR.S.`, `ARS`, `A. R.S.` to the canonical `A.R.S.` entry (#348),
+ * and to normalize possessive forms like `Burns'` (#363).
  */
 const _byStrippedPattern = new Map<string, CodeEntry>()
 for (const entry of abbreviatedCodes) {
   for (const pattern of entry.patterns) {
-    const stripped = pattern.toLowerCase().replace(/[.\s]/g, "")
+    const stripped = pattern.toLowerCase().replace(/[.\s']/g, "")
     if (stripped.length === 0) continue
     // Last-write-wins; abbreviated arrays are ordered longest-first within an
     // entry, so the SHORTEST (canonical) form for a given stripped key wins.
@@ -887,8 +888,10 @@ export function findAbbreviatedCode(abbrevText: string): CodeEntry | undefined {
   if (exact) return exact
 
   // 2. Stripped-form match — OCR variants like `AR.S.`, `ARS`, `A. R.S.`
-  //    all collapse to `ars` and resolve to the canonical `A.R.S.` entry. #348
-  const stripped = lower.replace(/[.\s]/g, "")
+  //    all collapse to `ars` and resolve to the canonical `A.R.S.` entry
+  //    (#348). Also strips apostrophes so `Burns' Indiana Statutes Annotated`
+  //    matches the entry's `Burns Indiana Statutes Annotated` form (#363).
+  const stripped = lower.replace(/[.\s']/g, "")
   if (stripped.length > 0) {
     const strippedHit = _byStrippedPattern.get(stripped)
     if (strippedHit) return strippedHit

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -198,6 +198,8 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
   // opinions use either the spelled-out `Ind. Code` / `Indiana Code` or the
   // dotless `IC` shorthand. Restricting Indiana to the dotless `IC` lets
   // Idaho own `I.C.` / `I. C.` without losing Indiana coverage.
+  // `IND. CODE` (uppercase) is also accepted — Indiana case captions and
+  // some treatises use the all-caps form (#363).
   {
     jurisdiction: "IN",
     abbreviations: [
@@ -210,7 +212,23 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
       "IC",
     ],
     regexFragment:
-      "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|IC",
+      "Burns\\s+Ind\\.?\\s+Code(?:\\s+Ann\\.?)?|Ind(?:iana)?\\.?\\s+Code(?:\\s+Ann\\.?)?|IND\\.?\\s+CODE|IC",
+  },
+  // Pre-1976 Burns Indiana Statutes Annotated — modern Indiana opinions
+  // still cite this when referencing pre-1976 statutory text (#363).
+  // Examples: `Burns Ind. Stat. Ann., § 10-3401 (1956 Repl.)`,
+  // `Ind. Stat. Ann. § 28-1710 (Burns 1971)`, `Burns' Indiana Statutes
+  // Annotated § 48-702`, `Ind. Ann. Stat. § 10-4709`.
+  {
+    jurisdiction: "IN",
+    abbreviations: [
+      "Burns Indiana Statutes Annotated",
+      "Burns Ind. Stat. Ann.",
+      "Ind. Stat. Ann.",
+      "Ind. Ann. Stat.",
+    ],
+    regexFragment:
+      "Burns(?:'s|')?\\s+Ind(?:iana)?\\.?\\s+Stat(?:utes)?\\.?(?:\\s+Ann(?:otated)?\\.?)?|Ind(?:iana)?\\.?\\s+Stat\\.?\\s+Ann\\.?|Ind(?:iana)?\\.?\\s+Ann\\.?\\s+Stat\\.?",
   },
   // ── New Jersey ─────────────────────────────────────────────────────────────
   {

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -24,6 +24,7 @@ import { extractChapterAct } from "./statutes/extractChapterAct"
 import { extractColoradoProse } from "./statutes/extractColoradoProse"
 import { extractFederal } from "./statutes/extractFederal"
 import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
+import { extractIcYearEdition } from "./statutes/extractIcYearEdition"
 import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
 import { extractKsaYearEdition } from "./statutes/extractKsaYearEdition"
@@ -138,6 +139,8 @@ export function extractStatute(
     case "florida-postfix":
     case "florida-prefix-spelled":
       return extractFloridaStatute(token, transformationMap)
+    case "ic-year-edition":
+      return extractIcYearEdition(token, transformationMap)
     case "idaho-postfix":
       return extractIdahoPostfix(token, transformationMap)
     case "ksa-year-edition":

--- a/src/extract/statutes/extractIcYearEdition.ts
+++ b/src/extract/statutes/extractIcYearEdition.ts
@@ -1,0 +1,79 @@
+/**
+ * Indiana Code year-edition form — `IC 1971, 35-13-4-4`
+ *
+ * The year between IC and the section is the compilation/edition year of
+ * the Indiana Code, not the section. The trailing `, NN-N-N` separator
+ * distinguishes this from a bare `IC NN-N-N` modern citation. #363
+ *
+ * Same family as Colorado `C.R.S. 1963 § N` (#352), Minnesota
+ * `Minn. St. 1971, § N` (#371), Kansas `K.S.A. YYYY Supp. NN-NNN` (#367).
+ *
+ * @module extract/statutes/extractIcYearEdition
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const IC_YEAR_RE =
+  /^IC\s+(\d{4}),\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)$/d
+
+export function extractIcYearEdition(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = IC_YEAR_RE.exec(text)!
+  const year = Number.parseInt(match[1], 10)
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "IC",
+    section,
+    subsection,
+    pincite: subsection,
+    year,
+    jurisdiction: "IN",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -280,6 +280,21 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Indiana Code year-edition form: `IC 1971, 35-13-4-4` — the year
+    // between IC and the section is the compilation/edition year of the
+    // Indiana Code, not the section. abbreviated-code would silently
+    // capture the year as section. The trailing `, NN-N-N` separator
+    // distinguishes this from a bare `IC NN-N-N` modern citation. Listed
+    // BEFORE `abbreviated-code` so this shape wins. #363
+    //
+    // Captures: (1) edition year, (2) section body.
+    id: "ic-year-edition",
+    regex:
+      /\bIC\s+(\d{4}),\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+    description: 'Indiana Code year-edition form: "IC 1971, 35-13-4-4" — #363',
+    type: "statute",
+  },
+  {
     id: "abbreviated-code",
     regex: buildAbbreviatedCodeRegex(),
     description: "Abbreviated state code citations for all US jurisdictions",

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1919,4 +1919,90 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Indiana pre-1976 Burns + IC year-edition + IND. CODE (#363)", () => {
+    it("year-edition: `IC 1971, 35-13-4-4` → year=1971, section=35-13-4-4", () => {
+      const cites = extractCitations("See IC 1971, 35-13-4-4.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("IC")
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("35-13-4-4")
+        expect(cites[0].year).toBe(1971)
+      }
+    })
+
+    it("uppercase: `IND. CODE 6-5-1-7`", () => {
+      const cites = extractCitations("See IND. CODE 6-5-1-7.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("6-5-1-7")
+      }
+    })
+
+    it("pre-1976: `Burns Ind. Stat. Ann., § 10-3401 (1956 Repl.)`", () => {
+      const cites = extractCitations("See Burns Ind. Stat. Ann., § 10-3401 (1956 Repl.).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("10-3401")
+        expect(cites[0].year).toBe(1956)
+        expect(cites[0].editionLabel).toBe("Repl.")
+      }
+    })
+
+    it("pre-1976: `Ind. Stat. Ann. § 28-1710 (Burns 1971)` with publisher year", () => {
+      const cites = extractCitations("See Ind. Stat. Ann. § 28-1710 (Burns 1971).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("28-1710")
+        expect(cites[0].year).toBe(1971)
+      }
+    })
+
+    it("pre-1976: `Burns' Indiana Statutes Annotated § 48-702` (apostrophe form)", () => {
+      const cites = extractCitations("See Burns' Indiana Statutes Annotated § 48-702.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("48-702")
+      }
+    })
+
+    it("pre-1976: `Ind. Ann. Stat. § 10-4709`", () => {
+      const cites = extractCitations("See Ind. Ann. Stat. § 10-4709.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Ind. Ann. Stat.")
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("10-4709")
+      }
+    })
+
+    it("regression: bare `IC 35-42-1-1` continues to work", () => {
+      const cites = extractCitations("See IC 35-42-1-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("IC")
+        expect(cites[0].jurisdiction).toBe("IN")
+        expect(cites[0].section).toBe("35-42-1-1")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #363. 50-opinion Indiana sweep showed 15+ misses across three failure modes:

1. **Pre-1976 Burns Indiana Statutes Annotated** (Burns Ind. Stat. Ann., Burns' Indiana Statutes Annotated, Ind. Stat. Ann., Ind. Ann. Stat.) — entirely unrecognized
2. **IC YYYY year-edition mis-parse** — \`IC 1971, 35-13-4-4\` captured year as section (silent wrong data)
3. **Uppercase \`IND. CODE\`** — not matched by case-sensitive regex

### Fixes

- **New pre-1976 Burns entry** for Indiana with multi-variant fragment. Sibling to Arkansas pre-1987 split (#349).
- **Apostrophe-aware stripped lookup**: \`findAbbreviatedCode\` now strips apostrophes alongside dots/whitespace so \`Burns' Indiana Statutes Annotated\` matches the apostrophe-less entry.
- **\`ic-year-edition\` tokenizer + extractor**: \`IC 1971, 35-13-4-4\` → year=1971, section=35-13-4-4. Joins year-edition family (Colorado #352, Minnesota #371, Kansas #367).
- **\`IND. CODE\` uppercase** added to Indiana regex fragment.

### Behavior

| Input | Before | After |
|---|---|---|
| \`IC 1971, 35-13-4-4\` | section=1971, rest dropped | section=35-13-4-4, year=1971 |
| \`Burns Ind. Stat. Ann., § 10-3401 (1956 Repl.)\` | not extracted | jur=IN, section=10-3401, year=1956, label=Repl. |
| \`Burns' Indiana Statutes Annotated § 48-702\` | jur=undefined | jur=IN |
| \`IND. CODE 6-5-1-7\` | not extracted | jur=IN, section=6-5-1-7 |
| \`IC 35-42-1-1\` | unchanged | unchanged |

### Deferred

- Indiana Acts session laws (\`Indiana Acts 1905, ch. 129, § 243\`) — pending unified sessionLaw type

## Test plan

- [x] 7 new tests under \`Indiana pre-1976 Burns + IC year-edition + IND. CODE (#363)\`
- [x] Full 2628-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)