### PR TITLE
feat: NH RSA chapter form (RSA chapter NNN-X, ch. NNN-X) (#378)

### DIFF
--- a/.changeset/issue-378-nh-rsa-chapter.md
+++ b/.changeset/issue-378-nh-rsa-chapter.md
@@ -1,0 +1,63 @@
+---
+"eyecite-ts": patch
+---
+
+feat: New Hampshire `RSA chapter NNN-X` and `RSA ch. NNN-X` chapter-only form (#378)
+
+NH uniquely cites the chapter number alone as a complete citation:
+`RSA chapter 169-D`, `RSA ch. 458-C`, `RSA [chapter] 173-B`. The
+colon-section form `RSA 511:2` was already handled by the
+`abbreviated-code` family, but the chapter-only variants were
+completely unrecognized.
+
+### Fix
+
+New `rsa-chapter` tokenizer pattern in
+`src/patterns/statutePatterns.ts` + dedicated `extractRsaChapter`
+extractor at `src/extract/statutes/extractRsaChapter.ts`. Handles:
+
+- `RSA chapter 169-D` (spelled `chapter`)
+- `RSA ch. 458-C` (abbreviated `ch.`)
+- `RSA [chapter] 173-B` (bracketed-chapter typographical
+  convention used by some NH opinions)
+
+Emits `code: "RSA"`, `jurisdiction: "NH"`, with the chapter
+identifier in `section` (NH treats the chapter as the citation's
+identifier when no individual subsection is pin-cited).
+
+### Scope notes
+
+The following pieces of #378 are intentionally deferred:
+
+- **Roman-numeral subsections** (`RSA 511:2, XIX`) — the trailing
+  `, XIX` is dropped; preserving it requires a different
+  subsection-grammar handling.
+- **Edition parentheticals** (`RSA chapter 458 (Supp. 2000)`,
+  `RSA chapter 165 (1977 and Supp. 1983)`) — single `Supp.` is
+  attached by the existing year-paren absorber; multi-edition
+  parentheticals (`(1977 and Supp. 1983)`) require additional
+  parsing.
+- **Session laws** (`Laws 1979, 377:1`, `Laws 2011, 268:4`) —
+  pending unified `sessionLaw` citation type.
+
+### Tests
+
+6 new tests under `New Hampshire RSA chapter form (#378)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `RSA chapter 169-D`
+- `RSA chapter 597`
+- `RSA ch. 458-C` (abbreviated)
+- `RSA [chapter] 173-B` (bracketed)
+- Regression: colon-section `RSA 511:2`
+- Regression: full Bluebook `N.H. Rev. Stat. Ann. § 511:2`
+
+Full 2642-test suite passes; no regressions.
+
+### Related
+
+NH is the only state whose primary citation form is
+chapter-only (the chapter number functions as a complete
+identifier — there's no implicit "section 1" assumption). This
+makes the pattern simple and unambiguous: the `RSA` prefix is
+distinctively NH.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -36,6 +36,7 @@ import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
 import { extractRrs1943 } from "./statutes/extractRrs1943"
+import { extractRsaChapter } from "./statutes/extractRsaChapter"
 
 /**
  * Legacy inline parser for unknown patterns.
@@ -158,6 +159,8 @@ export function extractStatute(
       return extractRlh(token, transformationMap)
     case "rrs-1943":
       return extractRrs1943(token, transformationMap)
+    case "rsa-chapter":
+      return extractRsaChapter(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractRsaChapter.ts
+++ b/src/extract/statutes/extractRsaChapter.ts
@@ -1,0 +1,53 @@
+/**
+ * New Hampshire RSA chapter form — `RSA chapter 169-D`, `RSA ch. 458-C`
+ *
+ * NH uniquely cites the chapter number alone (no section after the chapter)
+ * as a complete citation. The colon-section form `RSA 511:2` is already
+ * handled by the `abbreviated-code` family. #378
+ *
+ * The chapter goes into the `section` field — that's the canonical NH
+ * shape: `code: "RSA"`, `section: "169-D"`. NH opinions treat the chapter
+ * number as the citation identifier when no individual subsection is being
+ * pin-cited.
+ *
+ * @module extract/statutes/extractRsaChapter
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+
+const RSA_CHAPTER_RE = /^RSA\s+(?:\[chapter\]|chapter|ch\.?)\s+(\d+(?:-[A-Z])?)$/d
+
+export function extractRsaChapter(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = RSA_CHAPTER_RE.exec(text)!
+  const section = match[1]
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.section = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+  }
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence: 0.95,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "RSA",
+    section,
+    jurisdiction: "NH",
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -50,6 +50,23 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // New Hampshire Revised Statutes Annotated — chapter form. NH uniquely
+    // cites the chapter number alone (no section) as a valid citation:
+    // `RSA chapter 169-D`, `RSA ch. 458-C`, `RSA [chapter] 173-B`. The
+    // bracketed-chapter form (`[chapter]`) is a typographical convention
+    // used by some NH opinions to indicate the chapter token was inserted
+    // by the reporter rather than original text. The colon-section form
+    // (`RSA 511:2`) is already handled by `abbreviated-code`. #378
+    //
+    // Captures: (1) chapter body — digits + optional hyphen-letter suffix
+    // (NH uses forms like `169-D`, `458-C`).
+    id: "rsa-chapter",
+    regex: /\bRSA\s+(?:\[chapter\]|chapter|ch\.?)\s+(\d+(?:-[A-Z])?)/g,
+    description:
+      'New Hampshire RSA chapter-only form: "RSA chapter 169-D" / "RSA ch. 458-C" — #378',
+    type: "statute",
+  },
+  {
     id: "prose",
     regex: /\b[Ss]ection\s+(\d+[A-Za-z0-9-]*(?:\([^)]*\))*)\s+of\s+title\s+(\d+)\b/g,
     description:

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2062,4 +2062,71 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("New Hampshire RSA chapter form (#378)", () => {
+    it("extracts `RSA chapter 169-D` (chapter-only)", () => {
+      const cites = extractCitations("See RSA chapter 169-D.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RSA")
+        expect(cites[0].jurisdiction).toBe("NH")
+        expect(cites[0].section).toBe("169-D")
+      }
+    })
+
+    it("extracts `RSA chapter 597`", () => {
+      const cites = extractCitations("See RSA chapter 597.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("597")
+      }
+    })
+
+    it("extracts `RSA ch. 458-C` (abbreviated chapter)", () => {
+      const cites = extractCitations("See RSA ch. 458-C.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RSA")
+        expect(cites[0].section).toBe("458-C")
+      }
+    })
+
+    it("extracts `RSA [chapter] 173-B` (bracketed-chapter form)", () => {
+      const cites = extractCitations("See RSA [chapter] 173-B.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RSA")
+        expect(cites[0].section).toBe("173-B")
+      }
+    })
+
+    it("regression: colon-section `RSA 511:2` continues to work", () => {
+      const cites = extractCitations("See RSA 511:2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RSA")
+        expect(cites[0].section).toBe("511:2")
+      }
+    })
+
+    it("regression: full Bluebook `N.H. Rev. Stat. Ann. § 511:2` continues to work", () => {
+      const cites = extractCitations("See N.H. Rev. Stat. Ann. § 511:2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("NH")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #378. NH uniquely cites the chapter number alone (no section) as a complete citation. The colon-section form \`RSA 511:2\` already worked via \`abbreviated-code\`, but the chapter-only variants were completely unrecognized.

New \`rsa-chapter\` tokenizer + extractor handling:
- \`RSA chapter 169-D\` (spelled \`chapter\`)
- \`RSA ch. 458-C\` (abbreviated \`ch.\`)
- \`RSA [chapter] 173-B\` (bracketed-chapter typographical convention)

Emits \`code: \"RSA\"\`, \`jurisdiction: \"NH\"\`, with the chapter ID in \`section\`.

### Deferred

- Roman-numeral subsections (\`RSA 511:2, XIX\`)
- Multi-edition parentheticals (\`RSA chapter 165 (1977 and Supp. 1983)\`)
- Session laws (\`Laws 1979, 377:1\`) — pending unified sessionLaw type

## Test plan

- [x] 6 new tests under \`New Hampshire RSA chapter form (#378)\`
- [x] Full 2642-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)