### PR TITLE
feat: WV W.Va.Code routing + historical Code 1931 form (#406)

### DIFF
--- a/.changeset/issue-406-wv.md
+++ b/.changeset/issue-406-wv.md
@@ -1,0 +1,78 @@
+---
+"eyecite-ts": patch
+---
+
+feat: West Virginia `W.Va.Code` (no space) routing + historical `Code 1931` form (#406)
+
+WV opinions interchange `W.Va. Code` (with space) and `W.Va.Code`
+(no space). The no-space form was unrecognized, and worse, the NM
+bare-section pattern (#382) was silently capturing the `§ N-N-N`
+suffix and mis-routing every no-space WV citation to **New Mexico**
+(same family of regressions as the SC #397 fix).
+
+Modern WV opinions also cite the historical `Code 1931` form for
+statutory history — unrecognized.
+
+### Fixes
+
+- **WV fragment**: `\s+` between `W.Va.` and `Code` relaxed to
+  `\s*` so the no-space form matches the WV container pattern.
+  Span dedup then subsumes the NM bare-section match. WV
+  abbreviations reordered so `W. Va. Code Ann.` (Bluebook) is
+  canonical; no-space variants normalize via stripped-form
+  fallback.
+- **New `wv-code-1931` pattern**: matches `Code 1931, N-N-N, as
+  amended` / `Code, 1931, N-N-N` / `Code, N-N-N` (bare, no year).
+  The 3-part hyphenated section format disambiguates from
+  Georgia pre-1983 (2-part) and Virginia bare-Code (always
+  contains period). When the `1931` year is present, captures
+  as `year`. Listed BEFORE `ga-pre-1983` so WV 3-part sections
+  win span dedup.
+
+### Behavior changes
+
+- `W.Va.Code § 8-24-28` (no space) → `jurisdiction="WV"` (was:
+  mis-routed to NM)
+- `Code 1931, 49-6-3, as amended` → `code="W. Va. Code"`,
+  `jurisdiction="WV"`, `year=1931` (was: not extracted)
+- `Code, 1931, 49-6-3` → `year=1931` (was: not extracted)
+- `Code, 14-2-13` → WV (was: not extracted)
+- `W.Va. Code § 55-7B-1` (with space) → unchanged
+- `W. Va. Code Ann. § 17C-5-2` → unchanged
+
+### Scope notes
+
+The following pieces of #406 are intentionally deferred:
+
+- **Section ranges** (`W.Va. Code §§ 55-7B-1 to -12`) —
+  multi-section deferred across all states.
+- **Repl./Cum. Supp. parentheticals** (`(1976 Repl.Vol.)`,
+  `(Supp.2007)`) — these mostly attach via the generic year-paren
+  absorber from #349 #373, but the `Repl.Vol.` form may need
+  additional patterns.
+- **Chapter/Article prose** (`Chapter 5A, Article 3 of the Code
+  of West Virginia`) — prose form needs a different pattern.
+- **Local ordinances** (`Fairmont, W.Va. Ordinance 425, § 1.200`)
+  — out of scope for statutory extraction.
+
+### Tests
+
+5 new tests under `West Virginia W.Va. Code + historical Code
+1931 (#406)` in `tests/extract/extractStatute.test.ts`:
+
+- `W.Va.Code § 8-24-28` (no space — fixes NM mis-routing)
+- `Code 1931, 49-6-3, as amended` (historical with year)
+- `Code, 1931, 49-6-3` (comma-separated)
+- `Code, 14-2-13` (bare, no year)
+- Regression: `W.Va. Code § 55-7B-1` (with space)
+
+Full 2708-test suite passes; no regressions.
+
+### Related
+
+Second jurisdiction-routing regression caused by the NM
+bare-section pattern (#382) — first was SC (#397). Pattern:
+when a state's container regex requires `\s+` where the
+real-world form has `\s*`, the bare-section pattern matches
+the inner `§ N-N-N` and steals the citation. The fix is
+straightforward: relax the state's whitespace requirement.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -476,10 +476,16 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Wis\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|W\\.?S\\.?A\\.?",
   },
   // ── West Virginia ─────────────────────────────────────────────────────────
+  // West Virginia — `W.Va.Code` (no space) is a common form in WV court
+  // opinions. Relaxing `\s+` to `\s*` between `W.Va.` and `Code` prevents
+  // the NM bare-section pattern (#382) from silently capturing the
+  // `§ N-N-N` suffix when the no-space form is used. Canonical is
+  // `W. Va. Code Ann.` (Bluebook); ordered last so all variants
+  // normalize to it. #406
   {
     jurisdiction: "WV",
-    abbreviations: ["W. Va. Code Ann.", "W. Va. Code", "WV Code"],
-    regexFragment: "W\\.?\\s*Va\\.?\\s+Code(?:\\s+Ann\\.?)?|WV\\s+Code",
+    abbreviations: ["W. Va. Code", "WV Code", "W. Va. Code Ann."],
+    regexFragment: "W\\.?\\s*Va\\.?\\s*Code(?:\\s+Ann\\.?)?|WV\\s+Code",
   },
   // ── Wyoming ───────────────────────────────────────────────────────────────
   {

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -45,6 +45,7 @@ import { extractRigl1956 } from "./statutes/extractRigl1956"
 import { extractRsaChapter } from "./statutes/extractRsaChapter"
 import { extractTcaPostfix } from "./statutes/extractTcaPostfix"
 import { extractVaBareCode } from "./statutes/extractVaBareCode"
+import { extractWvCode1931 } from "./statutes/extractWvCode1931"
 
 /**
  * Legacy inline parser for unknown patterns.
@@ -185,6 +186,8 @@ export function extractStatute(
       return extractTcaPostfix(token, transformationMap)
     case "va-bare-code":
       return extractVaBareCode(token, transformationMap)
+    case "wv-code-1931":
+      return extractWvCode1931(token, transformationMap)
     default:
       // unknown patterns use legacy parser
       return extractLegacy(token, transformationMap)

--- a/src/extract/statutes/extractWvCode1931.ts
+++ b/src/extract/statutes/extractWvCode1931.ts
@@ -1,0 +1,81 @@
+/**
+ * West Virginia historical Code 1931 — `Code 1931, 49-6-3, as amended`
+ *
+ *   Code 1931, 49-6-3, as amended
+ *   Code, 1931, 49-6-3
+ *   Code, 14-2-13           (no year, comma-separated)
+ *
+ * West Virginia compiled its statutes in 1931. Modern WV opinions still
+ * cite the 1931 code for statutory history. The 3-part hyphenated section
+ * format (`N-N-N`) disambiguates from Georgia pre-1983 (2-part) and
+ * Virginia bare-Code (always contains period). #406
+ *
+ * @module extract/statutes/extractWvCode1931
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const WV_CODE_1931_RE =
+  /^Code,?(?:\s+(1931))?,\s+(\d+-\d+[A-Z]?-\d+(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)$/d
+
+export function extractWvCode1931(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = WV_CODE_1931_RE.exec(text)!
+  const year = match[1] ? Number.parseInt(match[1], 10) : undefined
+  const rawBody = match[2]
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[2]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.9
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "W. Va. Code",
+    section,
+    subsection,
+    pincite: subsection,
+    year,
+    jurisdiction: "WV",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -424,6 +424,24 @@ export const statutePatterns: Pattern[] = [
     // `abbreviated-code` so prefixed forms win span dedup. #358
     //
     // Captures: (1) "Code Ann." or "Code", (2) section body.
+    // West Virginia historical Code 1931 form: `Code 1931, 49-6-3, as
+    // amended` / `Code, 1931, 49-6-3` / `Code, 14-2-13` (no year). West
+    // Virginia compiled its statutes in 1931 and modern WV opinions still
+    // cite the 1931 code for statutory history. The 3-part hyphenated
+    // section format (`N-N-N`) plus the `Code 1931` or comma-separated
+    // `Code, ` prefix disambiguates from Georgia pre-1983 and Virginia
+    // bare-Code. Listed BEFORE `ga-pre-1983` so the longer 3-part WV
+    // sections win span dedup. #406
+    //
+    // Captures: (1) optional 1931 year, (2) section body.
+    id: "wv-code-1931",
+    regex:
+      /\bCode,?(?:\s+(1931))?,\s+(\d+-\d+[A-Z]?-\d+(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/g,
+    description:
+      'West Virginia historical Code 1931: "Code 1931, 49-6-3, as amended" / "Code, 14-2-13" — #406',
+    type: "statute",
+  },
+  {
     id: "ga-pre-1983",
     regex:
       /\b(Code(?:\s+Ann\.?)?)\s+§\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/g,

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2727,4 +2727,62 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("West Virginia W.Va. Code + historical Code 1931 (#406)", () => {
+    it("extracts `W.Va.Code § 8-24-28` (no space — no longer mis-routes to NM)", () => {
+      const cites = extractCitations("See W.Va.Code § 8-24-28.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("WV")
+        expect(cites[0].section).toBe("8-24-28")
+      }
+    })
+
+    it("extracts historical `Code 1931, 49-6-3, as amended`", () => {
+      const cites = extractCitations("See Code 1931, 49-6-3, as amended.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("W. Va. Code")
+        expect(cites[0].jurisdiction).toBe("WV")
+        expect(cites[0].section).toBe("49-6-3")
+        expect(cites[0].year).toBe(1931)
+      }
+    })
+
+    it("extracts historical `Code, 1931, 49-6-3` (comma-separated)", () => {
+      const cites = extractCitations("See Code, 1931, 49-6-3.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("49-6-3")
+        expect(cites[0].year).toBe(1931)
+      }
+    })
+
+    it("extracts bare `Code, 14-2-13` (no year — implicit 1931)", () => {
+      const cites = extractCitations("See Code, 14-2-13.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("WV")
+        expect(cites[0].section).toBe("14-2-13")
+      }
+    })
+
+    it("regression: `W.Va. Code § 55-7B-1` (with space) continues to work", () => {
+      const cites = extractCitations("See W.Va. Code § 55-7B-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("WV")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #406. WV opinions interchange \`W.Va. Code\` and \`W.Va.Code\`. The no-space form was unrecognized — and the NM bare-section pattern (#382) was silently capturing \`§ N-N-N\` and mis-routing every no-space WV citation to **New Mexico** (same regression family as SC #397).

- WV fragment \`\\s+\` → \`\\s*\` between \`W.Va.\` and \`Code\`. Abbreviations reordered so \`W. Va. Code Ann.\` (Bluebook) is canonical.
- New \`wv-code-1931\` tokenizer + extractor for \`Code 1931, N-N-N\`. 3-part hyphenated section disambiguates from Georgia pre-1983 (2-part) and Virginia (period required). Year captured as \`year\` when present.

### Behavior

| Input | Before | After |
|---|---|---|
| \`W.Va.Code § 8-24-28\` (no space) | mis-routed to NM | jur=WV |
| \`Code 1931, 49-6-3, as amended\` | not extracted | code=W. Va. Code, jur=WV, year=1931 |
| \`Code, 1931, 49-6-3\` | not extracted | year=1931 |
| \`Code, 14-2-13\` (no year) | not extracted | jur=WV |
| \`W.Va. Code § 55-7B-1\` (with space) | unchanged | unchanged |

### Deferred

- Section ranges (\`§§ 55-7B-1 to -12\`) — multi-section family
- Repl./Cum. Supp. parens — most attach via generic year-paren absorber
- Chapter/Article prose
- Local ordinances

## Test plan

- [x] 5 new tests under \`West Virginia W.Va. Code + historical Code 1931 (#406)\`
- [x] Full 2708-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)