### PR TITLE
feat: NY bare named-code (Penal Law § N) + bracket subdivisions (#386)

### DIFF
--- a/.changeset/issue-386-ny-bare-law.md
+++ b/.changeset/issue-386-ny-bare-law.md
@@ -1,0 +1,72 @@
+---
+"eyecite-ts": patch
+---
+
+feat: New York bare named-code form `Penal Law § N`, `Labor Law § N [3]` (#386)
+
+NY opinions omit the `N.Y.` prefix when citing their own state's
+codes — `Penal Law § 130.52` rather than `N.Y. Penal Law §
+130.52`. The disambiguator is the word `Law` after the code name
+(other states use `Code`). NY also uses **bracket-subdivision**
+form `[1]`, `[3-a]`, `[a]`, `[iv]` interchangeably with the
+canonical paren form `(1)`. Both were unrecognized.
+
+### Fix
+
+New `ny-bare-named-code` tokenizer pattern + dedicated
+`extractNyBareLaw` extractor. Listed AFTER `named-code` so the
+longer `N.Y. <Law> § N` form wins span dedup when the prefix is
+present. The enumerated list of NY law names is closed; matching
+is restricted to known NY codes so the false-positive risk is
+bounded.
+
+Section body accepts both `(...)` and `[...]` trailing groups,
+so `Penal Law § 130.00 [3]` and `Labor Law § 220 [3-a]` parse
+with the bracket subdivision in `subsection`.
+
+Emits `code: "<Name> Law"` (e.g., `"Penal Law"`),
+`jurisdiction: "NY"`.
+
+Supported NY law names: Penal, Labor, Real Property, General
+Business, General Obligations, General Municipal, Municipal
+Home Rule, Criminal Procedure, Insurance, Executive, Judiciary,
+Civil Practice, Civil Rights, Education, Public Health, Banking,
+Domestic Relations, Environmental Conservation, Election, Social
+Services, Estates Powers and Trusts, Vehicle and Traffic,
+Surrogate's Court Procedure, Family Court, Court of Claims,
+Workers' Compensation, Highway, Tax, Personal Property.
+
+### Scope notes
+
+The following pieces of #386 are intentionally deferred:
+
+- **CPLR / SCPA / N-PCL bare forms** (`CPLR 5601 (a)`, `SCPA
+  1803`, `N-PCL 1411 [a]`) — these don't follow the `<Name>
+  Law` pattern; need their own bare patterns.
+- **`CPLR article 78`** — article-based citation, separate
+  parse.
+- **`L YYYY, ch NNN` session laws** — pending unified
+  `sessionLaw` citation type.
+- **Town Code / municipal codes** — broadly out of scope.
+
+### Tests
+
+5 new tests under `New York bare named-code + bracket
+subdivisions (#386)` in `tests/extract/extractStatute.test.ts`:
+
+- Bare `Penal Law § 130.52`
+- `Penal Law § 130.00 [3]` (bracket subdivision)
+- `Labor Law § 220 [3-a]` (bracket with hyphen-letter)
+- `General Municipal Law § 874`
+- Regression: `N.Y. Penal Law § 130.52` (no duplicate)
+
+Full 2665-test suite passes; no regressions.
+
+### Related
+
+Companion to issue #12 (state bare-statute) for the NY laws
+that are commonly cited without prefix. The bracket-subdivision
+fix builds on the bracket-section work in #370 (MSA
+`23.710[252]`) — brackets are now accepted in three contexts:
+abbreviated-code section body, parseBody subsection chain, and
+NY named-code section body.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -34,6 +34,7 @@ import { extractMdArticleLetter } from "./statutes/extractMdArticleLetter"
 import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractNmBareSection } from "./statutes/extractNmBareSection"
+import { extractNyBareLaw } from "./statutes/extractNyBareLaw"
 import { extractOhChapter } from "./statutes/extractOhChapter"
 import { extractOrsChapter } from "./statutes/extractOrsChapter"
 import { extractProse } from "./statutes/extractProse"
@@ -160,6 +161,8 @@ export function extractStatute(
       return extractMinnStYearEdition(token, transformationMap)
     case "nm-bare-section":
       return extractNmBareSection(token, transformationMap)
+    case "ny-bare-named-code":
+      return extractNyBareLaw(token, transformationMap)
     case "oh-chapter":
       return extractOhChapter(token, transformationMap)
     case "ors-chapter":

--- a/src/extract/statutes/extractNyBareLaw.ts
+++ b/src/extract/statutes/extractNyBareLaw.ts
@@ -1,0 +1,81 @@
+/**
+ * New York bare named-code form — `Penal Law § 130.52`, `Labor Law § 220 [3-a]`
+ *
+ * NY opinions omit the `N.Y.` prefix when citing their own state's codes.
+ * The word `Law` after the code name is the disambiguator — other states
+ * use `Code`. Bracket-subdivision groups (`[3]`, `[a]`, `[iv]`) are
+ * accepted alongside the canonical `(N)` form. #386
+ *
+ * @module extract/statutes/extractNyBareLaw
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const NY_BARE_LAW_RE =
+  /^(Penal|Labor|Real Property|General Business|General Obligations|General Municipal|Municipal Home Rule|Criminal Procedure|Insurance|Executive|Judiciary|Civil Practice|Civil Rights|Education|Public Health|Banking|Domestic Relations|Environmental Conservation|Election|Social Services|Estates Powers and Trusts|Vehicle and Traffic|Surrogate's Court Procedure|Family Court|Court of Claims|Workers' Compensation|Highway|Tax|Personal Property)\s+Law\s+§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s+(?:\([^)]*\)|\[[^\]]*\]))*)$/d
+
+export function extractNyBareLaw(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = NY_BARE_LAW_RE.exec(text)!
+  const codeName = match[1]
+  const rawBody = match[2]
+  // parseBody splits on first `(` or `[` — strip any whitespace + extra
+  // subdivision tail groups so the section captures just the number.
+  const cleanBody = rawBody.replace(/\s+/g, "")
+  const { section, subsection, hasEtSeq } = parseBody(cleanBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.code = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.9
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: `${codeName} Law`,
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "NY",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -119,6 +119,28 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // New York bare named-code form: `Penal Law § 130.52`, `Labor Law §
+    // 220 [3-a]`. NY opinions omit the `N.Y.` prefix when citing their own
+    // state's codes (other states use `Code` while NY uses `Law` — the
+    // word `Law` after the code name is the disambiguator). The enumerated
+    // list of NY law names is closed; matching is restricted to known NY
+    // codes so the false-positive risk is bounded. Bracket-subdivision
+    // groups `[3]`, `[a]`, `[iv]` are accepted alongside the canonical
+    // `(N)` form — NY style is to use brackets when paren collisions are
+    // a concern. #386
+    //
+    // Listed AFTER `named-code` so the longer `N.Y. Penal Law § N` form
+    // wins span dedup when the `N.Y.` prefix is present.
+    //
+    // Captures: (1) code name, (2) section body with bracket/paren chain.
+    id: "ny-bare-named-code",
+    regex:
+      /\b(Penal|Labor|Real Property|General Business|General Obligations|General Municipal|Municipal Home Rule|Criminal Procedure|Insurance|Executive|Judiciary|Civil Practice|Civil Rights|Education|Public Health|Banking|Domestic Relations|Environmental Conservation|Election|Social Services|Estates Powers and Trusts|Vehicle and Traffic|Surrogate's Court Procedure|Family Court|Court of Claims|Workers' Compensation|Highway|Tax|Personal Property)\s+Law\s+§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s+(?:\([^)]*\)|\[[^\]]*\]))*)/g,
+    description:
+      'New York bare named-code form: "Penal Law § 130.00 [3]", "Labor Law § 220 [3-a]" — #386',
+    type: "statute",
+  },
+  {
     id: "mass-chapter",
     // Matches: Mass. Gen. Laws ch. X, § Y / M.G.L.A. c. X, § Y / G.L. c. X, § Y / A.L.M. c. X, § Y
     // Spacing between corpus prefix and `c.` is optional (`G.L.c.` is common

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2285,4 +2285,63 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("New York bare named-code + bracket subdivisions (#386)", () => {
+    it("extracts bare `Penal Law § 130.52`", () => {
+      const cites = extractCitations("See Penal Law § 130.52.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Penal Law")
+        expect(cites[0].jurisdiction).toBe("NY")
+        expect(cites[0].section).toBe("130.52")
+      }
+    })
+
+    it("extracts `Penal Law § 130.00 [3]` (bracket subdivision)", () => {
+      const cites = extractCitations("See Penal Law § 130.00 [3].").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Penal Law")
+        expect(cites[0].section).toBe("130.00")
+        expect(cites[0].subsection).toBe("[3]")
+      }
+    })
+
+    it("extracts `Labor Law § 220 [3-a]` (bracket subdivision with hyphen-letter)", () => {
+      const cites = extractCitations("See Labor Law § 220 [3-a].").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Labor Law")
+        expect(cites[0].section).toBe("220")
+        expect(cites[0].subsection).toBe("[3-a]")
+      }
+    })
+
+    it("extracts `General Municipal Law § 874`", () => {
+      const cites = extractCitations("See General Municipal Law § 874.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("General Municipal Law")
+        expect(cites[0].jurisdiction).toBe("NY")
+      }
+    })
+
+    it("regression: `N.Y. Penal Law § 130.52` produces exactly one citation", () => {
+      const cites = extractCitations("See N.Y. Penal Law § 130.52.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("NY")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #386. NY opinions omit the \`N.Y.\` prefix when citing their own state's codes (\`Penal Law § 130.52\` rather than \`N.Y. Penal Law § 130.52\`). The disambiguator is \`Law\` after the code name (other states use \`Code\`). NY also uses **bracket-subdivision** form \`[1]\`, \`[3-a]\`, \`[a]\`, \`[iv]\` interchangeably with paren form. Both were unrecognized.

New \`ny-bare-named-code\` tokenizer + extractor. Closed enumeration of 29 NY law names. Listed AFTER \`named-code\` so the longer \`N.Y. Penal Law § N\` form wins when the prefix is present. Section body accepts both \`(...)\` and \`[...]\` chains.

### Behavior

| Input | Before | After |
|---|---|---|
| \`Penal Law § 130.52\` | not extracted | code=Penal Law, jur=NY |
| \`Penal Law § 130.00 [3]\` | not extracted | section=130.00, sub=[3] |
| \`Labor Law § 220 [3-a]\` | not extracted | sub=[3-a] |
| \`General Municipal Law § 874\` | not extracted | extracted |
| \`N.Y. Penal Law § 130.52\` | extracted | exactly one cite (no duplicate) |

### Deferred

- CPLR / SCPA / N-PCL bare forms (different shape)
- \`CPLR article 78\` (article-based)
- \`L YYYY, ch NNN\` session laws — pending unified sessionLaw type
- Town Code / municipal codes — out of scope

## Test plan

- [x] 5 new tests under \`New York bare named-code + bracket subdivisions (#386)\`
- [x] Full 2665-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)