### PR TITLE
fix: caseName no longer absorbs trailing year/court-year/parallel-cite (#436)

### DIFF
--- a/.changeset/issue-436-casename-trailing-tokens.md
+++ b/.changeset/issue-436-casename-trailing-tokens.md
@@ -1,0 +1,41 @@
+---
+"eyecite-ts": patch
+---
+
+fix: caseName field no longer absorbs trailing year, court+year, and parallel-citation tokens (#436)
+
+The `caseName` field was absorbing content that doesn't belong to
+the name itself: **451 confirmed boundary violations** across all
+39 sampled states (379 trailing year `(YYYY)`, 9 trailing
+court+year `(Court YYYY)`, 63 trailing parallel-cite start
+`, NNN <reporter> NN`).
+
+### Fix
+
+After `extractCaseName` returns, strip trailing tokens from
+`caseName` in `src/extract/extractCase.ts`:
+
+- Trailing `(YYYY)` or `(Court YYYY)` paren → strip whole paren
+- Trailing `, NNN <Reporter> NN` parallel-cite start → strip
+- Trailing `, NNNN <STATE> NN` neutral-cite shape → strip
+
+The CSM year-first form's year continues to be captured into
+the `year` field by `extractCaseName`; only the surface text of
+the case name is cleaned.
+
+### Behavior changes
+
+- `Holton v. F. H. Stoltze Land & Lumber Co. (1981), 195 Mont. 1`
+  → `caseName="Holton v. F. H. Stoltze Land & Lumber Co."` (was
+  `"Holton v. F. H. Stoltze Land & Lumber Co. (1981)"`)
+- `United States v. Villano (10th Cir. 1987), 829 F.2d 1158`
+  → `caseName="United States v. Villano"` (was `"... v. Villano
+  (10th Cir. 1987)"`)
+- `State v. Lane, 1998 MT 76, 962 P.2d 1190` → `caseName="State
+  v. Lane"` on the P.2d cite (was `"State v. Lane, 1998 MT 76"`)
+
+### Tests
+
+3 new tests under `caseName trailing-token absorption (#436)`
+in `tests/extract/extractCase.test.ts`. Full 2766-test suite
+passes; no regressions.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -2588,6 +2588,24 @@ export function extractCase(
     if (caseNameResult) {
       caseName = caseNameResult.caseName
 
+      // Strip trailing year / court+year / parallel-cite tokens from
+      // caseName — the backward scan sometimes absorbs the CSM year paren
+      // or the start of a parallel citation. #436
+      //
+      // - Trailing `(YYYY)` or `(Court YYYY)` → strip whole paren.
+      // - Trailing `, NNNN <reporter token>` → strip the parallel-cite
+      //   start, e.g., `State v. Lane, 1998 MT 76` → `State v. Lane`.
+      if (caseName) {
+        // Trailing parenthetical (year or court+year)
+        caseName = caseName.replace(/\s*\((?:[^()]*\s)?\d{4}\)\s*$/, "").trim()
+        // Trailing comma + parallel-cite start (volume + reporter + page-like)
+        caseName = caseName
+          .replace(/,\s+\d+\s+[A-Z][A-Za-z.&'\d\s]*\d+\s*$/, "")
+          .trim()
+        // Trailing comma + neutral-cite shape (YYYY <state> NN)
+        caseName = caseName.replace(/,\s+\d{4}\s+[A-Z]+\s+\d+\s*$/, "").trim()
+      }
+
       // CSM year-first form puts the year *before* volume-reporter-page
       // (`In re K.F. (2009) 173 Cal.App.4th 655` — #19). Pick it up here when
       // there's no trailing court parenthetical to recover it from. Don't

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -6096,3 +6096,39 @@ describe("explanatory parentheticals not routed to court field (#431)", () => {
   })
 })
 
+describe("caseName trailing-token absorption (#436)", () => {
+  it("trailing `(YYYY)` paren stripped from caseName", () => {
+    const cs = extractCitations(
+      "In Holton v. F. H. Stoltze Land & Lumber Co. (1981), 195 Mont. 1.",
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "case") {
+      expect(cs[0].caseName).toBe("Holton v. F. H. Stoltze Land & Lumber Co.")
+    }
+  })
+
+  it("trailing `(Court YYYY)` paren stripped from caseName", () => {
+    const cs = extractCitations(
+      "See United States v. Villano (10th Cir. 1987), 829 F.2d 1158.",
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "case") {
+      expect(cs[0].caseName).toBe("United States v. Villano")
+    }
+  })
+
+  it("trailing `, NNNN <reporter> NN` parallel-cite start stripped", () => {
+    const cs = extractCitations(
+      "State v. Lane, 1998 MT 76, 962 P.2d 1190 (1998).",
+    ).filter((c) => c.type === "case")
+    // The case-citation (962 P.2d 1190) should have clean caseName
+    const caseCite = cs.find(
+      (c) => (c as { reporter?: string }).reporter === "P.2d",
+    )
+    expect(caseCite).toBeDefined()
+    if (caseCite?.type === "case") {
+      expect(caseCite.caseName).toBe("State v. Lane")
+    }
+  })
+})
+


### PR DESCRIPTION
## Summary

Closes #436. **451 confirmed boundary violations across all 39 sampled states**. \`caseName\` was absorbing content that doesn't belong: 379 trailing year \`(YYYY)\`, 9 court+year \`(Court YYYY)\`, 63 parallel-cite \`, NNN <reporter> NN\`.

Post-process \`caseName\` after \`extractCaseName\` returns — strip trailing paren and parallel-cite-start shapes via regex. CSM year-first year capture into the \`year\` field continues to work.

### Behavior

| Input | Before | After |
|---|---|---|
| \`Holton v. ... Co. (1981), 195 Mont. 1\` | caseName=\"... Co. (1981)\" | caseName=\"... Co.\" |
| \`U.S. v. Villano (10th Cir. 1987), 829 F.2d 1158\` | caseName=\"... Villano (10th Cir. 1987)\" | caseName=\"... Villano\" |
| \`State v. Lane, 1998 MT 76, 962 P.2d 1190\` (P.2d cite) | caseName=\"State v. Lane, 1998 MT 76\" | caseName=\"State v. Lane\" |

## Test plan

- [x] 3 new tests under \`caseName trailing-token absorption (#436)\`
- [x] Full 2766-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)