### PR TITLE
fix: Id. antecedent resolution respects signals, quote zones, and pincite shape (#480)

### DIFF
--- a/.changeset/id-antecedent-resolution-480.md
+++ b/.changeset/id-antecedent-resolution-480.md
@@ -1,0 +1,59 @@
+---
+"eyecite-ts": minor
+---
+
+fix: `Id.` antecedent resolution respects Bluebook signals, quote zones, and pincite shape (#480)
+
+The resolver previously stamped the nearest preceding full citation as
+`Id.`'s antecedent, regardless of how the citation appeared. In
+documents with intervening signal-phrase citations (`See also …`,
+`Cf. …`), block-quoted material, or mixed case/statute references,
+this produced wrong antecedents for downstream consumers.
+
+### What changed
+
+`DocumentResolver.resolveId` now walks back over the citations list and
+scores candidates instead of taking the last-set `lastResolvedIndex`. The
+new scoring axes:
+
+1. **Signal-phrase awareness.** Citations introduced with `see`, `see
+   also`, `see generally`, `cf.`, `but cf.`, `compare`, or any `, e.g.`
+   variant are treated as *asides* and skipped when a non-signaled
+   candidate is in scope. Direct-engagement signals (`accord`, `contra`,
+   `but see`) remain strong. Members of a string-cite group inherit the
+   group's leading signal.
+2. **Quote-boundary respect.** Citations inside markdown blockquotes
+   (`> …` lines) or inline paired double-quotes (`"…"`) don't compete
+   for `Id.`'s antecedent unless `Id.` itself is in the same quote zone.
+3. **Family preference from pincite shape.** `Id. at NNN` prefers a
+   case-family antecedent; `Id. § NNN(x)` prefers a statute-family
+   antecedent. A statute in the gap no longer captures a following
+   `Id. at 125` when an earlier case is in scope.
+4. **Case-name window check.** When the prose immediately before `Id.`
+   names a case that doesn't match the picked antecedent (`"As Resek
+   held, … Id."`), the resolver commits to the chosen antecedent but
+   reports `confidence: 0.75` and an ambiguity warning so consumers
+   can surface the conflict for review.
+
+The short-form chain behavior is preserved: a `shortFormCase`/`supra`/
+`Id.` that resolved to an earlier full citation still re-anchors the
+"current authority" for a following `Id.`.
+
+### Behavior change
+
+Two existing tests were updated to reflect criterion 5 (non-case
+deprioritization): when a statute interrupts a case discussion and the
+next `Id.` has a page-style pincite, the resolver now points to the
+case rather than the statute. Consumers that relied on the previous
+"most-recent authority of any type" rule will see different
+`resolution.resolvedTo` indices in these mixed-type sequences. A
+statute-only context still resolves `Id.` to the statute.
+
+### Tests
+
+18 new tests in `tests/resolve/issue480_idAntecedent.test.ts` cover all
+five acceptance criteria from the issue: simple `case → Id.`
+(no regression), signal-phrase intervening cites (`see also`, `cf.`,
+`see`, `but cf.`, `compare`, `see generally`), block-quote and inline-
+quote skip, matching/mismatching case-name window, and case/statute
+family routing. Full suite: 2962 tests pass.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -12,6 +12,7 @@
 
 import type {
   Citation,
+  CitationSignal,
   FullCaseCitation,
   IdCitation,
   ShortFormCaseCitation,
@@ -43,6 +44,123 @@ function getFullSpan(citation: Citation): Span | undefined {
 }
 
 /**
+ * Bluebook signal categories that mark a citation as an *aside* — supporting,
+ * comparative, or background — rather than a primary cited authority.
+ * Citations carrying a weak signal are skipped when picking an `Id.`
+ * antecedent unless no stronger candidate is in scope. Suggested-contradiction
+ * (`but cf.`) is weak; direct-contradiction (`contra`, `but see`) is strong
+ * because the writer is squarely engaging the cited authority.
+ */
+const WEAK_SIGNALS: ReadonlySet<CitationSignal> = new Set<CitationSignal>([
+  "see",
+  "see also",
+  "see generally",
+  "cf",
+  "but cf",
+  "compare",
+  "e.g.",
+  "see, e.g.",
+  "see also, e.g.",
+  "cf., e.g.",
+  "but cf., e.g.",
+])
+
+/**
+ * Family classification used when matching `Id.` to an antecedent. Page-style
+ * pincites (`Id. at 70`) point to `case`-family authorities (case, journal,
+ * neutral, court reporter). Section-style pincites (`Id. § 1983(c)`) point
+ * to `statute`-family authorities (statute, public-law, regulation).
+ */
+type CitationFamily = "case" | "statute" | "other"
+
+function citationFamily(citation: Citation): CitationFamily {
+  switch (citation.type) {
+    case "case":
+    case "journal":
+    case "neutral":
+      return "case"
+    case "statute":
+    case "publicLaw":
+    case "federalRegister":
+    case "statutesAtLarge":
+      return "statute"
+    default:
+      return "other"
+  }
+}
+
+/**
+ * Detects block-quote and inline-quote zones in **original** text and
+ * returns sorted, non-overlapping `{start, end}` ranges in original-text
+ * coordinates. Callers must look up citations via `span.originalStart`,
+ * not `cleanStart` — the clean pipeline collapses newlines so a markdown
+ * `> …` becomes inline with the surrounding sentence and the line-based
+ * blockquote shape is lost. Two zone shapes are recognized:
+ *
+ *   - Markdown blockquotes: contiguous lines whose first non-whitespace
+ *     character is `>`. The zone spans from the first such line's start to
+ *     the end of the last contiguous line.
+ *   - Inline paired double-quotes: greedy `"…"` regions on a single content
+ *     stretch. We only accept pairs that are at most ~600 chars apart, which
+ *     filters most cases of stray unbalanced quotes; longer "quotes" would
+ *     swallow unrelated citations and produce wrong skips.
+ */
+function detectQuoteZones(text: string): Array<{ start: number; end: number }> {
+  const zones: Array<{ start: number; end: number }> = []
+
+  // Markdown blockquotes (`>` lines).
+  let lineStart = 0
+  let zoneStart = -1
+  for (let i = 0; i <= text.length; i++) {
+    const atEnd = i === text.length
+    if (atEnd || text[i] === "\n") {
+      const line = text.substring(lineStart, i)
+      const trimmed = line.replace(/^[ \t]*/, "")
+      const isQuoteLine = trimmed.startsWith(">")
+      if (isQuoteLine) {
+        if (zoneStart === -1) zoneStart = lineStart
+      } else if (zoneStart !== -1) {
+        zones.push({ start: zoneStart, end: lineStart })
+        zoneStart = -1
+      }
+      lineStart = i + 1
+    }
+  }
+  if (zoneStart !== -1) zones.push({ start: zoneStart, end: text.length })
+
+  // Inline paired double-quotes.
+  const MAX_INLINE_QUOTE_LEN = 600
+  let openPos = -1
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== '"') continue
+    if (openPos === -1) {
+      openPos = i
+    } else {
+      const length = i - openPos + 1
+      if (length <= MAX_INLINE_QUOTE_LEN) {
+        zones.push({ start: openPos, end: i + 1 })
+      }
+      openPos = -1
+    }
+  }
+
+  zones.sort((a, b) => a.start - b.start)
+  return zones
+}
+
+function isInZone(
+  pos: number,
+  zones: ReadonlyArray<{ start: number; end: number }>,
+): { start: number; end: number } | undefined {
+  // Linear scan is fine; zone counts in real briefs are well under 50.
+  for (const zone of zones) {
+    if (pos < zone.start) return undefined
+    if (pos < zone.end) return zone
+  }
+  return undefined
+}
+
+/**
  * Document-scoped resolver that processes citations sequentially
  * and resolves short-form citations to their antecedents.
  */
@@ -54,6 +172,14 @@ export class DocumentResolver {
   }
   private readonly context: ResolutionContext
   private readonly partyNameTree: BKTree
+  private readonly quoteZones: ReadonlyArray<{ start: number; end: number }>
+  /** Parenthesis depth at each citation's start (filled lazily by resolve()). */
+  private parenDepths: number[] = []
+  /** Resolution results accumulated during the in-flight resolve() pass. */
+  private resolutions: Array<ResolutionResult | undefined> = []
+  /** Resolved citations accumulated during the in-flight resolve() pass; used
+   *  for fullSpan-based parenthetical-child detection on later candidates. */
+  private resolvedSoFar: ResolvedCitation[] = []
 
   /**
    * Creates a new DocumentResolver.
@@ -78,6 +204,7 @@ export class DocumentResolver {
     }
 
     this.partyNameTree = new BKTree(levenshteinDistance)
+    this.quoteZones = detectQuoteZones(text)
 
     // Initialize resolution context
     this.context = {
@@ -111,13 +238,12 @@ export class DocumentResolver {
   resolve(): ResolvedCitation[] {
     const resolved: ResolvedCitation[] = []
 
-    // Precompute, for each citation, its parenthesis depth at its start
-    // position relative to the raw document. A citation inside `(...)` is
-    // a parenthetical child of whatever opened that paren — typically the
-    // preceding citation's explanatory `(quoting X)` or `(citing Y)` block.
-    // This is more robust than relying on `fullSpan`, which is only computed
-    // for `case`/`docket` citations (shortFormCase, statute, etc. lack it).
-    const parenDepths = this.computeParenDepths()
+    // Reset per-call state so a single DocumentResolver can be reused (the
+    // public API currently constructs a fresh one per document, but the
+    // per-instance fields make the algorithm easier to follow).
+    this.parenDepths = this.computeParenDepths()
+    this.resolutions = new Array(this.citations.length).fill(undefined)
+    this.resolvedSoFar = resolved
 
     for (let i = 0; i < this.citations.length; i++) {
       this.context.citationIndex = i
@@ -137,43 +263,19 @@ export class DocumentResolver {
           resolution = this.resolveShortFormCase(citation)
           break
         default:
-          // Full citation - update context for future resolutions.
+          // Full citation. The new Id. resolver walks back over the citations
+          // list and consults `this.resolutions[i]` for short-form chains, so
+          // it no longer needs `context.lastResolvedIndex` as a fast path.
+          // We still need to register party names for `supra`.
           if (isFullCitation(citation)) {
-            // Bluebook Rule 4.1: Id. refers to the immediately preceding
-            // *cited authority*. A full citation parsed inside another
-            // citation's explanatory parenthetical (e.g. "(citing X)" or
-            // "(quoting Y)") is a sub-reference within the parent's
-            // citation, not the cited authority of that sentence — so it
-            // must not become Id.'s default antecedent. Detection uses
-            // paren depth (works for any prior citation type) with the
-            // legacy fullSpan check as fallback for case-name-prefixed
-            // citations whose `(...)` ends before the paren-depth model
-            // catches up.
-            const isParentheticalChild =
-              parenDepths[i] > 0 ||
-              resolved.some((prior) => {
-                const priorFullSpan = getFullSpan(prior)
-                if (!priorFullSpan) return false
-                return (
-                  priorFullSpan.cleanStart <= citation.span.cleanStart &&
-                  priorFullSpan.cleanEnd >= citation.span.cleanEnd
-                )
-              })
-            if (!isParentheticalChild) {
-              this.context.lastResolvedIndex = i
-            }
             this.trackFullCitation(citation, i)
           }
           break
       }
 
-      // After resolving a short-form citation, update lastResolvedIndex
-      // to the full citation it resolved to (transitive resolution).
-      // If resolution failed, lastResolvedIndex is NOT updated --
-      // a subsequent Id. will also fail (matching Python eyecite behavior).
-      if (resolution?.resolvedTo !== undefined) {
-        this.context.lastResolvedIndex = resolution.resolvedTo
-      }
+      // Record the resolution so a subsequent `Id.` walking backward can
+      // follow short-form chains (shortForm/supra/Id. → full antecedent).
+      this.resolutions[i] = resolution
 
       // Bluebook Rule 4.1: an `Id.` refers to the same authority and page(s)
       // cited in the antecedent. When the antecedent is a case citation,
@@ -208,8 +310,7 @@ export class DocumentResolver {
               idOut.plaintiffNormalized = antecedent.plaintiffNormalized
             if (antecedent.defendantNormalized)
               idOut.defendantNormalized = antecedent.defendantNormalized
-            if (antecedent.proceduralPrefix)
-              idOut.proceduralPrefix = antecedent.proceduralPrefix
+            if (antecedent.proceduralPrefix) idOut.proceduralPrefix = antecedent.proceduralPrefix
           }
 
           citationOut = idOut
@@ -255,27 +356,288 @@ export class DocumentResolver {
   }
 
   /**
-   * Resolves Id. citation to the most recently cited authority.
-   * Uses lastResolvedIndex which tracks the most recent successfully
-   * resolved citation (full, short-form, supra, or Id.).
+   * Resolves `Id.` to the most recent preceding *cited authority*, respecting
+   * Bluebook signal categories, block-/inline-quote zones, and the family
+   * (case vs. statute) implied by `Id.`'s pincite shape (#480).
+   *
+   * Algorithm:
+   *   1. Walk backward from `currentIndex`, normalizing short-form citations
+   *      (shortFormCase/supra/Id.) to their resolved antecedent. Dedupe by
+   *      effective primary index so a case mentioned via a short-form earlier
+   *      doesn't get double-counted with its full-cite further back.
+   *   2. Filter candidates that are parenthetical children (existing #214
+   *      behavior) or in a quote zone outside `Id.`'s own zone.
+   *   3. Score remaining candidates: family-match dominates, then signal
+   *      strength, then (implicitly) recency (first-added = most recent
+   *      effective mention).
+   *   4. Apply the case-name window check to surface ambiguity when the prose
+   *      immediately before `Id.` mentions a different case name.
    */
-  private resolveId(_citation: IdCitation): ResolutionResult | undefined {
+  private resolveId(citation: IdCitation): ResolutionResult | undefined {
     const currentIndex = this.context.citationIndex
-    const antecedentIndex = this.context.lastResolvedIndex
+    const preferredFamily = this.getIdPreferredFamily(citation)
+    const idQuoteZone = isInZone(citation.span.originalStart, this.quoteZones)
 
-    // No preceding citation has been resolved yet
-    if (antecedentIndex === undefined) {
-      return this.createFailureResult("No preceding citation found")
+    interface Candidate {
+      index: number
+      family: CitationFamily
+      weak: boolean
+    }
+    const candidates: Candidate[] = []
+    const seen = new Set<number>()
+
+    for (let i = currentIndex - 1; i >= 0; i--) {
+      const c = this.citations[i]
+      let primaryIdx: number
+
+      if (isFullCitation(c)) {
+        primaryIdx = i
+      } else {
+        // shortForm/Id./supra — follow the resolution chain. If it failed to
+        // resolve we skip it: a broken short-form shouldn't pin Id. to a
+        // citation the writer didn't successfully cite.
+        const prev = this.resolutions[i]
+        if (!prev || prev.resolvedTo === undefined) continue
+        primaryIdx = prev.resolvedTo
+      }
+
+      if (seen.has(primaryIdx)) continue
+      seen.add(primaryIdx)
+
+      const cit = this.citations[primaryIdx]
+      if (!isFullCitation(cit)) continue
+      if (this.isParentheticalChild(primaryIdx)) continue
+      if (!this.isWithinScope(primaryIdx, currentIndex)) continue
+
+      // Quote-boundary respect: a citation inside a quote zone is not eligible
+      // as Id.'s antecedent unless the Id. itself is in the same zone.
+      const candidateZone = isInZone(cit.span.originalStart, this.quoteZones)
+      if (candidateZone && candidateZone !== idQuoteZone) continue
+
+      candidates.push({
+        index: primaryIdx,
+        family: citationFamily(cit),
+        weak: this.isCandidateWeakSignal(cit),
+      })
     }
 
-    // Check scope boundary
-    if (!this.isWithinScope(antecedentIndex, currentIndex)) {
-      return this.createFailureResult("Antecedent citation outside scope boundary")
+    if (candidates.length === 0) {
+      // Diagnose: did we have any preceding citation at all? If not, the
+      // legacy failure message helps consumers debug "Id. before any cite".
+      const anyPrior = currentIndex > 0
+      return this.createFailureResult(
+        anyPrior ? "Antecedent citation outside scope boundary" : "No preceding citation found",
+      )
     }
+
+    // Score each candidate. Family-match dominates (Id.'s pincite shape
+    // tells us which family of authority the writer intended). Strong
+    // (unsignaled or direct-engagement) candidates beat weak (aside)
+    // candidates. Recency breaks ties — candidates are pushed in reverse
+    // document order, so the first match at a given score is the most
+    // recent effective mention.
+    const score = (c: Candidate) => {
+      let s = 0
+      if (c.family === preferredFamily) s += 1000
+      if (!c.weak) s += 100
+      return s
+    }
+    let best = candidates[0]
+    let bestScore = score(best)
+    for (let i = 1; i < candidates.length; i++) {
+      const s = score(candidates[i])
+      if (s > bestScore) {
+        best = candidates[i]
+        bestScore = s
+      }
+    }
+
+    // Case-name window check: if the prose immediately before Id. names a
+    // case that doesn't match the picked antecedent, downgrade confidence and
+    // flag ambiguity (without refusing to commit).
+    const { confidence, warnings } = this.applyCaseNameWindowCheck(best.index, citation)
 
     return {
-      resolvedTo: antecedentIndex,
-      confidence: 1.0, // Id. resolution is unambiguous when successful
+      resolvedTo: best.index,
+      confidence,
+      warnings,
+    }
+  }
+
+  /**
+   * Determines whether `Id.`'s pincite shape implies a case or statute
+   * antecedent. We peek at the cleaned text immediately after `Id.`'s span
+   * end because the regex in `extractIdCitation` only captures page-style
+   * pincites (`at NNN`, `¶ NNN`); a section-style pincite (`§ NNN`) lives
+   * in the raw text but not on the IdCitation object.
+   */
+  private getIdPreferredFamily(citation: IdCitation): CitationFamily {
+    // Look at up to 20 chars after Id.'s span end for a `§` token.
+    const start = citation.span.cleanEnd
+    const end = Math.min(this.text.length, start + 20)
+    const tail = this.text.substring(start, end)
+    if (/^\s*[,]?\s*§§?\s*\d/.test(tail)) return "statute"
+    return "case"
+  }
+
+  /**
+   * Computes the "effective" signal for a citation. Citations inside a
+   * string-cite group inherit the leading signal of the group's first
+   * member when they have no signal of their own — the Bluebook rule that
+   * a leading signal governs the entire string cite.
+   */
+  private getEffectiveSignal(citation: Citation): CitationSignal | undefined {
+    if (citation.signal) return citation.signal
+    const groupId = citation.stringCitationGroupId
+    if (!groupId) return undefined
+    // First member of the group carries the leading signal.
+    for (const c of this.citations) {
+      if (c.stringCitationGroupId === groupId && c.stringCitationIndex === 0) {
+        return c.signal
+      }
+    }
+    return undefined
+  }
+
+  private isCandidateWeakSignal(citation: Citation): boolean {
+    const sig = this.getEffectiveSignal(citation)
+    return sig !== undefined && WEAK_SIGNALS.has(sig)
+  }
+
+  /**
+   * `(citing X)` / `(quoting Y)` detection (#214). Two strategies in OR:
+   *   - paren depth > 0 at the citation's start (works for any prior
+   *     citation type — statute, journal, etc.);
+   *   - the citation's clean-span is wholly inside a previously-resolved
+   *     citation's `fullSpan` (case-name-prefixed citations sometimes have
+   *     `(...)` ranges that close before the paren-depth scan catches up).
+   */
+  private isParentheticalChild(index: number): boolean {
+    if (this.parenDepths[index] > 0) return true
+    const cit = this.citations[index]
+    for (let i = 0; i < this.resolvedSoFar.length; i++) {
+      if (i === index) continue // a citation cannot be a paren child of itself
+      const prior = this.resolvedSoFar[i]
+      const priorFullSpan = getFullSpan(prior)
+      if (!priorFullSpan) continue
+      if (
+        priorFullSpan.cleanStart <= cit.span.cleanStart &&
+        priorFullSpan.cleanEnd >= cit.span.cleanEnd
+      ) {
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
+   * Scans the prose between the previous citation and `Id.` for a case-name
+   * mention. If a name is found and doesn't match the picked antecedent's
+   * caseName/plaintiff/defendant, returns a downgraded confidence and an
+   * ambiguity warning so consumers can surface it for review. Matching
+   * names (or no name in the window) return undefined → caller uses the
+   * default Id. confidence of 1.0.
+   */
+  private applyCaseNameWindowCheck(
+    antecedentIndex: number,
+    citation: IdCitation,
+  ): { confidence: number; warnings: string[] | undefined } {
+    const DEFAULT = { confidence: 1.0, warnings: undefined as string[] | undefined }
+    const antecedent = this.citations[antecedentIndex]
+    if (antecedent.type !== "case") return DEFAULT
+
+    // Window: prose between the *immediately preceding citation* and Id.,
+    // capped at 80 chars before Id. start. Bounding on the prior citation
+    // (not the antecedent) ensures intermediate case names — which the
+    // resolver may have deprioritized as asides — don't pollute the window
+    // and produce false-positive ambiguity warnings.
+    const idStart = citation.span.cleanStart
+    let windowStart = Math.max(0, idStart - 80)
+    const prevIndex = this.context.citationIndex - 1
+    if (prevIndex >= 0) {
+      const prev = this.citations[prevIndex]
+      windowStart = Math.max(windowStart, prev.span.cleanEnd)
+    }
+    if (windowStart >= idStart) return DEFAULT
+
+    const window = this.text.substring(windowStart, idStart)
+
+    // Match capitalized words that are case-name-like. Filter out common
+    // English/legal prose words that happen to be capitalized.
+    const STOPWORDS = new Set([
+      "As",
+      "The",
+      "This",
+      "That",
+      "These",
+      "Those",
+      "In",
+      "Here",
+      "There",
+      "Court",
+      "Courts",
+      "Supreme",
+      "Circuit",
+      "District",
+      "State",
+      "States",
+      "Federal",
+      "Plaintiff",
+      "Defendant",
+      "Petitioner",
+      "Respondent",
+      "Appellant",
+      "Appellee",
+      "Government",
+      "United",
+      "We",
+      "It",
+      "Id",
+      "See",
+      "Compare",
+      "Cf",
+      "But",
+      "Also",
+      "Held",
+      "Holds",
+      "Held,",
+    ])
+    const tokens = window.match(/(?<![a-zA-Z])[A-Z][a-z]+(?:'s)?/g)
+    if (!tokens) return DEFAULT
+    const names = tokens.filter((t) => !STOPWORDS.has(t.replace(/'s$/, "")))
+    if (names.length === 0) return DEFAULT
+
+    const target = new Set<string>()
+    if (antecedent.plaintiffNormalized) target.add(antecedent.plaintiffNormalized)
+    if (antecedent.defendantNormalized) target.add(antecedent.defendantNormalized)
+    if (antecedent.caseName) target.add(antecedent.caseName.toLowerCase())
+
+    let matched = false
+    let mismatchName: string | undefined
+    for (const n of names) {
+      const lc = n.replace(/'s$/, "").toLowerCase()
+      let hit = false
+      for (const t of target) {
+        if (t === lc || t.includes(lc) || lc.includes(t)) {
+          hit = true
+          break
+        }
+      }
+      if (hit) {
+        matched = true
+        break
+      }
+      if (!mismatchName) mismatchName = n.replace(/'s$/, "")
+    }
+
+    if (matched) return DEFAULT
+    if (!mismatchName) return DEFAULT
+
+    return {
+      confidence: 0.75,
+      warnings: [
+        `Ambiguous Id. antecedent: prose mentions "${mismatchName}" but resolved to "${antecedent.caseName ?? antecedent.defendantNormalized ?? antecedent.plaintiffNormalized ?? "(unknown)"}"`,
+      ],
     }
   }
 
@@ -389,9 +751,7 @@ export class DocumentResolver {
         const defendant = c.defendantNormalized
         const hit = (name: string | undefined) =>
           name !== undefined &&
-          (name === targetParty ||
-            name.includes(targetParty) ||
-            targetParty.includes(name))
+          (name === targetParty || name.includes(targetParty) || targetParty.includes(name))
         return hit(plaintiff) || hit(defendant)
       })
       if (namedMatch !== undefined) {

--- a/tests/integration/resolution.test.ts
+++ b/tests/integration/resolution.test.ts
@@ -228,19 +228,30 @@ describe("Resolution Integration Tests", () => {
       expect(id!.resolution?.failureReason).toBeDefined()
     })
 
-    it("resolves Id. after statute citation", () => {
+    it("Id. with no pincite after case → statute skips the statute (#480)", () => {
+      // Bluebook-aware behavior: `Id.` with a page-style (or absent) pincite
+      // refers to the most recent *case-family* authority. A statute in the
+      // gap is deprioritized when an earlier case is in scope.
       const text = "Smith v. Jones, 500 F.2d 123 (2020). " + "42 U.S.C. § 1983. " + "Id."
 
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
 
-      const statute = citations.find((c) => c.type === "statute")
+      const smith = citations.find((c) => c.type === "case")
       const id = citations.find((c) => c.type === "id")
 
-      expect(statute).toBeDefined()
+      expect(smith).toBeDefined()
       expect(id).toBeDefined()
 
-      const statuteIndex = citations.indexOf(statute!)
-      expect(id!.resolution?.resolvedTo).toBe(statuteIndex)
+      const smithIndex = citations.indexOf(smith!)
+      expect(id!.resolution?.resolvedTo).toBe(smithIndex)
+    })
+
+    it("Id. resolves to a statute when no case is in scope", () => {
+      const text = "42 U.S.C. § 1983. Id."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const statute = citations.find((c) => c.type === "statute")!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
     })
 
     it("resolves chain of Id. through short-form", () => {
@@ -684,9 +695,11 @@ Second paragraph: Id. at 125.`
       expect(citations[1].type).toBe("statute")
       expect(citations[1].resolution).toBeUndefined()
 
-      // Id. resolves to statute (the most recently cited authority, index 1)
+      // Id. resolves to the case, not the intervening statute (#480 — non-case
+      // citations don't compete with the most recent case when Id.'s pincite
+      // shape (`at 125`) implies a case-family antecedent).
       expect(citations[2].type).toBe("id")
-      expect(citations[2].resolution?.resolvedTo).toBe(1)
+      expect(citations[2].resolution?.resolvedTo).toBe(0)
 
       // Supra resolves to case (index 0)
       expect(citations[3].type).toBe("supra")

--- a/tests/resolve/issue480_idAntecedent.test.ts
+++ b/tests/resolve/issue480_idAntecedent.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Issue #480: Id./short-form antecedent resolution for complex documents.
+ *
+ * The current resolver picks the most-recent non-parenthetical-child full
+ * citation as Id.'s antecedent regardless of:
+ *   - signal phrases (see/see also/cf./but cf./compare/see generally)
+ *   - block-quote zones (citations inside `>` blockquotes shouldn't compete)
+ *   - the citation type "family" implied by Id.'s pincite shape (a page-style
+ *     pincite means a case is intended; a section-style pincite means a
+ *     statute is intended)
+ *   - a case name mentioned in the prose immediately before Id. (the
+ *     case-name window heuristic — if the window names a case that doesn't
+ *     match the picked antecedent, surface ambiguity)
+ *
+ * These tests encode the desired behavior. They fail under the pre-fix
+ * resolver and pass after the targeted DocumentResolver changes.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #480: Id./short-form antecedent resolution", () => {
+  // Criterion 1: simple case → Id. — no regression.
+  describe("simple case → Id. (no regression)", () => {
+    it("resolves Id. to the only preceding case", () => {
+      const text = "Smith v. Jones, 100 F.2d 123 (2d Cir. 1990). Id. at 125."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const smith = citations.find((c) => c.type === "case")!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    })
+
+    it("resolves Id. to the most-recent of two unsignaled cases", () => {
+      const text =
+        "People v. Resek, 3 N.Y.3d 385 (2004). " +
+        "People v. Henderson, 28 N.Y.3d 63 (2016). Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+  })
+
+  // Criterion 3: signal-phrase awareness — see / see also / cf. / but cf. /
+  // compare / see generally are "asides" and should not become Id. antecedents
+  // when a more-recent non-signaled case is in scope.
+  describe("signal-phrase awareness", () => {
+    it("Id. skips over a 'see also' intervening case", () => {
+      const text =
+        "People v. Henderson, 28 N.Y.3d 63, 70 (2016). " +
+        "See also People v. Molineux, 168 N.Y. 264 (1901). Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+
+    it("Id. skips over a 'cf.' intervening case", () => {
+      const text =
+        "People v. Henderson, 28 N.Y.3d 63, 70 (2016). " +
+        "Cf. People v. Molineux, 168 N.Y. 264 (1901). Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+
+    it("Id. skips over a 'see' intervening case", () => {
+      const text =
+        "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
+        "See Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+
+    it("Id. skips over a 'but cf.' intervening case", () => {
+      const text =
+        "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
+        "But cf. Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+
+    it("Id. skips over a 'compare' intervening case", () => {
+      const text =
+        "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
+        "Compare Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+
+    it("Id. skips over a 'see generally' intervening case", () => {
+      const text =
+        "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
+        "See generally Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+
+    it("Id. resolves to a weakly-signaled case when no strong case is in scope", () => {
+      // Only weakly-signaled candidates exist; fall back to most recent.
+      const text =
+        "See People v. Resek, 3 N.Y.3d 385 (2004). " +
+        "See also People v. Molineux, 168 N.Y. 264 (1901). Id. at 270."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const molineux = citations.find((c) => c.type === "case" && c.volume === 168)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(molineux))
+    })
+
+    it("Id. does not skip a string-cite group when its members share a leading signal", () => {
+      // Existing behavior preserved: "See A; B" is a single string-cite group;
+      // Id. resolves to B (the most-recent member of the group).
+      const text =
+        "See Smith v. Jones, 100 F.2d 123 (2d Cir. 1990); " +
+        "Doe v. Roe, 200 F.3d 456 (3d Cir. 2000). Id. at 458."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const doe = citations.find((c) => c.type === "case" && c.volume === 200)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(doe))
+    })
+  })
+
+  // Criterion 2: quote-boundary respect — citations inside a block quote or
+  // inline quote don't compete; Id. immediately after the quote refers to the
+  // case that introduced the quote.
+  describe("quote-boundary respect", () => {
+    it("Id. after a markdown blockquote skips citations inside the quote", () => {
+      const text =
+        "People v. Henderson, 28 N.Y.3d 63, 70 (2016) held the following:\n\n" +
+        '> "We have long required courts to give a limiting instruction. People v.\n' +
+        '> Williams, 50 N.Y.2d 996 (1980); People v. Beam, 57 N.Y.2d 241 (1982)."\n\n' +
+        "Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+
+    it("Id. after an inline quoted passage skips citations inside the quote", () => {
+      // The Id. follows a closing quote that wraps the intervening case.
+      const text =
+        "People v. Henderson, 28 N.Y.3d 63, 70 (2016) noted, " +
+        '"the rule traces back to People v. Williams, 50 N.Y.2d 996 (1980)." ' +
+        "Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+    })
+  })
+
+  // Criterion 4: case-name window check — when the prose immediately before
+  // Id. mentions a case name that doesn't match the picked antecedent, the
+  // resolution is marked as ambiguous (lower confidence + warning) rather
+  // than committed silently.
+  describe("case-name window check", () => {
+    it("matching window name → high confidence, no ambiguity warning", () => {
+      const text =
+        "People v. Resek, 3 N.Y.3d 385 (2004). " +
+        "People v. Henderson, 28 N.Y.3d 63, 70 (2016). " +
+        "As Henderson held, the rule is settled. Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+      expect(id.resolution?.confidence).toBeGreaterThanOrEqual(0.95)
+      const hasAmbiguity = id.resolution?.warnings?.some((w: string) => /ambig/i.test(w)) ?? false
+      expect(hasAmbiguity).toBe(false)
+    })
+
+    it("non-matching window name → ambiguity warning + downgraded confidence", () => {
+      // "As Resek held" precedes Id. but Henderson is the most-recent candidate.
+      // The resolver still commits to Henderson (recency wins) but flags
+      // ambiguity so consumers can review.
+      const text =
+        "People v. Resek, 3 N.Y.3d 385, 388 (2004). " +
+        "People v. Henderson, 28 N.Y.3d 63, 70 (2016). " +
+        "As Resek held, the rule is settled. Id. at 70."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const id = citations.find((c) => c.type === "id")!
+      // Still resolved (we don't refuse to commit), but with lower confidence
+      // and an ambiguity warning.
+      expect(id.resolution?.resolvedTo).not.toBeUndefined()
+      expect(id.resolution?.confidence).toBeLessThan(1.0)
+      const hasAmbiguity = id.resolution?.warnings?.some((w: string) => /ambig/i.test(w)) ?? false
+      expect(hasAmbiguity).toBe(true)
+    })
+  })
+
+  // Criterion 5: non-case citations don't compete with case citations for
+  // Id.'s antecedent when Id.'s pincite shape suggests a case (the default).
+  // A statute is only a valid Id. antecedent when no case is in scope OR when
+  // Id. carries a section-style pincite (e.g., `Id. § 1983(c)`).
+  describe("non-case citations don't compete", () => {
+    it("case → statute → Id. (page pincite) skips the statute", () => {
+      const text = "Smith v. Jones, 500 F.2d 123 (2020). 42 U.S.C. § 1983. Id. at 125."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const smith = citations.find((c) => c.type === "case")!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    })
+
+    it("case → statute → Id. (no pincite) skips the statute", () => {
+      const text = "Smith v. Jones, 500 F.2d 123 (2020). 42 U.S.C. § 1983. Id."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const smith = citations.find((c) => c.type === "case")!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    })
+
+    it("statute-only context: Id. still resolves to the statute (only option)", () => {
+      const text = "42 U.S.C. § 1983. Id."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const statute = citations.find((c) => c.type === "statute")!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
+    })
+
+    it("section-style trailing pincite (`Id. § 1983(c)`) keeps statute antecedent", () => {
+      // Id. is followed by a `§` token in the surrounding text, signaling the
+      // writer intends a statute antecedent. Resolve to the most-recent
+      // statute (the statute, not the case).
+      const text = "Smith v. Jones, 500 F.2d 123 (2020). 42 U.S.C. § 1983. Id. § 1983(c)."
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const statute = citations.find((c) => c.type === "statute")!
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
+    })
+  })
+})


### PR DESCRIPTION
Closes #480.

## Summary

The resolver previously stamped the nearest preceding full citation as `Id.`'s antecedent regardless of how it appeared. In documents with intervening signal-phrase citations (`See also …`, `Cf. …`), block-quoted material, or mixed case/statute references, this produced wrong antecedents for downstream consumers.

`DocumentResolver.resolveId` now walks back over the citations list and scores candidates instead of taking `lastResolvedIndex`. All five acceptance criteria from #480 are implemented in one PR with default-on behavior.

## What changed

1. **Signal-phrase awareness.** `see`, `see also`, `see generally`, `cf.`, `but cf.`, `compare`, and any `, e.g.` variant are treated as *asides* and skipped when a non-signaled candidate is in scope. Direct-engagement signals (`accord`, `contra`, `but see`) remain strong. String-cite group members inherit the leader's signal.
2. **Quote-boundary respect.** Citations inside markdown `>` blockquotes or inline paired double-quotes don't compete unless `Id.` is in the same zone. Zones are detected in *original* text because cleaning collapses newlines.
3. **Family preference from pincite shape.** `Id. at NNN` prefers a case-family antecedent; `Id. § NNN(x)` prefers a statute-family antecedent. A statute in the gap no longer captures a following `Id. at 125` when an earlier case is in scope.
4. **Case-name window check.** When the prose immediately before `Id.` names a case that doesn't match the picked antecedent (`"As Resek held, … Id."`), the resolver commits to the chosen antecedent but reports `confidence: 0.75` and an ambiguity warning so consumers can surface the conflict for review.
5. Short-form chain behavior preserved — `shortFormCase`/`supra`/`Id.` that resolved to an earlier full citation still re-anchors the "current authority" for a following `Id.`.

## Behavior change (semver minor)

Two existing tests were updated for criterion 5: when a statute interrupts a case discussion and the next `Id.` has a page-style pincite, the resolver now points to the case rather than the statute. Consumers that relied on the previous "most-recent authority of any type" rule will see different `resolution.resolvedTo` indices in these mixed-type sequences. A statute-only context still resolves `Id.` to the statute.

## Test plan

- [x] 18 new regression tests in `tests/resolve/issue480_idAntecedent.test.ts` covering all five acceptance criteria
- [x] All existing tests pass (2962 passing, 9 skipped, 95 test files)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm size` within 50 kB limit (34.43 kB)
- [x] Manual repro of all four failure modes from the issue verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)