### PR TITLE
feat: caseName backward search runs on neutral citations (#441)

### DIFF
--- a/.changeset/issue-441-neutral-casename.md
+++ b/.changeset/issue-441-neutral-casename.md
@@ -1,0 +1,44 @@
+---
+"eyecite-ts": patch
+---
+
+feat: case name backward search now runs on neutral citations (`YYYY ST NNN`) (#441)
+
+Neutral (vendor-neutral / public-domain) citations of the form
+`YYYY ST NNN` (`2015 MT 255`, `2004 MT 108`) and database forms
+(`1994 WL 49932`) were extracting successfully but **never
+captured a case name** — 80 occurrences in the corpus where
+canonical `<caseName>, YYYY ST NNN` form should have produced
+the name.
+
+### Fix
+
+`extractNeutral` now runs the same `extractCaseName` backward
+search as full-case extraction:
+
+- Runs when `cleanedText` is provided (matching the case
+  extractor's signature)
+- Applies the same trailing-token cleanup as #436 (strip
+  trailing year paren, parallel-cite start, neutral-cite
+  shape)
+- Strips leading prose/signal prefixes (`In`, `See`, `See
+  also`, `Cf.`, `But see`, `Accord`, `Contra`, `Compare`,
+  `E.g.`)
+
+`NeutralCitation` type extended with optional `caseName?:
+string` field.
+
+### Behavior changes
+
+- `In Christian v. Atl. Richfield Co., 2015 MT 255` →
+  `caseName="Christian v. Atl. Richfield Co."` (was `null`)
+- `See Farmers Union Mut. Ins. Co. v. Staples, 2004 MT 108` →
+  `caseName="Farmers Union Mut. Ins. Co. v. Staples"`
+- `Blair v. Mid-Continent Cas. Co., 2007 MT 208` →
+  `caseName="Blair v. Mid-Continent Cas. Co."`
+
+### Tests
+
+3 new tests under `neutral-citation caseName backward search
+(#441)` in `tests/extract/extractCase.test.ts`. Full 2766-test
+suite passes; no regressions.

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -12,7 +12,7 @@ import type { NeutralCitation } from "@/types/citation"
 import type { NeutralComponentSpans } from "@/types/componentSpans"
 import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
 import type { StructuredDate } from "./dates"
-import { parseParenthetical } from "./extractCase"
+import { extractCaseName, parseParenthetical } from "./extractCase"
 import { parsePincite, type PinciteInfo } from "./pincite"
 
 /** Matches a trailing pincite on a neutral citation. Accepts both
@@ -211,6 +211,37 @@ export function extractNeutral(
   // Confidence: 1.0 (neutral format is unambiguous)
   const confidence = 1.0
 
+  // Case-name backward search — the canonical neutral form is
+  // `<caseName>, YYYY ST NNN` (`Christian v. Atl. Richfield Co., 2015 MT
+  // 255`). Without this, case-name association on neutral cites is lost
+  // (#441).
+  let caseName: string | undefined
+  if (cleanedText) {
+    const cnResult = extractCaseName(cleanedText, span.cleanStart)
+    if (cnResult) {
+      caseName = cnResult.caseName
+      if (caseName) {
+        // Strip leading signal/prose words (`See`, `See also`, `In`,
+        // `Cf.`, `But see`) — the neutral extractor doesn't run the
+        // case extractor's signal-extraction pre-pass, so these stay
+        // in caseName otherwise.
+        caseName = caseName
+          .replace(
+            /^(?:But\s+see(?:\s+also)?,?\s+|See\s+also,?\s+|See\s+generally\s+|See,\s+e\.g\.,?\s+|See\s+|Cf\.\s+|In\s+|Accord\s+|Contra\s+|Compare\s+|E\.g\.,?\s+)/,
+            "",
+          )
+          .trim()
+        // Apply the same trailing-token cleanup as full-case extraction so
+        // parallel-cite starts and year parens aren't absorbed (#436).
+        caseName = caseName.replace(/\s*\((?:[^()]*\s)?\d{4}\)\s*$/, "").trim()
+        caseName = caseName
+          .replace(/,\s+\d+\s+[A-Z][A-Za-z.&'\d\s]*\d+\s*$/, "")
+          .trim()
+        caseName = caseName.replace(/,\s+\d{4}\s+[A-Z]+\s+\d+\s*$/, "").trim()
+      }
+    }
+  }
+
   return {
     type: "neutral",
     text,
@@ -232,6 +263,7 @@ export function extractNeutral(
     pincite,
     pinciteInfo,
     ...(date ? { date } : {}),
+    ...(caseName ? { caseName } : {}),
     spans,
   }
 }

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -576,6 +576,10 @@ export interface NeutralCitation extends CitationBase {
    */
   date?: import("../extract/dates").StructuredDate
 
+  /** Case name captured from backward search (#441).
+   *  Canonical form: `<caseName>, YYYY ST NNN`. */
+  caseName?: string
+
   /** Precise text positions for each parsed component of this citation. */
   spans?: NeutralComponentSpans
 }

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -6132,3 +6132,41 @@ describe("caseName trailing-token absorption (#436)", () => {
   })
 })
 
