### PR TITLE
fix: Illinois `Ill. App. 3d` and Minnesota `N.W.2d` reporter normalization (#465, #466)

### DIFF
--- a/.changeset/reporter-spacing-ill-nw.md
+++ b/.changeset/reporter-spacing-ill-nw.md
@@ -1,0 +1,38 @@
+---
+"eyecite-ts": patch
+---
+
+fix: Illinois `Ill. App. 3d` and Minnesota `N.W.2d` reporter normalization (#465, #466)
+
+Two reporter-spacing normalizations were inconsistent with
+Bluebook T1:
+
+- **#465** — `Ill. App.3d` (no space before ordinal) preserved
+  as-is. The Bluebook canonical form is `Ill. App. 3d` (with
+  space). 19 occurrences in the IL sample.
+- **#466** — `N. W.2d` (space between `N.` and `W.`) preserved
+  as-is. The canonical form is `N.W.2d` (no inner space). 13
+  occurrences in the MN sample. Same pattern affects `S.W.`,
+  `N.E.`, `S.E.` regional reporters.
+
+### Fix
+
+In `normalizeReporterSpacing`:
+
+1. **Regional-reporter inner-space collapse** runs before the
+   general ordinal-suffix collapse:
+   `\b([NS])\.\s+([WE])\.` → `$1.$2.` covers
+   `N.W.` / `N.E.` / `S.W.` / `S.E.` regardless of input
+   spacing.
+2. **Illinois Appellate restore** runs after the general
+   collapse to add back the space the general rule strips:
+   `\bIll\.\s+App\.(\d+[a-z]+)` → `Ill. App. $1`.
+
+### Tests
+
+11 new tests in `tests/clean/reporterSpacingIllNw.test.ts`
+covering both directions (already-canonical and corrupted
+input) for `Ill. App. 2d/3d` and the four regional reporters
+`N.W.2d / S.W.2d / N.E.2d / S.E.2d`. Updated one existing #332
+regression sentinel to reflect the new canonical Illinois form.
+Full 2936-test suite passes.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -213,6 +213,12 @@ export function normalizeReporterSpacing(text: string): string {
   result = result.replace(/\bU\.\s*S\.\s*C\./g, "U.S.C.")
   result = result.replace(/\bC\.\s*F\.\s*R\./g, "C.F.R.")
 
+  // Regional-reporter inner-space collapse (N.W., S.W., N.E., S.E.):
+  // OCR / typesetter inserts a space between the directional letters
+  // (`N. W.2d` → `N.W.2d`). The general ordinal-suffix collapse below
+  // would handle the `2d` portion but not the inner letter-pair space. #466
+  result = result.replace(/\b([NS])\.\s+([WE])\./g, "$1.$2.")
+
   // Specific reporter abbreviation collapses
   result = result.replace(/\bU\.\s+S\./g, "U.S.")
   result = result.replace(/\bS\.\s+Ct\./g, "S.Ct.")
@@ -223,6 +229,11 @@ export function normalizeReporterSpacing(text: string): string {
   // General ordinal-suffix collapse: "Supp. 2d" → "Supp.2d", "Ed. 2d" → "Ed.2d",
   // "St. 3d" → "St.3d", "So. 2d" → "So.2d", "Wis. 2d" → "Wis.2d"
   result = result.replace(/([A-Za-z])\.\s+(\d+[a-z]+)/g, "$1.$2")
+
+  // Illinois Appellate Reports — restore the space `App.` strips out by the
+  // general rule above. Bluebook T1 canonical form is `Ill. App. 2d` /
+  // `Ill. App. 3d` (with a space before the ordinal). #465
+  result = result.replace(/\bIll\.\s+App\.(\d+[a-z]+)/g, "Ill. App. $1")
 
   return result
 }

--- a/tests/clean/reporterSpacingIllNw.test.ts
+++ b/tests/clean/reporterSpacingIllNw.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+const findCase = (text: string): FullCaseCitation | undefined => {
+  const cites = extractCitations(text)
+  return cites.find((c): c is FullCaseCitation => c.type === "case")
+}
+
+describe("Illinois Appellate reporter normalization (#465)", () => {
+  it("`Ill. App.3d` (no space before 3d) → canonical `Ill. App. 3d`", () => {
+    const text = "382 Ill. App.3d 802"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("Ill. App. 3d")
+  })
+
+  it("`Ill. App.2d` → `Ill. App. 2d`", () => {
+    const text = "313 Ill. App.2d 842"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("Ill. App. 2d")
+  })
+
+  it("`Ill. App. 3d` (already canonical) stays the same", () => {
+    const text = "315 Ill. App. 3d 221"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("Ill. App. 3d")
+  })
+
+  it("non-Illinois `Wis. 2d` still collapses to `Wis.2d` (regression)", () => {
+    const text = "300 Wis. 2d 880"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("Wis.2d")
+  })
+})
+
+describe("Regional reporter inner-space collapse (#466)", () => {
+  it("`N. W.2d` (space between N. and W.) → `N.W.2d`", () => {
+    const text = "19 N. W.2d 324"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("N.W.2d")
+  })
+
+  it("`N. W. 2d` (spaces everywhere) → `N.W.2d`", () => {
+    const text = "80 N. W. 2d 863"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("N.W.2d")
+  })
+
+  it("`S. W. 2d` → `S.W.2d`", () => {
+    const text = "100 S. W. 2d 200"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("S.W.2d")
+  })
+
+  it("`N. E. 2d` → `N.E.2d`", () => {
+    const text = "100 N. E. 2d 200"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("N.E.2d")
+  })
+
+  it("`S. E. 2d` → `S.E.2d`", () => {
+    const text = "100 S. E. 2d 200"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("S.E.2d")
+  })
+
+  it("`N.W.2d` (already canonical) stays the same", () => {
+    const text = "19 N.W.2d 324"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("N.W.2d")
+  })
+
+  it("inside running text: `Smith v. Doe, 103 N. W.2d 397 (Minn. 1960)`", () => {
+    const text = "Smith v. Doe, 103 N. W.2d 397 (Minn. 1960)"
+    const cite = findCase(text)
+    expect(cite?.reporter).toBe("N.W.2d")
+    expect(cite?.caseName).toBe("Smith v. Doe")
+    expect(cite?.year).toBe(1960)
+  })
+})

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5951,8 +5951,9 @@ describe("Illinois rule-marker boundary in state-reporter pattern (#332)", () =>
     expect(cases).toHaveLength(1)
     if (cases[0]?.type === "case") {
       expect(cases[0].volume).toBe(123)
-      // Reporter is post-normalization (`Ill. App. 3d` → `Ill. App.3d`)
-      expect(cases[0].reporter).toBe("Ill. App.3d")
+      // Reporter preserves the Bluebook T1 canonical form `Ill. App. 3d`
+      // (with space before the ordinal). See #465.
+      expect(cases[0].reporter).toBe("Ill. App. 3d")
       expect(cases[0].page).toBe(456)
     }
   })


### PR DESCRIPTION
## Summary

Closes #465 and #466. Both are reporter-spacing normalizations that didn't match Bluebook T1 canonical forms:

- **#465** — `Ill. App.3d` (no space before ordinal) preserved as-is. Bluebook canonical: `Ill. App. 3d` (with space). 19 occurrences in IL sample.
- **#466** — `N. W.2d` (space between `N.` and `W.`) preserved as-is. Canonical: `N.W.2d` (no inner space). 13 occurrences in MN sample. Same pattern affects `S.W.`, `N.E.`, `S.E.` regional reporters.

## Fix

In `normalizeReporterSpacing` (`src/clean/cleaners.ts`):

1. **Regional-reporter inner-space collapse** runs before the general ordinal-suffix collapse:
   ```
   \b([NS])\.\s+([WE])\.   →  $1.$2.
   ```
   Covers `N.W.` / `N.E.` / `S.W.` / `S.E.` regardless of input spacing.

2. **Illinois Appellate space-restoration** runs after the general collapse to add back the space the general rule strips:
   ```
   \bIll\.\s+App\.(\d+[a-z]+)  →  Ill. App. $1
   ```

## Test plan

- [x] 11 new tests in `tests/clean/reporterSpacingIllNw.test.ts`:
  - `Ill. App.3d` → `Ill. App. 3d`
  - `Ill. App.2d` → `Ill. App. 2d`
  - `Ill. App. 3d` already-canonical preserved
  - `Wis. 2d` → `Wis.2d` (non-IL regression preserved)
  - `N. W.2d` → `N.W.2d`
  - `N. W. 2d` → `N.W.2d`
  - `S. W. 2d`, `N. E. 2d`, `S. E. 2d` analogs
  - `N.W.2d` already-canonical preserved
  - running text with case-name + court+year
- [x] Updated one existing **#332** regression sentinel to reflect the new canonical Illinois form
- [x] Full **2936-test suite** passes
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)