### PR TITLE
fix: LA La.R.S. (no space) routing (#415)

### DIFF
--- a/.changeset/issue-415-la-spacing.md
+++ b/.changeset/issue-415-la-spacing.md
@@ -1,0 +1,59 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Louisiana `La.R.S.` (no space) — colon title:section form (#415)
+
+Louisiana court style commonly uses `La.R.S. NN:NNN` (no space
+between `La.` and `R.S.`). The LA fragment required `\s+` between
+the prefix and `R.S.`, so the no-space form was unrecognized.
+
+### Fix
+
+- **LA fragment**: `\s+` between `La.` and `R.S.` relaxed to
+  `\s*` so the no-space form matches.
+- **Canonical normalization**: LA abbreviations reordered so
+  `La. R.S.` (Bluebook standard) is the last element /
+  canonical. The no-space variant normalizes to `La. R.S.` via
+  the stripped-form fallback.
+
+### Behavior changes
+
+- `La.R.S. 48:453` → `code="La. R.S."`, `jurisdiction="LA"`,
+  `section="48:453"` (was: not extracted)
+- `La.R.S. 23:1032` → LA, section preserves colon
+- `La. R.S. 48:453` (with space) → unchanged
+
+### Scope notes
+
+The following pieces of #415 are intentionally deferred:
+
+- **Bare `R.S. NN:NNN`** (no `La.` prefix) — too generic
+  without context.
+- **Section ranges** (`La.R.S. 48:441 to 460`,
+  `La.R.S. 39:1401-06`) — multi-section deferred across all
+  states.
+- **OCR variant** (`R.S. 23 :- 1061`) — OCR cleanup upstream.
+- **Code of Civil Procedure / Criminal Procedure Article N** —
+  named-article statutory codes; needs separate pattern.
+- **Bare `Article N` follow-ons** — short-form citation
+  problem.
+- **`Act N of YYYY`** session laws — pending unified
+  `sessionLaw` citation type.
+
+### Tests
+
+3 new tests under `Louisiana \`La.R.S.\` no-space variant
+(#415)` in `tests/extract/extractStatute.test.ts`:
+
+- `La.R.S. 48:453` (no space)
+- `La.R.S. 23:1032` (canonical court style)
+- Regression: `La. R.S. 48:453` (with space)
+
+Full 2726-test suite passes; no regressions.
+
+### Related
+
+Whitespace-tolerance + canonical-reorder fix in the same family
+as SC (#397), WV (#406), PA (#392), and the broader spacing-
+tolerance family (AZ #348, OH #388, TN #398).

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -342,11 +342,14 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     regexFragment: "Ky\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|KRS",
   },
   // ── Louisiana ─────────────────────────────────────────────────────────────
+  // Louisiana — relaxed `La.R.S.` (no space between `La.` and `R.S.`)
+  // is a common LA court style. Canonical is `La. R.S.` (Bluebook);
+  // ordered last so the no-space variant normalizes to it. #415
   {
     jurisdiction: "LA",
-    abbreviations: ["La. Rev. Stat. Ann.", "La. R.S.", "LSA-R.S."],
+    abbreviations: ["La. Rev. Stat. Ann.", "LSA-R.S.", "La. R.S."],
     regexFragment:
-      "La\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|La\\.?\\s+R\\.?S\\.?|LSA-R\\.?S\\.?",
+      "La\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|La\\.?\\s*R\\.?S\\.?|LSA-R\\.?S\\.?",
   },
   // ── Maine ─────────────────────────────────────────────────────────────────
   {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2916,4 +2916,39 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Louisiana `La.R.S.` no-space variant (#415)", () => {
+    it("extracts `La.R.S. 48:453` (no space, colon title:section)", () => {
+      const cites = extractCitations("See La.R.S. 48:453.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("La. R.S.")
+        expect(cites[0].jurisdiction).toBe("LA")
+        expect(cites[0].section).toBe("48:453")
+      }
+    })
+
+    it("extracts `La.R.S. 23:1032` (canonical court style)", () => {
+      const cites = extractCitations("See La.R.S. 23:1032.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].section).toBe("23:1032")
+        expect(cites[0].jurisdiction).toBe("LA")
+      }
+    })
+
+    it("regression: `La. R.S. 48:453` (with space) continues to work", () => {
+      const cites = extractCitations("See La. R.S. 48:453.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("LA")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #415. LA court style commonly uses \`La.R.S. NN:NNN\` (no space between \`La.\` and \`R.S.\`). The LA fragment required \`\\s+\`, so the no-space form was unrecognized.

- LA fragment \`\\s+\` → \`\\s*\` between \`La.\` and \`R.S.\`
- Abbreviations reordered: \`La. R.S.\` (Bluebook) is canonical; no-space variant normalizes via stripped-form fallback.

### Behavior

| Input | Before | After |
|---|---|---|
| \`La.R.S. 48:453\` | not extracted | code=La. R.S., jur=LA, section=48:453 |
| \`La.R.S. 23:1032\` | not extracted | section preserves colon |
| \`La. R.S. 48:453\` | unchanged | unchanged |

### Deferred

- Bare \`R.S. NN:NNN\` (no La. prefix)
- Section ranges (multi-section family)
- OCR variant (\`R.S. 23 :- 1061\`)
- Code of Civil/Criminal Procedure Article N — named-article codes
- Bare Article N follow-ons — short-form citation
- \`Act N of YYYY\` session laws — pending unified sessionLaw type

## Test plan

- [x] 3 new tests under \`Louisiana \`La.R.S.\` no-space variant (#415)\`
- [x] Full 2726-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)