### PR TITLE
fix: docket-number pattern accepts PACER colon prefix (`2:17-cv-00413`)

### DIFF
--- a/.changeset/docket-pacer-colon.md
+++ b/.changeset/docket-pacer-colon.md
@@ -1,0 +1,33 @@
+---
+"eyecite-ts": patch
+---
+
+fix: docket-number pattern accepts PACER colon prefix (e.g. `2:17-cv-00413`)
+
+Federal district courts use the PACER/CM/ECF format where the
+docket number has a court-division colon prefix:
+`2:17-cv-00413` (E.D.N.Y. division 2, case year 2017,
+civil-type, sequence 00413). The previous pattern did not
+include `:` in the docket-number character class, so
+
+```
+G. v. United Healthcare, No. 2:17-cv-00413 (D. Utah June 9, 2020)
+```
+
+was silently dropped.
+
+### Fix
+
+Extended the docket-number regex to accept an optional
+single-colon division prefix: `[A-Za-z\d]+(?::?[A-Za-z\d]+)?`
+in front of the existing hyphen/space-separated parts.
+
+### Tests
+
+3 new tests in `tests/extract/extractDocket.test.ts`:
+- PACER `No. 2:17-cv-00413 (D. Utah June 9, 2020)` (user-reported)
+- PACER with `Civil No.` prefix and colon
+- anonymized single-letter plaintiff `G. v. United Healthcare`
+
+Full 2942-test suite passes; existing hyphen-only and
+space-separated formats still extract.

--- a/src/extract/extractDocket.ts
+++ b/src/extract/extractDocket.ts
@@ -66,7 +66,7 @@ export function extractDocket(
   // match[1]. The docket number may start with letters (CT trial-court
   // `CV-01-...`, GA `A08A0646`) or digits.
   const tokenRegex =
-    /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+)\)/
+    /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?::?[A-Za-z\d]+)?(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+)\)/
   const match = tokenRegex.exec(text)
   if (!match) return undefined
 

--- a/src/patterns/docketPatterns.ts
+++ b/src/patterns/docketPatterns.ts
@@ -33,7 +33,7 @@ export const docketPatterns: Pattern[] = [
     // The `\bNo\.` anchor + space-separated paren keep this narrow without a
     // case-name lookbehind — case-name validation lives in the extractor.
     regex:
-      /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+\s(\d{4}))\)/g,
+      /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?::?[A-Za-z\d]+)?(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+\s(\d{4}))\)/g,
     description:
       'Docket-number citation: "Party v. Party, [C.A./Civ./Civil/Case/Adv./Docket] No. <docket> (<court> <year>)"',
     type: "docket",

--- a/tests/extract/extractDocket.test.ts
+++ b/tests/extract/extractDocket.test.ts
@@ -238,5 +238,39 @@ describe("Docket citation extraction (#215)", () => {
       expect(docket).toBeDefined()
       expect(docket?.docketNumber).toBe("18-cv-7039")
     })
+
+    it("PACER format with colon: `No. 2:17-cv-00413`", () => {
+      const text =
+        "G. v. United Healthcare, No. 2:17-cv-00413 (D. Utah June 9, 2020)."
+      const citations = extractCitations(text)
+      const docket = citations.find((c) => c.type === "docket") as
+        | DocketCitation
+        | undefined
+      expect(docket).toBeDefined()
+      expect(docket?.docketNumber).toBe("2:17-cv-00413")
+      expect(docket?.caseName).toBe("G. v. United Healthcare")
+    })
+
+    it("PACER format with prefix and colon: `Civil No. 1:22-cv-1234`", () => {
+      const text =
+        "Smith v. Jones, Civil No. 1:22-cv-1234 (S.D.N.Y. Apr. 1, 2024)."
+      const citations = extractCitations(text)
+      const docket = citations.find((c) => c.type === "docket") as
+        | DocketCitation
+        | undefined
+      expect(docket).toBeDefined()
+      expect(docket?.docketNumber).toBe("1:22-cv-1234")
+    })
+
+    it("anonymized single-letter plaintiff: `G. v. United Healthcare`", () => {
+      const text =
+        "G. v. United Healthcare, No. 2:17-cv-00413 (D. Utah 2020)."
+      const citations = extractCitations(text)
+      const docket = citations.find((c) => c.type === "docket") as
+        | DocketCitation
+        | undefined
+      expect(docket).toBeDefined()
+      expect(docket?.caseName).toBe("G. v. United Healthcare")
+    })
   })
 })


### PR DESCRIPTION
## Summary

User-reported bug: `G. v. United Healthcare, No. 2:17-cv-00413 (D. Utah June 9, 2020)` was silently dropped. The PACER/CM/ECF format used by federal district courts has a court-division colon prefix on the docket number (`2:17-cv-00413` = division 2, year 2017, civil, sequence 00413).

## Fix

Extended the docket-number regex to accept an optional single-colon division prefix:

```
[A-Za-z\d]+(?::?[A-Za-z\d]+)?
```

in front of the existing hyphen/space-separated parts. Pattern handles:

- `2:17-cv-00413` (PACER with colon)
- `18 C 7039` (N.D. Ill. space-separated — #473)
- `18-cv-7039` (federal civil hyphenated)
- `CV-01-0508597` (CT trial-court letter-prefix)
- `2023-0522-KSJM` (Delaware Chancery)

## Test plan

- [x] 3 new tests:
  - PACER `No. 2:17-cv-00413 (D. Utah June 9, 2020)` (user's exact example)
  - PACER with `Civil No.` prefix and colon
  - anonymized single-letter plaintiff `G. v. United Healthcare`
- [x] Full **2942-test suite** passes; existing formats still extract
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)