### PR TITLE
fix: bare-party shortform accepts `at p. N` / `at pp. N-M` (#454)

### DIFF
--- a/.changeset/issue-454-ca-at-page.md
+++ b/.changeset/issue-454-ca-at-page.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix: bare-party shortform accepts `at p. N` / `at pp. N-M` / `at page N` (#454)
+
+The #439 fix recognized `Smith, at 12` but not the California
+Style Manual variant `Smith, at p. 12` — **26 CA occurrences**
+in the v0.16.0 replay used the `p.` / `pp.` page-prefix form and
+were dropped.
+
+### Fix
+
+Extended the pincite-capture regex in
+`detectBarePartyBackReferences` to accept an optional
+`p.` / `pp.` / `page` / `pages` between `at` and the digit:
+
+```
+(?<![A-Za-z'])(<name>)\s*,\s*at\s+(?:pp?\.?\s*|pages?\s+)?(<pincite>)
+```
+
+### Tests
+
+7 new tests under `California style \`at p. N\` / \`at pp. N-M\`
+(#454)` in `tests/extract/issue439BarePartyShortform.test.ts`:
+`at p. N`, `at pp. N-M`, `at page N`, `at pages N-M`, multi-word
+plaintiff, non-digit FP rejection, and the no-prefix regression.
+Full 2874-test suite passes.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -922,10 +922,14 @@ function detectBarePartyBackReferences(
 
   for (const [name, anchorList] of anchorsByName) {
     const escapedName = escapeRegex(name)
+    // Optional page-prefix: California Style Manual uses `at p. N` / `at pp.
+    // N-M` for short-form pincite refs. Also accept spelled-out `page` /
+    // `pages`. (#454)
+    const pagePrefix = "(?:pp?\\.?\\s*|pages?\\s+)?"
     const pincitePart =
       "\\d+(?:[-\\u2013\\u2014]\\d+)?(?:,\\s*\\d+(?:[-\\u2013\\u2014]\\d+)?)*"
     const pattern = new RegExp(
-      `(?<![A-Za-z'])(${escapedName})\\s*,\\s*at\\s+(${pincitePart})`,
+      `(?<![A-Za-z'])(${escapedName})\\s*,\\s*at\\s+${pagePrefix}(${pincitePart})`,
       "g",
     )
 

--- a/tests/extract/issue439BarePartyShortform.test.ts
+++ b/tests/extract/issue439BarePartyShortform.test.ts
@@ -546,4 +546,65 @@ describe("issue #439 — bare-party shortform back-reference", () => {
       expect(names).toEqual(["Jones", "Smith"])
     })
   })
+
+  describe("California style `at p. N` / `at pp. N-M` (#454)", () => {
+    it("`Taylor, at p. 19` extracts with pincite=19", () => {
+      const text = "Taylor v. State, 50 Cal. 3d 10, 19 (1990). Taylor, at p. 19."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].partyName).toBe("Taylor")
+      expect(short[0].pincite).toBe(19)
+    })
+
+    it("multi-word plaintiff with p. prefix", () => {
+      const text =
+        "Woodland Hills v. City, 23 Cal. 3d 917 (1979). Woodland Hills, at p. 947."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(947)
+    })
+
+    it("`Lexin, at pp. 1085-1092` with pp. (plural) prefix and range", () => {
+      const text =
+        "Lexin v. Superior Court, 47 Cal. 4th 1050 (2010). Lexin, at pp. 1085-1092."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(1085)
+      expect(short[0].pinciteInfo?.endPage).toBe(1092)
+    })
+
+    it("`Smith, at page 19` spelled-out form", () => {
+      const text = "Smith v. State, 50 Cal. 3d 10 (1990). Smith, at page 19."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(19)
+    })
+
+    it("`Smith, at pages 19-22` spelled-out plural form", () => {
+      const text = "Smith v. State, 50 Cal. 3d 10 (1990). Smith, at pages 19-22."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(19)
+    })
+
+    it("does not match `at p.` followed by non-digit", () => {
+      const text = "Smith v. State, 50 Cal. 3d 10 (1990). Smith, at p. trial..."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(0)
+    })
+
+    it("non-CA-style `Smith, at 19` still works after #454 (regression)", () => {
+      const text = "Smith v. State, 100 F.2d 10 (1990). Smith, at 19."
+      const cites = extractCitations(text)
+      const short = shortForms(cites)
+      expect(short).toHaveLength(1)
+      expect(short[0].pincite).toBe(19)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #454. The #439 fix recognized `Smith, at 12` but not the California Style Manual variant `Smith, at p. 12` — **26 CA occurrences** in the v0.16.0 replay used the `p.` / `pp.` page-prefix form and were silently dropped.

## Fix

Extended the pincite-capture regex in `detectBarePartyBackReferences` (`src/extract/extractCitations.ts`) to accept an optional `p.` / `pp.` / `page` / `pages` between `at` and the digit:

```
(?<![A-Za-z'])(<name>)\s*,\s*at\s+(?:pp?\.?\s*|pages?\s+)?(<pincite>)
```

## Test plan

- [x] 7 new tests under `California style \`at p. N\` / \`at pp. N-M\` (#454)`:
  - `Taylor, at p. 19` extracts pincite=19
  - multi-word plaintiff with p. prefix
  - `Lexin, at pp. 1085-1092` (plural `pp.` + range)
  - `Smith, at page 19` spelled-out
  - `Smith, at pages 19-22` spelled-out plural
  - `at p. trial` (non-digit) FP rejected
  - regression: `Smith, at 19` no-prefix form still works
- [x] Full **2874-test suite** passes; no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)