### PR TITLE
feat: RI General Laws 1956 (G.L. 1956 (YYYY Reenactment) §N-N-N) (#393)

### DIFF
--- a/.changeset/issue-393-ri-gl-1956.md
+++ b/.changeset/issue-393-ri-gl-1956.md
@@ -1,0 +1,58 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Rhode Island General Laws 1956 `G.L. 1956 (1969 Reenactment) §N-N-N` (#393)
+
+RI uses `G.L. 1956` (General Laws of 1956) as its modern
+statutory code, with an optional `(YYYY Reenactment)`
+parenthetical indicating which reenactment volume was in
+effect. The `1956` literal year is the disambiguator from
+Massachusetts `G.L. c. NNN` (chapter form).
+
+### Fix
+
+New `rigl-1956` tokenizer pattern + dedicated `extractRigl1956`
+extractor. Captures both the canonical full form
+(`G.L. 1956 (1969 Reenactment) §11-23-1`) and the simpler forms
+(`G.L. 1956 §N-N-N`, `G. L. 1956, §N-N-N`). The reenactment
+year goes into the `year` field and `editionLabel` is set to
+`"Reenactment"` when present.
+
+### Scope notes
+
+The following pieces of #393 are intentionally deferred:
+
+- **Bare-section follow-ons** (`§45-32-22`, `§11-8-3`) —
+  short-form citation problem, not extraction.
+- **Bare-section ranges** (`§§45-32-11 to 45-32-21`,
+  `§§45-32-4 and 45-32-11`) — multi-section deferred across all
+  states.
+- **`(YYYY Reenactment)` as bare parenthetical** after a
+  bare-section follow-on — would need standalone-paren
+  handling.
+- **`P.L. YYYY, ch. NNN` public laws** — pending unified
+  `sessionLaw` citation type.
+- **OCR variant** (`§6A-9-307(l)` — `l` is misread `1`) —
+  edge case; OCR cleanup belongs upstream.
+
+### Tests
+
+5 new tests under `Rhode Island General Laws 1956 (#393)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `G.L. 1956 (1969 Reenactment) §11-23-1` (full form)
+- `G. L. 1956 (1969 Reenactment) §9-21-2` (spaced)
+- `G. L. 1956, §10-7-1` (no reenactment paren)
+- `G.L. 1956 §11-23-1` (no comma, no reenactment)
+- Regression: Massachusetts `G.L. c. 93A` still routes to MA
+
+Full 2684-test suite passes; no regressions.
+
+### Related
+
+The disambiguation pattern (year literal vs. chapter marker)
+follows the precedent established by Colorado `C.R.S. 1963`
+(#352), Alabama `Code 1940` (#343), Hawaii `RLH 1935` (#359),
+Nebraska `R.R.S. 1943` (#373). Every state with a 19xx-year
+compilation has its own pattern with the year embedded.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -40,6 +40,7 @@ import { extractOrsChapter } from "./statutes/extractOrsChapter"
 import { extractProse } from "./statutes/extractProse"
 import { extractRlh } from "./statutes/extractRlh"
 import { extractRrs1943 } from "./statutes/extractRrs1943"
+import { extractRigl1956 } from "./statutes/extractRigl1956"
 import { extractRsaChapter } from "./statutes/extractRsaChapter"
 import { extractTcaPostfix } from "./statutes/extractTcaPostfix"
 
@@ -172,6 +173,8 @@ export function extractStatute(
       return extractRlh(token, transformationMap)
     case "rrs-1943":
       return extractRrs1943(token, transformationMap)
+    case "rigl-1956":
+      return extractRigl1956(token, transformationMap)
     case "rsa-chapter":
       return extractRsaChapter(token, transformationMap)
     case "tca-postfix":

--- a/src/extract/statutes/extractRigl1956.ts
+++ b/src/extract/statutes/extractRigl1956.ts
@@ -1,0 +1,77 @@
+/**
+ * Rhode Island General Laws 1956 — `G.L. 1956 (1969 Reenactment) §11-23-1`
+ *
+ * The `1956` literal year is the disambiguator vs. Massachusetts `G.L. c.
+ * NNN` (chapter form). The optional `(YYYY Reenactment)` parenthetical
+ * indicates which reenactment volume was in effect. #393
+ *
+ * @module extract/statutes/extractRigl1956
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const RIGL_1956_RE =
+  /^G\.?\s*L\.?\s+1956\s*(?:\((\d{4})\s+Reenactment\))?\s*,?\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)$/d
+
+export function extractRigl1956(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = RIGL_1956_RE.exec(text)!
+  const reenactmentYear = match[1] ? Number.parseInt(match[1], 10) : undefined
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "G.L. 1956",
+    section,
+    subsection,
+    pincite: subsection,
+    year: reenactmentYear,
+    editionLabel: reenactmentYear !== undefined ? "Reenactment" : undefined,
+    jurisdiction: "RI",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -320,6 +320,22 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Rhode Island General Laws 1956 — modern RI statutory code. The
+    // `G.L. 1956` (or spaced `G. L. 1956`) prefix is distinctive because
+    // of the `1956` literal year, which disambiguates from Massachusetts
+    // `G.L. c. NNN` (chapter form). RI opinions often include a
+    // `(YYYY Reenactment)` parenthetical indicating which reenactment
+    // volume was in effect. #393
+    //
+    // Captures: (1) optional reenactment year, (2) section body.
+    id: "rigl-1956",
+    regex:
+      /\bG\.?\s*L\.?\s+1956\s*(?:\((\d{4})\s+Reenactment\))?\s*,?\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+    description:
+      'Rhode Island General Laws 1956: "G.L. 1956 (1969 Reenactment) §11-23-1" — #393',
+    type: "statute",
+  },
+  {
     // Maryland article-letter codes — post-2002 the Maryland Code is
     // organized into named articles, each with a 2- or 3-letter prefix
     // used as the bare citation form (no `Md.` prefix): `HG § 19-906`,

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2479,4 +2479,65 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Rhode Island General Laws 1956 (#393)", () => {
+    it("extracts `G.L. 1956 (1969 Reenactment) §11-23-1` (full form)", () => {
+      const cites = extractCitations("See G.L. 1956 (1969 Reenactment) §11-23-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("G.L. 1956")
+        expect(cites[0].jurisdiction).toBe("RI")
+        expect(cites[0].section).toBe("11-23-1")
+        expect(cites[0].year).toBe(1969)
+        expect(cites[0].editionLabel).toBe("Reenactment")
+      }
+    })
+
+    it("extracts spaced `G. L. 1956 (1969 Reenactment) §9-21-2`", () => {
+      const cites = extractCitations("See G. L. 1956 (1969 Reenactment) §9-21-2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("G.L. 1956")
+        expect(cites[0].section).toBe("9-21-2")
+        expect(cites[0].year).toBe(1969)
+      }
+    })
+
+    it("extracts `G. L. 1956, §10-7-1` (no reenactment paren)", () => {
+      const cites = extractCitations("See G. L. 1956, §10-7-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("RI")
+        expect(cites[0].section).toBe("10-7-1")
+        expect(cites[0].year).toBeUndefined()
+      }
+    })
+
+    it("extracts `G.L. 1956 §11-23-1` (no comma, no reenactment)", () => {
+      const cites = extractCitations("See G.L. 1956 §11-23-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("RI")
+        expect(cites[0].section).toBe("11-23-1")
+      }
+    })
+
+    it("regression: Massachusetts `G.L. c. 93A` still routes to MA", () => {
+      const cites = extractCitations("See G.L. c. 93A.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MA")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #393. RI uses \`G.L. 1956\` with optional \`(YYYY Reenactment)\` parenthetical. The \`1956\` literal year is the disambiguator from Massachusetts \`G.L. c. NNN\`.

New \`rigl-1956\` tokenizer + extractor. Handles full form with reenactment paren, simple form, spaced \`G. L.\` variant. Reenactment year → \`year\` + \`editionLabel: \"Reenactment\"\`.

### Behavior

| Input | Result |
|---|---|
| \`G.L. 1956 (1969 Reenactment) §11-23-1\` | jur=RI, section=11-23-1, year=1969, label=Reenactment |
| \`G. L. 1956 (1969 Reenactment) §9-21-2\` | spaced variant |
| \`G. L. 1956, §10-7-1\` | no reenactment paren |
| \`G.L. c. 93A\` (Mass) | unchanged |

### Deferred

- Bare-section follow-ons (\`§45-32-22\`) — short-form citation problem
- Bare-section ranges (\`§§45-32-11 to 45-32-21\`) — multi-section family
- \`(YYYY Reenactment)\` as bare parenthetical after follow-on
- \`P.L. YYYY, ch. NNN\` session laws

## Test plan

- [x] 5 new tests under \`Rhode Island General Laws 1956 (#393)\`
- [x] Full 2684-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)