### PR TITLE
test: high-volume regression for Idaho I.C. → ID routing (#422)

### DIFF
--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -3067,4 +3067,60 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Idaho I.C. routing (high-volume regression — #422)", () => {
+    it("`I.C. § 19-2719` routes to Idaho (×11 in 50-opinion sample)", () => {
+      const cites = extractCitations("See I.C. § 19-2719.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("I.C.")
+        expect(cites[0].jurisdiction).toBe("ID")
+        expect(cites[0].section).toBe("19-2719")
+      }
+    })
+
+    it("`I.C. § 12-121` routes to Idaho", () => {
+      const cites = extractCitations("See I.C. § 12-121.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("`I.C. § 67-7709(1)(b)` with subsection routes to Idaho", () => {
+      const cites = extractCitations("See I.C. § 67-7709(1)(b).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("ID")
+        expect(cites[0].section).toBe("67-7709")
+        expect(cites[0].subsection).toBe("(1)(b)")
+      }
+    })
+
+    it("`under I.C. § 19-2719` (mid-sentence) routes to Idaho", () => {
+      const cites = extractCitations("Found under I.C. § 19-2719.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("regression: `IC 35-42-1-1` (no dots) still routes to Indiana", () => {
+      const cites = extractCitations("See IC 35-42-1-1.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("IN")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #422. Issue reported 131 mis-routes (Idaho \`I.C.\` → Indiana) in a 50-opinion sample against v0.15.7.

The fix already landed in #360 (Indiana fragment tightened to literal \`IC\` so dotted \`I.C.\` belongs to Idaho). Verified all examples from the issue's quality-issue evidence now route correctly:

| Input | Result |
|---|---|
| \`I.C. § 19-2719\` (×11 in sample) | code=I.C., jur=ID |
| \`I.C. § 12-121\` (×6) | jur=ID |
| \`I.C. § 67-7709(1)(b)\` | jur=ID, sub=(1)(b) |
| \`under I.C. § 19-2719\` | jur=ID |
| \`IC 35-42-1-1\` (no dots) | jur=IN (unchanged) |

Adding regression tests to lock in the behavior and detect future regressions.

No changeset (test-only PR).

## Test plan

- [x] 5 new tests under \`Idaho I.C. routing (high-volume regression — #422)\`
- [x] Full test suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)