### PR TITLE
feat: Oregon ORS chapter-only form (ORS chapter NN) (#387)

### DIFF
--- a/.changeset/issue-387-or-chapter.md
+++ b/.changeset/issue-387-or-chapter.md
@@ -1,0 +1,46 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Oregon `ORS chapter NN` chapter-only form (#387)
+
+The modern `ORS NNN.NNN` section form was already handled by
+`abbreviated-code`, but the chapter-only reference `ORS chapter
+34` (treating the chapter number as a complete citation, like NH
+RSA and OH R.C.) was unrecognized.
+
+### Fix
+
+New `ors-chapter` tokenizer pattern + dedicated
+`extractOrsChapter` extractor. Emits `code: "ORS"`,
+`jurisdiction: "OR"`, with the chapter ID in `section` (matching
+the convention from NH `rsa-chapter` #378 and OH `oh-chapter`
+#388).
+
+### Scope notes
+
+The following pieces of #387 are intentionally deferred:
+
+- **Oregon Laws session laws** (`Or Laws 2013, ch 25, § 1`,
+  `Oregon Laws 1981, chapter 784`) — pending unified
+  `sessionLaw` citation type.
+- **Oregon municipal codes** (`Cornelius City Code section
+  10.40.030`, `CCC section 10.40.030`) — municipal codes
+  broadly out of scope.
+
+### Tests
+
+2 new tests under `Oregon ORS chapter-only form (#387)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `ORS chapter 34` (chapter-only)
+- Regression: `ORS 131.315(7)` (modern form)
+
+Full 2662-test suite passes; no regressions.
+
+### Related
+
+Third chapter-only state pattern after NH `rsa-chapter` (#378)
+and OH `oh-chapter` (#388). The shape is becoming a reusable
+template for states whose statute compilations support
+chapter-level references.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -35,6 +35,7 @@ import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractNmBareSection } from "./statutes/extractNmBareSection"
 import { extractOhChapter } from "./statutes/extractOhChapter"
+import { extractOrsChapter } from "./statutes/extractOrsChapter"
 import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
 import { extractRrs1943 } from "./statutes/extractRrs1943"
@@ -161,6 +162,8 @@ export function extractStatute(
       return extractNmBareSection(token, transformationMap)
     case "oh-chapter":
       return extractOhChapter(token, transformationMap)
+    case "ors-chapter":
+      return extractOrsChapter(token, transformationMap)
     case "rlh":
       return extractRlh(token, transformationMap)
     case "rrs-1943":

--- a/src/extract/statutes/extractOrsChapter.ts
+++ b/src/extract/statutes/extractOrsChapter.ts
@@ -1,0 +1,49 @@
+/**
+ * Oregon Revised Statutes chapter-only form — `ORS chapter 34`
+ *
+ * Oregon (like NH and OH) allows chapter-only references where the
+ * chapter number functions as a complete citation. The modern
+ * `ORS NNN.NNN` section form is already handled by `abbreviated-code`.
+ * #387
+ *
+ * @module extract/statutes/extractOrsChapter
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+
+const ORS_CHAPTER_RE = /^ORS\s+chapter\s+(\d+)$/d
+
+export function extractOrsChapter(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = ORS_CHAPTER_RE.exec(text)!
+  const section = match[1]
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.section = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+  }
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence: 0.95,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "ORS",
+    section,
+    jurisdiction: "OR",
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -80,6 +80,18 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Oregon Revised Statutes chapter-only form: `ORS chapter 34`. The
+    // modern `ORS NNN.NNN` section form is already handled by
+    // `abbreviated-code`; this pattern captures chapter-only references.
+    // #387
+    //
+    // Captures: (1) chapter number.
+    id: "ors-chapter",
+    regex: /\bORS\s+chapter\s+(\d+)/g,
+    description: 'Oregon Revised Statutes chapter-only form: "ORS chapter 34" — #387',
+    type: "statute",
+  },
+  {
     id: "prose",
     regex: /\b[Ss]ection\s+(\d+[A-Za-z0-9-]*(?:\([^)]*\))*)\s+of\s+title\s+(\d+)\b/g,
     description:

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2259,4 +2259,30 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Oregon ORS chapter-only form (#387)", () => {
+    it("extracts `ORS chapter 34`", () => {
+      const cites = extractCitations("See ORS chapter 34.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("ORS")
+        expect(cites[0].jurisdiction).toBe("OR")
+        expect(cites[0].section).toBe("34")
+      }
+    })
+
+    it("regression: `ORS 131.315(7)` (modern form) continues to work", () => {
+      const cites = extractCitations("See ORS 131.315(7).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("ORS")
+        expect(cites[0].jurisdiction).toBe("OR")
+        expect(cites[0].section).toBe("131.315")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #387. Modern \`ORS NNN.NNN\` already worked; \`ORS chapter NN\` chapter-only didn't.

New \`ors-chapter\` tokenizer + extractor. Third chapter-only state pattern after NH (#378) and OH (#388). Emits \`code: \"ORS\"\`, \`jur: \"OR\"\`, \`section: <chapter>\`.

### Deferred

- Or Laws session laws (\`Or Laws 2013, ch 25, § 1\`)
- Oregon municipal codes (\`Cornelius City Code\`, \`CCC\`) — out of scope

## Test plan

- [x] 2 new tests under \`Oregon ORS chapter-only form (#387)\`
- [x] Full 2662-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)