### PR TITLE
feat: New Mexico bare-section form Section NN-N-NN(X) / § NN-N-NN (#382)

### DIFF
--- a/.changeset/issue-382-nm-bare-section.md
+++ b/.changeset/issue-382-nm-bare-section.md
@@ -1,0 +1,56 @@
+---
+"eyecite-ts": patch
+---
+
+feat: New Mexico bare-section form `Section 32A-2-7(A)` / `§ 41-2-2` (#382)
+
+NM opinions cite NMSA 1978 sections in a distinctive bare form
+without the code abbreviation — the three-hyphen section format
+(`\d[A-Z]?-\d[A-Z]?-\d[A-Z]?`) is unique among state codes and
+serves as the disambiguator. A 50-opinion NM sweep produced
+dozens of misses on these forms.
+
+### Fix
+
+New `nm-bare-section` tokenizer pattern in
+`src/patterns/statutePatterns.ts` + dedicated
+`extractNmBareSection` extractor at
+`src/extract/statutes/extractNmBareSection.ts`. Matches both
+`§ 41-2-2` (symbol form) and `Section 32A-2-7(A)` (spelled-out
+form). Listed AFTER `abbreviated-code` so that a full
+`NMSA 1978, § 41-2-2` citation isn't double-counted (the
+abbreviated-code container would otherwise tie with this
+contained pattern, leaving a duplicate cite at the inner span).
+
+Uses `(?<![A-Za-z])` lookbehind anchor instead of `\b` because
+the pattern can start at `§` (non-word char where `\b` doesn't
+apply).
+
+Emits `code: "NMSA 1978"`, `jurisdiction: "NM"`, `section` with
+the three-hyphen body, and `subsection` for any trailing
+parenthetical (`(A)`, `(B)`, `(1)`).
+
+### Scope notes
+
+The following pieces of #382 are intentionally deferred:
+
+- **NMRA rule citations** (`Rule 16-110(C) NMRA`) — rule
+  citations broadly deferred per #295.
+- **Public Law form** (`Public Law 567`) — used in NM opinions
+  for federal statutes; separate `publicLaw` family.
+
+### Tests
+
+5 new tests under `New Mexico bare-section form (#382)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `Section 32A-2-7(A)` (letter-prefix first part)
+- `Section 22-10A-27(B)` (letter-prefix middle part)
+- `§ 41-2-2` (symbol form, no subsection)
+- Regression: `NMSA 1978, § 41-2-2` produces exactly one
+  citation (no duplicate from the contained inner span)
+- Regression: Maryland `CP § 10-105(e)` (two-hyphen) doesn't
+  collide — the three-hyphen requirement keeps the patterns
+  disjoint
+
+Full 2649-test suite passes; no regressions.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -33,6 +33,7 @@ import { extractMcaPostfix } from "./statutes/extractMcaPostfix"
 import { extractMdArticleLetter } from "./statutes/extractMdArticleLetter"
 import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
+import { extractNmBareSection } from "./statutes/extractNmBareSection"
 import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
 import { extractRrs1943 } from "./statutes/extractRrs1943"
@@ -155,6 +156,8 @@ export function extractStatute(
       return extractMdArticleLetter(token, transformationMap)
     case "minn-st-year-edition":
       return extractMinnStYearEdition(token, transformationMap)
+    case "nm-bare-section":
+      return extractNmBareSection(token, transformationMap)
     case "rlh":
       return extractRlh(token, transformationMap)
     case "rrs-1943":

--- a/src/extract/statutes/extractNmBareSection.ts
+++ b/src/extract/statutes/extractNmBareSection.ts
@@ -1,0 +1,75 @@
+/**
+ * New Mexico bare-section form — `Section 32A-2-7(A)`, `§ 41-2-2`
+ *
+ * NM opinions cite NMSA 1978 sections in a distinctive bare form without
+ * the code abbreviation. The three-hyphen section format
+ * (`\d[A-Z]?-\d[A-Z]?-\d[A-Z]?`) is unique among state codes and serves
+ * as the disambiguator. #382
+ *
+ * @module extract/statutes/extractNmBareSection
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const NM_BARE_SECTION_RE =
+  /^(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9]+\))*)$/d
+
+export function extractNmBareSection(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = NM_BARE_SECTION_RE.exec(text)!
+  const rawBody = match[1]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.9
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "NMSA 1978",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "NM",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -335,6 +335,26 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // New Mexico bare-section form: `Section 32A-2-7(A)`, `§ 41-2-2`. NM
+    // opinions cite NMSA 1978 sections without a code prefix — the three-
+    // hyphen section format (`\d[A-Z]?-\d[A-Z]?-\d[A-Z]?`) is distinctive
+    // among state codes and serves as the disambiguator. Listed AFTER
+    // `abbreviated-code` so a full `NMSA 1978, § 41-2-2` citation is not
+    // double-counted by this bare-section pattern (the abbreviated-code
+    // container would otherwise tie with this contained pattern, leaving
+    // a duplicate cite at the inner span). #382
+    //
+    // Captures: (1) section body — three-part hyphenated form with
+    // optional uppercase-letter suffixes and optional parenthetical
+    // subsection (`(A)`, `(B)`, `(1)`).
+    id: "nm-bare-section",
+    regex:
+      /(?<![A-Za-z])(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9]+\))*)/g,
+    description:
+      'New Mexico bare-section form: "Section 32A-2-7(A)" / "§ 41-2-2" — #382',
+    type: "statute",
+  },
+  {
     id: "ca-bare-code",
     regex: buildCaBareCodeRegex(),
     description:

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2129,4 +2129,64 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("New Mexico bare-section form (#382)", () => {
+    it("extracts `Section 32A-2-7(A)` (bare, letter-prefix first part)", () => {
+      const cites = extractCitations("Section 32A-2-7(A) requires.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("NMSA 1978")
+        expect(cites[0].jurisdiction).toBe("NM")
+        expect(cites[0].section).toBe("32A-2-7")
+        expect(cites[0].subsection).toBe("(A)")
+      }
+    })
+
+    it("extracts `Section 22-10A-27(B)` (letter-prefix middle part)", () => {
+      const cites = extractCitations("See Section 22-10A-27(B).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("22-10A-27")
+        expect(cites[0].subsection).toBe("(B)")
+      }
+    })
+
+    it("extracts `§ 41-2-2` (symbol form, no subsection)", () => {
+      const cites = extractCitations("See § 41-2-2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("NMSA 1978")
+        expect(cites[0].jurisdiction).toBe("NM")
+        expect(cites[0].section).toBe("41-2-2")
+      }
+    })
+
+    it("regression: `NMSA 1978, § 41-2-2` produces exactly one citation (no duplicate)", () => {
+      const cites = extractCitations("See NMSA 1978, § 41-2-2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("NMSA 1978")
+        expect(cites[0].jurisdiction).toBe("NM")
+        expect(cites[0].section).toBe("41-2-2")
+      }
+    })
+
+    it("regression: Maryland `CP § 10-105(e)` (two-hyphen) doesn't collide", () => {
+      const cites = extractCitations("See CP § 10-105(e).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MD")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #382. NM opinions cite NMSA 1978 sections in a distinctive bare form without the code abbreviation — the three-hyphen section format (\`\\d[A-Z]?-\\d[A-Z]?-\\d[A-Z]?\`) is unique among state codes and serves as the disambiguator. A 50-opinion NM sweep produced dozens of misses on these forms.

New \`nm-bare-section\` tokenizer + extractor. Listed AFTER \`abbreviated-code\` so a full \`NMSA 1978, § 41-2-2\` doesn't double-emit. Uses \`(?<![A-Za-z])\` lookbehind (not \`\\b\`) so \`§\`-anchored matches work.

### Behavior

| Input | Result |
|---|---|
| \`Section 32A-2-7(A)\` | code=NMSA 1978, jur=NM, section=32A-2-7, sub=(A) |
| \`Section 22-10A-27(B)\` | section=22-10A-27, sub=(B) |
| \`§ 41-2-2\` | code=NMSA 1978, jur=NM, section=41-2-2 |
| \`NMSA 1978, § 41-2-2\` | exactly one citation (no duplicate) |
| \`CP § 10-105(e)\` (Maryland) | unaffected — three-hyphen requirement keeps disjoint |

### Deferred

- NMRA rule citations (\`Rule 16-110(C) NMRA\`) — deferred per #295
- Public Law form (\`Public Law 567\`) — separate publicLaw family

## Test plan

- [x] 5 new tests under \`New Mexico bare-section form (#382)\`
- [x] Full 2649-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)