### PR TITLE
fix: WV bare-section follow-ons inherit WV jurisdiction (#432)

### DIFF
--- a/.changeset/issue-432-wv-bare-section-context.md
+++ b/.changeset/issue-432-wv-bare-section-context.md
@@ -1,0 +1,35 @@
+---
+"eyecite-ts": patch
+---
+
+fix: WV bare-section follow-ons inherit WV jurisdiction (#432)
+
+Bare-section citations of the form `§ N-N-N` were always routed
+to New Mexico (`NM`), because the `nm-bare-section` pattern
+defaults to NM regardless of document context. In West Virginia
+opinions, the conventional follow-on after one fully-qualified
+`W.Va. Code §` or `Code 1931 §` reference is `§ 55-7B-7`,
+`§ 61-3-12`, `§ 8-24-1`, etc. — **33 occurrences** mis-routed
+to NM in WV-sample opinions.
+
+### Fix
+
+New `inheritBareSectionJurisdiction` post-extract pass in
+`src/extract/extractCitations.ts`. Forward single-pass over
+citations: tracks the most recent WV / NM jurisdictional context
+established by a full-form statute citation, and reassigns
+bare-section `NMSA 1978` citations to `W. Va. Code` (jurisdiction
+`WV`) when WV context is active.
+
+This is the fourth and final entry in the cross-jurisdiction
+routing cluster: #54 (MSA→MN), #58 (R.C.→OH), #422 (I.C.→IN),
+now this. Each used context-aware disambiguation rather than
+hardcoding state precedence.
+
+### Tests
+
+6 new tests under `WV bare-section context propagation (#432)`
+in `tests/extract/extractStatute.test.ts` covering: WV-context
+inheritance, multi-bare inheritance, no-context default-to-NM,
+NM-context regression, and WV→NM context switching mid-document.
+Full 2792-test suite passes; no regressions.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -453,6 +453,12 @@ export function extractCitations(
   // `28 U.S.C. § 1331 (West 2018)` → publisher="West", year=2018.
   attachStatuteYearParen(citations, cleaned)
 
+  // Step 4.7: Disambiguate bare-section statute jurisdiction by document
+  // context. NM and WV both use `§ N-N-N` shapes; when a WV full citation
+  // appears earlier in the document, follow-on bare sections inherit WV
+  // jurisdiction. (#432)
+  inheritBareSectionJurisdiction(citations)
+
   // Step 4.75: Detect string citation groups (semicolon-separated)
   detectStringCitations(citations, cleaned)
 
@@ -732,6 +738,44 @@ function attachStatuteYearParen(citations: Citation[], cleaned: string): void {
       cite.editionLabel = token.replace(/\s+/g, " ").trim()
     } else {
       cite.publisher = token
+    }
+  }
+}
+
+/**
+ * Reassign jurisdiction for bare-section statute citations (`§ N-N-N`) based
+ * on document context. The `nm-bare-section` pattern claims NM by default
+ * because the three-hyphen section shape is most common in New Mexico, but
+ * other states (notably West Virginia) share the shape. When a full-form WV
+ * statute citation appears earlier in the document, follow-on bare sections
+ * should inherit WV jurisdiction. (#432)
+ *
+ * Forward single-pass: tracks the most recent jurisdictional context from
+ * full-form statute citations (those whose matchedText does NOT start with a
+ * bare `§` / `Section ` marker). When a bare NM-tagged citation appears, it
+ * is reassigned if the active context is WV.
+ */
+function inheritBareSectionJurisdiction(citations: Citation[]): void {
+  let context: "WV" | "NM" | null = null
+
+  for (const cite of citations) {
+    if (cite.type !== "statute") continue
+
+    const isBareSection = /^(?:§|Section\s)/.test(cite.matchedText)
+
+    if (!isBareSection) {
+      if (cite.jurisdiction === "WV") context = "WV"
+      else if (cite.jurisdiction === "NM") context = "NM"
+      continue
+    }
+
+    if (
+      cite.jurisdiction === "NM" &&
+      cite.code === "NMSA 1978" &&
+      context === "WV"
+    ) {
+      cite.jurisdiction = "WV"
+      cite.code = "W. Va. Code"
     }
   }
 }

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -3268,4 +3268,68 @@ describe("extractStatute", () => {
       }
     })
   })
