### PR TITLE
test: lock in Vermont V.S.A. canonical extraction (#404)

### DIFF
--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2785,4 +2785,43 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Vermont V.S.A. canonical court style (#404)", () => {
+    it("extracts `13 V.S.A. § 3253(a)(8)` (canonical)", () => {
+      const cites = extractCitations("See 13 V.S.A. § 3253(a)(8).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("V.S.A.")
+        expect(cites[0].jurisdiction).toBe("VT")
+        expect(cites[0].title).toBe(13)
+        expect(cites[0].section).toBe("3253")
+        expect(cites[0].subsection).toBe("(a)(8)")
+      }
+    })
+
+    it("extracts `23 V.S.A. § 1201(a)(1)` (canonical with subsection)", () => {
+      const cites = extractCitations("See 23 V.S.A. § 1201(a)(1).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("VT")
+        expect(cites[0].title).toBe(23)
+        expect(cites[0].section).toBe("1201")
+      }
+    })
+
+    it("extracts `32 V.S.A. § 9741` (bare)", () => {
+      const cites = extractCitations("See 32 V.S.A. § 9741.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].title).toBe(32)
+        expect(cites[0].section).toBe("9741")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #404. Vermont's canonical \`N V.S.A. § N\` court style already extracts correctly — likely fixed incidentally by the universal section-connector work (#348) and related changes since v0.15.3 (when #404 was filed).

Adding regression tests to lock in the behavior:

| Input | Result |
|---|---|
| \`13 V.S.A. § 3253(a)(8)\` | code=V.S.A., jur=VT, title=13, section=3253, sub=(a)(8) |
| \`23 V.S.A. § 1201(a)(1)\` | jur=VT, title=23, section=1201 |
| \`32 V.S.A. § 9741\` | title=32, section=9741 |

### Deferred (not extraction problems)

- Bare-section follow-ons (\`§ 7624(c)\`) — short-form citation problem
- OCR variants (\`13 Y.S.A.\` — V→Y misread) — belongs upstream of citation extraction
- Adjourned Session session laws (\`1967, No. 334 (Adj. Sess.), § 1\`) — pending unified sessionLaw type

No changeset (test-only PR).

## Test plan

- [x] 3 new tests under \`Vermont V.S.A. canonical court style (#404)\`
- [x] Full test suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)