### PR TITLE
feat: bare-party shortform back-references `Smith, at 12` (#439)

### DIFF
--- a/.changeset/issue-439-bare-party-shortform.md
+++ b/.changeset/issue-439-bare-party-shortform.md
@@ -1,0 +1,65 @@
+---
+"eyecite-ts": minor
+---
+
+feat: bare-party shortform back-references `Smith, at 12` (#439)
+
+After a full citation establishes `Smith v. Jones, 100 F.2d 50`,
+subsequent shorthand `Smith, at 12` is the standard Bluebook
+back-reference but was not captured by the regex tokenizer because
+it lacks the volume+reporter shape. **47 occurrences** across
+the 50-state baseline were unrecognized — common forms include
+`Striker, at 871`, `Pacheco, at 65`, `Hutchison, at 887-88`, and
+multi-word entities like `South Hollywood Hills Citizens Ass'n,
+at 73`.
+
+### Fix
+
+New `detectBarePartyBackReferences` post-extract pass in
+`src/extract/extractCitations.ts` (step 4.72):
+
+1. Builds a party-name index from full case citations using
+   `plaintiff` / `defendant` (plus stripped variants that drop
+   procedural prefixes like `In re`, `Estate of`, and
+   sentence-initial connectors like `See`, `Cf.`, `Then`).
+2. For each indexed name, scans the cleaned text for
+   `<name>, at <pincite>` matches that come after the anchor's
+   position and do not overlap an existing citation.
+3. Emits a `ShortFormCaseCitation` inheriting `volume` /
+   `reporter` / `page` from the anchor, with `partyName` and
+   `pincite` set from the match.
+
+When multiple anchors share a name, the most-recent one whose
+end precedes the bare-ref wins (Bluebook short-form refers to the
+most recent establishment).
+
+### False-positive defenses
+
+- **Anchor required**: only names that already appear as a party
+  in an earlier full citation can match. Bare `Smith, at 12` with
+  no prior `Smith v. ...` is left as prose.
+- **Min name length (3)**: 2-character anchors (`Wu`, `Lu`) are
+  not indexed.
+- **Blocklist**: common captions (`United States`, `State`,
+  `People`, signal/connector words) are blocked.
+- **Word-boundary lookbehind**: `(?<![A-Za-z'])` prevents
+  partial-prefix matches like `mySmith, at 12`.
+- **Numeric pincite required**: `Smith, at noon` or `Smith, at
+  the time` are rejected.
+- **Mandatory comma**: `Smith at 12` (no comma) is rejected as
+  ambiguous prose.
+
+### Tests
+
+57 new tests under `tests/extract/issue439BarePartyShortform.test.ts`
+covering basic positive cases, pincite shapes (single, hyphenated
+range, comma-list, short-hyphen `887-88`), name shapes (apostrophe,
+hyphen, multi-word, `In re Smith`), multi-reference scenarios,
+most-recent anchor selection, span fidelity (clean + original with
+HTML cleaning), false-positive avoidance, real samples from the
+issue body, citation metadata, resolver integration, compatibility
+with existing supra/`Id.`/short-form patterns, and state-reporter
+forms (Wis. 2d, Mass.). Full 2855-test suite passes.
+
+Closes the final outstanding bug in the 15-bug cross-cutting
+cluster from #450.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -46,6 +46,8 @@ import { detectParallelCitations } from "./detectParallel"
 import { detectStringCitations, detectLeadingSignals } from "./detectStringCites"
 import { extractId, extractShortFormCase, extractSupra } from "./extractShortForms"
 import { applyFalsePositiveFilters } from "./filterFalsePositives"
+import { parsePincite } from "./pincite"
+import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
 
 /**
  * Regex to parse "volume reporter page" from a citation token's text.
@@ -459,6 +461,10 @@ export function extractCitations(
   // jurisdiction. (#432)
   inheritBareSectionJurisdiction(citations)
 
+  // Step 4.72: Detect bare-party shortform back-references (`Smith, at 12`)
+  // anchored to earlier full case citations. (#439)
+  detectBarePartyBackReferences(citations, cleaned, transformationMap)
+
   // Step 4.75: Detect string citation groups (semicolon-separated)
   detectStringCitations(citations, cleaned)
 
@@ -778,6 +784,222 @@ function inheritBareSectionJurisdiction(citations: Citation[]): void {
       cite.code = "W. Va. Code"
     }
   }
+}
+
+/**
+ * Detect bare-party shortform back-references (`Smith, at 12`) anchored to
+ * earlier full case citations. After the first full citation establishes
+ * `Smith v. Jones, 100 F.2d 50`, subsequent shorthand `Smith, at 12` is a
+ * standard Bluebook back-reference but is not captured by the regex
+ * tokenizer because it lacks the volume+reporter shape. (#439)
+ *
+ * Algorithm:
+ *   1. Build a party-name index from FullCaseCitation plaintiff/defendant
+ *      names. Names < MIN_NAME_LEN chars and a small blocklist of common
+ *      generic captions are excluded to keep false-positive risk low.
+ *   2. For each indexed name, scan the cleaned text for
+ *      `<name>, at <pincite>` matches AFTER the anchor's position.
+ *   3. Reject matches that overlap an existing citation's span (avoids
+ *      double-counting when the bare-party form is itself part of a larger
+ *      string-cite or back-reference).
+ *   4. Emit a ShortFormCaseCitation inheriting `volume` / `reporter` /
+ *      `page` from the anchor, with `partyName` and `pincite` set from
+ *      the match.
+ *
+ * Conservative anchoring: only names that already appear as a party in a
+ * full citation can match. This is the core FP defense — bare `Smith, at 5`
+ * with no prior `Smith v. ...` citation is left as prose.
+ */
+const BARE_PARTY_MIN_NAME_LEN = 3
+const BARE_PARTY_BLOCKED_NAMES = new Set([
+  "the",
+  "and",
+  "but",
+  "for",
+  "see",
+  "see also",
+  "cf",
+  "but see",
+  "but cf",
+  "compare",
+  "accord",
+  "state",
+  "people",
+  "court",
+  "plaintiff",
+  "defendant",
+  "appellant",
+  "appellee",
+  "petitioner",
+  "respondent",
+  "united states",
+])
+
+function detectBarePartyBackReferences(
+  citations: Citation[],
+  cleaned: string,
+  transformationMap: TransformationMap,
+): void {
+  type Anchor = {
+    cite: import("@/types/citation").FullCaseCitation
+    name: string
+    normalized: string
+  }
+
+  // Strip leading procedural prefixes (`In re`, `Estate of`, `Ex parte`) and
+  // sentence-initial signal connectors (`See`, `Cf.`, `Then`, `Compare`) from
+  // captured plaintiff names so the bare back-reference matches the residual
+  // distinguishing name (`Smith` from `In re Smith`).
+  const stripNamePrefix = (raw: string): string => {
+    let s = raw.trim()
+    // Procedural prefix: `In re X`, `Estate of X`, `Ex parte X`, `Matter of X`.
+    s = s.replace(
+      /^(?:In\s+re|Estate\s+of|Ex\s+parte|Matter\s+of|Application\s+of)\s+/i,
+      "",
+    )
+    // Sentence-initial signal connectors that bleed into the captured plaintiff.
+    s = s.replace(
+      /^(?:But\s+(?:see|cf\.?)|See(?:\s+also)?|Compare|Cf\.?|Accord|E\.\s*g\.?|Also|Then)\s+/,
+      "",
+    )
+    return s.trim()
+  }
+
+  const anchors: Anchor[] = []
+  const seenKeys = new Set<string>()
+  const addAnchor = (
+    cite: import("@/types/citation").FullCaseCitation,
+    raw: string,
+    norm: string | undefined,
+  ): void => {
+    const trimmed = raw.trim()
+    if (trimmed.length < BARE_PARTY_MIN_NAME_LEN) return
+    const normalized = (norm ?? trimmed.toLowerCase()).trim()
+    if (BARE_PARTY_BLOCKED_NAMES.has(normalized)) return
+    const key = `${cite.span.cleanStart}:${trimmed}`
+    if (seenKeys.has(key)) return
+    seenKeys.add(key)
+    anchors.push({ cite, name: trimmed, normalized })
+  }
+
+  for (const cite of citations) {
+    if (cite.type !== "case") continue
+    if (cite.plaintiff) {
+      addAnchor(cite, cite.plaintiff, cite.plaintiffNormalized)
+      const stripped = stripNamePrefix(cite.plaintiff)
+      if (stripped && stripped !== cite.plaintiff) {
+        addAnchor(cite, stripped, stripped.toLowerCase())
+      }
+    }
+    if (cite.defendant) {
+      addAnchor(cite, cite.defendant, cite.defendantNormalized)
+      const stripped = stripNamePrefix(cite.defendant)
+      if (stripped && stripped !== cite.defendant) {
+        addAnchor(cite, stripped, stripped.toLowerCase())
+      }
+    }
+  }
+
+  if (anchors.length === 0) return
+
+  const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+  // Group anchors by their exact display name. When several anchors share
+  // a name, the LATEST one whose end-position precedes the bare-ref wins
+  // (Bluebook short-form refers to the most recent establishment).
+  const anchorsByName = new Map<string, Anchor[]>()
+  for (const a of anchors) {
+    const list = anchorsByName.get(a.name) ?? []
+    list.push(a)
+    anchorsByName.set(a.name, list)
+  }
+  for (const list of anchorsByName.values()) {
+    list.sort((a, b) => a.cite.span.cleanStart - b.cite.span.cleanStart)
+  }
+
+  const newCitations: Citation[] = []
+  const seenSpans = new Set<string>()
+
+  for (const [name, anchorList] of anchorsByName) {
+    const escapedName = escapeRegex(name)
+    const pincitePart =
+      "\\d+(?:[-\\u2013\\u2014]\\d+)?(?:,\\s*\\d+(?:[-\\u2013\\u2014]\\d+)?)*"
+    const pattern = new RegExp(
+      `(?<![A-Za-z'])(${escapedName})\\s*,\\s*at\\s+(${pincitePart})`,
+      "g",
+    )
+
+    let match: RegExpExecArray | null
+    while ((match = pattern.exec(cleaned)) !== null) {
+      const start = match.index
+      const end = start + match[0].length
+
+      // Find the latest anchor whose end is before this match.
+      let anchor: Anchor | undefined
+      for (const candidate of anchorList) {
+        if (candidate.cite.span.cleanEnd > start) break
+        anchor = candidate
+      }
+      if (!anchor) continue
+
+      if (overlapsExistingCitation(citations, start, end)) continue
+
+      const key = `${start}-${end}`
+      if (seenSpans.has(key)) continue
+      seenSpans.add(key)
+
+      // For comma-list pincites (`12-13, 21`), parse just the first chunk —
+      // the head page is the canonical pincite.
+      const firstChunk = match[2].split(",")[0].trim()
+      const pinciteInfo = parsePincite(firstChunk) ?? undefined
+      const pincite = pinciteInfo?.page
+
+      const { originalStart, originalEnd } = resolveOriginalSpan(
+        { cleanStart: start, cleanEnd: end },
+        transformationMap,
+      )
+
+      const anchorPage =
+        typeof anchor.cite.page === "number"
+          ? anchor.cite.page
+          : Number.parseInt(String(anchor.cite.page), 10) || undefined
+
+      newCitations.push({
+        type: "shortFormCase",
+        text: match[0],
+        matchedText: match[0],
+        confidence: 0.85,
+        processTimeMs: 0,
+        patternsChecked: 0,
+        span: { cleanStart: start, cleanEnd: end, originalStart, originalEnd },
+        volume: anchor.cite.volume,
+        reporter: anchor.cite.reporter,
+        page: anchorPage,
+        pincite,
+        pinciteInfo,
+        partyName: match[1],
+        partyNameNormalized: anchor.normalized,
+      })
+    }
+  }
+
+  if (newCitations.length === 0) return
+
+  citations.push(...newCitations)
+  citations.sort((a, b) => a.span.cleanStart - b.span.cleanStart)
+}
+
+function overlapsExistingCitation(
+  citations: Citation[],
+  start: number,
+  end: number,
+): boolean {
+  for (const c of citations) {
+    if (c.span.cleanEnd <= start) continue
+    if (c.span.cleanStart >= end) continue
+    return true
+  }
+  return false
 }
 
 function inheritParallelCaseName(citations: Citation[]): void {

--- a/tests/extract/issue439BarePartyShortform.test.ts
+++ b/tests/extract/issue439BarePartyShortform.test.ts
@@ -1,0 +1,549 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import { stripHtmlTags } from "@/clean"
+import type { Citation, ShortFormCaseCitation } from "@/types/citation"
+
+const shortForms = (cites: Citation[]): ShortFormCaseCitation[] =>
+  cites.filter((c): c is ShortFormCaseCitation => c.type === "shortFormCase")
+
+describe("issue #439 — bare-party shortform back-reference", () => {
+  describe("basic positive cases", () => {
+    it("extracts `Smith, at 12` after `Smith v. Jones`", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12, held."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].partyName).toBe("Smith")
+      expect(short[0].pincite).toBe(12)
+    })
+
+    it("extracts defendant-side back-ref (`Jones, at 12` after `Smith v. Jones`)", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Jones, at 12, dissented."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].partyName).toBe("Jones")
+      expect(short[0].pincite).toBe(12)
+    })
+
+    it("inherits volume / reporter / page from anchor citation", () => {
+      const text =
+        "Smith v. Jones, 500 F.2d 100, 105 (9th Cir. 1990). Smith, at 110, held that..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].volume).toBe(500)
+      expect(short[0].reporter).toMatch(/F\.2d/)
+      expect(short[0].page).toBe(100)
+      expect(short[0].pincite).toBe(110)
+    })
+
+    it("emits citations sorted in document order", () => {
+      const text =
+        "See Smith v. Jones, 100 F.2d 50 (1990). Later, Smith, at 12, held; see also Adams v. Brown, 200 F.3d 60 (2000)."
+      const cites = extractCitations(text)
+      for (let i = 1; i < cites.length; i++) {
+        expect(cites[i].span.cleanStart).toBeGreaterThanOrEqual(cites[i - 1].span.cleanStart)
+      }
+    })
+  })
+
+  describe("pincite shapes", () => {
+    it("hyphenated page range: `Smith, at 12-13`", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12-13."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(12)
+      expect(short[0].pinciteInfo?.endPage).toBe(13)
+      expect(short[0].pinciteInfo?.isRange).toBe(true)
+    })
+
+    it("short-form hyphenated range: `Smith, at 887-88`", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 887-88."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(887)
+    })
+
+    it("comma-separated multi pincite: `Smith, at 12-13, 21`", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12-13, 21 (dictum)."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(12)
+    })
+
+    it("single page pincite is parsed as numeric", () => {
+      const text = "Striker v. Foo, 500 F.2d 100 (1990). Striker, at 871."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(871)
+    })
+  })
+
+  describe("name shapes", () => {
+    it("apostrophe in name: `O'Brien, at 5`", () => {
+      const text = "O'Brien v. State, 100 F.2d 50 (1990). O'Brien, at 5."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].partyName).toBe("O'Brien")
+    })
+
+    it("hyphenated name: `Smith-Jones, at 12`", () => {
+      const text = "Smith-Jones v. State, 100 F.2d 50 (1990). Smith-Jones, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].partyName).toBe("Smith-Jones")
+    })
+
+    it("multi-word entity: `South Hollywood Hills Citizens Ass'n, at 73`", () => {
+      const text =
+        "South Hollywood Hills Citizens Ass'n v. City, 100 F.2d 50 (1990). The court in South Hollywood Hills Citizens Ass'n, at 73, held..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].partyName).toBe("South Hollywood Hills Citizens Ass'n")
+      expect(short[0].pincite).toBe(73)
+    })
+
+    it("`In re Smith` anchor allows `Smith, at 12` back-ref", () => {
+      const text = "In re Smith, 100 F.2d 50 (1990). Smith, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short.length).toBeGreaterThanOrEqual(1)
+      expect(short[0].partyName).toBe("Smith")
+    })
+  })
+
+  describe("multiple references", () => {
+    it("multiple bare-refs to same anchor", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12. Later, Smith, at 14."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(2)
+      expect(short[0].pincite).toBe(12)
+      expect(short[1].pincite).toBe(14)
+    })
+
+    it("two cases with disjoint party names — each gets its own back-ref", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990). Then Adams v. Brown, 200 F.3d 60 (2000). Smith, at 12. Adams, at 22."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(2)
+      expect(short[0].partyName).toBe("Smith")
+      expect(short[0].volume).toBe(100)
+      expect(short[1].partyName).toBe("Adams")
+      expect(short[1].volume).toBe(200)
+    })
+
+    it("same plaintiff in two cases — bare-ref points to most-recent anchor", () => {
+      const text =
+        "First, Smith v. Foo, 100 F.2d 1 (1990). Then Smith v. Bar, 200 F.3d 2 (2000). Smith, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      // The bare-ref appears after both anchors, so it should bind to the
+      // more recent (the `200 F.3d 2` citation, volume=200).
+      expect(short[0].volume).toBe(200)
+    })
+
+    it("two same-name anchors with a bare-ref between them — bare-ref binds to earlier", () => {
+      const text =
+        "Smith v. Foo, 100 F.2d 1 (1990). Smith, at 12. Then Smith v. Bar, 200 F.3d 2 (2000)."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].volume).toBe(100)
+    })
+  })
+
+  describe("span fidelity", () => {
+    it("cleanStart / cleanEnd point to the bare-party match in cleaned text", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12, held."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      const { cleanStart, cleanEnd } = short[0].span
+      expect(text.slice(cleanStart, cleanEnd)).toBe("Smith, at 12")
+    })
+
+    it("originalStart / originalEnd map past stripped HTML tags", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990). <em>Smith</em>, at 12, held."
+      const cites = extractCitations(text, { cleaners: [stripHtmlTags] })
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      const { originalStart, originalEnd } = short[0].span
+      // originalStart should point at the `S` of the visible `Smith` (past
+      // the opening `<em>` tag). originalEnd lands past the digits `12`.
+      expect(text.slice(originalStart, originalStart + 5)).toBe("Smith")
+      expect(text.slice(originalStart, originalEnd)).toContain("Smith")
+      expect(text.slice(originalStart, originalEnd)).toContain("at 12")
+    })
+  })
+
+  describe("negative cases (false-positive avoidance)", () => {
+    it("bare `Smith, at 12` with NO earlier full citation → not extracted", () => {
+      const text = "Striker, at 871"
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("bare-ref BEFORE the anchor in text → not extracted", () => {
+      const text = "Smith, at 12, said. Later, Smith v. Jones, 100 F.2d 50 (1990) was decided."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("pincite must be numeric — `Smith, at noon` not extracted", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at noon, the court..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("explanatory text `Smith, at the time, ...` not extracted", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at the time, was wrong."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("no comma → not extracted: `Smith at 12` is ambiguous prose", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith at 12 was unclear."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("anchor name `The` (blocked common word) not used", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). The, at 12, was unclear."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("does not partial-match `Smithson, at 12` against anchor `Smith`", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smithson, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      // Lookbehind on `[A-Za-z']` should reject the `Smithson` prefix-collision.
+      expect(short).toHaveLength(0)
+    })
+
+    it("does not match across leading letter (`mySmith, at 12`)", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). mySmith, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("`Smith, supra, at 12` is supra, not bare-party (no FP)", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). See Smith, supra, at 12."
+      const cites = extractCitations(text)
+      const bareParty = shortForms(cites).filter(
+        (c) => /^[A-Z][\w']*, at \d+$/.test(c.matchedText.trim()),
+      )
+      // `Smith, supra, at 12` already routes to supra extraction — our bare-
+      // party pass must NOT also emit a duplicate `Smith, at 12` citation.
+      expect(bareParty).toHaveLength(0)
+    })
+
+    it("`Smith, 500 F.2d at 125` is volume-reporter shortform, not bare-party", () => {
+      const text = "Smith v. Jones, 500 F.2d 50 (1990). Smith, 500 F.2d at 125."
+      const cites = extractCitations(text)
+      const shorts = shortForms(cites)
+      // The traditional `Smith, vol reporter at page` form already covers
+      // this. Our bare-party pass should not duplicate it.
+      const bareForms = shorts.filter((c) => !c.matchedText.match(/F\.2d/))
+      expect(bareForms).toHaveLength(0)
+    })
+
+    it("two-character name `Lu` would be blocked by min-length filter", () => {
+      // Even if `Lu` were a real plaintiff, it's below BARE_PARTY_MIN_NAME_LEN
+      // and would not be indexed. The test asserts a 3-char name doesn't
+      // pollute as a back-ref source.
+      const text = "Lu v. State, 100 F.2d 50 (1990). Lu, at 12, said."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("blocked anchor `United States, at 5` does not back-reference", () => {
+      const text =
+        "United States v. Smith, 100 F.2d 50 (1990). United States, at 5, argued."
+      const cites = extractCitations(text)
+      const short = shortForms(cites).filter(
+        (c) => c.partyName?.toLowerCase() === "united states",
+      )
+      expect(short).toHaveLength(0)
+    })
+  })
+
+  describe("real samples from issue body", () => {
+    it("`Striker, at 871`", () => {
+      const text = "Striker v. Foo, 500 F.2d 100 (1990). Striker, at 871, held."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].partyName).toBe("Striker")
+      expect(short[0].pincite).toBe(871)
+    })
+
+    it("`Pacheco, at 65`", () => {
+      const text = "Pacheco v. State, 100 N.E.2d 50 (2000). Pacheco, at 65."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(65)
+    })
+
+    it("`Hutchison, at 887-88`", () => {
+      const text =
+        "Hutchison v. Doe, 600 F.3d 880 (5th Cir. 2010). Hutchison, at 887-88, held."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(887)
+    })
+
+    it("`Rewolinski, at 12-13, 21` page-range + multi-page", () => {
+      const text =
+        "Rewolinski v. State, 600 F.3d 10 (7th Cir. 2010). Rewolinski, at 12-13, 21 (dictum)."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(12)
+    })
+  })
+
+  describe("citation metadata", () => {
+    it("emits type='shortFormCase'", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short[0].type).toBe("shortFormCase")
+    })
+
+    it("partyNameNormalized is lowercase", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short[0].partyNameNormalized).toBe("smith")
+    })
+
+    it("confidence is bounded between 0 and 1", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short[0].confidence).toBeGreaterThan(0)
+      expect(short[0].confidence).toBeLessThanOrEqual(1)
+    })
+
+    it("matchedText equals text and contains both party name and pincite", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12, held."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short[0].matchedText).toBe("Smith, at 12")
+      expect(short[0].text).toBe("Smith, at 12")
+    })
+
+    it("pinciteInfo.isRange true for hyphenated pincites", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12-15."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short[0].pinciteInfo?.isRange).toBe(true)
+      expect(short[0].pinciteInfo?.endPage).toBe(15)
+    })
+  })
+
+  describe("multiple matches per anchor", () => {
+    it("two refs to same anchor in the same sentence", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990). The court held in Smith, at 12, and Smith, at 14, that..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(2)
+      expect(short[0].pincite).toBe(12)
+      expect(short[1].pincite).toBe(14)
+    })
+
+    it("ref inside a parenthetical phrase", () => {
+      const text =
+        "See Smith v. Jones, 100 F.2d 50 (1990) (overruling, in part, Smith, at 12)."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(12)
+    })
+
+    it("ref across paragraphs", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990).\n\nIn the second paragraph, Smith, at 12, was central."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+    })
+  })
+
+  describe("non-overlap with existing citations", () => {
+    it("bare-party shortform does not duplicate when text already had a full citation", () => {
+      // First cite: Smith v. Jones, 100 F.2d 50. Second mention is also a
+      // full case citation: 200 F.3d 100. Both should be extracted as 'case'.
+      // Our pass should not also emit a bare-party citation overlapping the
+      // second cite.
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990). Then Smith v. Doe, 200 F.3d 100 (2000)."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      // Neither full cite is bare-party — both have "v." structure.
+      expect(short).toHaveLength(0)
+    })
+  })
+
+  describe("resolver integration", () => {
+    it("`resolve: true` returns resolved bare-party shortform", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12, held."
+      const resolved = extractCitations(text, { resolve: true })
+      const short = resolved.filter((c) => c.type === "shortFormCase")
+      expect(short.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it("bare-party shortform has resolution metadata when `resolve: true`", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12, held."
+      const resolved = extractCitations(text, { resolve: true })
+      const bareShort = resolved.find(
+        (r) => r.type === "shortFormCase" && r.partyName === "Smith",
+      )
+      expect(bareShort).toBeDefined()
+      if (bareShort && bareShort.type === "shortFormCase") {
+        // Resolver attaches a `resolution` field on short-form citations.
+        expect("resolution" in bareShort).toBe(true)
+      }
+    })
+  })
+
+  describe("compatibility — does not break existing patterns", () => {
+    it("existing `Id. at 12` still extracts", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Id. at 12."
+      const cites = extractCitations(text)
+      const id = cites.find((c) => c.type === "id")
+      expect(id).toBeDefined()
+    })
+
+    it("existing `Smith, supra, at 12` still extracts as supra", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). See Smith, supra, at 12."
+      const cites = extractCitations(text)
+      const supra = cites.find((c) => c.type === "supra")
+      expect(supra).toBeDefined()
+    })
+
+    it("existing `Smith, 500 F.2d at 125` (vol+reporter shortform) still extracts", () => {
+      const text = "Smith v. Jones, 500 F.2d 50 (1990). See Smith, 500 F.2d at 125."
+      const cites = extractCitations(text)
+      const shortWithVolume = cites.find(
+        (c) => c.type === "shortFormCase" && /F\.2d/.test(c.matchedText),
+      )
+      expect(shortWithVolume).toBeDefined()
+    })
+  })
+
+  describe("trailing punctuation", () => {
+    it("trailing period not absorbed into pincite", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short[0].pincite).toBe(12)
+      expect(short[0].matchedText).toBe("Smith, at 12")
+    })
+
+    it("trailing semicolon not absorbed", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 12; see also..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short[0].pincite).toBe(12)
+    })
+
+    it("trailing close paren not absorbed", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990) (citing Smith, at 12)."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short.length).toBeGreaterThanOrEqual(1)
+      expect(short[0].pincite).toBe(12)
+    })
+  })
+
+  describe("state reporters", () => {
+    it("Wisconsin Wis. 2d back-ref `Hutchison, at 887-88`", () => {
+      const text =
+        "Hutchison v. State, 300 Wis. 2d 880, 887 (2007). Hutchison, at 887-88, applies here."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short.length).toBeGreaterThanOrEqual(1)
+      expect(short[0].partyName).toBe("Hutchison")
+      expect(short[0].pincite).toBe(887)
+    })
+
+    it("Massachusetts back-ref", () => {
+      const text =
+        "Athas v. Commonwealth, 200 Mass. 78 (1990). Athas, at 79, held that..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short.length).toBeGreaterThanOrEqual(1)
+      expect(short[0].partyName).toBe("Athas")
+      expect(short[0].pincite).toBe(79)
+    })
+
+    it("state opinion with mixed federal anchors", () => {
+      const text =
+        "See Foo v. State, 100 N.E.2d 50 (Ind. 2010); Bar v. Smith, 600 F.3d 200 (7th Cir. 2010). The court in Foo, at 65, agreed, while Bar, at 220, dissented."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(2)
+      expect(short.map((s) => s.partyName).sort()).toEqual(["Bar", "Foo"])
+    })
+  })
+
+  describe("ambiguous prose edge cases", () => {
+    it("`Smith, at 5 we have` — pincite followed by prose word is risky but matches", () => {
+      // Documents the current (lenient) behavior. The pincite-then-letter
+      // pattern is rare in real opinions but possible. Reviewers can tighten
+      // later if FP rate climbs. Asserted as a regression sentinel.
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990). Smith, at 5 we have a different rule."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      // Either 0 or 1 is acceptable — primary check is no exceptions thrown.
+      expect(short.length).toBeLessThanOrEqual(1)
+      if (short.length === 1) expect(short[0].pincite).toBe(5)
+    })
+
+    it("`Smith, at the start` — non-numeric pincite rejected", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50 (1990). Smith, at the start of trial..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+  })
+
+  describe("plaintiff-only and defendant-only anchoring", () => {
+    it("matches against either plaintiff or defendant", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990). Both Smith, at 12 and Jones, at 13."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(2)
+      const names = short.map((s) => s.partyName).sort()
+      expect(names).toEqual(["Jones", "Smith"])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #439 — closes the final bug in the 15-bug cross-cutting cluster from roadmap #450.

After a full citation establishes `Smith v. Jones, 100 F.2d 50`, subsequent shorthand `Smith, at 12` is the standard Bluebook back-reference but was not captured by the regex tokenizer because it lacks the volume+reporter shape. **47 occurrences** across the 50-state baseline were unrecognized.

## Approach

Built strictly via TDD. New `detectBarePartyBackReferences` post-extract pass:

1. **Index build**: party-name → list of anchor citations from each full case citation's `plaintiff` / `defendant` (and stripped variants that drop procedural prefixes like `In re`, `Estate of`, plus sentence-initial connectors like `See`, `Cf.`, `Then`).
2. **Scan**: for each indexed name, scan the cleaned text for `<name>, at <pincite>` matches that come after the anchor's position and do not overlap an existing citation.
3. **Emit**: `ShortFormCaseCitation` inheriting `volume` / `reporter` / `page` from the anchor; `partyName` and `pincite` from the match.
4. **Most-recent-wins**: when multiple anchors share a name, the most-recent one whose end precedes the bare-ref takes the binding (Bluebook convention).

## False-positive defenses

The issue noted that bare `<Name>, at <NNN>` is regex-FP-prone in prose (`She said, at the time, ...`). Defenses:

| Defense | Mechanism |
|---|---|
| **Anchor required** | Only names that already appear as a party in an earlier full citation can match. Bare `Smith, at 12` with no prior `Smith v. ...` is left as prose. |
| **Min length 3** | 2-char anchors (`Wu`, `Lu`) are not indexed. |
| **Caption blocklist** | `United States`, `State`, `People`, signal words (`See`, `Cf.`, `But`, …) are not indexed. |
| **Word-boundary** | `(?<![A-Za-z'])` rejects prefix collisions (`mySmith, at 12`, `Smithson, at 12`). |
| **Numeric pincite** | `Smith, at noon` / `Smith, at the time` are rejected. |
| **Comma required** | `Smith at 12` (no comma) is rejected as ambiguous prose. |
| **No overlap** | Matches that overlap an existing extracted citation are dropped. |

## Test plan

- [x] **57 new tests** under `tests/extract/issue439BarePartyShortform.test.ts`:
  - basic positive: plaintiff / defendant anchoring, inherited reporter, doc-order sorting
  - pincite shapes: single, hyphenated range, short hyphen `887-88`, comma-list `12-13, 21`
  - name shapes: apostrophe (`O'Brien`), hyphen (`Smith-Jones`), multi-word entity, `In re X`
  - multi-reference: same anchor reused, two cases with different anchors, most-recent-anchor selection
  - span fidelity: clean and original positions survive HTML cleaning
  - negative (FP avoidance): no prior anchor, bare-ref-before-anchor, non-numeric pincite, lowercase name, partial-match prefix, signal word as name, `Smith, supra, at 12`, `Smith, 500 F.2d at 125`
  - real samples from issue body: `Striker`, `Pacheco`, `Hutchison`, `Rewolinski`
  - metadata: type, partyNameNormalized, confidence, matchedText, pinciteInfo
  - state reporters: `Wis. 2d`, `Mass.`, mixed federal/state
  - resolver integration with `resolve: true`
  - compatibility: existing `Id.` / supra / volume+reporter shortform still extract
  - trailing punctuation: period / semicolon / close-paren
- [x] Full **2855-test suite** passes; no regressions
- [x] `pnpm typecheck` clean
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)