### PR TITLE
fix: Tennessee T.C.A. variants — sec. connector, postfix, dotless TCA (#398)

### DIFF
--- a/.changeset/issue-398-tn-tca.md
+++ b/.changeset/issue-398-tn-tca.md
@@ -1,0 +1,66 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Tennessee `T.C.A.` variants — `sec.` connector, postfix form, dotless `TCA` (#398)
+
+Tennessee opinions interchange every stylistic variant of the
+T.C.A. abbreviation. Most worked already, but the `sec.` / `Sec.`
+section connector (universal across multiple states) and the
+postfix `§ N, T.C.A.` form were unrecognized.
+
+### Fixes
+
+- **Universal `sec.` / `Sec.` section connector**: the section
+  connector in `buildAbbreviatedCodeRegex` and `ABBREVIATED_RE`
+  now accepts `sec.` / `Sec.` alongside `§`, `§§`, and the
+  spelled-out word `section(s)` / `Section(s)`. This is a
+  Tennessee-driven change but benefits any state that
+  interchanges these forms.
+- **T.C.A. postfix pattern**: new `tca-postfix` tokenizer +
+  dedicated `extractTcaPostfix` extractor for `§ 39-904, T.C.A.`
+  Sibling to florida-postfix, idaho-postfix, mca-postfix.
+- **Canonical `T.C.A.`**: Tennessee abbreviations array
+  reordered so `T.C.A.` (Bluebook standard with dots) is the
+  last element / canonical. The dotless `TCA` and spaced variants
+  now normalize to `T.C.A.` via the stripped-form fallback.
+
+### Behavior changes
+
+- `T.C.A. sec. 40-2407` → extracted (was: not extracted)
+- `T.C.A. Sec. 40-3809` → extracted
+- `TCA sec. 40-2528` → `code="T.C.A."` (canonicalized)
+- `§ 39-904, T.C.A.` (postfix) → extracted
+- `T.C.A. § 39-2404` → unchanged
+- `T.C.A. 40-2020` (no connector) → unchanged
+
+### Scope notes
+
+The following pieces of #398 are intentionally deferred:
+
+- **Multi-section lists** (`T.C.A. Secs. 40-3806, 40-3814, and
+  40-3818`) — multi-section deferred across all states.
+- **OCR variant `TOA`** (TCA misread) — edge case; OCR
+  cleanup belongs upstream of citation extraction.
+
+### Tests
+
+6 new tests under `Tennessee T.C.A. variants + postfix (#398)`
+in `tests/extract/extractStatute.test.ts`:
+
+- `T.C.A. sec. 40-2407` (sec. connector)
+- `T.C.A. Sec. 40-3809` (capital Sec.)
+- `TCA sec. 40-2528` (dotless, canonicalized)
+- `§ 39-904, T.C.A.` (postfix)
+- Regression: `T.C.A. § 39-2404`
+- Regression: `Tenn. Code Ann. § 39-2404`
+
+Full 2671-test suite passes; no regressions.
+
+### Related
+
+Universal `sec.` connector follows the pattern established by
+the universal `Section`/`section` word connector (#348). Postfix
+form is the fourth state-postfix pattern after Florida (#356),
+Idaho (#360), and Montana (#372). The canonicalization
+reordering matches the Ohio pattern (#388).

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -77,14 +77,16 @@ export function buildAbbreviatedCodeRegex(): RegExp {
     // Period and comma guards prevent sentence punctuation from being
     // absorbed into the section.
     //
-    // Section connector: `§`, `§§`, or the spelled-out word `section(s)` /
-    // `Section(s)` (#348). Arizona and several other state corpora cite as
-    // `A.R.S. section 14-2804(A)` interchangeably with `A.R.S. § 14-2804(A)`.
+    // Section connector: `§`, `§§`, the spelled-out word `section(s)` /
+    // `Section(s)` (#348), or the abbreviation `sec.` / `Sec.` (Tennessee
+    // and several other state corpora interchange these — #398). Arizona
+    // cites as `A.R.S. section 14-2804(A)` interchangeably with `A.R.S. §
+    // 14-2804(A)`.
     // Optional comma between code name and connector (`Idaho Code, § N`) is
     // common in Idaho practice (#360) and harmless elsewhere.
     // Trailing subscript groups accept either parens or brackets — MSA uses
     // `[N]` for subdivisions (`MSA 23.710[252]`) #370.
-    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9])|,(?=\\d))*(?:\\([^)]*\\)|\\[[^\\]]*\\])*(?:\\s*et\\s+seq\\.?)?)`,
+    `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?|[Ss]ec\\.?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9])|,(?=\\d))*(?:\\([^)]*\\)|\\[[^\\]]*\\])*(?:\\s*et\\s+seq\\.?)?)`,
     "g",
   )
 }
@@ -439,9 +441,12 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "S\\.?D\\.?\\s+Codified\\s+Laws|S\\.?D\\.?C\\.?L\\.?|SDCL",
   },
   // ── Tennessee ─────────────────────────────────────────────────────────────
+  // Canonical abbreviation is `T.C.A.` (Bluebook); ordered last so the
+  // stripped-form fallback normalizes `TCA` (no dots) and spaced variants
+  // to it. #398
   {
     jurisdiction: "TN",
-    abbreviations: ["Tenn. Code Ann.", "Tennessee Code", "T.C.A.", "TN Code"],
+    abbreviations: ["Tenn. Code Ann.", "Tennessee Code", "TN Code", "T.C.A."],
     regexFragment: "Tenn(?:essee)?\\.?\\s+Code(?:\\s+Ann\\.?)?|T\\.?C\\.?A\\.?|TN\\s+Code",
   },
   // ── Vermont ───────────────────────────────────────────────────────────────

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -41,6 +41,7 @@ import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
 import { extractRrs1943 } from "./statutes/extractRrs1943"
 import { extractRsaChapter } from "./statutes/extractRsaChapter"
+import { extractTcaPostfix } from "./statutes/extractTcaPostfix"
 
 /**
  * Legacy inline parser for unknown patterns.
@@ -173,6 +174,8 @@ export function extractStatute(
       return extractRrs1943(token, transformationMap)
     case "rsa-chapter":
       return extractRsaChapter(token, transformationMap)
+    case "tca-postfix":
+      return extractTcaPostfix(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -19,16 +19,16 @@ import { parseBody } from "./parseBody"
 
 // Section body: period only allowed when followed by alphanumeric so a
 // trailing sentence period is never captured (#283).
-// Section connector mirrors the tokenizer pattern: `§`, `§§`, or the
-// spelled-out word `section(s)` / `Section(s)` (#348). Without this, the
-// lazy abbreviation capture would absorb the word `section` and break
-// `findAbbreviatedCode` lookups (e.g., `Arkansas Code Annotated section
-// 11-9-102` would emit abbrevText="Arkansas Code Annotated section").
+// Section connector mirrors the tokenizer pattern: `§`, `§§`, the
+// spelled-out word `section(s)` / `Section(s)` (#348), or the abbreviation
+// `sec.` / `Sec.` (Tennessee corpora — #398). Without these, the lazy
+// abbreviation capture would absorb the connector word and break
+// `findAbbreviatedCode` lookups.
 // Optional comma between code and connector (`Idaho Code, § N`) #360.
 // Trailing subscript groups accept either parens or brackets — MSA #370.
 // Internal comma allowed when followed by digit — Kansas `23-9,101` #367.
 const ABBREVIATED_RE =
