### PR TITLE
feat: `Id.` inherits caseName / plaintiff / defendant from antecedent

### DIFF
--- a/.changeset/id-inherits-casename.md
+++ b/.changeset/id-inherits-casename.md
@@ -1,0 +1,32 @@
+---
+"eyecite-ts": minor
+---
+
+feat: `Id.` inherits caseName / plaintiff / defendant from antecedent
+
+Previously, `Id.` citations carried only pincite metadata (with
+pincite-inheritance added in v0.16.1). The caption fields
+(`caseName`, `plaintiff`, `defendant`, `proceduralPrefix`) had
+to be retrieved via `resolution.resolvedTo` walking, which is
+inconvenient for consumers that just want each citation to
+describe its case.
+
+### Fix
+
+`IdCitation` now exposes optional `caseName`, `plaintiff`,
+`defendant`, `plaintiffNormalized`, `defendantNormalized`, and
+`proceduralPrefix` fields. The resolver populates them from the
+antecedent when `resolve: true` and the antecedent is a `case`
+citation. Behavior unchanged for:
+- statute / non-case antecedents (no caption to inherit)
+- `resolve: false` (no resolver pass)
+- `Id.` with no antecedent
+
+### Tests
+
+9 new tests in `tests/resolve/idInheritsCaseName.test.ts`:
+basic case inheritance, `In re` proceduralPrefix propagation,
+plaintiff/defendant inheritance, chained `Id.`, no-antecedent
+no-op, statute-antecedent no-op, `resolve: false` no-op, and
+short-form chain transitive inheritance. Full 2901-test suite
+passes.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -175,28 +175,43 @@ export class DocumentResolver {
         this.context.lastResolvedIndex = resolution.resolvedTo
       }
 
-      // Bluebook Rule 4.1: an `Id.` without an explicit `at NNN` refers
-      // to the same page(s) cited in the antecedent. When the antecedent
-      // carried a pincite and the Id. did not, propagate the pincite.
+      // Bluebook Rule 4.1: an `Id.` refers to the same authority and page(s)
+      // cited in the antecedent. When the antecedent is a case citation,
+      // propagate its caption (caseName, plaintiff, defendant, procedural
+      // prefix). When the Id. lacks an explicit `at NNN`, also propagate
+      // pincite from the antecedent. Consumers can then use the Id.
+      // directly without walking `resolution.resolvedTo`.
       let citationOut: Citation = citation
