### PR TITLE
fix: caseName backward search stops at prior `(YYYY)` paren + list connector

### DIFF
--- a/.changeset/casename-bounded-by-prior-year-paren.md
+++ b/.changeset/casename-bounded-by-prior-year-paren.md
@@ -1,0 +1,42 @@
+---
+"eyecite-ts": patch
+---
+
+fix: caseName backward search stops at prior citation's `(YYYY)` paren when followed by a list connector
+
+In citation lists with lowercase connectors like
+`...(Del. 1984), and Rales v. Blasband, 634 A.2d 927 (Del. 1993)`,
+the case-name backward search was crossing the previous
+citation's `(YYYY)` closing paren and absorbing it into the
+third citation's plaintiff:
+
+```
+got: caseName="Del. 1984), and Rales v. Blasband"
+     plaintiff="Del. 1984), and Rales"
+exp: caseName="Rales v. Blasband"
+     plaintiff="Rales"
+```
+
+`SENTENCE_BOUNDARY_REGEX` (`[.)]\s+(?=[A-Z(])`) requires the
+character after the boundary to be uppercase, so it skipped the
+lowercase `and` connector and let the backward search continue.
+
+### Fix
+
+New `PRIOR_YEAR_PAREN_BOUNDARY_REGEX` recognizes
+`<year>)\s*(?:,\s*(and|or|see|but\s+see|see\s+also|e\.g\.)|;)\s+`
+as a citation boundary. The connector word is required so the
+boundary doesn't false-positive on Montana / California
+year-first captions where the comma after the year leads to a
+parallel reporter (`Holton v. Co. (1981), 195 Mont. 1` — the
+`, 195` is a reporter, not a list connector).
+
+### Tests
+
+7 new tests in `tests/extract/issueCaseNameYearParenBoundary.test.ts`:
+three-case list with `, and`, two-case list with `, and`,
+semicolon connector, `see also` connector, multi-period court
+abbrev, and two regression sentinels (simple single citation,
+first citation in a list). Full 2925-test suite passes;
+existing #436 Montana-year-paren and #19 California-year-first
+tests still pass.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1105,6 +1105,19 @@ const PAREN_SIGNAL_BOUNDARY_REGEX =
  *  plaintiff field. #323 */
 const SENTENCE_BOUNDARY_REGEX = /[.)]\s+(?=[A-Z(])/g
 
+/** Prior-citation year-paren boundary: a closing paren preceded by a 4-digit
+ *  year, followed by an explicit citation-list connector word (`and`, `or`,
+ *  `see`, `but see`, `see also`, `e.g.`) or a semicolon. Catches the gap
+ *  left by SENTENCE_BOUNDARY_REGEX when the next caption's first word is
+ *  lowercase (e.g., `(Del. 1984), and Rales v. Blasband` — `and` is
+ *  lowercase so the sentence regex skips it).
+ *
+ *  The connector word is required (not optional) so we don't false-positive
+ *  on Montana / California year-first captions like `Holton v. Co. (1981),
+ *  195 Mont. 1` (the `, 195` is a parallel reporter, not a list connector). */
+const PRIOR_YEAR_PAREN_BOUNDARY_REGEX =
+  /\b\d{4}\)\s*(?:,\s*(?:and|or|see(?:\s+also)?|but\s+see|e\.g\.)|;)\s+/g
+
 /** Louisiana docket-prefix boundary (#232). Matches the Louisiana citation
  *  shape `NN-NNNN (La. ... M/D/YY)` or `YYYY-K-NNNN (La. ... M/D/YY)` that
  *  precedes the parallel `So. 2d` / `So. 3d` reporter citation. The capture
@@ -1231,6 +1244,19 @@ export function extractCaseName(
   // Check parenthetical signal boundaries (#182)
   PAREN_SIGNAL_BOUNDARY_REGEX.lastIndex = 0
   while ((match = PAREN_SIGNAL_BOUNDARY_REGEX.exec(precedingText)) !== null) {
+    const boundaryEnd = match.index + match[0].length
+    if (boundaryEnd > lastBoundaryIndex) {
+      lastBoundaryIndex = boundaryEnd
+    }
+  }
+
+  // Check prior-citation year-paren boundaries: `(YYYY), ` followed by an
+  // optional list connector (`and`/`or`/`see`/`;`). Catches the gap left by
+  // SENTENCE_BOUNDARY_REGEX when the next caption's first word is lowercase
+  // (e.g., `(Del. 1984), and Rales v. Blasband` — `and` is lowercase so the
+  // sentence regex skips it).
+  PRIOR_YEAR_PAREN_BOUNDARY_REGEX.lastIndex = 0
+  while ((match = PRIOR_YEAR_PAREN_BOUNDARY_REGEX.exec(precedingText)) !== null) {
     const boundaryEnd = match.index + match[0].length
     if (boundaryEnd > lastBoundaryIndex) {
       lastBoundaryIndex = boundaryEnd

--- a/tests/extract/issueCaseNameYearParenBoundary.test.ts
+++ b/tests/extract/issueCaseNameYearParenBoundary.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+const findByPage = (
+  text: string,
+  page: number | string,
+): FullCaseCitation | undefined => {
+  const cites = extractCitations(text)
+  return cites.find(
+    (c): c is FullCaseCitation =>
+      c.type === "case" && String(c.page) === String(page),
+  )
+}
+
+describe("caseName backward search bounded by prior citation's (YYYY) paren", () => {
+  describe("citation lists joined by `, and`", () => {
+    it("third citation in `A, B, and C` triple — caseName isolated to C", () => {
+      const text =
+        "In United Food & Commercial Workers Union v. Zuckerberg, 262 A.3d 1034 (Del. 2021), the Court adopted a test that blends elements from Aronson v. Lewis, 473 A.2d 805 (Del. 1984), and Rales v. Blasband, 634 A.2d 927 (Del. 1993)."
+      const third = findByPage(text, 927)
+      expect(third).toBeDefined()
+      expect(third?.caseName).toBe("Rales v. Blasband")
+      expect(third?.plaintiff).toBe("Rales")
+      expect(third?.defendant).toBe("Blasband")
+    })
+
+    it("second citation in `A, and B` pair — caseName isolated to B", () => {
+      const text =
+        "See Foo v. Bar, 100 F.2d 50 (1990), and Baz v. Qux, 200 F.3d 100 (2000)."
+      const second = findByPage(text, 100)
+      expect(second).toBeDefined()
+      expect(second?.caseName).toBe("Baz v. Qux")
+      expect(second?.plaintiff).toBe("Baz")
+    })
+
+    it("semicolon connector: `A; B` — second caseName isolated", () => {
+      const text =
+        "See Foo v. Bar, 100 F.2d 50 (1990); Baz v. Qux, 200 F.3d 100 (2000)."
+      const second = findByPage(text, 100)
+      expect(second).toBeDefined()
+      expect(second?.caseName).toBe("Baz v. Qux")
+    })
+
+    it("`see also` connector: `A; see also B` — second caseName isolated", () => {
+      const text =
+        "Foo v. Bar, 100 F.2d 50 (1990); see also Baz v. Qux, 200 F.3d 100 (2000)."
+      const second = findByPage(text, 100)
+      expect(second).toBeDefined()
+      expect(second?.caseName).toBe("Baz v. Qux")
+    })
+  })
+
+  describe("court+year paren with multiple periods", () => {
+    it("court abbrev with two periods `(D. Del. 1984)` doesn't pollute next caseName", () => {
+      const text =
+        "Smith v. Jones, 100 F. Supp. 2d 50 (D. Del. 1984), and Adams v. Brown, 200 F.3d 100 (3d Cir. 1995)."
+      const second = findByPage(text, 100)
+      expect(second).toBeDefined()
+      expect(second?.caseName).toBe("Adams v. Brown")
+    })
+  })
+
+  describe("regressions: single citations still work", () => {
+    it("simple `Smith v. Jones, 100 F.2d 50 (1990)`", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990)."
+      const cite = findByPage(text, 50)
+      expect(cite?.caseName).toBe("Smith v. Jones")
+    })
+
+    it("first citation in a list keeps its full case name", () => {
+      const text =
+        "In United Food & Commercial Workers Union v. Zuckerberg, 262 A.3d 1034 (Del. 2021), the rule applies."
+      const first = findByPage(text, 1034)
+      expect(first?.caseName).toBe(
+        "United Food & Commercial Workers Union v. Zuckerberg",
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

User report: in a citation triple like

```
United Food & Commercial Workers Union v. Zuckerberg, 262 A.3d 1034 (Del. 2021), the Court adopted a test that blends elements from Aronson v. Lewis, 473 A.2d 805 (Del. 1984), and Rales v. Blasband, 634 A.2d 927 (Del. 1993).
```

the third citation's case-name backward search greedily absorbed the previous citation's closing year paren:

```
got: caseName="Del. 1984), and Rales v. Blasband"
     plaintiff="Del. 1984), and Rales"
exp: caseName="Rales v. Blasband"
     plaintiff="Rales"
```

## Root cause

`SENTENCE_BOUNDARY_REGEX` (`[.)]\s+(?=[A-Z(])`) requires the next character to be uppercase, so it skipped the lowercase `and` connector and let the backward search continue past `(Del. 1984)`. The plaintiff char class allows `()`, so the regex matched `D...v...Blasband` with plaintiff = `Del. 1984), and Rales`.

## Fix

New `PRIOR_YEAR_PAREN_BOUNDARY_REGEX` recognizes a closing year paren followed by an explicit list connector:

```
\b\d{4}\)\s*(?:,\s*(?:and|or|see(?:\s+also)?|but\s+see|e\.g\.)|;)\s+
```

The connector word is required so the boundary doesn't false-positive on Montana / California year-first captions where the comma after the year leads to a parallel reporter (`Holton v. Co. (1981), 195 Mont. 1` — the `, 195` is a reporter, not a list connector).

## Test plan

- [x] 7 new tests in `tests/extract/issueCaseNameYearParenBoundary.test.ts`:
  - three-citation list (user's exact example)
  - two-citation list with `, and`
  - semicolon connector
  - `see also` connector
  - multi-period court abbreviation `(D. Del. 1984)`
  - regression: simple single citation
  - regression: first citation in a list keeps full name
- [x] Full **2925-test suite** passes; no regressions
- [x] **#436** (Montana year-paren `(1981), 195 Mont.`) test still passes
- [x] **#19** (California year-first `Smith v. Doe (1990) 50 Cal.3d`) tests still pass
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)