### PR TITLE
feat: Georgia pre-1983 Code Code Ann. § N-N (#358)

### DIFF
--- a/.changeset/issue-358-ga-pre-1983.md
+++ b/.changeset/issue-358-ga-pre-1983.md
@@ -1,0 +1,61 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Georgia pre-1983 Code (`Code Ann. § 26-2101`, `Code § 27-2501`) (#358)
+
+Georgia replaced its old "Code" / "Code of Georgia Annotated" with
+OCGA in 1983. Modern Georgia opinions still cite the pre-1983 code
+for statutory history. Bare `Code Ann.` (no state prefix) and bare
+`Code` are unambiguously Georgia — other states use prefixed forms
+(`Md. Code Ann.`, `Ind. Code Ann.`) which are handled by the
+`named-code` / `abbreviated-code` patterns.
+
+### Fix
+
+New `ga-pre-1983` tokenizer pattern + dedicated `extractGaPre1983`
+extractor. The TWO-part hyphenated section format (`\d+-\d+` with
+negative lookahead `(?![\d-])` so 3-part OCGA-style sections like
+`15-11-26` don't partial-match) serves as the disambiguator. Listed
+AFTER `abbreviated-code` so prefixed forms (`Ark. Code Ann.`,
+`Idaho Code`, etc.) win span dedup.
+
+Emits `code: "Code"` or `"Code Ann."`, `jurisdiction: "GA"`, and
+the two-part section.
+
+### Scope notes
+
+The following pieces of #358 are intentionally deferred:
+
+- **Code parenthetical history** (`Code Ann. § 67-1316 (Ga. L.
+  1958, p. 655; as amended)`) — the inner `(Ga. L. ...)`
+  session-law parenthetical needs separate parsing.
+- **`Ga. L. YYYY, p. NNN` session laws** — pending unified
+  `sessionLaw` citation type.
+- **CPA parenthetical cross-references** (`CPA § 17(a) (Code Ann.
+  § 81A-117(a))`) — same family.
+
+### Tests
+
+6 new tests under `Georgia pre-1983 Code (#358)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `Code Ann. § 26-2101` (bare with Ann.)
+- `Code § 27-2501` (bare, no Ann.)
+- `Code § 110-501` (longer title)
+- Regression: Maryland `Md. Code Ann. § 10-105` (still MD)
+- Regression: modern OCGA `OCGA § 15-11-26(b)` (3-part, no
+  partial match)
+- Regression: `Ga. Code Ann. § 16-5-1` (3-part, exactly one
+  citation — named-code wins via span dedup)
+
+Full 2694-test suite passes; no regressions.
+
+### Related
+
+The bare-pattern approach mirrors the NY bare named-code form
+(#386) but with a more constrained section-format disambiguator.
+The 2-part vs. 3-part hyphenated-section distinction (`26-2101`
+vs. `15-11-26`) is the same disambiguator used by the NM
+bare-section pattern (#382) but in the opposite direction —
+Georgia uses 2-part while NM uses 3-part.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -24,6 +24,7 @@ import { extractChapterAct } from "./statutes/extractChapterAct"
 import { extractColoradoProse } from "./statutes/extractColoradoProse"
 import { extractFederal } from "./statutes/extractFederal"
 import { extractFloridaStatute } from "./statutes/extractFloridaStatute"
+import { extractGaPre1983 } from "./statutes/extractGaPre1983"
 import { extractIcYearEdition } from "./statutes/extractIcYearEdition"
 import { extractIdahoPostfix } from "./statutes/extractIdahoPostfix"
 import { extractIllRevStat } from "./statutes/extractIllRevStat"
@@ -147,6 +148,8 @@ export function extractStatute(
     case "florida-postfix":
     case "florida-prefix-spelled":
       return extractFloridaStatute(token, transformationMap)
+    case "ga-pre-1983":
+      return extractGaPre1983(token, transformationMap)
     case "ic-year-edition":
       return extractIcYearEdition(token, transformationMap)
     case "irc":

--- a/src/extract/statutes/extractGaPre1983.ts
+++ b/src/extract/statutes/extractGaPre1983.ts
@@ -1,0 +1,79 @@
+/**
+ * Georgia pre-1983 Code — `Code § 27-2501`, `Code Ann. § 26-2101`
+ *
+ * Georgia replaced its old "Code" / "Code of Georgia Annotated" with OCGA
+ * in 1983. Modern Georgia opinions still cite the pre-1983 code for
+ * statutory history. The bare `Code Ann.` / `Code` (no state prefix) is
+ * always Georgia — other states use prefixed forms (`Md. Code Ann.`,
+ * `Ind. Code Ann.`) that the `named-code` pattern handles. #358
+ *
+ * @module extract/statutes/extractGaPre1983
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const GA_PRE_1983_RE =
+  /^(Code(?:\s+Ann\.?)?)\s+§\s*(\d+-\d+(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)$/d
+
+export function extractGaPre1983(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = GA_PRE_1983_RE.exec(text)!
+  const codeName = match[1]
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.code = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.85
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: codeName,
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "GA",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -412,6 +412,26 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Georgia pre-1983 Code — `Code § 27-2501`, `Code Ann. § 26-2101`,
+    // `Code § 110-501`. Georgia replaced its old "Code" / "Code of Georgia
+    // Annotated" with OCGA in 1983. Modern Georgia opinions still cite the
+    // pre-1983 code for statutory history. The TWO-part hyphenated section
+    // format (`\d+-\d+` with negative lookahead `(?![\d-])` so 3-part
+    // OCGA-style sections don't partial-match) is the disambiguator —
+    // bare `Code Ann.` is always Georgia (other states use prefixed
+    // `Md. Code Ann.`, `Ind. Code Ann.`, etc., which the `named-code`
+    // and `abbreviated-code` patterns handle). Listed AFTER
+    // `abbreviated-code` so prefixed forms win span dedup. #358
+    //
+    // Captures: (1) "Code Ann." or "Code", (2) section body.
+    id: "ga-pre-1983",
+    regex:
+      /\b(Code(?:\s+Ann\.?)?)\s+§\s*(\d+-\d+(?![\d-])(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/g,
+    description:
+      'Georgia pre-1983 Code: "Code Ann. § 26-2101" / "Code § 27-2501" — #358',
+    type: "statute",
+  },
+  {
     // New Mexico bare-section form: `Section 32A-2-7(A)`, `§ 41-2-2`. NM
     // opinions cite NMSA 1978 sections without a code prefix — the three-
     // hyphen section format (`\d[A-Z]?-\d[A-Z]?-\d[A-Z]?`) is distinctive

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2590,4 +2590,72 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Georgia pre-1983 Code (#358)", () => {
+    it("extracts `Code Ann. § 26-2101` (bare, Georgia pre-1983)", () => {
+      const cites = extractCitations("See Code Ann. § 26-2101.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Code Ann.")
+        expect(cites[0].jurisdiction).toBe("GA")
+        expect(cites[0].section).toBe("26-2101")
+      }
+    })
+
+    it("extracts `Code § 27-2501` (bare, no Ann.)", () => {
+      const cites = extractCitations("See Code § 27-2501.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Code")
+        expect(cites[0].jurisdiction).toBe("GA")
+        expect(cites[0].section).toBe("27-2501")
+      }
+    })
+
+    it("extracts `Code § 110-501` (longer title)", () => {
+      const cites = extractCitations("See Code § 110-501.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("110-501")
+      }
+    })
+
+    it("regression: Maryland `Md. Code Ann. § 10-105` still routes to MD", () => {
+      const cites = extractCitations("See Md. Code Ann. § 10-105.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("MD")
+      }
+    })
+
+    it("regression: modern OCGA `OCGA § 15-11-26(b)` (3-part) doesn't collide", () => {
+      const cites = extractCitations("See OCGA § 15-11-26(b).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("OCGA")
+        expect(cites[0].section).toBe("15-11-26")
+      }
+    })
+
+    it("regression: `Ga. Code Ann. § 16-5-1` (3-part) produces exactly one citation", () => {
+      const cites = extractCitations("See Ga. Code Ann. § 16-5-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("GA")
+        expect(cites[0].section).toBe("16-5-1")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #358. Georgia replaced its old Code with OCGA in 1983. Modern opinions still cite the pre-1983 code. Bare \`Code Ann.\` (no state prefix) is unambiguously Georgia.

New \`ga-pre-1983\` tokenizer + extractor. The two-part hyphenated section format \`\\d+-\\d+(?![\\d-])\` is the disambiguator — 3-part OCGA sections like \`15-11-26\` don't partial-match. Listed AFTER \`abbreviated-code\` so prefixed forms (\`Ark. Code Ann.\`, etc.) win span dedup.

### Behavior

| Input | Result |
|---|---|
| \`Code Ann. § 26-2101\` | code=Code Ann., jur=GA |
| \`Code § 27-2501\` | code=Code, jur=GA |
| \`Md. Code Ann. § 10-105\` | jur=MD (unchanged) |
| \`OCGA § 15-11-26(b)\` | unchanged |
| \`Ga. Code Ann. § 16-5-1\` | exactly one cite (named-code) |

### Deferred

- Inner \`(Ga. L. YYYY, p. NNN)\` parenthetical history references
- \`Ga. L. YYYY, p. NNN\` session laws — pending unified sessionLaw type
- CPA cross-references

## Test plan

- [x] 6 new tests under \`Georgia pre-1983 Code (#358)\`
- [x] Full 2694-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)