### PR TITLE
fix: Ohio R. C. spaced variant + R.C. Chapter form (#388)

### DIFF
--- a/.changeset/issue-388-oh-spaced.md
+++ b/.changeset/issue-388-oh-spaced.md
@@ -1,0 +1,69 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Ohio `R. C.` (spaced) and `R.C. Chapter N` (chapter-only) forms (#388)
+
+Ohio's canonical statutory abbreviation is `R.C.` (Revised Code),
+but the spelled-out form `R. C.` with a space between `R.` and
+`C.` is the dominant form in court-published Ohio opinions — more
+common than the no-space `R.C.` variant. eyecite-ts didn't
+recognize the spaced form, and the `R. C. Chapter NNNN`
+chapter-only variant was also missing for both spacings.
+
+### Fixes
+
+- **Spaced `R. C.`**: Ohio regex fragment in
+  `src/data/stateStatutes.ts` now admits inter-letter spacing
+  (`R\.?\s*C\.?` instead of `R\.?C\.?`). The federal Internal
+  Revenue Code (`I.R.C.`, #376) has its own dedicated pattern
+  with higher priority, so the `I.` prefix won't trigger Ohio.
+- **Canonical normalization**: Ohio's abbreviations array was
+  reordered so `R.C.` (Bluebook standard, with dots) is the last
+  element and becomes the canonical short form. Spaced variants
+  (`R. C.`, `R . C .`) and dotless variants (`RC`) all resolve
+  to `R.C.` via the stripped-form fallback.
+- **Chapter form**: new `oh-chapter` tokenizer pattern +
+  dedicated `extractOhChapter` extractor handles both spacings
+  of `R.C. Chapter N` / `R. C. Chapter N`. The chapter
+  identifier goes into the `section` field (matching the
+  convention established by the NH `rsa-chapter` extractor for
+  chapter-only citations).
+
+### Behavior changes
+
+- `R. C. 713.15` → `code="R.C."`, `jurisdiction="OH"`,
+  `section="713.15"` (was: not extracted)
+- `R. C. 5321.15(C)` → with subsection `(C)`
+- `R. C. Chapter 1702` → `section="1702"` (was: not extracted)
+- `R.C. Chapter 4509` → `section="4509"` (was: not extracted)
+- `R.C. 5302.20` → unchanged
+- `I.R.C. § 1367` → unchanged (still federal, not Ohio)
+
+### Scope notes
+
+The following pieces of #388 are intentionally deferred:
+
+- **Prose form** (`section 120.33 of the Revised Code`) — needs
+  a different pattern; multiple states have similar prose forms.
+
+### Tests
+
+6 new tests under `Ohio R. C. spacing variant + R.C. Chapter
+form (#388)` in `tests/extract/extractStatute.test.ts`:
+
+- Spaced `R. C. 713.15`
+- Spaced `R. C. 5321.15(C)` with subsection
+- Spaced chapter `R. C. Chapter 1702`
+- No-space chapter `R.C. Chapter 4509`
+- Regression: `R.C. 5302.20`
+- Regression: federal `I.R.C. § 1367` still routes to federal
+
+Full 2655-test suite passes; no regressions.
+
+### Related
+
+Spacing-tolerance fix follows the pattern established by Arizona
+A.R.S. (#348), Arkansas (#349), Hawaii I.C. → Idaho (#360), and
+Indiana → Idaho disambiguation (#360). Chapter-only form mirrors
+NH `rsa-chapter` (#378).

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -101,10 +101,17 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Fla\\.?\\s*Stat(?:utes)?\\.?(?:\\s*Ann\\.?)?|F\\.?S\\.?",
   },
   // ── Ohio ───────────────────────────────────────────────────────────────────
+  // Inter-letter spacing tolerance — `R. C. 713.15` (with space) is the
+  // dominant Ohio court-published style, more common than the no-space
+  // `R.C. 713.15`. The federal Internal Revenue Code (`I.R.C.`) has its
+  // own dedicated pattern (#376) so the `I.` prefix won't trigger Ohio.
+  // Canonical abbreviation is `R.C.` (Bluebook); ordered last so the
+  // stripped-form fallback normalizes spaced/dotless variants to it. #388
   {
     jurisdiction: "OH",
-    abbreviations: ["Ohio Rev. Code Ann.", "Ohio Rev. Code", "O.R.C.", "ORC", "R.C.", "RC"],
-    regexFragment: "Ohio\\s+Rev\\.?\\s+Code(?:\\s+Ann\\.?)?|O\\.?R\\.?C\\.?|R\\.?C\\.?",
+    abbreviations: ["Ohio Rev. Code Ann.", "Ohio Rev. Code", "O.R.C.", "ORC", "RC", "R.C."],
+    regexFragment:
+      "Ohio\\s+Rev\\.?\\s+Code(?:\\s+Ann\\.?)?|O\\.?\\s*R\\.?\\s*C\\.?|R\\.?\\s*C\\.?",
   },
   // ── Michigan ───────────────────────────────────────────────────────────────
   {

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -34,6 +34,7 @@ import { extractMdArticleLetter } from "./statutes/extractMdArticleLetter"
 import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractNmBareSection } from "./statutes/extractNmBareSection"
+import { extractOhChapter } from "./statutes/extractOhChapter"
 import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
 import { extractRrs1943 } from "./statutes/extractRrs1943"
@@ -158,6 +159,8 @@ export function extractStatute(
       return extractMinnStYearEdition(token, transformationMap)
     case "nm-bare-section":
       return extractNmBareSection(token, transformationMap)
+    case "oh-chapter":
+      return extractOhChapter(token, transformationMap)
     case "rlh":
       return extractRlh(token, transformationMap)
     case "rrs-1943":

--- a/src/extract/statutes/extractOhChapter.ts
+++ b/src/extract/statutes/extractOhChapter.ts
@@ -1,0 +1,49 @@
+/**
+ * Ohio Revised Code Chapter form — `R.C. Chapter 4509`, `R. C. Chapter 1702`
+ *
+ * Ohio (like NH) allows chapter-only references where the chapter number
+ * functions as a complete citation. Spacing between `R.` and `C.` is
+ * optional. The chapter identifier goes into the `section` field, matching
+ * the convention established by the NH `rsa-chapter` extractor. #388
+ *
+ * @module extract/statutes/extractOhChapter
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+
+const OH_CHAPTER_RE = /^R\.?\s*C\.?\s+Chapter\s+(\d+)$/d
+
+export function extractOhChapter(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = OH_CHAPTER_RE.exec(text)!
+  const section = match[1]
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.section = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+  }
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence: 0.95,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "R.C.",
+    section,
+    jurisdiction: "OH",
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -67,6 +67,19 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Ohio Revised Code Chapter form: `R.C. Chapter 4509`, `R. C. Chapter
+    // 1702`. The chapter number is treated as a complete citation (Ohio,
+    // like NH, allows chapter-only references). Spacing between `R.` and
+    // `C.` is optional — both `R.C.` and `R. C.` are accepted. #388
+    //
+    // Captures: (1) chapter number.
+    id: "oh-chapter",
+    regex: /\bR\.?\s*C\.?\s+Chapter\s+(\d+)/g,
+    description:
+      'Ohio Revised Code chapter-only form: "R.C. Chapter 4509" / "R. C. Chapter 1702" — #388',
+    type: "statute",
+  },
+  {
     id: "prose",
     regex: /\b[Ss]ection\s+(\d+[A-Za-z0-9-]*(?:\([^)]*\))*)\s+of\s+title\s+(\d+)\b/g,
     description:

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2189,4 +2189,74 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Ohio R. C. spacing variant + R.C. Chapter form (#388)", () => {
+    it("extracts spaced `R. C. 713.15`", () => {
+      const cites = extractCitations("See R. C. 713.15.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.C.")
+        expect(cites[0].jurisdiction).toBe("OH")
+        expect(cites[0].section).toBe("713.15")
+      }
+    })
+
+    it("extracts spaced `R. C. 5321.15(C)` with subsection", () => {
+      const cites = extractCitations("See R. C. 5321.15(C).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.C.")
+        expect(cites[0].section).toBe("5321.15")
+        expect(cites[0].subsection).toBe("(C)")
+      }
+    })
+
+    it("extracts spaced chapter `R. C. Chapter 1702`", () => {
+      const cites = extractCitations("See R. C. Chapter 1702.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.C.")
+        expect(cites[0].jurisdiction).toBe("OH")
+        expect(cites[0].section).toBe("1702")
+      }
+    })
+
+    it("extracts no-space chapter `R.C. Chapter 4509`", () => {
+      const cites = extractCitations("See R.C. Chapter 4509.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("4509")
+      }
+    })
+
+    it("regression: `R.C. 5302.20` (no space) continues to work", () => {
+      const cites = extractCitations("See R.C. 5302.20.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("R.C.")
+        expect(cites[0].section).toBe("5302.20")
+      }
+    })
+
+    it("regression: federal `I.R.C. § 1367` still routes to federal (not Ohio)", () => {
+      const cites = extractCitations("See I.R.C. § 1367.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("I.R.C.")
+        expect(cites[0].jurisdiction).toBe("US")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #388. The dominant Ohio court style is \`R. C. NNN.NN\` with a space between \`R.\` and \`C.\` — more common than the no-space \`R.C.\` form — but eyecite-ts only matched the no-space variant. The \`R.C. Chapter NNNN\` chapter-only form was also missing for both spacings.

### Fixes

- **Spaced \`R. C.\`**: Ohio regex fragment now admits inter-letter spacing (\`R\\.?\\s*C\\.?\`). The federal IRC pattern (#376) has higher priority, so the \`I.\` prefix won't trigger Ohio.
- **Canonical normalization**: Ohio abbreviations array reordered so \`R.C.\` (Bluebook) is the last element / canonical. Spaced (\`R. C.\`) and dotless (\`RC\`) variants resolve to \`R.C.\` via the stripped-form fallback.
- **\`oh-chapter\` pattern**: handles \`R.C. Chapter N\` and \`R. C. Chapter N\`. Chapter ID goes into \`section\` (matches NH \`rsa-chapter\` convention).

### Behavior

| Input | Before | After |
|---|---|---|
| \`R. C. 713.15\` | not extracted | code=R.C., section=713.15 |
| \`R. C. 5321.15(C)\` | not extracted | section=5321.15, sub=(C) |
| \`R. C. Chapter 1702\` | not extracted | section=1702 |
| \`R.C. Chapter 4509\` | not extracted | section=4509 |
| \`R.C. 5302.20\` | unchanged | unchanged |
| \`I.R.C. § 1367\` | unchanged | unchanged (federal) |

### Deferred

- Prose form (\`section 120.33 of the Revised Code\`)

## Test plan

- [x] 6 new tests under \`Ohio R. C. spacing variant + R.C. Chapter form (#388)\`
- [x] Full 2655-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)