### PR TITLE
fix: year-as-volume neutral citations survive filterFalsePositives (NY Slip Op, WL, LEXIS)

### DIFF
--- a/.changeset/neutral-year-volume.md
+++ b/.changeset/neutral-year-volume.md
@@ -1,0 +1,30 @@
+---
+"eyecite-ts": patch
+---
+
+fix: year-as-volume neutral citations survive `filterFalsePositives` (NY Slip Op, WL, LEXIS, IL App)
+
+`MAX_PLAUSIBLE_VOLUME = 2000` flagged any citation with volume > 2000 as a
+likely zip code or junk number. Vendor-neutral reporters use the year of
+decision as the "volume" (`2026 NY Slip Op 01627`, `2024 WL 12345`,
+`2025 IL App (1st) 230456`, `2026 U.S. App. LEXIS 7890`), so every such
+citation from 2001 onward was being dropped when callers passed
+`filterFalsePositives: true`.
+
+### Fix
+
+`isImplausibleVolume` now allows volumes in the plausible-year range
+(1900–2099) regardless of the cap. Truly garbage values — 5-digit zip
+codes (≥ 10000), 4-digit numbers outside the year window (e.g., `3500`)
+— still flag.
+
+### Tests
+
+4 new tests in `tests/extract/issue480FollowupNeutralYearVolume.test.ts`:
+- `2026 NY Slip Op 01627` survives filtering (the original reproduction
+  from the user report).
+- `2030 NY Slip Op` survives (future-year safety through 2099).
+- `DC 20006 Counsel for Appellees 20004` still filtered (5-digit zip).
+- `3500 F.3d 5` still filtered (4-digit but not year-shaped).
+
+Full suite: 2966 tests pass.