+describe("neutral-citation caseName backward search (#441)", () => {
+  it("`Christian v. Atl. Richfield Co., 2015 MT 255` captures caseName on neutral cite", () => {
+    const cs = extractCitations(
+      "In Christian v. Atl. Richfield Co., 2015 MT 255, the court held",
+    ).filter((c) => c.type === "neutral")
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "neutral") {
+      expect((cs[0] as { caseName?: string }).caseName).toBe(
+        "Christian v. Atl. Richfield Co.",
+      )
+    }
+  })
+
+  it("`Farmers Union Mut. Ins. Co. v. Staples, 2004 MT 108` (leading See stripped)", () => {
+    const cs = extractCitations(
+      "See Farmers Union Mut. Ins. Co. v. Staples, 2004 MT 108.",
+    ).filter((c) => c.type === "neutral")
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "neutral") {
+      expect((cs[0] as { caseName?: string }).caseName).toBe(
+        "Farmers Union Mut. Ins. Co. v. Staples",
+      )
+    }
+  })
+
+  it("`Blair v. Mid-Continent Cas. Co., 2007 MT 208` (no leading signal)", () => {
+    const cs = extractCitations("Blair v. Mid-Continent Cas. Co., 2007 MT 208.").filter(
+      (c) => c.type === "neutral",
+    )
+    expect(cs).toHaveLength(1)
+    if (cs[0]?.type === "neutral") {
+      expect((cs[0] as { caseName?: string }).caseName).toBe(
+        "Blair v. Mid-Continent Cas. Co.",
+      )
+    }
+  })
+})
+


### PR DESCRIPTION
## Summary

Closes #441. Neutral citations (\`YYYY ST NNN\` form like \`2015 MT 255\`, \`2004 MT 108\`, \`1994 WL 49932\`) were extracting successfully but **never captured a case name** — 80 occurrences in the corpus.

\`extractNeutral\` now runs the same \`extractCaseName\` backward search as full-case extraction, with #436 trailing-token cleanup applied and leading prose/signal prefixes stripped.

\`NeutralCitation\` type extended with \`caseName?: string\`.

### Behavior

| Input | Before | After |
|---|---|---|
| \`In Christian v. Atl. Richfield Co., 2015 MT 255\` | caseName=null | caseName=\"Christian v. Atl. Richfield Co.\" |
| \`See Farmers Union Mut. Ins. Co. v. Staples, 2004 MT 108\` | null | \"Farmers Union Mut. Ins. Co. v. Staples\" |
| \`Blair v. Mid-Continent Cas. Co., 2007 MT 208\` | null | \"Blair v. Mid-Continent Cas. Co.\" |

## Test plan

- [x] 3 new tests under \`neutral-citation caseName backward search (#441)\`
- [x] Full 2766-test suite passes locally
- [x] Typecheck clean
- [x] Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)