### PR TITLE
fix: I.R.C. § N (Internal Revenue Code) no longer mis-classified as Ohio (#376)

### DIFF
--- a/.changeset/issue-376-irc.md
+++ b/.changeset/issue-376-irc.md
@@ -1,0 +1,65 @@
+---
+"eyecite-ts": patch
+---
+
+fix: `I.R.C. § N` (Internal Revenue Code) no longer mis-classified as Ohio Revised Code (#376)
+
+A 37-opinion New Jersey sweep showed 14 out of 14 (100%) `I.R.C.`
+citations mis-routed to Ohio: the regex engine matched Ohio's
+`R\.?C\.?` fragment starting at the second character of `I.R.C.`,
+silently producing `code: "R.C.", jurisdiction: "OH"` and
+truncating the federal IRC reference. Every federal-tax statutory
+citation in the corpus was lost.
+
+### Fix
+
+New `irc` tokenizer pattern in `src/patterns/statutePatterns.ts`
++ dedicated `extractIrc` extractor at
+`src/extract/statutes/extractIrc.ts`. Matches both the dotted
+`I.R.C.` and dotless `IRC` forms. Listed BEFORE
+`abbreviated-code` so the longer `I.R.C.` match wins span dedup
+over Ohio's `R.C.` match at the same position. Output:
+`code: "I.R.C."`, `jurisdiction: "US"`, `section`, `subsection`.
+Dotless `IRC` is also normalized to canonical `"I.R.C."`.
+
+### Behavior changes
+
+- `I.R.C. § 1367` → `code="I.R.C."`, `jurisdiction="US"` (was:
+  `code="R.C."`, `jurisdiction="OH"`)
+- `I.R.C. § 1366(a)(1)` → with subsection
+- `IRC § 1341` → `code="I.R.C."` (normalized)
+- Ohio `Ohio Rev. Code Ann. § 2925.03` → unchanged
+- Ohio `R.C. § 2925.03` → unchanged
+
+### Scope notes
+
+The following pieces of #376 are intentionally deferred:
+
+- **Prose `§ N et seq. of the Internal Revenue Code`** —
+  prose-form IRC references; needs a different pattern.
+- **N.J.S.A. colon-shorthand** (`N.J.S.A. 54A:9-8(c) and :8-7`
+  — `:8-7` is title-carry-forward shorthand) — same family as
+  Montana `-206` form, deferred with multi-section work.
+
+### Tests
+
+5 new tests under `Internal Revenue Code I.R.C. — federal, not
+Ohio (#376)` in `tests/extract/extractStatute.test.ts`:
+
+- `I.R.C. § 1367`
+- `I.R.C. § 1366(a)(1)` with subsection
+- Bare `IRC § 1341` (normalized to I.R.C.)
+- Regression: `Ohio Rev. Code Ann. § 2925.03`
+- Regression: `R.C. § 2925.03`
+
+Full 2636-test suite passes; no regressions.
+
+### Related
+
+Same family of jurisdiction-routing bugs as #370 (Michigan MSA
+→ Minnesota) and #360 (Idaho I.C. → Indiana) — when a longer
+abbreviation contains a shorter state-code abbreviation as a
+suffix, the regex engine matches the shorter pattern at the
+wrong position. The fix pattern (longer-match wins via container
+shape + span dedup) is now established across these three
+state-pair mis-classifications.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -27,6 +27,7 @@ import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
 import { extractIcYearEdition } from "./statutes/extractIcYearEdition"
 import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
+import { extractIrc } from "./statutes/extractIrc"
 import { extractKsaYearEdition } from "./statutes/extractKsaYearEdition"
 import { extractMcaPostfix } from "./statutes/extractMcaPostfix"
 import { extractMdArticleLetter } from "./statutes/extractMdArticleLetter"
@@ -141,6 +142,8 @@ export function extractStatute(
       return extractFloridaStatute(token, transformationMap)
     case "ic-year-edition":
       return extractIcYearEdition(token, transformationMap)
+    case "irc":
+      return extractIrc(token, transformationMap)
     case "idaho-postfix":
       return extractIdahoPostfix(token, transformationMap)
     case "ksa-year-edition":

--- a/src/extract/statutes/extractIrc.ts
+++ b/src/extract/statutes/extractIrc.ts
@@ -1,0 +1,80 @@
+/**
+ * Internal Revenue Code (IRC) — federal tax code citations
+ *
+ *   I.R.C. § 1367
+ *   I.R.C. § 1366(a)(1)
+ *   IRC § 1341
+ *
+ * The `I.R.C.` form is the canonical Bluebook abbreviation for Title 26 of
+ * the U.S. Code (Internal Revenue Code); bare `IRC` is also common in tax
+ * opinions. Without this dedicated pattern, Ohio's `R.C.` regex fragment
+ * matched the suffix of `I.R.C.` and silently routed every IRC citation
+ * to Ohio jurisdiction. #376
+ *
+ * @module extract/statutes/extractIrc
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const IRC_RE =
+  /^(?:I\.R\.C\.|IRC)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)$/d
+
+export function extractIrc(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = IRC_RE.exec(text)!
+  const rawBody = match[1]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "I.R.C.",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "US",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -33,6 +33,23 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Internal Revenue Code (IRC) — federal tax code citations. The `I.R.C.`
+    // form is the canonical Bluebook abbreviation; bare `IRC` is also common.
+    // Without this pattern, Ohio's `R.C.` regex matches the suffix of
+    // `I.R.C.` and silently routes every IRC citation to Ohio jurisdiction
+    // (14/14 misclassifications in a 37-opinion NJ sweep). #376
+    //
+    // Listed BEFORE `abbreviated-code` so the longer `I.R.C.` match wins
+    // span dedup over Ohio's `R.C.` match at the same position.
+    //
+    // Captures: (1) section body.
+    id: "irc",
+    regex:
+      /\b(?:I\.R\.C\.|IRC)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+    description: 'Internal Revenue Code: "I.R.C. § 1367", "IRC § 1341" — #376',
+    type: "statute",
+  },
+  {
     id: "prose",
     regex: /\b[Ss]ection\s+(\d+[A-Za-z0-9-]*(?:\([^)]*\))*)\s+of\s+title\s+(\d+)\b/g,
     description:

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2005,4 +2005,61 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Internal Revenue Code I.R.C. — federal, not Ohio (#376)", () => {
+    it("extracts `I.R.C. § 1367` as federal", () => {
+      const cites = extractCitations("See I.R.C. § 1367.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("I.R.C.")
+        expect(cites[0].jurisdiction).toBe("US")
+        expect(cites[0].section).toBe("1367")
+      }
+    })
+
+    it("extracts `I.R.C. § 1366(a)(1)` with subsection", () => {
+      const cites = extractCitations("See I.R.C. § 1366(a)(1).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("1366")
+        expect(cites[0].subsection).toBe("(a)(1)")
+      }
+    })
+
+    it("extracts bare `IRC § 1341` as federal (normalized to I.R.C.)", () => {
+      const cites = extractCitations("See IRC § 1341.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("I.R.C.")
+        expect(cites[0].jurisdiction).toBe("US")
+      }
+    })
+
+    it("regression: Ohio `Ohio Rev. Code § 2925.03` still routes to Ohio", () => {
+      const cites = extractCitations("See Ohio Rev. Code Ann. § 2925.03.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("OH")
+      }
+    })
+
+    it("regression: bare Ohio `R.C. § 2925.03` still routes to Ohio", () => {
+      const cites = extractCitations("See R.C. § 2925.03.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.C.")
+        expect(cites[0].jurisdiction).toBe("OH")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #376. **Critical bug**: a 37-opinion NJ sweep showed **14/14 (100%)** of \`I.R.C.\` citations mis-routed to Ohio. The regex engine matched Ohio's \`R\\.?C\\.?\` fragment starting at the second character of \`I.R.C.\`, silently producing \`code=\"R.C.\", jurisdiction=\"OH\"\` and losing every federal-tax statutory reference in the corpus.

New \`irc\` tokenizer pattern + dedicated \`extractIrc\` extractor. Matches both \`I.R.C.\` (dotted) and \`IRC\` (dotless, normalized to canonical \`I.R.C.\`). Listed BEFORE \`abbreviated-code\` so the longer \`I.R.C.\` match wins span dedup over Ohio's \`R.C.\` match at the same position.

### Behavior

| Input | Before | After |
|---|---|---|
| \`I.R.C. § 1367\` | code=R.C., jur=OH | code=I.R.C., jur=US |
| \`I.R.C. § 1366(a)(1)\` | code=R.C., jur=OH | code=I.R.C., jur=US, sub=(a)(1) |
| \`IRC § 1341\` | not extracted | code=I.R.C. (normalized), jur=US |
| \`Ohio Rev. Code Ann. § 2925.03\` | unchanged | unchanged |
| \`R.C. § 2925.03\` | unchanged | unchanged |

### Deferred

- Prose \`§ N et seq. of the Internal Revenue Code\` (needs different pattern)
- N.J.S.A. colon-shorthand (\`N.J.S.A. 54A:9-8(c) and :8-7\`) — multi-section family

### Related

Same family as #370 (Michigan MSA → Minnesota) and #360 (Idaho I.C. → Indiana): when a longer abbreviation contains a shorter state-code abbreviation as a suffix.

## Test plan

- [x] 5 new tests under \`Internal Revenue Code I.R.C. — federal, not Ohio (#376)\`
- [x] Full 2636-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)