--- a/src/extract/filterFalsePositives.ts
+++ b/src/extract/filterFalsePositives.ts
@@ -229,6 +229,15 @@ const SINGLE_DIGIT_PROSE_WORDS: ReadonlySet<string> = new Set([
  *  zip codes (5-digit numbers like 20006) and other non-citation numbers. */
 const MAX_PLAUSIBLE_VOLUME = 2000
 
+/** Plausible year range for citations whose "volume" is actually a year.
+ *  Vendor-neutral reporters — NY Slip Op, IL App, OK CIV APP, WL, LEXIS,
+ *  Ohio neutral, etc. — use the year of decision as the volume number,
+ *  routinely exceeding MAX_PLAUSIBLE_VOLUME. Cap at 2099 keeps the
+ *  heuristic deterministic and still catches truly garbage numeric
+ *  volumes (e.g., parsed zip codes ≥ 10000). */
+const MIN_PLAUSIBLE_YEAR_VOLUME = 1900
+const MAX_PLAUSIBLE_YEAR_VOLUME = 2099
+
 /** Docket number pattern: 1-2 digit prefix + hyphen + 4+ digit suffix.
  *  E.g., "24-30706", "23-12345". Real hyphenated citation volumes look
  *  like "1984-1" (4-digit year + short index). */
@@ -245,7 +254,18 @@ function isImplausibleVolume(citation: Citation): boolean {
   // Only check purely numeric volumes; hyphenated volumes (strings) are
   // handled by isDocketNumberVolume
   if (typeof caseCit.volume !== "number") return false
-  return caseCit.volume > MAX_PLAUSIBLE_VOLUME
+  if (caseCit.volume <= MAX_PLAUSIBLE_VOLUME) return false
+  // Year-as-volume neutral citations (e.g. `2026 NY Slip Op 01627`,
+  // `2024 WL 12345`) routinely exceed the reporter-volume cap. Treat
+  // values in the plausible-year window as legitimate volumes; truly
+  // large numbers (zip codes ≥ 10000, future-year noise) still flag.
+  if (
+    caseCit.volume >= MIN_PLAUSIBLE_YEAR_VOLUME &&
+    caseCit.volume <= MAX_PLAUSIBLE_YEAR_VOLUME
+  ) {
+    return false
+  }
+  return true
 }
 
 /**

--- a/tests/extract/issue480FollowupNeutralYearVolume.test.ts
+++ b/tests/extract/issue480FollowupNeutralYearVolume.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Year-as-volume neutral citations should not be filtered as false
+ * positives. Reporters like "NY Slip Op", "WL", "LEXIS", and Illinois /
+ * Ohio neutrals use the *year* as the volume number — so a 2026 NY Slip
+ * Op citation has volume=2026, which collides with the existing
+ * MAX_PLAUSIBLE_VOLUME (2000) zip-code heuristic.
+ *
+ * These tests pin the desired behavior: a citation whose volume is a
+ * plausible 4-digit year (1900–2099) passes the implausible-volume
+ * filter regardless of whether it exceeds 2000.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+
+describe("Year-as-volume neutral citations survive filterFalsePositives", () => {
+  it("extracts NY Slip Op with year=2026 under filterFalsePositives", () => {
+    const text =
+      "In People v. Henderson, 2026 NY Slip Op 01627 (2026), the Court of " +
+      "Appeals again reversed a conviction for erroneous admission of Molineux " +
+      "evidence."
+
+    const cites = extractCitations(text, { filterFalsePositives: true })
+    expect(cites).toHaveLength(1)
+    expect(cites[0].type === "case" || cites[0].type === "neutral").toBe(true)
+    const cit = cites[0] as { volume: number | string; reporter: string }
+    expect(cit.volume).toBe(2026)
+    expect(cit.reporter).toBe("NY Slip Op")
+  })
+
+  it("extracts 2030 NY Slip Op (future-year safety)", () => {
+    const text = "See People v. Future, 2030 NY Slip Op 00001."
+    const cites = extractCitations(text, { filterFalsePositives: true })
+    expect(cites.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("still filters obvious zip-code-shaped 5-digit volumes", () => {
+    // 5-digit "volume" with prose-shaped reporter — clearly not a citation.
+    const text = "Counsel for Appellant, DC 20006 Counsel for Appellees 20004."
+    const cites = extractCitations(text, { filterFalsePositives: true })
+    expect(cites).toHaveLength(0)
+  })
+
+  it("still filters non-year 4-digit volumes outside plausible year range", () => {
+    // Volume 3500 is too large to be a year and too large to be a real reporter
+    // volume. Should still be filtered.
+    const text = "Fake v. Cite, 3500 F.3d 5 (2024)."
+    const cites = extractCitations(text, { filterFalsePositives: true })
+    expect(cites).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Followup to #480 / #481. The false-positive filter's `MAX_PLAUSIBLE_VOLUME = 2000` was dropping every vendor-neutral citation that uses the year of decision as the volume (`2026 NY Slip Op 01627`, `2024 WL 12345`, `2025 IL App (1st) 230456`, `2026 U.S. App. LEXIS 7890`, etc.) when callers passed `filterFalsePositives: true`.

The original cap was chosen to catch 5-digit zip codes (\"DC 20006\") and other junk numbers in random prose. It happened to work pre-2001 because no plausible reporter volume hit 4 digits. Now that we're in 2026, every modern slip-op-style citation collides with the cap.

## Reproduction (the user-reported text)

```
In People v. Henderson, 2026 NY Slip Op 01627 (2026), the Court of
Appeals again reversed a conviction for erroneous admission of
Molineux evidence...
```

Before:
```
extractCitations(text)                            → 1 cite, confidence=0.1, warning="Volume 2026 exceeds maximum plausible volume"
extractCitations(text, {filterFalsePositives:true}) → 0 cites
```

After:
```
extractCitations(text, {filterFalsePositives:true}) → 1 cite, NY Slip Op, vol=2026, page=1627
```

## Fix

`isImplausibleVolume` now allows volumes in the plausible-year range (1900–2099) regardless of the 2000 cap. Genuinely garbage values — 5-digit zip codes (≥ 10000), 4-digit numbers outside the year window — still flag.

Hardcoded window (not `new Date().getFullYear()`) for deterministic test behavior; 2099 is far enough out that we can revisit when it matters.

## Test plan

- [x] 4 new regression tests in `tests/extract/issue480FollowupNeutralYearVolume.test.ts`
  - NY Slip Op 2026 extraction survives (the user's repro)
  - 2030 NY Slip Op survives (future-year safety)
  - 5-digit zip-shaped volume still filtered
  - 4-digit non-year volume (`3500 F.3d`) still filtered
- [x] Full suite: 2966 tests pass (+4 from new tests)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)