### PR TITLE
feat: VA bare Code § N.N-NNN + tighten GA pre-1983 (#405)

### DIFF
--- a/.changeset/issue-405-va-bare-code.md
+++ b/.changeset/issue-405-va-bare-code.md
@@ -1,0 +1,73 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Virginia bare `Code § 18.2-308.2` form + tighten Georgia pre-1983 disambiguator (#405)
+
+Virginia uses a bare `Code §` form (no `Va.` prefix) as its
+canonical statutory citation style. A 50-opinion VA sample
+produced 30+ misses — the largest single-state miss volume in
+the sweep series.
+
+### Fix
+
+- **New `va-bare-code` tokenizer pattern + extractor**: matches
+  bare `Code § N.N-NNN` and the explicit `Virginia Code §
+  N.N-NNN`. Output: `code: "Code"` / `"Virginia Code"`,
+  `jurisdiction: "VA"`.
+
+- **Disambiguator from Georgia pre-1983**: Virginia sections
+  always include at least one PERIOD (`18.2-308.2`,
+  `20-107.3(D)`, `8.01-581.17`), while Georgia pre-1983 sections
+  never do (`26-2101`, `27-2501`, `110-501`). The VA pattern
+  matches `(?:\d+\.\d+-\d+(?:\.\d+)?|\d+-\d+\.\d+)` — either
+  title has period or section has period (or both).
+
+- **Tighten Georgia pre-1983 pattern**: added negative
+  lookahead `(?!\.\d)` after the section so Virginia sections
+  with period-followed-by-digit don't mis-route to Georgia.
+  Sentence-end periods (`Code § 26-2101.`) still allow
+  Georgia matching because `(?!\.\d)` only rejects when period
+  is followed by digit. Fixes a regression introduced with the
+  Georgia pre-1983 pattern (#358).
+
+### Behavior changes
+
+- `Code § 18.2-308.2` → `code="Code"`, `jurisdiction="VA"`
+  (was: not extracted)
+- `Code § 46.2-1571` → VA (was: not extracted)
+- `Code § 20-107.3(D)` → VA, `subsection="(D)"` (was:
+  mis-classified as GA with truncated section "20-107")
+- `Virginia Code § 8.01-581.17` → VA (was: not extracted)
+- `Code § 27-2501` → unchanged (GA, no periods in section)
+- `Va. Code Ann. § 18.2-308.2` → unchanged (VA via named-code)
+
+### Scope notes
+
+The following pieces of #405 are intentionally deferred:
+
+- **Bare-section follow-on** (`§ 8.01-20.1`) — short-form
+  citation problem, not extraction.
+
+### Tests
+
+6 new tests under `Virginia bare Code form (#405)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `Code § 18.2-308.2` (canonical VA)
+- `Code § 46.2-1571` (period in title only)
+- `Code § 20-107.3(D)` (period in section only, with subsection)
+- `Virginia Code § 8.01-581.17` (explicit prefix)
+- Regression: Georgia `Code § 27-2501` still routes to GA
+- Regression: `Va. Code Ann. § 18.2-308.2` continues to work
+
+Full 2701-test suite passes; no regressions.
+
+### Related
+
+This is the largest-impact fix in the bare-code family. The
+period-vs-no-period disambiguator is a clean structural
+distinction that should be robust against false positives in
+either direction. Pairs the Georgia pre-1983 pattern (#358)
+with a corresponding Virginia pattern, with disjoint section
+formats keeping them mutually exclusive.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -44,6 +44,7 @@ import { extractRrs1943 } from "./statutes/extractRrs1943"
 import { extractRigl1956 } from "./statutes/extractRigl1956"
 import { extractRsaChapter } from "./statutes/extractRsaChapter"
 import { extractTcaPostfix } from "./statutes/extractTcaPostfix"
+import { extractVaBareCode } from "./statutes/extractVaBareCode"
 
 /**
  * Legacy inline parser for unknown patterns.
@@ -182,6 +183,8 @@ export function extractStatute(
       return extractRsaChapter(token, transformationMap)
     case "tca-postfix":
       return extractTcaPostfix(token, transformationMap)
+    case "va-bare-code":
+      return extractVaBareCode(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractVaBareCode.ts
+++ b/src/extract/statutes/extractVaBareCode.ts
@@ -1,0 +1,79 @@
+/**
+ * Virginia bare-Code form — `Code § 18.2-308.2`, `Virginia Code § 8.01-581.17`
+ *
+ * Virginia's canonical court style omits the `Va.` prefix. The
+ * disambiguator from Georgia pre-1983 (also bare `Code §`) is the PERIOD
+ * in the title or section — Virginia sections always include at least one
+ * period (`18.2-308.2`, `20-107.3`), while Georgia pre-1983 sections never
+ * do (`26-2101`, `27-2501`). #405
+ *
+ * @module extract/statutes/extractVaBareCode
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const VA_BARE_CODE_RE =
+  /^(Virginia\s+Code|Code)\s+§\s*((?:\d+\.\d+-\d+(?:\.\d+)?|\d+-\d+\.\d+)(?:\([A-Za-z0-9]+\))*)$/d
+
+export function extractVaBareCode(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = VA_BARE_CODE_RE.exec(text)!
+  const codeName = match[1].replace(/\s+/g, " ")
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.code = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.9
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: codeName,
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "VA",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -426,9 +426,29 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) "Code Ann." or "Code", (2) section body.
     id: "ga-pre-1983",
     regex:
-      /\b(Code(?:\s+Ann\.?)?)\s+§\s*(\d+-\d+(?![\d-])(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/g,
+      /\b(Code(?:\s+Ann\.?)?)\s+§\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/g,
     description:
-      'Georgia pre-1983 Code: "Code Ann. § 26-2101" / "Code § 27-2501" — #358',
+      'Georgia pre-1983 Code: "Code Ann. § 26-2101" / "Code § 27-2501" — #358 (#405 tightened)',
+    type: "statute",
+  },
+  {
+    // Virginia bare-Code form: `Code § 18.2-308.2`, `Code § 46.2-1571`,
+    // `Virginia Code § 8.01-581.17`, `Code § 20-107.3(D)`. Virginia's
+    // canonical court style omits the `Va.` prefix. The disambiguator from
+    // Georgia pre-1983 (also bare `Code §`) is the PERIOD in the title or
+    // section — Virginia sections always include at least one period
+    // (`18.2-308.2`, `20-107.3`), while Georgia pre-1983 sections never
+    // do (`26-2101`, `27-2501`). #405
+    //
+    // Listed AFTER `abbreviated-code` and `ga-pre-1983` so the more
+    // specific patterns win span dedup when their conditions are met.
+    //
+    // Captures: (1) "Virginia Code" or "Code", (2) section body.
+    id: "va-bare-code",
+    regex:
+      /\b(Virginia\s+Code|Code)\s+§\s*((?:\d+\.\d+-\d+(?:\.\d+)?|\d+-\d+\.\d+)(?:\([A-Za-z0-9]+\))*)/g,
+    description:
+      'Virginia bare Code form: "Code § 18.2-308.2" / "Virginia Code § 8.01-581.17" — #405',
     type: "statute",
   },
   {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2658,4 +2658,73 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Virginia bare Code form (#405)", () => {
+    it("extracts `Code § 18.2-308.2` (canonical VA)", () => {
+      const cites = extractCitations("See Code § 18.2-308.2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Code")
+        expect(cites[0].jurisdiction).toBe("VA")
+        expect(cites[0].section).toBe("18.2-308.2")
+      }
+    })
+
+    it("extracts `Code § 46.2-1571` (period in title only)", () => {
+      const cites = extractCitations("See Code § 46.2-1571.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("46.2-1571")
+        expect(cites[0].jurisdiction).toBe("VA")
+      }
+    })
+
+    it("extracts `Code § 20-107.3(D)` (period in section only, with subsection)", () => {
+      const cites = extractCitations("See Code § 20-107.3(D).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("VA")
+        expect(cites[0].section).toBe("20-107.3")
+        expect(cites[0].subsection).toBe("(D)")
+      }
+    })
+
+    it("extracts `Virginia Code § 8.01-581.17` (explicit prefix)", () => {
+      const cites = extractCitations("See Virginia Code § 8.01-581.17.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Virginia Code")
+        expect(cites[0].jurisdiction).toBe("VA")
+        expect(cites[0].section).toBe("8.01-581.17")
+      }
+    })
+
+    it("regression: Georgia `Code § 27-2501` (no periods) still routes to GA", () => {
+      const cites = extractCitations("See Code § 27-2501.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("GA")
+      }
+    })
+
+    it("regression: `Va. Code Ann. § 18.2-308.2` (prefixed) continues to work", () => {
+      const cites = extractCitations("See Va. Code Ann. § 18.2-308.2.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("VA")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #405. Virginia uses bare \`Code §\` as canonical court style. A 50-opinion VA sample produced **30+ misses** — the largest single-state miss volume in the sweep series.

New \`va-bare-code\` tokenizer + extractor. Disambiguator from Georgia pre-1983 (also bare \`Code §\`): VA sections **always** include a period (\`18.2-308.2\`, \`20-107.3\`, \`8.01-581.17\`); Georgia pre-1983 sections **never** do (\`26-2101\`, \`27-2501\`).

Also tightens \`ga-pre-1983\` with negative lookahead \`(?!\\.\\d)\` so \`Code § 20-107.3\` no longer mis-routes to GA. Sentence-end periods still allow GA matching.

### Behavior

| Input | Before | After |
|---|---|---|
| \`Code § 18.2-308.2\` | not extracted | VA, section=18.2-308.2 |
| \`Code § 46.2-1571\` | not extracted | VA |
| \`Code § 20-107.3(D)\` | mis-classified to GA (truncated) | VA, sub=(D) |
| \`Virginia Code § 8.01-581.17\` | not extracted | VA |
| \`Code § 27-2501\` | unchanged (GA) | unchanged (GA) |
| \`Va. Code Ann. § ...\` | unchanged | unchanged |

### Deferred

- Bare-section follow-on (\`§ 8.01-20.1\`) — short-form citation problem

## Test plan

- [x] 6 new tests under \`Virginia bare Code form (#405)\`
- [x] Full 2701-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)