### PR TITLE
fix: et seq. captured by state-postfix patterns (#419)

### DIFF
--- a/.changeset/issue-419-et-seq-postfix.md
+++ b/.changeset/issue-419-et-seq-postfix.md
@@ -1,0 +1,83 @@
+---
+"eyecite-ts": patch
+---
+
+fix: `et seq.` captured by state-postfix patterns (FL, ID, MCA, TN, WI) (#419)
+
+The `et seq.` suffix was systematically dropped from state-postfix
+citations — `§§ 77-6-301 et seq., MCA` extracted only `77-6-301`
+and lost the legally-significant "and the following sections"
+marker. A 50-state baseline corpus showed 59 misses across 17
+states (some via abbreviated-code which already worked; the
+remainder via the postfix patterns introduced in #356, #360,
+#372, #398, #414).
+
+### Fix
+
+The section-body capture group in all five state-postfix
+tokenizer patterns + their mirroring extractor regexes now
+accepts the optional `(?:\s+et\s+seq\.?)?` trailer:
+
+- `florida-postfix` + `florida-prefix-spelled` (#356)
+- `idaho-postfix` (#360)
+- `mca-postfix` (#372)
+- `tca-postfix` (#398)
+- `wi-stats-postfix` (#414)
+
+`parseBody` already strips the trailer and sets `hasEtSeq:
+true` — the fix just lets the trailer get captured in the
+section group so it reaches parseBody.
+
+The Wisconsin extractor's whitespace-collapse step
+(`replace(/\s+/g, "")`) was updated to split off the `et seq.`
+trailer first, preserving the marker while still collapsing
+spaces inside `(N)` subsection groups.
+
+### Behavior changes
+
+- `§§ 77-6-301 et seq., MCA` → `hasEtSeq=true`, jur=MT (was:
+  not extracted as MCA — instead silently mis-routed to NM via
+  the bare-section fallback because the postfix container
+  failed)
+- `§ 812.035 et seq., Florida Statutes` → `hasEtSeq=true`
+- `Section 23-908 et seq., Idaho Code` → `hasEtSeq=true`
+- `§ 39-904 et seq., T.C.A.` → `hasEtSeq=true`
+- `§ 76.09 et seq., Stats.` → `hasEtSeq=true`
+
+### Scope notes
+
+The following pieces of #419 are intentionally deferred:
+
+- **CA Code Regs.** (`Cal. Code Regs., tit. 14, § 15000 et
+  seq.`) — admin regs broadly deferred per #320.
+- **NJ Admin Code** (`N.J.A.C. 18:46-1.1 et seq.`) — same.
+- **Treatises** (`1 Larson, Workmen's Compensation Law § 15.00
+  et seq.`) — deferred per #307.
+- **Rules** (`RALJ 1.1 et seq.`, `RAP 16.3 et seq.`) — deferred
+  per #295.
+
+The dominant statute occurrences (the 50 in the issue's
+distribution) are now captured.
+
+### Tests
+
+6 new tests under `et seq. captured by state-postfix patterns
+(#419)` in `tests/extract/extractStatute.test.ts`:
+
+- MCA postfix `§§ 77-6-301 et seq., MCA`
+- Florida postfix `§ 812.035 et seq., Florida Statutes`
+- Idaho postfix `Section 23-908 et seq., Idaho Code`
+- TN postfix `§ 39-904 et seq., T.C.A.`
+- WI postfix `§ 76.09 et seq., Stats.`
+- Regression: `Ark. Code Ann. § 9-27-301 et seq. (Supp. 1989)`
+
+Full 2735-test suite passes; no regressions.
+
+### Related
+
+This fix also incidentally repairs a Montana-→-NM
+mis-classification: `§§ 77-6-301 et seq., MCA` was previously
+silently mis-routed to NM because the MCA postfix pattern
+failed (didn't capture et seq.), letting the NM bare-section
+pattern (#382) match the inner `§§ 77-6-301`. With the postfix
+container now capturing the full citation, MT wins.

--- a/src/extract/statutes/extractFloridaStatute.ts
+++ b/src/extract/statutes/extractFloridaStatute.ts
@@ -27,10 +27,10 @@ import { parseBody } from "./parseBody"
 // `^` anchor is fine here — the extractor receives only the matched span,
 // so the leading position is always the start of the captured token text.
 const FLORIDA_POSTFIX_RE =
-  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)$/d
+  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)$/d
 
 const FLORIDA_PREFIX_SPELLED_RE =
-  /^Florida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)$/d
+  /^Florida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?)$/d
 
 export function extractFloridaStatute(
   token: Token,

--- a/src/extract/statutes/extractIdahoPostfix.ts
+++ b/src/extract/statutes/extractIdahoPostfix.ts
@@ -16,7 +16,7 @@ import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from 
 import { parseBody } from "./parseBody"
 
 const IDAHO_POSTFIX_RE =
-  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Idaho\s+Code(?:\s+Ann\.?)?$/d
+  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+Idaho\s+Code(?:\s+Ann\.?)?$/d
 
 export function extractIdahoPostfix(
   token: Token,

--- a/src/extract/statutes/extractMcaPostfix.ts
+++ b/src/extract/statutes/extractMcaPostfix.ts
@@ -17,7 +17,7 @@ import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from 
 import { parseBody } from "./parseBody"
 
 const MCA_POSTFIX_RE =
-  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+MCA$/d
+  /^(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+MCA$/d
 
 export function extractMcaPostfix(
   token: Token,

--- a/src/extract/statutes/extractTcaPostfix.ts
+++ b/src/extract/statutes/extractTcaPostfix.ts
@@ -15,7 +15,7 @@ import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from 
 import { parseBody } from "./parseBody"
 
 const TCA_POSTFIX_RE =
-  /^(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+T\.?C\.?A\.?$/d
+  /^(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+T\.?C\.?A\.?$/d
 
 export function extractTcaPostfix(
   token: Token,

--- a/src/extract/statutes/extractWiStatsPostfix.ts
+++ b/src/extract/statutes/extractWiStatsPostfix.ts
@@ -19,7 +19,7 @@ import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from 
 import { parseBody } from "./parseBody"
 
 const WI_STATS_POSTFIX_RE =
-  /^(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*),?\s+(?:Stats\.|STATS\.)$/d
+  /^(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*(?:\s+et\s+seq\.?)?),?\s+(?:Stats\.|STATS\.)$/d
 
 export function extractWiStatsPostfix(
   token: Token,
@@ -27,7 +27,13 @@ export function extractWiStatsPostfix(
 ): StatuteCitation {
   const { text, span } = token
   const match = WI_STATS_POSTFIX_RE.exec(text)!
-  const rawBody = match[1].replace(/\s+/g, "")
+  // Split off the optional ` et seq.` trailer before collapsing whitespace,
+  // so the section body's spaces inside `(N)` groups can still be removed
+  // while preserving the et seq. marker for parseBody (#419).
+  const etSeqMatch = match[1].match(/\s+et\s+seq\.?$/)
+  const sectionPart = etSeqMatch ? match[1].slice(0, -etSeqMatch[0].length) : match[1]
+  const cleanSection = sectionPart.replace(/\s+/g, "")
+  const rawBody = etSeqMatch ? `${cleanSection} et seq.` : cleanSection
   const { section, subsection, hasEtSeq } = parseBody(rawBody)
 
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -240,7 +240,7 @@ export const statutePatterns: Pattern[] = [
     // `\b` wouldn't anchor at end-of-string. The closed alternation
     // (`Florida Statutes | Fla. Stat.`) is specific enough on its own.
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)/g,
     description:
       'Florida postfix statute form: "section 812.035(7), Florida Statutes" / "§83.15, Florida Statutes" — #356',
     type: "statute",
@@ -254,7 +254,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "florida-prefix-spelled",
     regex:
-      /\bFlorida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+      /\bFlorida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?)/g,
     description:
       'Florida spelled-out prefix form: "Florida Statute 679.504(3)" / "Florida Statutes §73.071" — #356',
     type: "statute",
@@ -269,7 +269,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "idaho-postfix",
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Idaho\s+Code(?:\s+Ann\.?)?/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+Idaho\s+Code(?:\s+Ann\.?)?/g,
     description:
       'Idaho postfix statute form: "Section 23-908(4), Idaho Code" — #360',
     type: "statute",
@@ -284,7 +284,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "mca-postfix",
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+MCA/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+MCA/g,
     description: 'Montana Code Annotated postfix form: "§ 77-6-205(2), MCA" — #372',
     type: "statute",
   },
@@ -297,7 +297,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "tca-postfix",
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+T\.?C\.?A\.?/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+T\.?C\.?A\.?/g,
     description:
       'Tennessee Code Annotated postfix form: "§ 39-904, T.C.A." — #398',
     type: "statute",
@@ -329,7 +329,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "wi-stats-postfix",
     regex:
-      /(?<![A-Za-z])(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*),?\s+(?:Stats\.|STATS\.)/g,
+      /(?<![A-Za-z])(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*(?:\s+et\s+seq\.?)?),?\s+(?:Stats\.|STATS\.)/g,
     description:
       'Wisconsin Statutes postfix form: "§ 76.09, Stats." / "sec. 805.13(3), Stats." — #414',
     type: "statute",

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2951,4 +2951,75 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("et seq. captured by state-postfix patterns (#419)", () => {
+    it("MCA postfix: `§§ 77-6-301 et seq., MCA` → hasEtSeq=true, jur=MT", () => {
+      const cites = extractCitations("See §§ 77-6-301 et seq., MCA.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("MCA")
+        expect(cites[0].jurisdiction).toBe("MT")
+        expect(cites[0].section).toBe("77-6-301")
+        expect(cites[0].hasEtSeq).toBe(true)
+      }
+    })
+
+    it("Florida postfix: `§ 812.035 et seq., Florida Statutes` → hasEtSeq=true", () => {
+      const cites = extractCitations("See § 812.035 et seq., Florida Statutes.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("FL")
+        expect(cites[0].hasEtSeq).toBe(true)
+      }
+    })
+
+    it("Idaho postfix: `Section 23-908 et seq., Idaho Code` → hasEtSeq=true", () => {
+      const cites = extractCitations("See Section 23-908 et seq., Idaho Code.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("ID")
+        expect(cites[0].hasEtSeq).toBe(true)
+      }
+    })
+
+    it("TN postfix: `§ 39-904 et seq., T.C.A.` → hasEtSeq=true", () => {
+      const cites = extractCitations("See § 39-904 et seq., T.C.A.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("TN")
+        expect(cites[0].hasEtSeq).toBe(true)
+      }
+    })
+
+    it("WI postfix: `§ 76.09 et seq., Stats.` → hasEtSeq=true", () => {
+      const cites = extractCitations("See § 76.09 et seq., Stats.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("WI")
+        expect(cites[0].hasEtSeq).toBe(true)
+      }
+    })
+
+    it("regression: abbreviated-code form `Ark. Code Ann. § 9-27-301 et seq. (Supp. 1989)`", () => {
+      const cites = extractCitations(
+        "See Ark. Code Ann. § 9-27-301 et seq. (Supp. 1989).",
+      ).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].hasEtSeq).toBe(true)
+        expect(cites[0].year).toBe(1989)
+        expect(cites[0].editionLabel).toBe("Supp.")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #419. The \`et seq.\` suffix was systematically dropped from state-postfix citations. 50-state baseline showed 59 misses across 17 states.

Section-body capture group in all 5 state-postfix tokenizer patterns + extractor regexes now accepts optional \`(?:\\s+et\\s+seq\\.?)?\` trailer. \`parseBody\` already strips it and sets \`hasEtSeq=true\` — the fix lets the trailer reach parseBody.

**Bonus fix**: \`§§ 77-6-301 et seq., MCA\` was previously silently mis-routed to NM (NM bare-section matched the inner \`§§ 77-6-301\` because MCA postfix failed without et seq. support). MCA now wins.

### Behavior

| Input | Before | After |
|---|---|---|
| \`§§ 77-6-301 et seq., MCA\` | mis-routed to NM, no et seq. | code=MCA, jur=MT, hasEtSeq=true |
| \`§ 812.035 et seq., Florida Statutes\` | no et seq. | hasEtSeq=true |
| \`Section 23-908 et seq., Idaho Code\` | no et seq. | hasEtSeq=true |
| \`§ 39-904 et seq., T.C.A.\` | no et seq. | hasEtSeq=true |
| \`§ 76.09 et seq., Stats.\` | no et seq. | hasEtSeq=true |
| \`Ark. Code Ann. § 9-27-301 et seq. (Supp. 1989)\` | unchanged | unchanged |

### Deferred

- CA Code Regs., NJ Admin Code — admin regs deferred per #320
- Treatises (\`1 Larson, Workmen's Compensation Law § 15.00 et seq.\`) — deferred per #307
- Rules (\`RALJ 1.1 et seq.\`) — deferred per #295

## Test plan

- [x] 6 new tests under \`et seq. captured by state-postfix patterns (#419)\`
- [x] Full 2735-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)