### PR TITLE
fix: plural `§§ N, N` / `§§ N and N` emits one citation per section (#453)

### DIFF
--- a/.changeset/issue-453-plural-section-list.md
+++ b/.changeset/issue-453-plural-section-list.md
@@ -1,0 +1,39 @@
+---
+"eyecite-ts": patch
+---
+
+fix: plural `§§ N, N` / `§§ N and N` emits one citation per section (#453)
+
+When a statute reference uses the plural section symbol `§§`
+followed by multiple sections (`§§ 18-8004, 18-8005(5)`,
+`§§ 13-108 and 13-621`), only the first section was captured —
+**60 occurrences across 10 states** in the v0.16.0 corpus were
+losing the second and subsequent sections.
+
+### Fix
+
+New `expandPluralSectionList` post-extract pass (step 4.4 in
+`extractCitations.ts`):
+
+1. For each statute citation whose `matchedText` contains `§§`,
+   scan the cleaned text immediately after its end.
+2. Match a continuation pattern of `(,|and|to) <section>` and
+   emit one new `StatuteCitation` per match.
+3. Each continuation inherits `code`, `jurisdiction`, `title`,
+   `year`, `publisher`, `editionLabel`, etc. from the head
+   citation; only `section` differs.
+
+Connectors: `,` / ` and ` / ` to `. Section format covers
+`12940`, `18-8004`, `12945(b)`, `707-701(1)`.
+
+### Tests
+
+11 new tests in `tests/extract/issue453PluralSection.test.ts`:
+comma-separated lists, three-section lists, `and` connector,
+inherited code/jurisdiction, singular-§ regression, span
+fidelity, subsection on second section, and space-padded
+connector. Full 2885-test suite passes.
+
+The range form `§§ 16-1605-1607` (chapter+range expansion) is
+deferred to a follow-up issue — this fix covers the most common
+comma/`and`-separated forms.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -430,6 +430,10 @@ export function extractCitations(
     citations.push(citation)
   }
 
+  // Step 4.4: Expand plural-section statute lists (`§§ N, N` /
+  // `§§ N and N`) into one statute citation per section. (#453)
+  expandPluralSectionList(citations, cleaned, transformationMap)
+
   // Step 4.5: Link subsequent history citations using Union-Find.
   // Three-phase approach: match signals → union chains → aggregate entries.
   // Invariant: citations are in text order (guaranteed by token-order processing above).
@@ -834,6 +838,80 @@ const BARE_PARTY_BLOCKED_NAMES = new Set([
   "respondent",
   "united states",
 ])
+
+/**
+ * Expand a plural `§§ N, N` (or `§§ N and N`) statute reference into one
+ * StatuteCitation per section. The tokenizer captures only the FIRST
+ * section; this pass walks the text right after a `§§`-marked statute
+ * citation and emits additional citations for each comma-/`and`-separated
+ * section it finds. Each emitted citation inherits `code`, `jurisdiction`,
+ * `title`, `year`, `publisher`, `editionLabel`, and other metadata from
+ * the head citation. (#453)
+ *
+ * Connector grammar: `,` | ` and ` | ` to `.
+ * Section grammar: `\d[\w-]*(?:\([A-Za-z0-9]+\))*` — covers
+ * `12940`, `18-8004`, `12945(b)`, `707-701(1)`.
+ */
+function expandPluralSectionList(
+  citations: Citation[],
+  cleaned: string,
+  transformationMap: TransformationMap,
+): void {
+  const sectionPart = "\\d[\\w-]*(?:\\([A-Za-z0-9]+\\))*"
+  const connectorPart = "\\s*,\\s*|\\s+and\\s+|\\s+to\\s+"
+  const continuationRe = new RegExp(
+    `^(?:${connectorPart})(${sectionPart})`,
+  )
+
+  const newCitations: Citation[] = []
+
+  for (const cite of citations) {
+    if (cite.type !== "statute") continue
+    if (!cite.matchedText.includes("§§")) continue
+
+    let cursor = cite.span.cleanEnd
+    while (cursor < cleaned.length) {
+      const slice = cleaned.slice(cursor)
+      const m = continuationRe.exec(slice)
+      if (!m) break
+
+      const fullMatchLen = m[0].length
+      const sectionText = m[1]
+      const sectionStart = cursor + fullMatchLen - sectionText.length
+      const sectionEnd = cursor + fullMatchLen
+
+      const { originalStart, originalEnd } = resolveOriginalSpan(
+        { cleanStart: sectionStart, cleanEnd: sectionEnd },
+        transformationMap,
+      )
+
+      const continuation: import("@/types/citation").StatuteCitation = {
+        ...cite,
+        text: sectionText,
+        matchedText: sectionText,
+        section: sectionText,
+        span: {
+          cleanStart: sectionStart,
+          cleanEnd: sectionEnd,
+          originalStart,
+          originalEnd,
+        },
+        // Don't carry subsection/pincite from the head — those were specific
+        // to the head section.
+        subsection: undefined,
+        pincite: undefined,
+        spans: undefined,
+      }
+      newCitations.push(continuation)
+
+      cursor = sectionEnd
+    }
+  }
+
+  if (newCitations.length === 0) return
+  citations.push(...newCitations)
+  citations.sort((a, b) => a.span.cleanStart - b.span.cleanStart)
+}
 
 function detectBarePartyBackReferences(
   citations: Citation[],

--- a/tests/extract/issue453PluralSection.test.ts
+++ b/tests/extract/issue453PluralSection.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+describe("issue #453 — plural `§§` section lists", () => {
+  describe("comma-separated", () => {
+    it("`Idaho Code §§ 18-8004, 18-8005(5)` emits two citations", () => {
+      const text = "Idaho Code §§ 18-8004, 18-8005(5) requires..."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+      expect(sts[0].section).toBe("18-8004")
+      expect(sts[1].section).toBe("18-8005(5)")
+    })
+
+    it("`I.C. §§ 61-624, 61-629` emits two citations", () => {
+      const text = "I.C. §§ 61-624, 61-629."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+      expect(sts[0].section).toBe("61-624")
+      expect(sts[1].section).toBe("61-629")
+    })
+
+    it("`Cal. Gov. Code §§ 12940, 12945` emits two citations", () => {
+      const text = "See Cal. Gov. Code §§ 12940, 12945."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+      expect(sts[0].section).toBe("12940")
+      expect(sts[1].section).toBe("12945")
+    })
+
+    it("three-section list `§§ 100, 200, 300`", () => {
+      const text = "28 U.S.C. §§ 100, 200, 300."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(3)
+      expect(sts.map((s) => s.section)).toEqual(["100", "200", "300"])
+    })
+  })
+
+  describe("`and` connector", () => {
+    it("`§§ 13-108 and 13-621` emits two citations", () => {
+      const text = "A.R.S. §§ 13-108 and 13-621."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+      expect(sts[0].section).toBe("13-108")
+      expect(sts[1].section).toBe("13-621")
+    })
+  })
+
+  describe("inherited code/jurisdiction", () => {
+    it("subsequent sections inherit code and jurisdiction from first", () => {
+      const text = "I.C. §§ 61-624, 61-629."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+      expect(sts[1].code).toBe(sts[0].code)
+      expect(sts[1].jurisdiction).toBe(sts[0].jurisdiction)
+    })
+  })
+
+  describe("singular `§` (regression)", () => {
+    it("singular `§` with comma after is not split (it's just text following)", () => {
+      // `28 U.S.C. § 1331, with...` — only ONE citation, the comma is prose.
+      const text = "See 28 U.S.C. § 1331, which is well-established."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(1)
+      expect(sts[0].section).toBe("1331")
+    })
+
+    it("`§ 1331` alone still works as before", () => {
+      const text = "28 U.S.C. § 1331 provides..."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(1)
+    })
+  })
+
+  describe("span positions", () => {
+    it("each emitted citation has its own span pointing at its section", () => {
+      const text = "I.C. §§ 61-624, 61-629."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+      expect(text.slice(sts[1].span.cleanStart, sts[1].span.cleanEnd)).toContain("61-629")
+    })
+  })
+
+  describe("edge cases", () => {
+    it("subsection on second section: `§§ 12940, 12945(b)`", () => {
+      const text = "Cal. Gov. Code §§ 12940, 12945(b)."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+      expect(sts[1].section).toBe("12945(b)")
+    })
+
+    it("space inside `§§ 100 , 200` still parses", () => {
+      const text = "28 U.S.C. §§ 100 , 200."
+      const cites = extractCitations(text)
+      const sts = statutes(cites)
+      expect(sts).toHaveLength(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #453. When a statute reference uses the plural section symbol `§§` followed by multiple sections (`§§ 18-8004, 18-8005(5)`, `§§ 13-108 and 13-621`), only the first section was captured — **60 occurrences across 10 states** in the v0.16.0 corpus were losing the second and subsequent sections.

## State distribution

| State | Occurrences |
|---|---:|
| ID | 16 |
| CA | 15 |
| HI | 10 |
| AZ | 7 |
| AL, CT | 2 each |
| FL, GA | 3 each |
| IL, LA | 1 each |

## Approach

Built strictly via TDD. New `expandPluralSectionList` post-extract pass (step 4.4 in `extractCitations.ts`):

1. For each statute citation whose `matchedText` contains `§§`, scan the cleaned text immediately after its end.
2. Match a continuation pattern of `(,|and|to) <section>` and emit one new `StatuteCitation` per match.
3. Each continuation inherits `code`, `jurisdiction`, `title`, `year`, `publisher`, `editionLabel`, etc. from the head citation; only `section` differs.

Connectors: `,` / ` and ` / ` to `. Section format covers `12940`, `18-8004`, `12945(b)`, `707-701(1)`.

## Behavior table

| Input | Before | After |
|---|---|---|
| `Idaho Code §§ 18-8004, 18-8005(5)` | 1 cite (drops `18-8005(5)`) | **2 cites** |
| `I.C. §§ 16-1606 and 1607` | 1 cite (drops `1607`) | **2 cites** |
| `Cal. Gov. Code §§ 12940, 12945(b)` | 1 cite (drops `12945(b)`) | **2 cites** |
| `28 U.S.C. § 1331, with...` | 1 cite | 1 cite (regression preserved) |

## Test plan

- [x] 11 new tests in `tests/extract/issue453PluralSection.test.ts`:
  - comma-separated lists (2-cite and 3-cite)
  - `and` connector
  - inherited code/jurisdiction
  - singular-`§` regression (comma after is prose, not split)
  - span fidelity
  - subsection on second section
  - space-padded connector
- [x] Full **2885-test suite** passes; no regressions
- [x] `pnpm typecheck` clean

## Deferred

- **Range form** `§§ N-N-N` (e.g. `§§ 16-1605-1607` → 3 cites) requires chapter-prefix carry-forward heuristics. Filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)