-      if (
-        citation.type === "id" &&
-        citation.pincite === undefined &&
-        resolution?.resolvedTo !== undefined
-      ) {
+      if (citation.type === "id" && resolution?.resolvedTo !== undefined) {
         const antecedent = this.citations[resolution.resolvedTo]
-        if (
-          antecedent &&
-          "pincite" in antecedent &&
-          typeof antecedent.pincite === "number"
-        ) {
-          const idOut: IdCitation = {
-            ...(citation as IdCitation),
-            pincite: antecedent.pincite,
+        if (antecedent) {
+          const idOut: IdCitation = { ...(citation as IdCitation) }
+
+          // Pincite inheritance (when Id. has none explicit).
+          if (
+            idOut.pincite === undefined &&
+            "pincite" in antecedent &&
+            typeof antecedent.pincite === "number"
+          ) {
+            idOut.pincite = antecedent.pincite
+            if ("pinciteInfo" in antecedent && antecedent.pinciteInfo) {
+              idOut.pinciteInfo = antecedent.pinciteInfo
+            }
           }
-          if ("pinciteInfo" in antecedent && antecedent.pinciteInfo) {
-            idOut.pinciteInfo = antecedent.pinciteInfo
+
+          // Case-name inheritance (only when antecedent is a `case`).
+          if (antecedent.type === "case") {
+            if (antecedent.caseName) idOut.caseName = antecedent.caseName
+            if (antecedent.plaintiff) idOut.plaintiff = antecedent.plaintiff
+            if (antecedent.defendant) idOut.defendant = antecedent.defendant
+            if (antecedent.plaintiffNormalized)
+              idOut.plaintiffNormalized = antecedent.plaintiffNormalized
+            if (antecedent.defendantNormalized)
+              idOut.defendantNormalized = antecedent.defendantNormalized
+            if (antecedent.proceduralPrefix)
+              idOut.proceduralPrefix = antecedent.proceduralPrefix
           }
+
           citationOut = idOut
         }
       }

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -732,6 +732,24 @@ export interface IdCitation extends CitationBase {
    * can post-classify if needed. #303
    */
   parenthetical?: string
+  /**
+   * Case name inherited from the antecedent (full citation that the `Id.`
+   * resolves to). Populated by the resolver when `resolve: true` and the
+   * antecedent is a `case`-type citation. Undefined otherwise. Consumers
+   * who don't enable resolution should walk `resolution.resolvedTo` to
+   * find the antecedent.
+   */
+  caseName?: string
+  /** Inherited plaintiff name from antecedent (resolver-populated). */
+  plaintiff?: string
+  /** Inherited defendant name from antecedent (resolver-populated). */
+  defendant?: string
+  /** Inherited normalized plaintiff name from antecedent. */
+  plaintiffNormalized?: string
+  /** Inherited normalized defendant name from antecedent. */
+  defendantNormalized?: string
+  /** Inherited procedural prefix (`In re`, `Estate of`, etc.) from antecedent. */
+  proceduralPrefix?: string
   /** Component-level spans (currently just `pincite`; extend when needed). */
   spans?: import("./componentSpans").IdComponentSpans
 }

--- a/tests/resolve/idInheritsCaseName.test.ts
+++ b/tests/resolve/idInheritsCaseName.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { IdCitation } from "@/types/citation"
+
+describe("Id. inherits caseName from antecedent", () => {
+  it("`Id. at 1133` after `In re Hanford, 292 F.3d 1124, 1133` inherits caseName", () => {
+    const text =
+      'In re Hanford Nuclear Reservation Litig., 292 F.3d 1124, 1133 (9th Cir. 2002). The court explained the rule. Id. at 1133.'
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id).toBeDefined()
+    expect(id?.caseName).toBe("In re Hanford Nuclear Reservation Litig.")
+  })
+
+  it("`Id.` after `Smith v. Jones` inherits caseName='Smith v. Jones'", () => {
+    const text = "Smith v. Jones, 100 F.2d 50 (1990). Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id?.caseName).toBe("Smith v. Jones")
+  })
+
+  it("Id. inherits plaintiff and defendant fields", () => {
+    const text = "Smith v. Jones, 100 F.2d 50 (1990). Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id?.plaintiff).toBe("Smith")
+    expect(id?.defendant).toBe("Jones")
+  })
+
+  it("Id. inherits proceduralPrefix when antecedent has one", () => {
+    const text =
+      "In re Estate of Smith, 200 F.3d 100 (2010). The probate court said so. Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id?.proceduralPrefix).toBe("In re")
+  })
+
+  it("two consecutive `Id.`s both inherit the same caseName", () => {
+    const text = "Smith v. Jones, 100 F.2d 50 (1990). Id. Id. at 55."
+    const cites = extractCitations(text, { resolve: true })
+    const ids = cites.filter((c): c is IdCitation => c.type === "id")
+    expect(ids).toHaveLength(2)
+    expect(ids[0].caseName).toBe("Smith v. Jones")
+    expect(ids[1].caseName).toBe("Smith v. Jones")
+  })
+
+  it("Id. with no antecedent has no caseName", () => {
+    const text = "Id. at 5."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id?.caseName).toBeUndefined()
+  })
+
+  it("Id. resolving to non-case (statute) does not gain a caseName", () => {
+    const text = "See 28 U.S.C. § 1331. Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id?.caseName).toBeUndefined()
+  })
+
+  it("`resolve: false` (default) does not propagate caseName onto Id.", () => {
+    const text = "Smith v. Jones, 100 F.2d 50 (1990). Id."
+    const cites = extractCitations(text)
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id?.caseName).toBeUndefined()
+  })
+
+  it("Id. after a short-form chain inherits root case's caseName", () => {
+    // Smith v. Jones (full) → Smith, supra (short) → Id.
+    // The Id. should inherit from Smith v. Jones (the chain root).
+    const text =
+      "Smith v. Jones, 100 F.2d 50 (1990). Later, Smith, supra. Id. at 60."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c) => c.type === "id") as IdCitation | undefined
+    expect(id?.caseName).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
## Summary

User report: `Id.` after `In re Hanford Nuclear Reservation Litig., 292 F.3d 1124, 1133 (9th Cir. 2002)` did not inherit the antecedent's case name. The `Id.` citation only carried pincite — caption fields (`caseName`, `plaintiff`, `defendant`, `proceduralPrefix`) had to be retrieved via `resolution.resolvedTo` walking, which is inconvenient for consumers that just want each citation to describe its case.

## Fix

`IdCitation` now exposes optional `caseName`, `plaintiff`, `defendant`, `plaintiffNormalized`, `defendantNormalized`, and `proceduralPrefix` fields. The resolver populates them from the antecedent when `resolve: true` and the antecedent is a `case` citation.

This is the natural extension of the v0.16.1 pincite-inheritance fix — `Id.` now fully describes the cited authority for consumers without requiring resolution-chain walking.

## Behavior

| Input | `Id.` inherits |
|---|---|
| `In re Hanford, 292 F.3d 1124 (9th Cir. 2002). Id.` | caseName="In re Hanford…", proceduralPrefix="In re" |
| `Smith v. Jones, 100 F.2d 50 (1990). Id.` | caseName, plaintiff="Smith", defendant="Jones" |
| `Smith v. Jones, 100 F.2d 50 (1990). Smith, supra. Id.` | Transitive — caseName from Smith v. Jones (chain root) |
| `28 U.S.C. § 1331. Id.` | No-op (statute antecedent has no caseName) |
| `Smith v. Jones, 100 F.2d 50. Id.` with `resolve: false` | No-op (no resolver pass) |

## Test plan

- [x] 9 new tests in `tests/resolve/idInheritsCaseName.test.ts`:
  - basic case-name inheritance
  - `In re` proceduralPrefix propagation
  - plaintiff/defendant fields
  - chained `Id.` (both inherit same caseName)
  - no-antecedent no-op
  - statute-antecedent no-op
  - `resolve: false` no-op
  - short-form chain transitive inheritance (Smith v. Jones → Smith, supra → Id.)
- [x] Full **2901-test suite** passes; no regressions
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)