### PR TITLE
feat: WA RCW chapter-postfix form chapter 49.60 RCW (#408)

### DIFF
--- a/.changeset/issue-408-wa-rcw-chapter-postfix.md
+++ b/.changeset/issue-408-wa-rcw-chapter-postfix.md
@@ -1,0 +1,48 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Washington RCW chapter-postfix form `chapter 49.60 RCW` (#408)
+
+Canonical Washington court style places the chapter number BEFORE
+RCW (postfix form), unlike the prefix `RCW chapter NN` form used
+in other states. The `NN.NN` chapter format is distinctively
+Washington.
+
+### Fix
+
+New `rcw-chapter-postfix` tokenizer pattern + dedicated
+`extractRcwChapterPostfix` extractor. Accepts both lowercase
+`chapter` and capitalized `Chapter`. Emits `code: "RCW"`,
+`jurisdiction: "WA"`, with the chapter ID in `section` (matching
+the convention from `rsa-chapter` #378, `oh-chapter` #388,
+`ors-chapter` #387).
+
+### Scope notes
+
+The following pieces of #408 are intentionally deferred:
+
+- **`Laws of YYYY, ch. NNN, § N`** session laws — pending
+  unified `sessionLaw` citation type.
+- **`[former] N.NN.NN [(YYYY)]`** bracketed annotation — marks
+  superseded sections; needs separate handling.
+- **Section continuation** (`RCW 60.04 -.181(3)`) — multi-section
+  family.
+
+### Tests
+
+3 new tests under `Washington RCW chapter-postfix form (#408)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `chapter 49.60 RCW` (lowercase)
+- `Chapter 41.26 RCW` (capitalized)
+- Regression: `RCW 10.88.330` (prefix form)
+
+Full 2717-test suite passes; no regressions.
+
+### Related
+
+Sixth chapter-only state pattern (after NH `rsa-chapter` #378,
+OH `oh-chapter` #388, OR `ors-chapter` #387, plus the WV-1931
+historical pattern). Washington's distinctive postfix variant
+(chapter BEFORE the code abbreviation) is unique in the family.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -43,6 +43,7 @@ import { extractRlh } from "./statutes/extractRlh"
 import { extractRrs1943 } from "./statutes/extractRrs1943"
 import { extractRigl1956 } from "./statutes/extractRigl1956"
 import { extractRsaChapter } from "./statutes/extractRsaChapter"
+import { extractRcwChapterPostfix } from "./statutes/extractRcwChapterPostfix"
 import { extractTcaPostfix } from "./statutes/extractTcaPostfix"
 import { extractVaBareCode } from "./statutes/extractVaBareCode"
 import { extractWvCode1931 } from "./statutes/extractWvCode1931"
@@ -178,6 +179,8 @@ export function extractStatute(
       return extractRlh(token, transformationMap)
     case "rrs-1943":
       return extractRrs1943(token, transformationMap)
+    case "rcw-chapter-postfix":
+      return extractRcwChapterPostfix(token, transformationMap)
     case "rigl-1956":
       return extractRigl1956(token, transformationMap)
     case "rsa-chapter":

--- a/src/extract/statutes/extractRcwChapterPostfix.ts
+++ b/src/extract/statutes/extractRcwChapterPostfix.ts
@@ -1,0 +1,50 @@
+/**
+ * Washington RCW chapter postfix form — `chapter 49.60 RCW`
+ *
+ * Canonical Washington court style places the chapter before RCW
+ * (the opposite of the prefix `RCW chapter` form used in other states).
+ * The chapter is in `NN.NN` format. The chapter identifier goes into the
+ * `section` field, matching the convention from `rsa-chapter` (NH),
+ * `oh-chapter`, and `ors-chapter`. #408
+ *
+ * @module extract/statutes/extractRcwChapterPostfix
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+
+const RCW_CHAPTER_POSTFIX_RE = /^[Cc]hapter\s+(\d+\.\d+)\s+RCW$/d
+
+export function extractRcwChapterPostfix(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = RCW_CHAPTER_POSTFIX_RE.exec(text)!
+  const section = match[1]
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    if (match.indices[1])
+      spans.section = spanFromGroupIndex(span.cleanStart, match.indices[1], transformationMap)
+  }
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence: 0.95,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "RCW",
+    section,
+    jurisdiction: "WA",
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -303,6 +303,21 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Washington chapter-postfix form: `chapter 49.60 RCW`, `Chapter 41.26
+    // RCW`. Canonical Washington court style places the chapter number
+    // before RCW (the opposite of the prefix `RCW chapter` form used in
+    // other states). The chapter is in `NN.NN` format — distinctively
+    // Washington. Listed BEFORE `abbreviated-code` so the container shape
+    // wins span dedup over a potential `RCW` standalone match. #408
+    //
+    // Captures: (1) chapter body in NN.NN form.
+    id: "rcw-chapter-postfix",
+    regex: /\b[Cc]hapter\s+(\d+\.\d+)\s+RCW/g,
+    description:
+      'Washington RCW chapter postfix form: "chapter 49.60 RCW" — #408',
+    type: "statute",
+  },
+  {
     // Nebraska Reissue Revised Statutes 1943 (R.R.S. 1943) — historical
     // form: `section 38-901, R. R. S. 1943` or `§ 30-2806, R.R.S. 1943,
     // Reissue 1975`. Nebraska compiled its statutes in 1943 and re-issues

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2824,4 +2824,39 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Washington RCW chapter-postfix form (#408)", () => {
+    it("extracts `chapter 49.60 RCW` (lowercase)", () => {
+      const cites = extractCitations("See chapter 49.60 RCW.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RCW")
+        expect(cites[0].jurisdiction).toBe("WA")
+        expect(cites[0].section).toBe("49.60")
+      }
+    })
+
+    it("extracts `Chapter 41.26 RCW` (capitalized)", () => {
+      const cites = extractCitations("See Chapter 41.26 RCW.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("41.26")
+      }
+    })
+
+    it("regression: `RCW 10.88.330` (prefix form) continues to work", () => {
+      const cites = extractCitations("See RCW 10.88.330.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("RCW")
+        expect(cites[0].section).toBe("10.88.330")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #408. Canonical WA court style places the chapter BEFORE RCW (postfix form), unlike the prefix \`RCW chapter NN\` form used in other states.

New \`rcw-chapter-postfix\` tokenizer + extractor. Accepts both lowercase and capitalized \`Chapter\`. Emits \`code: \"RCW\"\`, \`jurisdiction: \"WA\"\`, chapter in \`section\` (matches NH/OH/OR/WV chapter-only convention).

### Behavior

| Input | Result |
|---|---|
| \`chapter 49.60 RCW\` | code=RCW, jur=WA, section=49.60 |
| \`Chapter 41.26 RCW\` | section=41.26 |
| \`RCW 10.88.330\` | unchanged |

### Deferred

- \`Laws of YYYY, ch. NNN\` session laws — pending unified sessionLaw type
- \`[former] N.NN.NN [(YYYY)]\` bracketed annotation
- Section continuation (\`RCW 60.04 -.181(3)\`) — multi-section family

## Test plan

- [x] 3 new tests under \`Washington RCW chapter-postfix form (#408)\`
- [x] Full 2717-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)