### PR TITLE
fix: `Id.` skips citations inside a shortform's explanatory parenthetical

### DIFF
--- a/.changeset/id-skip-paren-child-shortform.md
+++ b/.changeset/id-skip-paren-child-shortform.md
@@ -1,0 +1,35 @@
+---
+"eyecite-ts": patch
+---
+
+fix: `Id.` skips citations inside a shortform's explanatory parenthetical
+
+When a short-form citation is followed by an explanatory
+parenthetical containing another full citation
+(`Dormitory Auth., 30 N.Y.3d at 710 (quoting Port Chester ...,
+40 N.Y.2d 652, 656 (1976))`), the inner citation is a
+sub-reference of the parent and must not become the antecedent
+for a subsequent `Id.`. Previously, only `case` and `docket`
+full citations had a `fullSpan` extending through their trailing
+parenthetical, so the resolver correctly detected paren-children
+of those types — but `shortFormCase` (and other non-case full
+citations) did not carry `fullSpan`, leaving their paren-children
+visible as Id. antecedents.
+
+### Fix
+
+`DocumentResolver` now precomputes parenthesis depth at every
+citation's start position from the raw text. A citation at
+depth > 0 is flagged as a parenthetical child regardless of
+which prior citation opened the `(`. The legacy `fullSpan`-based
+check is preserved as a fallback. `Id.` no longer resolves to
+citations buried inside an earlier explanatory parenthetical.
+
+### Tests
+
+7 new tests in `tests/resolve/idSkipsParenChildOfShortform.test.ts`
+covering the user-reported Dormitory Auth./Port Chester case,
+shortform-with-`(citing X)` parens, the existing case-with-paren
+regression, nested `(See A (citing B))` depth, statute inside a
+case paren, and `Id.` itself inside a parenthetical. Full
+2892-test suite passes.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -111,6 +111,14 @@ export class DocumentResolver {
   resolve(): ResolvedCitation[] {
     const resolved: ResolvedCitation[] = []
 
+    // Precompute, for each citation, its parenthesis depth at its start
+    // position relative to the raw document. A citation inside `(...)` is
+    // a parenthetical child of whatever opened that paren — typically the
+    // preceding citation's explanatory `(quoting X)` or `(citing Y)` block.
+    // This is more robust than relying on `fullSpan`, which is only computed
+    // for `case`/`docket` citations (shortFormCase, statute, etc. lack it).
+    const parenDepths = this.computeParenDepths()
+
     for (let i = 0; i < this.citations.length; i++) {
       this.context.citationIndex = i
       const citation = this.citations[i]
@@ -136,18 +144,21 @@ export class DocumentResolver {
             // citation's explanatory parenthetical (e.g. "(citing X)" or
             // "(quoting Y)") is a sub-reference within the parent's
             // citation, not the cited authority of that sentence — so it
-            // must not become Id.'s default antecedent. Detect this by
-            // checking whether the current cite's span lies within an
-            // earlier full cite's fullSpan. We still track it for
-            // supra/short-form resolution.
-            const isParentheticalChild = resolved.some((prior) => {
-              const priorFullSpan = getFullSpan(prior)
-              if (!priorFullSpan) return false
-              return (
-                priorFullSpan.cleanStart <= citation.span.cleanStart &&
-                priorFullSpan.cleanEnd >= citation.span.cleanEnd
-              )
-            })
+            // must not become Id.'s default antecedent. Detection uses
+            // paren depth (works for any prior citation type) with the
+            // legacy fullSpan check as fallback for case-name-prefixed
+            // citations whose `(...)` ends before the paren-depth model
+            // catches up.
+            const isParentheticalChild =
+              parenDepths[i] > 0 ||
+              resolved.some((prior) => {
+                const priorFullSpan = getFullSpan(prior)
+                if (!priorFullSpan) return false
+                return (
+                  priorFullSpan.cleanStart <= citation.span.cleanStart &&
+                  priorFullSpan.cleanEnd >= citation.span.cleanEnd
+                )
+              })
             if (!isParentheticalChild) {
               this.context.lastResolvedIndex = i
             }
@@ -199,6 +210,33 @@ export class DocumentResolver {
     }
 
     return resolved
+  }
+
+  /**
+   * Compute parenthesis depth at the start position of each citation.
+   * Walks the raw text once, counting `(` and `)` and recording the
+   * running depth at every citation's `span.cleanStart`. Depth > 0
+   * indicates the citation is nested inside an open parenthetical
+   * block (typically an explanatory `(quoting X)` / `(citing Y)`
+   * following an earlier citation).
+   */
+  private computeParenDepths(): number[] {
+    const depths: number[] = new Array(this.citations.length).fill(0)
+    if (this.citations.length === 0) return depths
+
+    let depth = 0
+    let pos = 0
+    for (let i = 0; i < this.citations.length; i++) {
+      const start = this.citations[i].span.cleanStart
+      while (pos < start && pos < this.text.length) {
+        const ch = this.text[pos]
+        if (ch === "(") depth++
+        else if (ch === ")" && depth > 0) depth--
+        pos++
+      }
+      depths[i] = depth
+    }
+    return depths
   }
 
   /**

--- a/tests/resolve/idSkipsParenChildOfShortform.test.ts
+++ b/tests/resolve/idSkipsParenChildOfShortform.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { IdCitation } from "@/types/citation"
+
+describe("Id. does not resolve to a citation inside a shortform's parenthetical", () => {
+  it("Id. after `<shortform> (quoting <full case>)` resolves to the shortform's underlying authority, not the quoted case", () => {
+    // Real-world example: a short-form `Dormitory Auth.` followed by an
+    // explanatory `(quoting <full citation>)` parenthetical, then a quotation,
+    // then `Id.`. The `Id.` should point at the shortform's antecedent
+    // (the original Dormitory Authority full citation), NOT at the case
+    // quoted inside the parenthetical.
+    const text =
+      'Dormitory Auth. v. State, 25 N.Y.3d 600 (2015). Dormitory Auth., 30 N.Y.3d at 710 (quoting Port Chester Elec. Constr. Corp. v. Atlas, 40 N.Y.2d 652, 656 (1976)). "In the absence of express language, such third parties are generally considered mere incidental beneficiaries." Id.'
+
+    const cites = extractCitations(text, { resolve: true })
+
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id).toBeDefined()
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+
+    const target = id?.resolution?.resolvedTo
+    expect(target).toBeDefined()
+    if (target === undefined) return
+    const targetCite = cites[target]
+    expect(targetCite.type).toBe("case")
+    if (targetCite.type === "case") {
+      // Should be the Dormitory Auth. full citation, not Port Chester.
+      expect(targetCite.plaintiff).toContain("Dormitory")
+    }
+  })
+
+  it("Id. inside `<full case> (citing <inner case>)` resolves to outer, not inner (already worked for `case`)", () => {
+    // Regression: this case already worked because the outer cite is a full
+    // `case` type with `fullSpan` extending through the paren.
+    const text =
+      'Smith v. Jones, 100 F.2d 50 (1990) (citing Doe v. Roe, 200 F.3d 100 (1985)). Id.'
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    const target = id?.resolution?.resolvedTo
+    expect(target).toBeDefined()
+    if (target === undefined) return
+    const targetCite = cites[target]
+    if (targetCite.type === "case") {
+      expect(targetCite.plaintiff).toBe("Smith")
+    }
+  })
+
+  it("Id. after `<shortform> (citing <inner full>)` skips inner full → resolves to shortform's antecedent", () => {
+    const text =
+      "Smith v. Jones, 100 F.2d 50 (1990). Smith, 100 F.2d at 55 (citing Other v. Case, 200 F.3d 100 (2000)). Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    const target = id?.resolution?.resolvedTo
+    expect(target).toBeDefined()
+    if (target === undefined) return
+    const targetCite = cites[target]
+    if (targetCite.type === "case") {
+      // Should be Smith v. Jones (outer, original) not Other v. Case (inner)
+      expect(targetCite.plaintiff).toBe("Smith")
+    }
+  })
+
+  it("nested `(See A; B (citing C))` — depth-2 C still skipped, Id. after closes to outer", () => {
+    const text =
+      "Top v. Case, 100 F.2d 1 (1990). (See Mid v. Case, 200 F.3d 2 (1995) (citing Inner v. Case, 300 F.4th 3 (2000))). Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    const target = id?.resolution?.resolvedTo
+    expect(target).toBeDefined()
+    if (target === undefined) return
+    // Id. should resolve to Top v. Case (the only depth-0 cite), not
+    // Mid (depth-1) or Inner (depth-2).
+    const targetCite = cites[target]
+    if (targetCite.type === "case") {
+      expect(targetCite.plaintiff).toBe("Top")
+    }
+  })
+
+  it("statute inside a citation's parenthetical does not become Id.'s antecedent", () => {
+    // Edge case: a case cite carries an explanatory paren that references a
+    // statute. The statute is depth-1 — it should not be Id.'s antecedent.
+    const text =
+      "Smith v. State, 100 F.2d 50 (1990) (interpreting 28 U.S.C. § 1331). Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    const target = id?.resolution?.resolvedTo
+    expect(target).toBeDefined()
+    if (target === undefined) return
+    const targetCite = cites[target]
+    expect(targetCite.type).toBe("case")
+  })
+
+  it("Id. INSIDE the parenthetical (depth > 0) is itself a paren-child", () => {
+    // Documentation test — when Id. is within a parenthetical block, the
+    // current behavior is whatever lastResolvedIndex held at the parent's
+    // entry. We assert that this case does not throw and resolves to SOME
+    // antecedent (the exact target is implementation-specific).
+    const text =
+      "Smith v. Jones, 100 F.2d 50 (1990) (citing Doe v. Roe, 200 F.3d 100; Id.)."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id).toBeDefined()
+    // The Id. should resolve to SOMETHING and not throw.
+    expect(id?.resolution).toBeDefined()
+  })
+
+  it("the user's actual example (Dormitory Auth. v. Port Chester quote)", () => {
+    // Exact reproduction of the bug reported by the user.
+    const text =
+      'Dormitory Auth. v. Council, 28 N.Y.3d 500 (2014). Dormitory Auth., 30 N.Y.3d at 710 (quoting Port Chester Elec. Constr. Corp. v. Atlas, 40 N.Y.2d 652, 656 (1976)). "In the absence of express language, such third parties are generally considered mere incidental beneficiaries." Id.'
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    const target = id?.resolution?.resolvedTo
+    expect(target).toBeDefined()
+    if (target === undefined) return
+    const targetCite = cites[target]
+    if (targetCite.type === "case") {
+      // Must point at Dormitory Auth., not Port Chester.
+      expect(targetCite.plaintiff).toContain("Dormitory")
+      expect(targetCite.plaintiff).not.toContain("Port Chester")
+    }
+  })
+})


### PR DESCRIPTION
## Summary

User report: `Id.` erroneously resolves to the citation buried inside an explanatory parenthetical instead of the primary preceding citation.

**Failing example:**
```
Dormitory Auth., 30 N.Y.3d at 710 (quoting Port Chester Elec. Constr. Corp. v. Atlas, 40 N.Y.2d 652, 656 (1976)). "In the absence of express language, such third parties are generally considered mere incidental beneficiaries." Id.
```

`Id.` should refer to **Dormitory Auth.** (the primary citation), not **Port Chester** (buried inside the `(quoting …)` parenthetical).

## Root cause

The resolver's existing paren-child detection relied on `fullSpan`, which is only computed for `case` and `docket` citations. `shortFormCase` (and other non-case full citations) lack `fullSpan`, so the resolver never noticed that the inner Port Chester citation was inside Dormitory Auth.'s explanatory parenthetical. Port Chester then updated `lastResolvedIndex` and became `Id.`'s antecedent.

## Fix

`DocumentResolver` now precomputes parenthesis depth at each citation's start position from the raw text. A citation at depth > 0 is flagged as a parenthetical child regardless of which prior citation opened the `(`. The legacy `fullSpan`-based check is preserved as a fallback for cases where the depth model misses (e.g., paren spanning multiple sentences).

## Test plan

- [x] 7 new tests in `tests/resolve/idSkipsParenChildOfShortform.test.ts`:
  - the user-reported Dormitory Auth./Port Chester case
  - `<shortform> (citing <inner full>)` → Id. resolves to shortform's antecedent
  - **regression**: `<full case> (citing <inner case>)` (already worked)
  - nested `(See A (citing B))` — depth-2 also flagged
  - statute inside a case paren is not Id.'s antecedent
  - documentation test for `Id.` itself inside a parenthetical
- [x] Full **2892-test suite** passes; no regressions
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)