### PR TITLE
fix: caseName multi-`v.` recovery preserves entity-suffix commas (`, Inc.` / `, LLC`)

### DIFF
--- a/.changeset/casename-entity-suffix-preserved.md
+++ b/.changeset/casename-entity-suffix-preserved.md
@@ -1,0 +1,43 @@
+---
+"eyecite-ts": patch
+---
+
+fix: caseName multi-`v.` recovery preserves entity-suffix commas (`, Inc.` / `, LLC` / `, Corp.`)
+
+Follow-up to the heading-boundary fix (#477). When a section
+heading + body produces a defendant with multiple `v.` anchors
+AND no heading-verb boundary (e.g., the body cite uses a docket
+number rather than a reporter), the recovery fell back to the
+existing comma-trim logic, which truncates at the FIRST comma
+in the defendant — incorrectly stripping entity suffixes like
+`, Inc.`:
+
+```
+Collins v. Anthem, Inc. Is Distinguishable
+In Collins v. Anthem, Inc., No. 20-CV-01969 (E.D.N.Y. Mar. 19, 2024) ...
+
+got: caseName="Collins v. Anthem"
+exp: caseName="Collins v. Anthem, Inc."
+```
+
+### Fix
+
+Multi-`v.` recovery is now reordered and entity-aware:
+
+1. **Heading-verb boundary first** (definitive). If the
+   defendant contains a standalone to-be verb (`Is`/`Are`/
+   `Was`/`Were`), truncate there. This preserves entity-suffix
+   commas because the verb sits between the entity suffix and
+   the heading-prose.
+2. **Comma-trim with entity-suffix skip**. When no heading-verb
+   is present, scan for commas — but skip any comma immediately
+   followed by `Inc.`, `LLC`, `Corp.`, `Co.`, `Ltd.`, `LLP`,
+   `LP`, `P.C.`, `N.A.`, `S.A.`, `GmbH`, or `S.p.A.`.
+
+### Tests
+
+3 new tests added to
+`tests/extract/issueCaseNameHeadingBoundary.test.ts` covering
+`Anthem, Inc.` / `Acme, LLC` / `Acme, Corp.` in the heading +
+body shape. Full 2952-test suite passes; #222 consolidated
+captions and #436 entity-suffix tests still pass.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1365,27 +1365,45 @@ export function extractCaseName(
       // Detect consolidated captions: vMatch[0] contains 2+ "v." anchors.
       // The non-greedy regex defendant (group 2) is anchored at the trailing
       // ",$" and so absorbs downstream comma-separated caption segments
-      // including their own "v." anchors (#222). Recovery: truncate the
-      // defendant at its first comma to keep just the first "X v. Y" pair.
+      // including their own "v." anchors (#222). Recovery has two stages:
+      //   1. Section-heading boundary first: if the defendant contains a
+      //      standalone to-be verb (`Is`/`Are`/`Was`/`Were`), the backward
+      //      search crossed a section heading. Real party names don't
+      //      contain these verbs — truncate there. This must run BEFORE
+      //      comma-trim because heading-boundary truncation preserves
+      //      entity-suffix commas like `Anthem, Inc.`.
+      //   2. Comma-trim: for consolidated captions without a heading verb,
+      //      truncate the defendant at its first comma — but only when the
+      //      text after the comma does NOT start with a corporate entity
+      //      suffix (`Inc.`, `LLC`, `Corp.`, etc.), which are part of the
+      //      defendant name itself.
       const vAnchorMatches = vMatch[0].match(/\bv(?:s)?\.\s/g)
       let defendantText = vMatch[2].trim()
       if (vAnchorMatches && vAnchorMatches.length >= 2) {
-        const firstCommaInDefendant = vMatch[2].indexOf(",")
-        if (firstCommaInDefendant !== -1) {
-          defendantText = vMatch[2].substring(0, firstCommaInDefendant).trim()
+        // Heading-verb boundary first.
+        const headingVerbMatch = /\s(?:Is|Are|Was|Were)\s/.exec(defendantText)
+        if (headingVerbMatch) {
+          defendantText = defendantText.substring(0, headingVerbMatch.index).trim()
+        } else {
+          // Fall back to comma-trim, skipping entity-suffix commas.
+          let scanFrom = 0
+          while (scanFrom < vMatch[2].length) {
+            const commaIdx = vMatch[2].indexOf(",", scanFrom)
+            if (commaIdx === -1) break
+            const after = vMatch[2].substring(commaIdx + 1).trimStart()
+            if (
+              /^(?:Inc|LLC|Corp|Ltd|Co|LLP|LP|P\.?C|N\.?A|S\.?A|GmbH|S\.?p\.?A)\.?(?:\b|$)/.test(
+                after,
+              )
+            ) {
+              // Entity-suffix comma — skip and keep scanning.
+              scanFrom = commaIdx + 1
+              continue
+            }
+            defendantText = vMatch[2].substring(0, commaIdx).trim()
+            break
+          }
         }
-      }
-
-      // Section-heading boundary: when the defendant captured includes a
-      // standalone capitalized to-be verb (`Is`, `Are`, `Was`, `Were`), the
-      // backward search crossed a section heading like `Smith v. Jones Is
-      // Distinguishable\nIn Smith v. Jones, 100 F.2d 50 (1990)`. Real
-      // corporate / party names don't contain these verbs as standalone
-      // tokens — truncate the defendant at the verb to recover the real
-      // defendant name.
-      const headingVerbMatch = /\s(?:Is|Are|Was|Were)\s/.exec(defendantText)
-      if (headingVerbMatch) {
-        defendantText = defendantText.substring(0, headingVerbMatch.index).trim()
       }
 
       // Preserve the source's `v` punctuation form in `caseName`. New York

--- a/tests/extract/issueCaseNameHeadingBoundary.test.ts
+++ b/tests/extract/issueCaseNameHeadingBoundary.test.ts
@@ -42,6 +42,31 @@ In Foo v. Bar, 100 F.2d 50 (1990), ...`
       expect(cite?.defendant).toBe("Anthem, Inc.")
     })
 
+    it("entity-suffix `, Inc.` preserved when heading triggers multi-`v.`", () => {
+      // The full text has both a section heading and the body citation. The
+      // heading triggers the multi-`v.` recovery, and the recovery must NOT
+      // truncate `Anthem, Inc.` at the entity-suffix comma.
+      const text = `Collins v. Anthem, Inc. Is Distinguishable
+In Collins v. Anthem, Inc., 100 F.2d 50 (1990), the court...`
+      const cite = findFirstCase(text)
+      expect(cite?.caseName).toBe("Collins v. Anthem, Inc.")
+      expect(cite?.defendant).toBe("Anthem, Inc.")
+    })
+
+    it("entity-suffix `, LLC` preserved with heading", () => {
+      const text = `Foo v. Acme, LLC Is Distinguishable
+In Foo v. Acme, LLC, 100 F.2d 50 (1990), ...`
+      const cite = findFirstCase(text)
+      expect(cite?.defendant).toBe("Acme, LLC")
+    })
+
+    it("entity-suffix `, Corp.` preserved with heading", () => {
+      const text = `Foo v. Acme, Corp. Is Distinguishable
+In Foo v. Acme, Corp., 100 F.2d 50 (1990), ...`
+      const cite = findFirstCase(text)
+      expect(cite?.defendant).toBe("Acme, Corp.")
+    })
+
     it("single citation with no heading still works", () => {
       const text = "Smith v. Jones, 100 F.2d 50 (1990)"
       const cite = findFirstCase(text)


### PR DESCRIPTION
## Summary

Follow-up to #477. When the heading-boundary fix doesn't apply (because the body cite uses a docket number, not a reporter), the fallback comma-trim incorrectly stripped entity suffixes:

```
Collins v. Anthem, Inc. Is Distinguishable
In Collins v. Anthem, Inc., No. 20-CV-01969 (E.D.N.Y. Mar. 19, 2024) ...

got: caseName="Collins v. Anthem"
exp: caseName="Collins v. Anthem, Inc."
```

## Fix

Reorder multi-`v.` recovery:

1. **Heading-verb boundary first** (definitive). If the defendant contains a standalone `Is`/`Are`/`Was`/`Were`, truncate there.
2. **Comma-trim fallback** now skips commas immediately followed by entity suffixes: `Inc.`, `LLC`, `Corp.`, `Co.`, `Ltd.`, `LLP`, `LP`, `P.C.`, `N.A.`, `S.A.`, `GmbH`, `S.p.A.`.

## Test plan

- [x] 3 new tests added to `tests/extract/issueCaseNameHeadingBoundary.test.ts`:
  - `Anthem, Inc.` preserved in heading + body shape
  - `Acme, LLC` preserved
  - `Acme, Corp.` preserved
- [x] Full **2952-test suite** passes
- [x] **#222** consolidated-caption tests still pass
- [x] **#436** entity-suffix tests still pass
- [x] **#477** heading-boundary tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)