### PR TITLE
fix: federal USC/CFR/USCA variants extracted as statutes (#428)

### DIFF
--- a/.changeset/issue-428-usc-cfr-variants.md
+++ b/.changeset/issue-428-usc-cfr-variants.md
@@ -1,0 +1,83 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Federal `USC` / `CFR` / `USCA` / "United States Code" variants extracted as statutes (#428)
+
+Federal-statute variants used in court-published opinions were
+mis-typed as `case` or not extracted at all. 29 mis-typed
+occurrences + 8 unextracted across 11 states.
+
+### Variants now supported
+
+- `42 USC 1983` (no periods, no §) — previously mis-typed as case
+- `42 CFR 447` — same
+- `11 USCA § 544(a)(3)` (West annotated) — previously not extracted
+- `49 U.S.C. Section 1513` (word `Section`) — was mis-typed as case
+- `42 United States Code section 1983` (spelled-out) — was
+  mis-typed as case
+
+### Fixes
+
+Three coordinated changes:
+
+1. **Pattern alternation**: USC and CFR regexes in
+   `src/patterns/statutePatterns.ts` extended to accept `USC` /
+   `USCA` / `U.S.C.` / `U.S.C.A.` / `United States Code` for the
+   USC side and `C.F.R.` / `CFR` / `Code of Federal Regulations`
+   for the CFR side. Connector (`§§?` / `Section(s)` / `Sec.` /
+   `Part`) made optional so bare `N USC NNNN` form matches.
+
+2. **Pattern priority**: USC/CFR/IRC patterns moved BEFORE
+   `casePatterns` in `extractCitations.ts` so the broad
+   `state-reporter` regex (which would otherwise match
+   `42 USC 1983` as vol-reporter-page) is subsumed by the
+   federal-statute container.
+
+3. **Extractor regex**: `FEDERAL_SECTION_RE` and
+   `FEDERAL_PART_RE` in `extractFederal.ts` match the same
+   expanded alternation, with an optional connector. Code is
+   canonicalized to Bluebook form (`U.S.C.` for USC family,
+   `C.F.R.` for CFR family) via stripped-form comparison.
+
+4. **False-positive blocklist**: USC/CFR/USCA added to the
+   `BLOCKED_REPORTERS` set in `filterFalsePositives.ts` so any
+   residual `state-reporter` match falls back to the
+   false-positive filter (low confidence + warning).
+
+### Behavior changes
+
+- `42 USC 1983` → `code="U.S.C."`, `title=42`, `section="1983"`
+  (was: type=case, warnings)
+- `42 CFR 447` → `code="C.F.R."`, `title=42`, `section="447"`
+- `11 USCA § 544(a)(3)` → `code="U.S.C."`, `title=11`,
+  `section="544"`, `subsection="(a)(3)"`
+- `49 U.S.C. Section 1513` → `code="U.S.C."`, `title=49`
+- `42 United States Code section 1983` → `code="U.S.C."`,
+  `title=42`
+- `42 U.S.C. § 1983` (canonical Bluebook) — unchanged
+
+### Behavior notes
+
+The `code` field is now canonicalized to Bluebook form. Previously
+the no-period variants would emit `code="USC"` / `"CFR"`
+preserving the input surface. Two existing tests (extractFederal
+"should extract USC without periods", "should handle CFR without
+periods") were updated to reflect the new canonicalized output;
+the corpus fixture entry for `15 USC § 78j` was updated similarly.
+
+### Scope notes
+
+The following pieces of #428 are intentionally deferred:
+
+- **`Title 18, USC Section 659`** title-prefix prose — needs
+  prose-form pattern with `Title N` prefix
+- **Multi-title shortcut** (`21 U.S.C. and 42`) — semantic
+  shorthand for "title 21 and title 42 of the U.S.C."
+
+### Tests
+
+7 new tests under `Federal USC / CFR variants (#428)` in
+`tests/extract/extractStatute.test.ts`. Full 2747-test suite
+passes; one corpus fixture and two extractFederal tests
+updated for the new canonicalized `code` output.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -225,13 +225,24 @@ export function extractCitations(
 
   // Step 2: Tokenize (synchronous)
   // Note: Pattern order matters for deduplication - more specific patterns first
+  // USC and CFR patterns are placed BEFORE casePatterns so the broad
+  // state-reporter regex (which matches `42 USC 1983` as vol-reporter-page)
+  // is subsumed by the more specific federal-statute match. Without this,
+  // `42 USC 1983` mis-types as `case`. #428
+  const federalStatutePatterns = statutePatterns.filter(
+    (p) => p.id === "usc" || p.id === "cfr" || p.id === "irc",
+  )
+  const otherStatutePatterns = statutePatterns.filter(
+    (p) => p.id !== "usc" && p.id !== "cfr" && p.id !== "irc",
+  )
   const allPatterns = options?.patterns || [
     ...neutralPatterns, // Most specific (year-based format)
     ...docketPatterns, // Docket-number citations (anchored by "No. ")
     ...shortFormPatterns, // Short-form (requires " at " keyword)
+    ...federalStatutePatterns, // USC/CFR/IRC — before casePatterns (#428)
     ...casePatterns, // Case citations (reporter-specific)
     ...constitutionalPatterns, // Constitutional citations (more specific than statutes)
-    ...statutePatterns, // Statutes (code-specific)
+    ...otherStatutePatterns, // State statutes (code-specific)
     ...journalPatterns, // Least specific (broad pattern)
   ]
   const tokens = tokenize(cleaned, allPatterns)

--- a/src/extract/filterFalsePositives.ts
+++ b/src/extract/filterFalsePositives.ts
@@ -62,6 +62,19 @@ const BLOCKED_REPORTERS: ReadonlySet<string> = new Set([
   "c.m.l.r.",
   // Historical English
   "edw.",
+  // Federal statute/regulation abbreviations — the broad state-reporter
+  // regex matches `42 USC 1983` and `42 CFR 447` (volume + token + page),
+  // mis-typing federal statutory citations as `case`. The volume-band
+  // check in `isImplausibleReporter` only runs for volumes 1–20, so high-
+  // volume federal-code citations slip through. Adding them here ensures
+  // they're filtered regardless of volume — the USC/CFR statute patterns
+  // will then capture them correctly. #428
+  "usc",
+  "usca",
+  "u.s.c.",
+  "u.s.c.a.",
+  "cfr",
+  "c.f.r.",
 ])
 
 /**

--- a/src/extract/statutes/extractFederal.ts
+++ b/src/extract/statutes/extractFederal.ts
@@ -13,10 +13,16 @@ import type { StatuteComponentSpans } from "@/types/componentSpans"
 import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
 import { parseBody } from "./parseBody"
 
-/** Regex to parse federal token: title + code + § + body */
-const FEDERAL_SECTION_RE = /^(\d+)\s+(\S+(?:\.\S+)*)\s*§§?\s*(.+)$/d
+/** Regex to parse federal token: title + code + (optional §/Section) + body.
+ *  Code matches the canonical Bluebook forms (`U.S.C.`, `C.F.R.`), West
+ *  annotated (`USCA`), no-period (`USC`, `CFR`), and the spelled-out
+ *  `United States Code` / `Code of Federal Regulations`. Connector is
+ *  optional — bare `N USC NNNN` and `N CFR NNNN` forms omit it. #428 */
+const FEDERAL_SECTION_RE =
+  /^(\d+)\s+(U\.?S\.?C\.?A?\.?|USCA?|United\s+States\s+Code|C\.?F\.?R\.?|Code\s+of\s+Federal\s+Regulations)\s*(?:§§?|[Ss]ections?|[Ss]ec\.?|Part|pt\.)?\s*(.+)$/d
 /** Regex to parse federal token: title + code + Part + body */
-const FEDERAL_PART_RE = /^(\d+)\s+(\S+(?:\.\S+)*)\s+(?:Part|pt\.)\s+(.+)$/d
+const FEDERAL_PART_RE =
+  /^(\d+)\s+(U\.?S\.?C\.?A?\.?|USCA?|United\s+States\s+Code|C\.?F\.?R\.?|Code\s+of\s+Federal\s+Regulations)\s+(?:Part|pt\.)\s+(.+)$/d
 
 /**
  * Extract a federal statute citation (USC or CFR) from a tokenized match.
@@ -36,8 +42,18 @@ export function extractFederal(
 
   if (bodyMatch) {
     title = Number.parseInt(bodyMatch[1], 10)
-    code = bodyMatch[2]
+    const rawCode = bodyMatch[2]
     rawBody = bodyMatch[3]
+    // Canonicalize code to Bluebook form. Variants `USC`, `USCA`, `United
+    // States Code` all normalize to `U.S.C.`; `CFR` / `C.F.R.` / `Code of
+    // Federal Regulations` normalize to `C.F.R.` Strip dots/spaces before
+    // comparing so `C.F.R.` matches `CFR`. #428
+    const stripped = rawCode.toUpperCase().replace(/[.\s]/g, "")
+    if (stripped.includes("CFR") || stripped.includes("FEDERALREGULATIONS")) {
+      code = "C.F.R."
+    } else {
+      code = "U.S.C."
+    }
   } else {
     // Fallback for edge cases
     code = token.patternId === "cfr" ? "C.F.R." : "U.S.C."

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -17,19 +17,30 @@ import type { Pattern } from "./casePatterns"
 
 export const statutePatterns: Pattern[] = [
   {
+    // U.S. Code — Bluebook canonical `42 U.S.C. § 1983` plus court-published
+    // variants: `42 USC 1983` (no periods, no §), `11 USCA § 544(a)(3)` (West
+    // annotated), `49 U.S.C. Section 1513` (spelled-out "Section"), `42
+    // United States Code section 1983` (fully spelled-out code name). #428
+    //
+    // The connector (`§§?` / `[Ss]ections?` / `[Ss]ec\.?`) is OPTIONAL —
+    // bare `N USC NNNN` form omits any connector. The leading `\b(\d+)`
+    // title is the disambiguator from prose.
     id: "usc",
     regex:
-      /\b(\d+)\s+(?:U\.S\.C\.?|USC)\s*§§?\s*(\d+[A-Za-z0-9-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(\d+)\s+(?:U\.?S\.?C\.?A?\.?|USCA?|United\s+States\s+Code)\s*(?:§§?|[Ss]ections?|[Ss]ec\.?)?\s*(\d+[A-Za-z0-9-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
     description:
-      'U.S. Code citations with optional subsections and et seq. (e.g., "42 U.S.C. § 1983(a)(1) et seq.")',
+      'U.S. Code citations (U.S.C., USC, USCA, "United States Code") with optional §/Section connector — #428',
     type: "statute",
   },
   {
+    // Code of Federal Regulations — Bluebook canonical `42 C.F.R. § 122.26`
+    // plus no-§ variants `42 CFR 447`, `45 CFR 303`, `29 CFR 1926`. The
+    // connector (`§§?` / `Part` / `Section`) is OPTIONAL. #428
     id: "cfr",
     regex:
-      /\b(\d+)\s+C\.?F\.?R\.?\s*(?:(?:Part|pt\.)\s+|§§?\s*)(\d+(?:\.\d+)?[A-Za-z0-9-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(\d+)\s+C\.?F\.?R\.?\s*(?:(?:Part|pt\.)\s+|§§?\s*|[Ss]ections?\s+|[Ss]ec\.?\s+)?(\d+(?:\.\d+)?[A-Za-z0-9-]*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
     description:
-      'Code of Federal Regulations with Part or §, subsections, et seq. (e.g., "12 C.F.R. Part 226", "40 C.F.R. § 122.26(b)(14)")',
+      'Code of Federal Regulations with optional Part/§/Section connector — #428',
     type: "statute",
   },
   {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -3123,4 +3123,90 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("Federal USC / CFR variants (#428)", () => {
+    it("`42 USC 1983` (no periods, no §) → canonical U.S.C.", () => {
+      const cites = extractCitations("under 42 USC 1983.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("U.S.C.")
+        expect(cites[0].title).toBe(42)
+        expect(cites[0].section).toBe("1983")
+      }
+    })
+
+    it("`23 USC 409` (no periods, no §) → U.S.C.", () => {
+      const cites = extractCitations("violates 23 USC 409.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("U.S.C.")
+        expect(cites[0].title).toBe(23)
+      }
+    })
+
+    it("`42 CFR 447` (no §) → C.F.R.", () => {
+      const cites = extractCitations("see 42 CFR 447.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("C.F.R.")
+        expect(cites[0].title).toBe(42)
+        expect(cites[0].section).toBe("447")
+      }
+    })
+
+    it("`11 USCA § 544(a)(3)` (West annotated) → U.S.C.", () => {
+      const cites = extractCitations("11 USCA § 544(a)(3).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("U.S.C.")
+        expect(cites[0].title).toBe(11)
+        expect(cites[0].section).toBe("544")
+        expect(cites[0].subsection).toBe("(a)(3)")
+      }
+    })
+
+    it("`49 U.S.C. Section 1513` (word Section) → U.S.C.", () => {
+      const cites = extractCitations("49 U.S.C. Section 1513.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("U.S.C.")
+        expect(cites[0].title).toBe(49)
+        expect(cites[0].section).toBe("1513")
+      }
+    })
+
+    it("`42 United States Code section 1983` (spelled-out) → U.S.C.", () => {
+      const cites = extractCitations("42 United States Code section 1983.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("U.S.C.")
+        expect(cites[0].title).toBe(42)
+        expect(cites[0].section).toBe("1983")
+      }
+    })
+
+    it("regression: canonical `42 U.S.C. § 1983` continues to work", () => {
+      const cites = extractCitations("42 U.S.C. § 1983.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("U.S.C.")
+        expect(cites[0].title).toBe(42)
+        expect(cites[0].section).toBe("1983")
+      }
+    })
+  })
 })

--- a/tests/extract/statutes/extractFederal.test.ts
+++ b/tests/extract/statutes/extractFederal.test.ts
@@ -24,10 +24,11 @@ describe("extractFederal", () => {
       expect(c.confidence).toBeGreaterThanOrEqual(0.95)
     })
 
-    it("should extract USC without periods", () => {
+    it("should extract USC without periods (canonicalized to U.S.C.)", () => {
       const c = extractFederal(makeToken("15 USC § 78j", "usc"), map)
       expect(c.title).toBe(15)
-      expect(c.code).toBe("USC")
+      // No-period form normalizes to Bluebook canonical (#428)
+      expect(c.code).toBe("U.S.C.")
       expect(c.section).toBe("78j")
       expect(c.jurisdiction).toBe("US")
     })
@@ -106,10 +107,11 @@ describe("extractFederal", () => {
       expect(c.subsection).toBe("(b)(14)")
     })
 
-    it("should handle CFR without periods", () => {
+    it("should handle CFR without periods (canonicalized to C.F.R.)", () => {
       const c = extractFederal(makeToken("40 CFR § 122", "cfr"), map)
       expect(c.title).toBe(40)
-      expect(c.code).toBe("CFR")
+      // No-period form normalizes to Bluebook canonical (#428)
+      expect(c.code).toBe("C.F.R.")
       expect(c.section).toBe("122")
     })
   })

--- a/tests/fixtures/statute-corpus.json
+++ b/tests/fixtures/statute-corpus.json
@@ -8,7 +8,7 @@
   {
     "text": "15 USC § 78j",
     "expected": [
-      { "type": "statute", "title": 15, "code": "USC", "section": "78j", "jurisdiction": "US" }
+      { "type": "statute", "title": 15, "code": "U.S.C.", "section": "78j", "jurisdiction": "US" }
     ]
   },
   {


### PR DESCRIPTION
## Summary

Closes #428. Federal-statute variants used in court-published opinions were mis-typed as \`case\` or not extracted. 29 mis-typed + 8 unextracted across 11 states.

| Input | Before | After |
|---|---|---|
| \`42 USC 1983\` (no §) | type=case | code=U.S.C., title=42, section=1983 |
| \`42 CFR 447\` | type=case | code=C.F.R. |
| \`11 USCA § 544(a)(3)\` | not extracted | code=U.S.C., title=11, section=544, sub=(a)(3) |
| \`49 U.S.C. Section 1513\` | type=case | code=U.S.C., title=49 |
| \`42 United States Code section 1983\` | type=case | code=U.S.C., title=42 |
| \`42 U.S.C. § 1983\` | unchanged | unchanged |

### Fixes

1. USC/CFR patterns accept dotless / USCA / spelled-out / \`Section\` connector
2. USC/CFR/IRC patterns moved BEFORE \`casePatterns\` so broad state-reporter regex is subsumed
3. \`extractFederal\` regex matches expanded alternation; code canonicalized to Bluebook
4. USC/CFR/USCA added to \`BLOCKED_REPORTERS\` for defense-in-depth

### Behavior note

\`code\` field is now always Bluebook canonical (\`U.S.C.\`, \`C.F.R.\`). Previously no-period variants emitted raw surface (\`USC\`, \`CFR\`). Two extractFederal tests and one corpus fixture updated.

### Deferred

- \`Title 18, USC Section 659\` title-prefix prose
- Multi-title shortcut (\`21 U.S.C. and 42\`)

## Test plan

- [x] 7 new tests under \`Federal USC / CFR variants (#428)\`
- [x] Full 2747-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)