+
+  describe("WV bare-section context propagation (#432)", () => {
+    it("bare `§ 55-7B-7` after `W.Va. Code` context → jurisdiction=WV", () => {
+      const text =
+        "W.Va. Code § 55-7B-1 establishes the rule. § 55-7B-7 mandates that..."
+      const cites = extractCitations(text).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(2)
+      if (cites[0]?.type === "statute") expect(cites[0].jurisdiction).toBe("WV")
+      if (cites[1]?.type === "statute") {
+        expect(cites[1].jurisdiction).toBe("WV")
+        expect(cites[1].code).toBe("W. Va. Code")
+        expect(cites[1].section).toBe("55-7B-7")
+      }
+    })
+
+    it("bare `§ 49-6-5` after `Code 1931` context → jurisdiction=WV", () => {
+      const text = "Code 1931, 49-6-3, as amended. § 49-6-5 also applies."
+      const cites = extractCitations(text).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(2)
+      if (cites[1]?.type === "statute") {
+        expect(cites[1].jurisdiction).toBe("WV")
+        expect(cites[1].code).toBe("W. Va. Code")
+      }
+    })
+
+    it("multiple bare sections after one WV context all inherit WV", () => {
+      const text =
+        "Under W.Va. Code § 55-7B-1, the rule applies. See § 61-3-12 and § 8-24-1."
+      const cites = extractCitations(text).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(3)
+      for (const cite of cites) {
+        if (cite.type === "statute") expect(cite.jurisdiction).toBe("WV")
+      }
+    })
+
+    it("bare-section with NO preceding context stays NM (default)", () => {
+      const cites = extractCitations("Section 32A-2-7(A).").filter(
+        (c) => c.type === "statute",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("NM")
+        expect(cites[0].code).toBe("NMSA 1978")
+      }
+    })
+
+    it("bare-section after NM context stays NM (regression)", () => {
+      const text =
+        "NMSA 1978, § 32A-2-1 provides. Section 32A-2-7(A) further states..."
+      const cites = extractCitations(text).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(2)
+      for (const cite of cites) {
+        if (cite.type === "statute") expect(cite.jurisdiction).toBe("NM")
+      }
+    })
+
+    it("WV context then later NM context — subsequent bare follows NM", () => {
+      const text =
+        "W.Va. Code § 55-7B-1 first. NMSA 1978, § 32A-2-1 next. § 7-1-3 last."
+      const cites = extractCitations(text).filter((c) => c.type === "statute")
+      expect(cites).toHaveLength(3)
+      if (cites[2]?.type === "statute") expect(cites[2].jurisdiction).toBe("NM")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #432 — fourth and final entry in the cross-jurisdiction routing cluster.

Bare-section citations of the form `§ N-N-N` were always routed to New Mexico, because the `nm-bare-section` pattern defaults to NM regardless of document context. In West Virginia opinions, the conventional follow-on after one fully-qualified `W.Va. Code §` or `Code 1931 §` reference is `§ 55-7B-7`, `§ 61-3-12`, `§ 8-24-1`, etc. — **33 occurrences mis-routed to NM** in WV-sample opinions.

## Approach

Adds `inheritBareSectionJurisdiction` post-extract pass in `extractCitations.ts`. Forward single-pass over citations: tracks the most recent WV / NM jurisdictional context established by a full-form statute citation, and reassigns bare-section `NMSA 1978` citations to `W. Va. Code` (jurisdiction `WV`) when WV context is active.

Implementation matches the issue's recommended fix #1 (per-document statute context propagation). Scope is limited to the WV/NM pair to keep the blast radius small; the same mechanism generalizes for future state pairs.

## Cross-jurisdiction routing cluster history

| Issue | Conflict | Resolution |
|---|---|---|
| #54 | MSA → MN | tighten regex |
| #58 | R.C. → OH | tighten regex |
| #422 | I.C. → IN | tighten regex |
| **#432** | **WV bare § → NM** | **document context** |

## Test plan

- [x] 6 new tests under `WV bare-section context propagation (#432)`:
  - bare `§ 55-7B-7` after `W.Va. Code` context → jur=WV
  - bare `§ 49-6-5` after `Code 1931` context → jur=WV
  - multiple bare sections after one WV context all inherit WV
  - bare-section with NO preceding context stays NM (default preserved)
  - bare-section after NM context stays NM (regression)
  - WV context then later NM context — subsequent bare follows NM
- [x] Full 2792-test suite passes
- [x] `pnpm typecheck` clean
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)