### PR TITLE
fix: caseName truncates at section-heading `Is`/`Are`/`Was`/`Were` boundary

### DIFF
--- a/.changeset/casename-heading-boundary.md
+++ b/.changeset/casename-heading-boundary.md
@@ -1,0 +1,38 @@
+---
+"eyecite-ts": patch
+---
+
+fix: caseName backward search truncates at section-heading `Is`/`Are`/`Was`/`Were` boundary
+
+In documents where a section heading repeats the case name —
+common in legal briefs:
+
+```
+Des Roches v. California Physicians' Service Is Distinguishable
+In Des Roches v. California Physicians' Service, 320 F.R.D. 486 (N.D. Cal. 2017), ...
+```
+
+— the case-name backward search absorbed the heading's text into
+the defendant, producing
+`caseName="Des Roches v. California Physicians' Service Is
+Distinguishable In Des Roches v. California Physicians' Service"`.
+The existing consolidated-caption recovery (#222) only truncates
+at the first comma in the defendant; section headings have no
+internal commas so the recovery didn't fire.
+
+### Fix
+
+After the multi-`v.` comma-truncation step, also check for a
+standalone capitalized to-be verb (`Is`, `Are`, `Was`, `Were`)
+inside the defendant. Real corporate / party names don't contain
+these verbs as standalone tokens, so their presence is a reliable
+heading-boundary signal. Truncate the defendant at the verb.
+
+### Tests
+
+7 new tests in `tests/extract/issueCaseNameHeadingBoundary.test.ts`:
+heading + body with the same case name (3 variants — `Is`,
+`Are`), plus regressions for `Anthem, Inc.` (real defendant
+preserved), single citations with no heading, California
+year-first form, and consolidated-caption first-comma trim.
+Full 2949-test suite passes.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1376,6 +1376,18 @@ export function extractCaseName(
         }
       }
 
+      // Section-heading boundary: when the defendant captured includes a
+      // standalone capitalized to-be verb (`Is`, `Are`, `Was`, `Were`), the
+      // backward search crossed a section heading like `Smith v. Jones Is
+      // Distinguishable\nIn Smith v. Jones, 100 F.2d 50 (1990)`. Real
+      // corporate / party names don't contain these verbs as standalone
+      // tokens — truncate the defendant at the verb to recover the real
+      // defendant name.
+      const headingVerbMatch = /\s(?:Is|Are|Was|Were)\s/.exec(defendantText)
+      if (headingVerbMatch) {
+        defendantText = defendantText.substring(0, headingVerbMatch.index).trim()
+      }
+
       // Preserve the source's `v` punctuation form in `caseName`. New York
       // courts use `v` (no period); federal/most state courts use `v.`. The
       // existing V_CASE_NAME_REGEX accepts both via `v(?:s)?\.?` — extract