-  /^(?:(\d+)\s+)?(.+?)\s*,?\s*(?:§§?|[Ss]ections?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9])|,(?=\d))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s*et\s+seq\.?)?)$/d
+  /^(?:(\d+)\s+)?(.+?)\s*,?\s*(?:§§?|[Ss]ections?|[Ss]ec\.?)?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9])|,(?=\d))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s*et\s+seq\.?)?)$/d
 
 export function extractAbbreviated(
   token: Token,

--- a/src/extract/statutes/extractTcaPostfix.ts
+++ b/src/extract/statutes/extractTcaPostfix.ts
@@ -1,0 +1,74 @@
+/**
+ * Tennessee Code Annotated postfix form — `§ 39-904, T.C.A.`
+ *
+ * Tennessee opinions sometimes place the code abbreviation AFTER the
+ * section, separated by a comma. Sibling to Florida, Idaho, and Montana
+ * postfix forms. #398
+ *
+ * @module extract/statutes/extractTcaPostfix
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const TCA_POSTFIX_RE =
+  /^(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+T\.?C\.?A\.?$/d
+
+export function extractTcaPostfix(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = TCA_POSTFIX_RE.exec(text)!
+  const rawBody = match[1]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "T.C.A.",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "TN",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -289,6 +289,20 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Tennessee Code Annotated postfix form: `§ 39-904, T.C.A.` — the code
+    // name appears AFTER the section, separated by a comma. Sibling to
+    // florida-postfix, idaho-postfix, mca-postfix. Listed BEFORE
+    // `abbreviated-code` so the container shape wins span dedup. #398
+    //
+    // Captures: (1) section body.
+    id: "tca-postfix",
+    regex:
+      /(?<![A-Za-z])(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+T\.?C\.?A\.?/g,
+    description:
+      'Tennessee Code Annotated postfix form: "§ 39-904, T.C.A." — #398',
+    type: "statute",
+  },
+  {
     // Nebraska Reissue Revised Statutes 1943 (R.R.S. 1943) — historical
     // form: `section 38-901, R. R. S. 1943` or `§ 30-2806, R.R.S. 1943,
     // Reissue 1975`. Nebraska compiled its statutes in 1943 and re-issues

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2344,4 +2344,72 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Tennessee T.C.A. variants + postfix (#398)", () => {
+    it("extracts `T.C.A. sec. 40-2407` (sec. connector)", () => {
+      const cites = extractCitations("See T.C.A. sec. 40-2407.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("T.C.A.")
+        expect(cites[0].jurisdiction).toBe("TN")
+        expect(cites[0].section).toBe("40-2407")
+      }
+    })
+
+    it("extracts `T.C.A. Sec. 40-3809` (capital Sec.)", () => {
+      const cites = extractCitations("See T.C.A. Sec. 40-3809.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("40-3809")
+      }
+    })
+
+    it("extracts `TCA sec. 40-2528` (dotless, canonicalized to T.C.A.)", () => {
+      const cites = extractCitations("See TCA sec. 40-2528.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("T.C.A.")
+        expect(cites[0].jurisdiction).toBe("TN")
+        expect(cites[0].section).toBe("40-2528")
+      }
+    })
+
+    it("extracts postfix `§ 39-904, T.C.A.`", () => {
+      const cites = extractCitations("See § 39-904, T.C.A.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("T.C.A.")
+        expect(cites[0].jurisdiction).toBe("TN")
+        expect(cites[0].section).toBe("39-904")
+      }
+    })
+
+    it("regression: `T.C.A. § 39-2404` continues to work", () => {
+      const cites = extractCitations("See T.C.A. § 39-2404.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("TN")
+      }
+    })
+
+    it("regression: `Tenn. Code Ann. § 39-2404` continues to work", () => {
+      const cites = extractCitations("See Tenn. Code Ann. § 39-2404.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Tenn. Code Ann.")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #398. Tennessee opinions interchange every T.C.A. stylistic variant. The \`sec.\` / \`Sec.\` connector and the postfix \`§ N, T.C.A.\` form were unrecognized.

- **Universal \`sec.\` connector**: \`buildAbbreviatedCodeRegex\` and \`ABBREVIATED_RE\` now accept \`sec.\` / \`Sec.\` alongside \`§\`, \`§§\`, \`section(s)\`, \`Section(s)\`. Tennessee-driven but benefits all states.
- **\`tca-postfix\` pattern**: 4th state-postfix pattern after Florida (#356), Idaho (#360), Montana (#372).
- **Canonical \`T.C.A.\`**: abbreviations reordered so \`T.C.A.\` (Bluebook) is canonical; dotless \`TCA\` and spaced variants normalize to it.

### Behavior

| Input | Before | After |
|---|---|---|
| \`T.C.A. sec. 40-2407\` | not extracted | extracted |
| \`T.C.A. Sec. 40-3809\` | not extracted | extracted |
| \`TCA sec. 40-2528\` | not extracted | code=T.C.A. (canonical) |
| \`§ 39-904, T.C.A.\` | not extracted | extracted |
| \`T.C.A. § 39-2404\` | unchanged | unchanged |

### Deferred

- Multi-section lists (\`T.C.A. Secs. 40-3806, 40-3814, and 40-3818\`)
- OCR variant \`TOA\` (edge case)

## Test plan

- [x] 6 new tests under \`Tennessee T.C.A. variants + postfix (#398)\`
- [x] Full 2671-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)