### PR TITLE
feat: WI Statutes postfix § NN.NN, Stats. / STATS. (#414)

### DIFF
--- a/.changeset/issue-414-wi-stats-postfix.md
+++ b/.changeset/issue-414-wi-stats-postfix.md
@@ -1,0 +1,60 @@
+---
+"eyecite-ts": patch
+---
+
+feat: Wisconsin Statutes postfix form `§ NN.NN, Stats.` + uppercase `STATS.` (#414)
+
+Wisconsin court style places the `Stats.` abbreviation AFTER the
+section, separated by a comma — `§ 76.09, Stats.`, `sec. 805.13(3),
+Stats.`, `§ 48.415(l)(a)3, STATS.` (uppercase). The dominant
+Wisconsin citation form (11 occurrences in a 50-opinion sample
+for `§ 76.09, Stats.` alone) was unrecognized.
+
+### Fix
+
+New `wi-stats-postfix` tokenizer pattern + dedicated
+`extractWiStatsPostfix` extractor. Sibling to florida-postfix,
+idaho-postfix, mca-postfix, tca-postfix — fifth state-postfix
+pattern, distinguished from the others by its trailing
+alphanumeric sub-subsection marker (`3` in `48.415(l)(a)3`).
+
+- Section connector accepts `§`, `§§`, `sec.`/`Sec.`,
+  `section`/`Section`.
+- Code abbreviation accepts both lowercase `Stats.` and
+  uppercase `STATS.`.
+- Section body allows trailing alphanumeric after paren chain
+  (`(l)(a)3`) for Wisconsin's sub-subsection notation.
+
+Emits `code: "Wis. Stat."`, `jurisdiction: "WI"`, section body
+with full subsection chain.
+
+### Scope notes
+
+The following pieces of #414 are intentionally deferred:
+
+- **`sec. (Rule) NN.NN, Stats.`** — Wisconsin evidence rules
+  cited as Stats. sections; needs handling of the inserted
+  `(Rule)` annotation.
+- **Bare-section follow-ons** (`§ 19.36(3)`, `§ 68.13`) —
+  short-form citation problem, not extraction.
+
+### Tests
+
+5 new tests under `Wisconsin Stats. postfix form (#414)` in
+`tests/extract/extractStatute.test.ts`:
+
+- `§ 76.09, Stats.` (canonical lowercase)
+- `§ 48.415(l)(a)3, STATS.` (uppercase + trailing
+  sub-subsection)
+- `sec. 805.13(3), Stats.` (word sec.)
+- `Section 48.415, Stats.` (capitalized word Section)
+- Regression: `Wis. Stat. § 803.04(2)` (modern prefix)
+
+Full 2721-test suite passes; no regressions.
+
+### Related
+
+Fifth state-postfix pattern after FL (#356), ID (#360), MT
+(#372), TN (#398). Wisconsin is unique in supporting trailing
+alphanumeric sub-subsection markers — other postfix states stop
+at the closing paren of the last subsection.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -46,6 +46,7 @@ import { extractRsaChapter } from "./statutes/extractRsaChapter"
 import { extractRcwChapterPostfix } from "./statutes/extractRcwChapterPostfix"
 import { extractTcaPostfix } from "./statutes/extractTcaPostfix"
 import { extractVaBareCode } from "./statutes/extractVaBareCode"
+import { extractWiStatsPostfix } from "./statutes/extractWiStatsPostfix"
 import { extractWvCode1931 } from "./statutes/extractWvCode1931"
 
 /**
@@ -189,6 +190,8 @@ export function extractStatute(
       return extractTcaPostfix(token, transformationMap)
     case "va-bare-code":
       return extractVaBareCode(token, transformationMap)
+    case "wi-stats-postfix":
+      return extractWiStatsPostfix(token, transformationMap)
     case "wv-code-1931":
       return extractWvCode1931(token, transformationMap)
     default:

--- a/src/extract/statutes/extractWiStatsPostfix.ts
+++ b/src/extract/statutes/extractWiStatsPostfix.ts
@@ -1,0 +1,78 @@
+/**
+ * Wisconsin Statutes postfix form — `§ 76.09, Stats.`
+ *
+ *   § 76.09, Stats.
+ *   sec. 805.13(3), Stats.
+ *   § 48.415(l)(a)3, STATS.   (uppercase, with trailing sub-subsection 3)
+ *
+ * Wisconsin court style places the `Stats.` abbreviation AFTER the
+ * section, separated by a comma. Both lowercase `Stats.` and uppercase
+ * `STATS.` are common. #414
+ *
+ * @module extract/statutes/extractWiStatsPostfix
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+const WI_STATS_POSTFIX_RE =
+  /^(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*),?\s+(?:Stats\.|STATS\.)$/d
+
+export function extractWiStatsPostfix(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = WI_STATS_POSTFIX_RE.exec(text)!
+  const rawBody = match[1].replace(/\s+/g, "")
+  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const bodyIdx = match.indices[1]
+    if (bodyIdx && section) {
+      const bodyStart = bodyIdx[0]
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [bodyStart, bodyStart + sectionSpanLen],
+        transformationMap,
+      )
+      if (subsection) {
+        const subStart = bodyStart + section.length
+        spans.subsection = spanFromGroupIndex(
+          span.cleanStart,
+          [subStart, subStart + subsection.length],
+          transformationMap,
+        )
+      }
+    }
+  }
+
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: "Wis. Stat.",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "WI",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -318,6 +318,23 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Wisconsin Statutes postfix form: `§ 76.09, Stats.`, `sec. 805.13(3),
+    // Stats.`, `§ 48.415(l)(a)3, STATS.`. Wisconsin court style places the
+    // `Stats.` abbreviation AFTER the section, separated by a comma. Both
+    // lowercase `Stats.` and uppercase `STATS.` are common. The trailing
+    // alphanumeric character (`3` in `48.415(l)(a)3`) is the Wisconsin
+    // sub-subsection marker. Listed BEFORE `abbreviated-code` so the
+    // container shape wins span dedup. #414
+    //
+    // Captures: (1) section body.
+    id: "wi-stats-postfix",
+    regex:
+      /(?<![A-Za-z])(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*),?\s+(?:Stats\.|STATS\.)/g,
+    description:
+      'Wisconsin Statutes postfix form: "§ 76.09, Stats." / "sec. 805.13(3), Stats." — #414',
+    type: "statute",
+  },
+  {
     // Nebraska Reissue Revised Statutes 1943 (R.R.S. 1943) — historical
     // form: `section 38-901, R. R. S. 1943` or `§ 30-2806, R.R.S. 1943,
     // Reissue 1975`. Nebraska compiled its statutes in 1943 and re-issues

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2859,4 +2859,61 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Wisconsin Stats. postfix form (#414)", () => {
+    it("extracts `§ 76.09, Stats.` (canonical lowercase)", () => {
+      const cites = extractCitations("See § 76.09, Stats.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Wis. Stat.")
+        expect(cites[0].jurisdiction).toBe("WI")
+        expect(cites[0].section).toBe("76.09")
+      }
+    })
+
+    it("extracts `§ 48.415(l)(a)3, STATS.` (uppercase, trailing sub-subsection)", () => {
+      const cites = extractCitations("See § 48.415(l)(a)3, STATS.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Wis. Stat.")
+        expect(cites[0].section).toBe("48.415(l)(a)3")
+      }
+    })
+
+    it("extracts `sec. 805.13(3), Stats.` (word sec.)", () => {
+      const cites = extractCitations("See sec. 805.13(3), Stats.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("WI")
+        expect(cites[0].section).toBe("805.13")
+      }
+    })
+
+    it("extracts `Section 48.415, Stats.` (capitalized word Section)", () => {
+      const cites = extractCitations("See Section 48.415, Stats.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("48.415")
+      }
+    })
+
+    it("regression: `Wis. Stat. § 803.04(2)` (modern prefix) continues to work", () => {
+      const cites = extractCitations("See Wis. Stat. § 803.04(2).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("Wis. Stat.")
+        expect(cites[0].jurisdiction).toBe("WI")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #414. WI court style places \`Stats.\` AFTER the section, separated by comma. \`§ 76.09, Stats.\` is the dominant form (11 occurrences in a 50-opinion sample). Both lowercase \`Stats.\` and uppercase \`STATS.\` are common.

New \`wi-stats-postfix\` tokenizer + extractor. 5th state-postfix pattern after FL/ID/MT/TN. Accepts \`§\` / \`sec.\` / \`Section\` connector. WI is unique in supporting trailing alphanumeric sub-subsection markers (\`48.415(l)(a)3\`).

### Behavior

| Input | Result |
|---|---|
| \`§ 76.09, Stats.\` | code=Wis. Stat., jur=WI, section=76.09 |
| \`§ 48.415(l)(a)3, STATS.\` | section=48.415(l)(a)3 (uppercase + sub-subsection) |
| \`sec. 805.13(3), Stats.\` | sec. connector |
| \`Section 48.415, Stats.\` | capitalized Section |
| \`Wis. Stat. § 803.04(2)\` | unchanged |

### Deferred

- \`sec. (Rule) NN.NN, Stats.\` — WI evidence rules as Stats. sections
- Bare-section follow-ons (\`§ 19.36(3)\`) — short-form citation problem

## Test plan

- [x] 5 new tests under \`Wisconsin Stats. postfix form (#414)\`
- [x] Full 2721-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)