--- a/tests/extract/issueCaseNameHeadingBoundary.test.ts
+++ b/tests/extract/issueCaseNameHeadingBoundary.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+const findFirstCase = (text: string): FullCaseCitation | undefined => {
+  const cites = extractCitations(text)
+  return cites.find((c): c is FullCaseCitation => c.type === "case")
+}
+
+describe("caseName backward search does not span section heading", () => {
+  describe("heading + body with same case name", () => {
+    it("`Des Roches v. ... Is Distinguishable\\nIn Des Roches v. ..., 320 F.R.D. 486`", () => {
+      const text = `Des Roches v. California Physicians' Service Is Distinguishable
+In Des Roches v. California Physicians' Service, 320 F.R.D. 486 (N.D. Cal. 2017), the court certified...`
+      const cite = findFirstCase(text)
+      expect(cite?.caseName).toBe("Des Roches v. California Physicians' Service")
+      expect(cite?.plaintiff).toBe("Des Roches")
+      expect(cite?.defendant).toBe("California Physicians' Service")
+    })
+
+    it("`Smith v. Jones Is Inapposite\\nThe Smith v. Jones, 100 F.2d 50 (1990) holding`", () => {
+      const text = `Smith v. Jones Is Inapposite
+The court in Smith v. Jones, 100 F.2d 50 (1990) held...`
+      const cite = findFirstCase(text)
+      expect(cite?.caseName).toBe("Smith v. Jones")
+      expect(cite?.defendant).toBe("Jones")
+    })
+
+    it("heading with `Are` boundary: `... Are Distinguishable`", () => {
+      const text = `Foo v. Bar Are Distinguishable
+In Foo v. Bar, 100 F.2d 50 (1990), ...`
+      const cite = findFirstCase(text)
+      expect(cite?.caseName).toBe("Foo v. Bar")
+      expect(cite?.defendant).toBe("Bar")
+    })
+  })
+
+  describe("regressions", () => {
+    it("real defendant `Anthem, Inc.` not truncated", () => {
+      const text = "Collins v. Anthem, Inc., 100 F.2d 50 (1990)"
+      const cite = findFirstCase(text)
+      expect(cite?.defendant).toBe("Anthem, Inc.")
+    })
+
+    it("single citation with no heading still works", () => {
+      const text = "Smith v. Jones, 100 F.2d 50 (1990)"
+      const cite = findFirstCase(text)
+      expect(cite?.defendant).toBe("Jones")
+    })
+
+    it("California year-first form preserved", () => {
+      const text = "People v. Smith (1990) 50 Cal.3d 100"
+      const cite = findFirstCase(text)
+      expect(cite?.caseName).toBe("People v. Smith")
+    })
+
+    it("consolidated captions still trim at comma", () => {
+      const text = "Smith v. Doe, et al. v. Jones, 100 F.2d 50 (1990)"
+      const cite = findFirstCase(text)
+      // The "consolidated caption" recovery truncates at first comma.
+      expect(cite?.defendant).toBeDefined()
+      expect(cite?.defendant?.includes(" v. ")).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

User report: in this brief excerpt

```
Des Roches v. California Physicians' Service Is Distinguishable
In Des Roches v. California Physicians' Service, 320 F.R.D. 486 (N.D. Cal. 2017), ...
```

the case-name backward search absorbed the heading's text into the defendant:

```
got: caseName="Des Roches v. California Physicians' Service Is Distinguishable
               In Des Roches v. California Physicians' Service"
exp: caseName="Des Roches v. California Physicians' Service"
```

## Root cause

The existing consolidated-caption recovery (#222) only truncates the defendant at its first comma, but section headings have no internal commas — so the recovery didn't fire and the lazy `+?` defendant extended all the way through the heading to the comma before the reporter.

## Fix

After the multi-`v.` comma-truncation step, also check for a standalone capitalized to-be verb (`Is`/`Are`/`Was`/`Were`) inside the defendant:

```typescript
const headingVerbMatch = /\s(?:Is|Are|Was|Were)\s/.exec(defendantText)
if (headingVerbMatch) {
  defendantText = defendantText.substring(0, headingVerbMatch.index).trim()
}
```

Real party / corporate names don't contain these verbs as standalone capitalized tokens, so their presence is a reliable heading-boundary signal.

## Test plan

- [x] 7 new tests in `tests/extract/issueCaseNameHeadingBoundary.test.ts`:
  - **user's exact case**: `Des Roches v. ... Is Distinguishable` + body
  - `Smith v. Jones Is Inapposite` + body
  - `Foo v. Bar Are Distinguishable` + body
  - **regression**: real defendant `Anthem, Inc.` preserved
  - **regression**: single citation with no heading
  - **regression**: California year-first form `People v. Smith (1990) 50 Cal.3d 100`
  - **regression**: consolidated-caption `Smith v. Doe, et al. v. Jones` first-comma trim
- [x] Full **2949-test suite** passes; no regressions
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)