### PR TITLE
fix: hyphenated year-range edition parens (Supp.1975-76) (#420)

### DIFF
--- a/.changeset/issue-420-year-range-paren.md
+++ b/.changeset/issue-420-year-range-paren.md
@@ -1,0 +1,48 @@
+---
+"eyecite-ts": patch
+---
+
+fix: hyphenated year-range edition parentheticals `(Supp.1975-76)` (#420)
+
+The no-space and spaced single-year forms (`(Supp. 1998)`,
+`(Supp.1998)`, `(Repl.1996)`) already worked via the year-paren
+absorber. Only the hyphenated year-range form
+(`(Supp.1975-76)`, `(Supp.1973-1975)`) was rejected because the
+regex's closing `\)` expected to immediately follow the captured
+`(\d{4})` year.
+
+### Fix
+
+`STATUTE_YEAR_PAREN_REGEX` in `src/extract/extractCitations.ts`
+now consumes an optional `(?:-\d{2,4})?` suffix after the year.
+The first year is captured as the `year` field; the suffix is
+consumed but not separately reported.
+
+### Behavior changes
+
+- `(Supp.1975-76)` → `year=1975`, `editionLabel="Supp."` (was:
+  not extracted)
+- `(Supp.1973-1975)` → `year=1973`, `editionLabel="Supp."`
+- `(Supp.1998)`, `(Supp. 1998)`, `(Repl.1996)`, `(Reissue 2003)`
+  — all unchanged
+
+### Scope notes
+
+The following pieces of #420 are intentionally deferred:
+
+- **Section ranges** (`§§ 15-78-10 to -200`, `§§ 13-108 and
+  13-621`) — multi-section family.
+- **Bare-section + edition paren follow-on** (`42-17-40
+  (Supp.2003)`) — short-form citation problem.
+
+### Tests
+
+4 new tests under `Year-range edition parentheticals (#420)` in
+`tests/extract/extractStatute.test.ts`:
+
+- Hyphenated year `(Supp.1975-76)`
+- Full year suffix `(Supp.1973-1975)`
+- Regression: no-space `(Supp.1998)`
+- Regression: spaced `(Supp. 1998)`
+
+Full 2735-test suite passes; no regressions.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -673,8 +673,12 @@ function inheritSubsequentHistoryCaseName(citations: Citation[]): void {
  * `.` and an optional second capitalized word so `Cum. Supp.` and
  * `Lexis Nexis` both flow through the same regex.
  */
+// Year supports optional hyphenated year-range suffix (`1975-76`, `1973-1975`)
+// — Arizona and a few other states use multi-year supplement parentheticals
+// like `(Supp.1975-76)`. The first year is captured; the suffix is consumed
+// but not separately reported. #420
 const STATUTE_YEAR_PAREN_REGEX =
-  /^\s*(?:,\s*(?:at\s+)?\d+(?:-\d+)?\s*)?\(\s*([A-Z][A-Za-z]+\.?(?:\s+[A-Z][A-Za-z]+\.?)?)?\s*(\d{4})\s*([A-Z][A-Za-z]+\.?(?:\s+[A-Z][A-Za-z]+\.?)?)?\s*\)/
+  /^\s*(?:,\s*(?:at\s+)?\d+(?:-\d+)?\s*)?\(\s*([A-Z][A-Za-z]+\.?(?:\s+[A-Z][A-Za-z]+\.?)?)?\s*(\d{4})(?:-\d{2,4})?\s*([A-Z][A-Za-z]+\.?(?:\s+[A-Z][A-Za-z]+\.?)?)?\s*\)/
 
 /**
  * Edition-label set — captured tokens that should populate `editionLabel`

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -3022,4 +3022,49 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Year-range edition parentheticals (#420)", () => {
+    it("extracts hyphenated year suffix: `(Supp.1975-76)` → year=1975, editionLabel=Supp.", () => {
+      const cites = extractCitations("See A.R.S. §§ 13-108 (Supp.1975-76).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].year).toBe(1975)
+        expect(cites[0].editionLabel).toBe("Supp.")
+      }
+    })
+
+    it("extracts full-year suffix: `(Supp.1973-1975)`", () => {
+      const cites = extractCitations("See A.R.S. § 13-108 (Supp.1973-1975).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].year).toBe(1973)
+      }
+    })
+
+    it("regression: no-space `(Supp.1998)` continues to work", () => {
+      const cites = extractCitations("See S.C.Code Ann. § 42-15-40 (Supp.1998).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].year).toBe(1998)
+        expect(cites[0].editionLabel).toBe("Supp.")
+      }
+    })
+
+    it("regression: spaced `(Supp. 1998)` continues to work", () => {
+      const cites = extractCitations("See S.C. Code Ann. § 42-15-40 (Supp. 1998).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].year).toBe(1998)
+        expect(cites[0].editionLabel).toBe("Supp.")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #420. Most no-space edition parens (\`(Supp.1998)\`, \`(Repl.1996)\`) already worked. Only the hyphenated year-range form (\`(Supp.1975-76)\`, \`(Supp.1973-1975)\`) was rejected.

\`STATUTE_YEAR_PAREN_REGEX\` now consumes optional \`(?:-\\d{2,4})?\` suffix after the year. First year captured as \`year\`.

### Behavior

| Input | Before | After |
|---|---|---|
| \`(Supp.1975-76)\` | not extracted | year=1975, label=Supp. |
| \`(Supp.1973-1975)\` | not extracted | year=1973 |
| \`(Supp.1998)\`, \`(Supp. 1998)\`, \`(Repl.1996)\` | unchanged | unchanged |

### Deferred

- Section ranges (\`§§ 15-78-10 to -200\`) — multi-section family
- Bare-section + edition paren follow-ons (\`42-17-40 (Supp.2003)\`) — short-form citation problem

## Test plan

- [x] 4 new tests under \`Year-range edition parentheticals (#420)\`
- [x] Full 2735-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)