### PR TITLE
fix: explanatory parens not routed to court field (#431)

### DIFF
--- a/.changeset/issue-431-explanatory-paren-not-court.md
+++ b/.changeset/issue-431-explanatory-paren-not-court.md
@@ -1,0 +1,51 @@
+---
+"eyecite-ts": patch
+---
+
+fix: explanatory parentheticals `(holding that...)` no longer routed to `court` field (#431)
+
+When a citation had a trailing **explanatory parenthetical** —
+`(holding that...)`, `(emphasis added)`, `(citations omitted)`,
+`(internal citations omitted)`, etc. — eyecite-ts mis-routed the
+content to the `court` field, leaving the case citation looking
+like it came from a non-existent court. 171 occurrences across
+15 states.
+
+### Fixes
+
+Two coordinated changes in `src/extract/extractCase.ts`:
+
+1. **`stripDateFromCourt` rejects explanatory text**: after the
+   date-stripping pass, the function now checks if the residual
+   text is actually a court abbreviation. Court abbreviations
+   (Bluebook T7) virtually always contain a period (`D.C. Cir.`,
+   `9th Cir.`, `S.D.N.Y.`). Text with no period and starting
+   with a known explanatory-signal word (`holding`, `finding`,
+   `quoting`, `emphasis`, `internal`, `citations`, `omitted`,
+   etc.), or text containing 3+ lowercase prose words, is now
+   rejected as a court candidate.
+
+2. **Explanatory first-paren falls through to classification**:
+   the parenthetical-chaining logic in `extractCase` used to
+   always skip the first paren on the assumption that it
+   carried metadata (year/court). With the fix above, an
+   explanatory first paren produces no metadata, so it now
+   falls through to be classified as a `Parenthetical` and
+   added to the `parentheticals` array.
+
+### Behavior changes
+
+- `336 Mont. 225 (holding that we review de novo)` →
+  `court=undefined`, `parentheticals=[{text: "holding that...",
+  type: "holding"}]` (was: `court="holding that we review..."`)
+- `368 Mont. 189 (emphasis in original)` → `court=undefined`
+- `243 P.3d 415 (internal citations omitted)` →
+  `court=undefined`
+- `100 U.S. 200 (D.C. Cir. 1980)` → unchanged
+- `100 U.S. 200 (1980)` → unchanged
+
+### Tests
+
+5 new tests under `explanatory parentheticals not routed to
+court field (#431)` in `tests/extract/extractCase.test.ts`.
+Full 2758-test suite passes; no regressions.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -526,7 +526,33 @@ function stripDateFromCourt(content: string): string | undefined {
   court = court.replace(new RegExp(`\\s*${MONTH_PATTERN.source}\\s*$`, "i"), "").trim()
   // Strip any trailing commas left over
   court = court.replace(/,\s*$/, "").trim()
-  return court && /[A-Za-z]/.test(court) ? court : undefined
+  if (!court || !/[A-Za-z]/.test(court)) return undefined
+
+  // Reject explanatory parentheticals — `(holding that...)`, `(emphasis
+  // added)`, `(citations omitted)`, etc. These are NOT court abbreviations
+  // even after date-stripping. Bluebook court abbreviations (T7) virtually
+  // always contain a period (`D.C. Cir.`, `9th Cir.`, `S.D.N.Y.`,
+  // `Cal.`). Content with no period and starting with a known
+  // explanatory-signal word or running multiple words of lowercase prose
+  // is an explanatory parenthetical that should NOT be routed to `court`.
+  // #431
+  if (!court.includes(".")) {
+    const firstWord = court.match(/^[a-z]+/i)?.[0].toLowerCase()
+    if (firstWord && (SIGNAL_WORDS.has(firstWord) ||
+      firstWord === "emphasis" || firstWord === "internal" ||
+      firstWord === "citations" || firstWord === "footnote" ||
+      firstWord === "alteration" || firstWord === "alterations" ||
+      firstWord === "omitted" || firstWord === "see")) {
+      return undefined
+    }
+    // Multi-word lowercase prose (>= 3 words) without any period is
+    // explanatory text, not a court abbreviation.
+    const words = court.split(/\s+/)
+    if (words.length >= 3 && words.every((w) => /^[a-z]/.test(w))) {
+      return undefined
+    }
+  }
+  return court
 }
 
 // ============================================================================
@@ -2360,8 +2386,19 @@ export function extractCase(
     // the shared trailing paren that sits past a parallel-cite chain.
     collected = collectParentheticals(cleanedText, postChainStart)
     allParens = collected.parens
-    // Skip first paren (already parsed above as court/year)
-    const remaining = parentheticalContent ? allParens.slice(1) : allParens
+    // Skip first paren only if it yielded actual metadata (year/court/
+    // disposition/justices/scope). When the first paren is an explanatory
+    // parenthetical (`holding that...`, `emphasis added`), no metadata is
+    // extracted and the paren should fall through to be classified as
+    // explanatory and added to `parentheticals`. #431
+    const firstParenIsMetadata =
+      parentheticalContent &&
+      (year !== undefined ||
+        court !== undefined ||
+        disposition !== undefined ||
+        justices !== undefined ||
+        scope !== undefined)
+    const remaining = firstParenIsMetadata ? allParens.slice(1) : allParens
     for (const raw of remaining) {
       const classified = classifyParenthetical(raw.text)
       if (classified.kind === "metadata") {

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -6040,3 +6040,59 @@ describe("signal field not falsely attached from distant prose (#430)", () => {
   })
 })
 
+describe("explanatory parentheticals not routed to court field (#431)", () => {
+  it("`(holding that...)` not routed to court; populated as parenthetical", () => {
+    const cs = extractCitations(
+      "336 Mont. 225 (holding that we review de novo).",
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "case") {
+      expect(cs[0].court).toBeUndefined()
+      expect(cs[0].parentheticals).toBeDefined()
+      expect(cs[0].parentheticals?.[0].text).toContain("holding that")
+      expect(cs[0].parentheticals?.[0].type).toBe("holding")
+    }
+  })
+
+  it("`(emphasis in original)` not routed to court", () => {
+    const cs = extractCitations("368 Mont. 189 (emphasis in original).").filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "case") {
+      expect(cs[0].court).toBeUndefined()
+    }
+  })
+
+  it("`(internal citations omitted)` not routed to court", () => {
+    const cs = extractCitations("243 P.3d 415 (internal citations omitted).").filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "case") {
+      expect(cs[0].court).toBeUndefined()
+    }
+  })
+
+  it("regression: `(D.C. Cir. 1980)` still routes court correctly", () => {
+    const cs = extractCitations("100 U.S. 200 (D.C. Cir. 1980).").filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "case") {
+      expect(cs[0].court).toBe("D.C. Cir.")
+      expect(cs[0].year).toBe(1980)
+    }
+  })
+
+  it("regression: `(1980)` year-only paren still works", () => {
+    const cs = extractCitations("100 U.S. 200 (1980).").filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "case") {
+      expect(cs[0].year).toBe(1980)
+    }
+  })
+})
+


### PR DESCRIPTION
## Summary

Closes #431. **171 occurrences across 15 states**. Explanatory parens like \`(holding that...)\`, \`(emphasis added)\`, \`(internal citations omitted)\` were being routed to the \`court\` field.

- \`stripDateFromCourt\` rejects content with no period that starts with a known explanatory-signal word OR contains 3+ lowercase prose words.
- Conditional skip in chained-paren logic: first paren falls through to classification when it yields no metadata.

### Behavior

| Input | Before | After |
|---|---|---|
| \`336 Mont. 225 (holding that...)\` | court="holding that..." | court=undefined, parentheticals=[{text, type:"holding"}] |
| \`368 Mont. 189 (emphasis in original)\` | court="emphasis in original" | court=undefined |
| \`243 P.3d 415 (internal citations omitted)\` | court="internal citations..." | court=undefined |
| \`100 U.S. 200 (D.C. Cir. 1980)\` | unchanged | unchanged |
| \`100 U.S. 200 (1980)\` | unchanged | unchanged |

## Test plan

- [x] 5 new tests under \`explanatory parentheticals not routed to court field (#431)\`
- [x] Full 2758-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)