### PR TITLE
fix: docket-number pattern accepts space-separated parts (e.g. `18 C 7039`)

### DIFF
--- a/.changeset/docket-space-separated-parts.md
+++ b/.changeset/docket-space-separated-parts.md
@@ -1,0 +1,39 @@
+---
+"eyecite-ts": patch
+---
+
+fix: docket-number pattern accepts space-separated parts (e.g. `18 C 7039`)
+
+Northern District of Illinois (and some other federal district
+courts) use space-separated docket numbers like `18 C 7039`
+(year + court code + sequence). The pattern only allowed
+hyphen-separated parts, so:
+
+```
+Carter v. Illinois Gaming Board, No. 18 C 7039 (N.D. Ill. Nov. 25, 2019)
+```
+
+was silently dropped.
+
+### Fix
+
+Extended the docket-number character class in both
+`docketPatterns.ts` and `extractDocket.ts` to allow space
+separators alongside hyphens:
+
+```
+[A-Za-z\d]+(?:[-\s][A-Za-z\d]+)*
+```
+
+The outer pattern's mandatory `\s+\(` before the court+year
+parenthetical preserves the natural bound — the docket-number
+stops where the court+year paren begins.
+
+### Tests
+
+3 new tests in `tests/extract/extractDocket.test.ts`:
+- N.D. Ill. `No. 18 C 7039 (N.D. Ill. Nov. 25, 2019)` (user-reported)
+- N.D. Ill. shorter form `No. 18 CV 1234`
+- hyphen-separated `No. 18-cv-7039` regression sentinel
+
+Full 2939-test suite passes.

--- a/src/extract/extractDocket.ts
+++ b/src/extract/extractDocket.ts
@@ -66,7 +66,7 @@ export function extractDocket(
   // match[1]. The docket number may start with letters (CT trial-court
   // `CV-01-...`, GA `A08A0646`) or digits.
   const tokenRegex =
-    /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?:-[\w\d]+)*)\s+\(([^)]+)\)/
+    /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+)\)/
   const match = tokenRegex.exec(text)
   if (!match) return undefined
 

--- a/src/patterns/docketPatterns.ts
+++ b/src/patterns/docketPatterns.ts
@@ -33,7 +33,7 @@ export const docketPatterns: Pattern[] = [
     // The `\bNo\.` anchor + space-separated paren keep this narrow without a
     // case-name lookbehind — case-name validation lives in the extractor.
     regex:
-      /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?:-[\w\d]+)*)\s+\(([^)]+\s(\d{4}))\)/g,
+      /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+\s(\d{4}))\)/g,
     description:
       'Docket-number citation: "Party v. Party, [C.A./Civ./Civil/Case/Adv./Docket] No. <docket> (<court> <year>)"',
     type: "docket",

--- a/tests/extract/extractDocket.test.ts
+++ b/tests/extract/extractDocket.test.ts
@@ -205,5 +205,38 @@ describe("Docket citation extraction (#215)", () => {
       expect(docket).toBeDefined()
       expect(docket?.docketNumber).toBe("CV-01-0508597")
     })
+
+    it("N.D. Ill. space-separated format: `No. 18 C 7039`", () => {
+      const text =
+        "Carter v. Illinois Gaming Board, No. 18 C 7039 (N.D. Ill. Nov. 25, 2019) (collecting Seventh Circuit cases)."
+      const citations = extractCitations(text)
+      const docket = citations.find((c) => c.type === "docket") as
+        | DocketCitation
+        | undefined
+      expect(docket).toBeDefined()
+      expect(docket?.docketNumber).toBe("18 C 7039")
+      expect(docket?.caseName).toBe("Carter v. Illinois Gaming Board")
+      expect(docket?.year).toBe(2019)
+    })
+
+    it("N.D. Ill. shorter form `No. 18 CV 1234`", () => {
+      const text = "Foo v. Bar, No. 18 CV 1234 (N.D. Ill. 2018)."
+      const citations = extractCitations(text)
+      const docket = citations.find((c) => c.type === "docket") as
+        | DocketCitation
+        | undefined
+      expect(docket).toBeDefined()
+      expect(docket?.docketNumber).toBe("18 CV 1234")
+    })
+
+    it("hyphen-separated still works (regression)", () => {
+      const text = "Foo v. Bar, No. 18-cv-7039 (N.D. Ill. 2018)."
+      const citations = extractCitations(text)
+      const docket = citations.find((c) => c.type === "docket") as
+        | DocketCitation
+        | undefined
+      expect(docket).toBeDefined()
+      expect(docket?.docketNumber).toBe("18-cv-7039")
+    })
   })
 })


### PR DESCRIPTION
## Summary

User-reported bug: `Carter v. Illinois Gaming Board, No. 18 C 7039 (N.D. Ill. Nov. 25, 2019)` was silently dropped. The N.D. Ill. uses space-separated docket numbers (year + court code + sequence), and the docket-number pattern only allowed hyphen-separated parts.

## Fix

Extended the docket-number character class to allow space separators alongside hyphens:

```
[A-Za-z\d]+(?:[-\s][A-Za-z\d]+)*
```

The outer pattern's mandatory `\s+\(` before the court+year parenthetical preserves the natural bound — the docket-number stops where the court+year paren begins.

## Test plan

- [x] 3 new tests:
  - N.D. Ill. `No. 18 C 7039 (N.D. Ill. Nov. 25, 2019)` (user's exact example)
  - N.D. Ill. shorter form `No. 18 CV 1234 (N.D. Ill. 2018)`
  - hyphen-separated `No. 18-cv-7039` regression sentinel
- [x] Full **2939-test suite** passes
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)