### PR TITLE
feat: state admin codes NMAC/OAR/COMAR/IDAPA/ARM (#438)

### DIFF
--- a/.changeset/issue-438-admin-codes.md
+++ b/.changeset/issue-438-admin-codes.md
@@ -1,0 +1,34 @@
+---
+"eyecite-ts": patch
+---
+
+feat: state admin codes NMAC / OAR / COMAR / IDAPA / ARM (#438)
+
+Five state administrative-code citation families were unrecognized
+— **105 misses** across the 50-state baseline. Extends #320
+(state admin codes) for these specific code abbreviations.
+
+| Code | State | Volume | Form |
+|---|---|---|---|
+| NMAC | New Mexico | 55 | postfix: `19.25.13.27 NMAC` |
+| OAR | Oregon | 24 | prefix: `OAR 734-050-0050` |
+| COMAR | Maryland | 14 | prefix: `COMAR 20.32.01.04F` |
+| IDAPA | Idaho | 5 | prefix: `IDAPA 58.01.03.004.03` |
+| ARM | Montana | 3 | postfix: `26.3.142(6), ARM` |
+
+### Fix
+
+New `state-admin-code` tokenizer pattern in
+`src/patterns/statutePatterns.ts` + `extractStateAdminCode` in
+`src/extract/statutes/extractStateAdminCode.ts`. Each form is
+anchored on the distinctive abbreviation so the pattern only
+fires for real admin-code references.
+
+Emits `code: <abbreviation>`, `jurisdiction: <state>`,
+`section: <hierarchical-id>`.
+
+### Tests
+
+5 new tests under `state admin codes (#438)` in
+`tests/extract/extractStatute.test.ts`. Full 2770-test suite
+passes; no regressions.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -44,6 +44,7 @@ import { extractRrs1943 } from "./statutes/extractRrs1943"
 import { extractRigl1956 } from "./statutes/extractRigl1956"
 import { extractRsaChapter } from "./statutes/extractRsaChapter"
 import { extractRcwChapterPostfix } from "./statutes/extractRcwChapterPostfix"
+import { extractStateAdminCode } from "./statutes/extractStateAdminCode"
 import { extractTcaPostfix } from "./statutes/extractTcaPostfix"
 import { extractVaBareCode } from "./statutes/extractVaBareCode"
 import { extractWiStatsPostfix } from "./statutes/extractWiStatsPostfix"
@@ -182,6 +183,8 @@ export function extractStatute(
       return extractRrs1943(token, transformationMap)
     case "rcw-chapter-postfix":
       return extractRcwChapterPostfix(token, transformationMap)
+    case "state-admin-code":
+      return extractStateAdminCode(token, transformationMap)
     case "rigl-1956":
       return extractRigl1956(token, transformationMap)
     case "rsa-chapter":

--- a/src/extract/statutes/extractStateAdminCode.ts
+++ b/src/extract/statutes/extractStateAdminCode.ts
@@ -1,0 +1,66 @@
+/**
+ * State Administrative Codes — `NMAC`, `OAR`, `COMAR`, `IDAPA`, `ARM`
+ *
+ * Five state administrative-code families, each with its own
+ * hierarchical-section format. NMAC and ARM are postfix; OAR, COMAR,
+ * IDAPA are prefix. #438
+ *
+ * @module extract/statutes/extractStateAdminCode
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
+
+interface AdminCodeMatch {
+  code: string
+  section: string
+  jurisdiction: string
+}
+
+function parseAdminCode(text: string): AdminCodeMatch | undefined {
+  // NMAC postfix: `19.25.13.27 NMAC`
+  let m = /^(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)\s+NMAC$/.exec(text)
+  if (m) return { code: "NMAC", section: m[1], jurisdiction: "NM" }
+  // NMAC prefix (rare but valid)
+  m = /^NMAC\s+(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)$/.exec(text)
+  if (m) return { code: "NMAC", section: m[1], jurisdiction: "NM" }
+  // OAR prefix: `OAR 734-050-0050`
+  m = /^OAR\s+(\d+-\d+-\d+)$/.exec(text)
+  if (m) return { code: "OAR", section: m[1], jurisdiction: "OR" }
+  // COMAR prefix: `COMAR 20.32.01.04F`
+  m = /^COMAR\s+(\d+\.\d+\.\d+\.\d+[A-Z]?)$/.exec(text)
+  if (m) return { code: "COMAR", section: m[1], jurisdiction: "MD" }
+  // IDAPA prefix: `IDAPA 58.01.03.004.03`
+  m = /^IDAPA\s+(\d+\.\d+\.\d+\.\d+\.\d+)$/.exec(text)
+  if (m) return { code: "IDAPA", section: m[1], jurisdiction: "ID" }
+  // ARM postfix: `26.3.142(6), ARM`
+  m = /^(\d+\.\d+\.\d+(?:\(\d+\))?),\s+ARM$/.exec(text)
+  if (m) return { code: "ARM", section: m[1], jurisdiction: "MT" }
+  return undefined
+}
+
+export function extractStateAdminCode(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const parsed = parseAdminCode(text)
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+  const spans: StatuteComponentSpans = {}
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence: 0.95,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: parsed?.code ?? text,
+    section: parsed?.section ?? "",
+    jurisdiction: parsed?.jurisdiction,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -329,6 +329,26 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // State administrative-code citations — five families that share the
+    // pattern `<code-abbreviation> <hierarchical-section>` (prefix) or
+    // `<hierarchical-section> <code-abbreviation>` (postfix). #438
+    //
+    // - NMAC (New Mexico, postfix): `19.25.13.27 NMAC`
+    // - OAR  (Oregon, prefix):       `OAR 734-050-0050`
+    // - COMAR (Maryland, prefix):    `COMAR 20.32.01.04F`
+    // - IDAPA (Idaho, prefix):       `IDAPA 58.01.03.004.03`
+    // - ARM  (Montana, postfix):     `26.3.142(6), ARM`
+    //
+    // Each form is anchored on the distinctive abbreviation so the
+    // pattern only fires for real admin-code references.
+    id: "state-admin-code",
+    regex:
+      /\b(?:(NMAC)\s+(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)|(?<=^|[^A-Za-z])(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)\s+(NMAC)|(OAR)\s+(\d+-\d+-\d+)|(COMAR)\s+(\d+\.\d+\.\d+\.\d+[A-Z]?)|(IDAPA)\s+(\d+\.\d+\.\d+\.\d+\.\d+)|(?<=^|[^A-Za-z])(\d+\.\d+\.\d+(?:\(\d+\))?),\s+(ARM)\b)/g,
+    description:
+      'State admin codes NMAC/OAR/COMAR/IDAPA/ARM — #438',
+    type: "statute",
+  },
+  {
     // Wisconsin Statutes postfix form: `§ 76.09, Stats.`, `sec. 805.13(3),
     // Stats.`, `§ 48.415(l)(a)3, STATS.`. Wisconsin court style places the
     // `Stats.` abbreviation AFTER the section, separated by a comma. Both

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -3209,4 +3209,63 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("state admin codes NMAC/OAR/COMAR/IDAPA/ARM (#438)", () => {
+    it("NMAC postfix: `19.25.13.27 NMAC` → jur=NM", () => {
+      const cites = extractCitations("violates 19.25.13.27 NMAC.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("NMAC")
+        expect(cites[0].jurisdiction).toBe("NM")
+        expect(cites[0].section).toBe("19.25.13.27")
+      }
+    })
+
+    it("OAR prefix: `OAR 734-050-0050` → jur=OR", () => {
+      const cites = extractCitations("under OAR 734-050-0050.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("OAR")
+        expect(cites[0].jurisdiction).toBe("OR")
+      }
+    })
+
+    it("COMAR prefix: `COMAR 20.32.01.04F` → jur=MD", () => {
+      const cites = extractCitations("see COMAR 20.32.01.04F.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("COMAR")
+        expect(cites[0].jurisdiction).toBe("MD")
+      }
+    })
+
+    it("IDAPA prefix: `IDAPA 58.01.03.004.03` → jur=ID", () => {
+      const cites = extractCitations("IDAPA 58.01.03.004.03.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("IDAPA")
+        expect(cites[0].jurisdiction).toBe("ID")
+      }
+    })
+
+    it("ARM postfix: `26.3.142(6), ARM` → jur=MT", () => {
+      const cites = extractCitations("26.3.142(6), ARM.").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].code).toBe("ARM")
+        expect(cites[0].jurisdiction).toBe("MT")
+        expect(cites[0].section).toBe("26.3.142(6)")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #438. 105 misses across 50-state baseline. 5 state admin-code families.

| Code | State | Volume | Form |
|---|---|---|---|
| NMAC | NM | 55 | postfix |
| OAR | OR | 24 | prefix |
| COMAR | MD | 14 | prefix |
| IDAPA | ID | 5 | prefix |
| ARM | MT | 3 | postfix |

## Test plan

- [x] 5 new tests
- [x] Full 2770-test suite passes
- [x] Typecheck clean
- [x] Patch changeset

🤖 Generated with [Claude Code](https://claude.com/claude-code)