### PR TITLE
fix: SC S.C.Code Ann. routing + canonical normalization (#397)

### DIFF
--- a/.changeset/issue-397-sc.md
+++ b/.changeset/issue-397-sc.md
@@ -1,0 +1,68 @@
+---
+"eyecite-ts": patch
+---
+
+fix: South Carolina `S.C.Code Ann.` (no space) routing + canonical normalization (#397)
+
+S.C. opinions interchange `S.C.Code Ann.` (no space between `S.C.`
+and `Code`) with `S.C. Code Ann.` (with space). The no-space form
+was unrecognized — and worse, the NM bare-section pattern (#382)
+was silently capturing the `§ N-N-N` suffix and mis-routing every
+no-space SC citation to **New Mexico** jurisdiction.
+
+### Fix
+
+- **SC fragment**: `\s+` between `S.C.` and `Code` relaxed to
+  `\s*` so the no-space form matches the SC container pattern.
+  Once the container matches, span dedup correctly subsumes the
+  NM bare-section pattern's contained match on `§ N-N-N`.
+- **Canonical `S.C. Code Ann.`**: SC abbreviations reordered so
+  `S.C. Code Ann.` (Bluebook standard with `Ann.`) is the last
+  element / canonical. The no-space `S.C.Code Ann.` form now
+  normalizes to it via the stripped-form fallback.
+
+### Behavior changes
+
+- `S.C.Code Ann. § 42-11-70 (1985)` → `code="S.C. Code Ann."`,
+  `jurisdiction="SC"`, `year=1985` (was: mis-routed to NM)
+- `S.C.Code Ann. § 42-15-40 (Supp. 1998)` →
+  `year=1998`, `editionLabel="Supp."` (Supp. label was already
+  recognized from #349)
+- `S.C.Code Ann. section 38-53-100(D)` → SC (was: NM)
+- `S.C. Code § 20-8-130(B)(1)` → unchanged
+- `S.C. Code Ann. § 42-11-70` → unchanged
+- `Section 32A-2-7(A)` (bare NM form) → unchanged (still NM)
+
+### Scope notes
+
+The following pieces of #397 are intentionally deferred:
+
+- **Postfix prose** (`section 20-3-130 of the South Carolina
+  Code`) — prose form needs a different pattern.
+- **Bare-section follow-ons** (`§ 38-77-160`,
+  `section 38-77-142`) — short-form citation problem, not
+  extraction.
+
+### Tests
+
+6 new tests under `South Carolina S.C.Code Ann. spacing variants
+(#397)` in `tests/extract/extractStatute.test.ts`:
+
+- `S.C.Code Ann. § 42-11-70 (1985)` (no-space, year paren)
+- `S.C.Code Ann. § 42-15-40 (Supp. 1998)` (Supp.
+  editionLabel)
+- `S.C.Code Ann. section 38-53-100(D)` (word section)
+- Regression: `S.C. Code § 20-8-130(B)(1)` (spaced, no Ann.)
+- Regression: `S.C. Code Ann. § 42-11-70`
+- Regression: NM `Section 32A-2-7(A)` still routes to NM
+
+Full 2677-test suite passes; no regressions.
+
+### Related
+
+The NM mis-routing problem demonstrates the importance of
+keeping container-shape patterns broad enough to match all
+state-style variants. The fix pattern (relax whitespace
+requirements in state fragments + reorder canonical
+abbreviations) follows the precedent established by Ohio (#388)
+and Tennessee (#398).

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -429,10 +429,18 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "R\\.?I\\.?\\s+Gen\\.?\\s+Laws|R\\.?I\\.?G\\.?L\\.?",
   },
   // ── South Carolina ────────────────────────────────────────────────────────
+  // South Carolina — `S.C.Code Ann.` (no space) is a common style in
+  // South Carolina court opinions; the `\s+` was too strict and silently
+  // routed every no-space form to the NM bare-section pattern via its
+  // contained-span match on `§ N-N-N`. Accepting `\s*` (zero or more
+  // spaces) here keeps the SC container match intact, which then
+  // subsumes the NM bare-section via span dedup. Canonical is `S.C. Code
+  // Ann.` (Bluebook); ordered last so spaced/no-space variants normalize
+  // to it. #397
   {
     jurisdiction: "SC",
-    abbreviations: ["S.C. Code Ann.", "S.C. Code"],
-    regexFragment: "S\\.?C\\.?\\s+Code(?:\\s+Ann\\.?)?",
+    abbreviations: ["S.C. Code", "S.C. Code Ann."],
+    regexFragment: "S\\.?C\\.?\\s*Code(?:\\s+Ann\\.?)?",
   },
   // ── South Dakota ──────────────────────────────────────────────────────────
   {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2412,4 +2412,71 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("South Carolina S.C.Code Ann. spacing variants (#397)", () => {
+    it("extracts `S.C.Code Ann. § 42-11-70 (1985)` (no space between S.C. and Code)", () => {
+      const cites = extractCitations("See S.C.Code Ann. § 42-11-70 (1985).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("S.C. Code Ann.")
+        expect(cites[0].jurisdiction).toBe("SC")
+        expect(cites[0].section).toBe("42-11-70")
+        expect(cites[0].year).toBe(1985)
+      }
+    })
+
+    it("extracts `S.C.Code Ann. § 42-15-40 (Supp. 1998)` with Supp. editionLabel", () => {
+      const cites = extractCitations("See S.C.Code Ann. § 42-15-40 (Supp. 1998).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].year).toBe(1998)
+        expect(cites[0].editionLabel).toBe("Supp.")
+      }
+    })
+
+    it("extracts `S.C.Code Ann. section 38-53-100(D)` (word section)", () => {
+      const cites = extractCitations("See S.C.Code Ann. section 38-53-100(D).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("SC")
+        expect(cites[0].section).toBe("38-53-100")
+      }
+    })
+
+    it("regression: `S.C. Code § 20-8-130(B)(1)` (spaced, no Ann.) continues to work", () => {
+      const cites = extractCitations("See S.C. Code § 20-8-130(B)(1).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("SC")
+      }
+    })
+
+    it("regression: `S.C. Code Ann. § 42-11-70` (spaced, with Ann.) continues to work", () => {
+      const cites = extractCitations("See S.C. Code Ann. § 42-11-70.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("S.C. Code Ann.")
+      }
+    })
+
+    it("regression: NM bare-section `Section 32A-2-7(A)` still routes to NM", () => {
+      const cites = extractCitations("Section 32A-2-7(A) requires.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("NM")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #397. S.C. opinions use \`S.C.Code Ann.\` (no space) interchangeably with \`S.C. Code Ann.\`. The no-space form was unrecognized — and the NM bare-section pattern (#382) was silently capturing \`§ N-N-N\` and mis-routing every no-space SC citation to **New Mexico**.

- **SC fragment** \`\\s+\` → \`\\s*\` so container matches the no-space form. Span dedup then subsumes NM bare-section's contained match.
- **Canonical \`S.C. Code Ann.\`**: abbreviations reordered so \`S.C. Code Ann.\` (Bluebook) is canonical; no-space form normalizes to it via stripped-form fallback.

### Behavior

| Input | Before | After |
|---|---|---|
| \`S.C.Code Ann. § 42-11-70 (1985)\` | mis-routed to NM | jur=SC, year=1985 |
| \`S.C.Code Ann. § 42-15-40 (Supp. 1998)\` | mis-routed to NM | year=1998, label=Supp. |
| \`S.C. Code § 20-8-130\` | unchanged | unchanged |
| \`Section 32A-2-7(A)\` (NM) | unchanged | unchanged |

### Deferred

- Postfix prose form (\`section 20-3-130 of the South Carolina Code\`)
- Bare-section follow-ons (\`§ 38-77-160\`) — short-form citation problem

## Test plan

- [x] 6 new tests including NM regression
- [x] Full 2677-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)