### PR TITLE
fix: PA P. S. / Pa. C. S. spaced variants (#392)

### DIFF
--- a/.changeset/issue-392-pa-spacing.md
+++ b/.changeset/issue-392-pa-spacing.md
@@ -1,0 +1,61 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Pennsylvania `P. S.` / `Pa. C. S.` (spaced) variants normalize to canonical forms (#392)
+
+Pennsylvania court opinions interchange `P.S.` / `P. S.` (Purdon's
+Statutes) and `Pa.C.S.` / `Pa. C. S.` / `Pa. C.S.` (Consolidated
+Statutes) freely. The spaced variants were unrecognized.
+
+### Fix
+
+- **Pennsylvania consolidated** (Pa.C.S.) fragment relaxed from
+  `Pa\.?\s*C\.?S\.?A?\.?` to `Pa\.?\s*C\.?\s*S\.?\s*A?\.?`,
+  allowing inter-letter whitespace.
+- **Pennsylvania unconsolidated** (P.S.) fragment relaxed from
+  `P\.?S\.?` to `P\.?\s*S\.?`.
+- **Canonical reordering**: abbreviations arrays reordered so
+  Bluebook canonical forms (`Pa.C.S.`, `P.S.`) are the last
+  elements. Spaced and dotless variants normalize to them via
+  the stripped-form fallback.
+
+### Behavior changes
+
+- `75 P. S. § 1037` → `code="P.S."`, `title=75`,
+  `section="1037"` (was: not extracted)
+- `42 Pa. C. S. § 7341` → `code="Pa.C.S."` (was: not extracted)
+- `40 P.S. § 991.1801`, `42 Pa.C.S. § 7341` → unchanged
+
+### Scope notes
+
+The following pieces of #392 are intentionally deferred:
+
+- **`Act of [Date], P.L. NNN, No. NNN, § N` session laws** —
+  pending unified `sessionLaw` citation type.
+- **Named-act references** (`Section 7(1) of the Wills Act of
+  1947`, `Section 319 of the Workmen's Compensation Act`) —
+  prose form; matches named-act registry rather than abbreviated
+  code.
+- **OCR variant** (`77 P:S. §671` — colon for period) — OCR
+  cleanup belongs upstream.
+
+### Tests
+
+4 new tests under `Pennsylvania P.S. / Pa.C.S. spacing variants
+(#392)` in `tests/extract/extractStatute.test.ts`:
+
+- Spaced `75 P. S. § 1037` (canonicalized to P.S.)
+- Spaced `42 Pa. C. S. § 7341` (canonicalized to Pa.C.S.)
+- Regression: `40 P.S. § 991.1801`
+- Regression: `42 Pa.C.S. § 7341`
+
+Full 2689-test suite passes; no regressions.
+
+### Related
+
+Spacing-tolerance fix is the fifth in this family: Arizona
+A.R.S. (#348), Ohio R.C. (#388), Tennessee T.C.A. (#398),
+South Carolina S.C. Code Ann. (#397), and now Pennsylvania
+P.S./Pa.C.S. Combined with the canonical reordering, the pattern
+established for these states is now used routinely.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -191,16 +191,22 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Ga\\.?\\s+Code(?:\\s+Ann\\.?)?|O\\.?C\\.?G\\.?A\\.?",
   },
   // ── Pennsylvania (consolidated) ────────────────────────────────────────────
+  // Inter-letter spacing tolerance — `Pa. C. S.` (with spaces) is a
+  // common Pennsylvania court-published style. Canonical is `Pa.C.S.`
+  // (Bluebook); ordered last so spaced variants normalize to it. #392
   {
     jurisdiction: "PA",
-    abbreviations: ["Pa. Cons. Stat.", "Pa.C.S.A.", "Pa.C.S.", "Pa. C.S.A.", "Pa. C.S."],
-    regexFragment: "Pa\\.?\\s*C\\.?S\\.?A?\\.?|Pa\\.?\\s+Cons\\.?\\s+Stat\\.?",
+    abbreviations: ["Pa. Cons. Stat.", "Pa. C.S.A.", "Pa. C.S.", "Pa.C.S.A.", "Pa.C.S."],
+    regexFragment: "Pa\\.?\\s*C\\.?\\s*S\\.?\\s*A?\\.?|Pa\\.?\\s+Cons\\.?\\s+Stat\\.?",
   },
   // ── Pennsylvania (unconsolidated) ──────────────────────────────────────────
+  // Inter-letter spacing tolerance — `P. S.` (with space) is a common
+  // Pennsylvania court-published style. Canonical is `P.S.` (Bluebook);
+  // ordered last so spaced/dotless variants normalize to it. #392
   {
     jurisdiction: "PA",
-    abbreviations: ["P.S.", "PS"],
-    regexFragment: "P\\.?S\\.?",
+    abbreviations: ["PS", "P.S."],
+    regexFragment: "P\\.?\\s*S\\.?",
   },
   // ── Indiana ────────────────────────────────────────────────────────────────
   // The bare dotted `I.C.` form is reserved for Idaho (#360) — Indiana

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2540,4 +2540,54 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Pennsylvania P.S. / Pa.C.S. spacing variants (#392)", () => {
+    it("extracts spaced `75 P. S. § 1037` (canonicalized to P.S.)", () => {
+      const cites = extractCitations("See 75 P. S. § 1037.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("P.S.")
+        expect(cites[0].jurisdiction).toBe("PA")
+        expect(cites[0].title).toBe(75)
+        expect(cites[0].section).toBe("1037")
+      }
+    })
+
+    it("extracts spaced `42 Pa. C. S. § 7341` (canonicalized to Pa.C.S.)", () => {
+      const cites = extractCitations("See 42 Pa. C. S. § 7341.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Pa.C.S.")
+        expect(cites[0].jurisdiction).toBe("PA")
+        expect(cites[0].title).toBe(42)
+        expect(cites[0].section).toBe("7341")
+      }
+    })
+
+    it("regression: `40 P.S. § 991.1801` (no space) continues to work", () => {
+      const cites = extractCitations("See 40 P.S. § 991.1801.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("P.S.")
+        expect(cites[0].section).toBe("991.1801")
+      }
+    })
+
+    it("regression: `42 Pa.C.S. § 7341` (no space) continues to work", () => {
+      const cites = extractCitations("See 42 Pa.C.S. § 7341.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Pa.C.S.")
+        expect(cites[0].section).toBe("7341")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #392. Pennsylvania court opinions interchange \`P.S.\`/\`P. S.\` (Purdon's) and \`Pa.C.S.\`/\`Pa. C. S.\`/\`Pa. C.S.\` (Consolidated) freely. Spaced variants were unrecognized.

- PA fragments relaxed to allow inter-letter whitespace (\`Pa\\.?\\s*C\\.?\\s*S\\.?\\s*A?\\.?\` and \`P\\.?\\s*S\\.?\`)
- Abbreviations reordered: Bluebook canonical (\`Pa.C.S.\`, \`P.S.\`) last so spaced/dotless variants normalize via stripped-form fallback

### Behavior

| Input | Before | After |
|---|---|---|
| \`75 P. S. § 1037\` | not extracted | code=P.S., title=75, section=1037 |
| \`42 Pa. C. S. § 7341\` | not extracted | code=Pa.C.S., title=42, section=7341 |
| \`40 P.S. § 991.1801\` | unchanged | unchanged |

### Deferred

- \`Act of [Date], P.L. NNN, No. NNN, § N\` session laws — pending unified sessionLaw type
- Named-act references (\`Section 7(1) of the Wills Act of 1947\`)
- OCR variant (\`77 P:S.\`)

### Related

5th state in the spacing-tolerance family: AZ (#348), OH (#388), TN (#398), SC (#397), now PA.

## Test plan

- [x] 4 new tests under \`Pennsylvania P.S. / Pa.C.S. spacing variants (#392)\`
- [x] Full 2689-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)