### PR TITLE
fix(resolve): inherit pincite per Bluebook Rule 4.1 / Indigo Book R6.2.2

### DIFF
--- a/.changeset/pincite-inheritance.md
+++ b/.changeset/pincite-inheritance.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": minor
+---
+
+fix(resolve): inherit pincite from immediate same-authority predecessor (Bluebook Rule 4.1)
+
+`Id.`, `supra`, and short-form-case citations now inherit their pincite from the **immediately preceding same-authority citation** — including from intermediate `Id. at X` or `supra, at X` predecessors — rather than only from the terminal full citation. This matches Bluebook Rule 4.1 / Indigo Book R6.2.2 and fixes a real bug.
+
+**Behavior changes:**
+
+- `Smith → Id. at 115 → bare Id.` now produces `pincite = 115` on the bare `Id.` (previously `55`, chasing past the intermediate to Smith's pincite).
+- `Smith → Other → Smith, supra, at 50 → bare Id.` now produces `pincite = 50` (previously `undefined`).
+- `Smith, at 100 → Id. at 115 → Id. → Id.` — all three trailing citations now correctly inherit `115`.
+- `Supra` and `ShortFormCaseCitation` gain pincite inheritance for the first time. Previously only `Id.` inherited.
+
+**New optional fields on `IdCitation`, `SupraCitation`, `ShortFormCaseCitation`:**
+
+- `pinciteInherited?: boolean` — true when `pincite` was inherited per Rule 4.1.
+- `pinciteInheritedFrom?: number` — array index (in `extractCitations(...).citations`) of the immediate predecessor that supplied the pincite. Follow transitively for the chain's originator.
+
+**Migration:** No code changes required for consumers reading `pincite`. The inherited value is semantically equivalent to one extracted directly (Rule 4.1 makes them identical). Consumers wanting to distinguish "explicit in text" from "inherited per rule" should branch on `pinciteInherited`.
+
+**Non-goals (future work):** statute-chain inheritance (blocked by the type system today — short-form pincite is `number` only); `MAX_OPINION_PAGE_COUNT`-style range validation on inherited pincites; expanding case-name inheritance to `Supra` and `ShortFormCaseCitation`.
+
+See `docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md` for the full design and `docs/research/2026-05-19-pincite-inheritance.md` for the Bluebook + Indigo Book + Python eyecite reference validation.

--- a/docs/research/2026-05-19-pincite-inheritance.md
+++ b/docs/research/2026-05-19-pincite-inheritance.md
@@ -36,7 +36,18 @@ Bluebook Rule 4.1 anchors `Id.` to the **immediately preceding cited authority**
 
 ### 1.1 The core rule
 
-Rule 4.1 of the 21st edition of *The Bluebook: A Uniform System of Citation* governs `Id.` It cannot be quoted verbatim here (the official online edition at `legalbluebook.com/bluebook/v21/rules/4-short-citation-forms/4-1-id` is paywalled), but the rule is uniformly summarized across every authoritative law-school guide consulted:
+The **Indigo Book 2.0** ([law.resource.org/pub/us/code/blue/indigobook-2.0-beta.html](https://law.resource.org/pub/us/code/blue/indigobook-2.0-beta.html)), the open-access companion to the Bluebook, states the rule directly at **R6.2.2 ("Use of _Id._")**:
+
+> "Use the short form _Id._ (capitalized in a citation sentence after a text sentence) or _id._ (uncapitalized within a sentence as citation clause) to support a statement where it refers to the same exact source cited in the **immediately preceding citation**."
+>
+> "_Id._ can be used alone, to indicate the **same page of the same source**. It can be used with a new pincite to a page, section, or other subdivision, to indicate a different portion of the immediately preceding source. **_Id._ can also refer to a preceding citation that is itself _Id._ or another short form of a citation.**"
+
+This is the load-bearing language for chained `Id.`s. It says **explicitly** that:
+- The reference is to the *immediately preceding* citation, not the chain's terminal authority.
+- Chained `Id.`s are first-class — `Id.` can refer to another `Id.`
+- A bare `Id.` after `Id. at 115` refers to "the same source" as `Id. at 115`, which itself is "page 115 of the same source as the earlier full citation." Substituting: bare `Id.` = page 115 of that source.
+
+The corresponding rule in the Bluebook proper (21st ed.) is **Rule 4.1**. It cannot be quoted verbatim here (the official online edition at `legalbluebook.com/bluebook/v21/rules/4-short-citation-forms/4-1-id` is paywalled), but the rule is uniformly summarized across every authoritative law-school guide consulted:
 
 > "_Id._ always refers to the immediately preceding cited authority, either in the same footnote or the previous footnote so long as it is the only authority cited in the preceding footnote."
 > — Tarlton Law Library, *Short form: Id., Infra, Supra, Hereinafter* (paraphrasing Rule 4.1) ([tarlton.law.utexas.edu](https://tarlton.law.utexas.edu/bluebook-legal-citation/short-form))
@@ -354,7 +365,12 @@ Cases 7 and 14 require the §5.1 parenthetical-depth refinement. Cases 11 is fre
 
 ## Sources
 
-**Bluebook authoritative summaries** (Rule 4.1):
+**Primary source — Indigo Book 2.0** (R6.2.2 "Use of _Id._" and R15.3 "Id." for cases):
+
+- [Indigo Book 2.0 beta](https://law.resource.org/pub/us/code/blue/indigobook-2.0-beta.html) — R6.2.2 explicitly anchors `Id.` to the "immediately preceding citation," confirms chaining (`Id.` can refer to another `Id.`), and confirms that `Id. at X` means "different portion of the immediately preceding source." Load-bearing source for this design.
+- [Indigo Book 1.0](https://law.resource.org/pub/us/code/blue/IndigoBook.html) — earlier R15.3 ("Using _Id._") with the same anchoring semantics; less explicit on chaining.
+
+**Bluebook authoritative summaries** (Rule 4.1 — the rule itself is paywalled):
 
 - [Tarlton Law Library — Short form: Id., Infra, Supra, Hereinafter](https://tarlton.law.utexas.edu/bluebook-legal-citation/short-form) — Rule 4.1 paraphrase; "immediately preceding cited authority"; parenthetical/history exception.
 - [UC Davis Mabie Law Library — Short Citation Forms](https://libguides.law.ucdavis.edu/c.php?g=1014499&p=7370559) — "Use Id. when citing the immediately preceding authority" + single-authority requirement.

--- a/docs/research/2026-05-19-pincite-inheritance.md
+++ b/docs/research/2026-05-19-pincite-inheritance.md
@@ -1,0 +1,384 @@
+# Research: Pincite Inheritance for Short-Form Legal Citations
+
+**Date:** 2026-05-19
+**Query:** Does the proposed linear-backward-scan-stop-at-authority-boundary algorithm for `Id.` pincite inheritance match Bluebook Rule 4.1 and the Python `eyecite` reference? What edge cases need tests?
+**Depth:** deep
+**Status:** Validates the proposed design. Two refinements recommended.
+
+---
+
+## Summary (TL;DR)
+
+**Recommendation: ship the proposed algorithm. It matches the Bluebook.**
+
+Bluebook Rule 4.1 anchors `Id.` to the **immediately preceding cited authority**, and a bare `Id.` (no `at NNN`) means "same source, same page as that immediately preceding citation." That preceding citation may itself be an `Id. at X` — in which case the bare `Id.` correctly inherits `X`, not the page of the original full citation. So `Smith, 1 U.S. 1, 100 → Id. at 115 → Id.` resolves the trailing `Id.` to **page 115**, exactly as the proposed linear backward scan does.
+
+**Python `eyecite` does not implement inheritance at all.** It stores whatever pincite the `Id.` token captured (`Id.` → no pincite; `Id. at 115` → pincite 115) and only **validates** it against the full citation's page range (`_has_invalid_pin_cite`, `MAX_OPINION_PAGE_COUNT = 150`). The eyecite-ts library already exceeds upstream by propagating pincite from the antecedent's first hop; this work extends propagation to the correct *intermediate* hop, which is the Bluebook-correct behavior.
+
+**Two adjustments to the design:**
+
+1. **Stop strictly at any prior citation with a defined pincite to the same authority** — don't keep walking backward past `Id. at 115` looking for "the next thing." The immediate predecessor with a pincite is authoritative. (The proposed algorithm already does this; just call it out as the rationale.)
+2. **Do not treat signals (`cf.`, `see also`, `but see`) or parentheticals as breaking the chain when they remain within the same authority cluster.** The Bluebook explicitly excludes parentheticals and prior/subsequent history from the "intervening authority" rule. eyecite-ts already counts on `resolvedTo` identity for the authority-boundary check, which is the right primitive — signals do not change `resolvedTo`, so the algorithm is already signal-safe.
+
+**Test edge cases to add** (full list in §6):
+
+- `Smith → Id. at 115 → Id.` → bare `Id.` inherits 115 (the regression case)
+- `Smith → Id. at 115 → Id. at 200 → Id.` → bare `Id.` inherits 200
+- `Smith, supra, at 50 → Id.` → bare `Id.` inherits 50
+- `Smith → Id. at 115 → Jones, 2 F.3d 1 → Id.` → bare `Id.` is `Jones`'s `Id.`, no pincite inherited (authority boundary)
+- `Smith → Id. at 115 (citing Other, 3 U.S. 1) → Id.` → bare `Id.` still inherits 115 (parenthetical is not intervening)
+- Section-style pincites: `42 U.S.C. § 1983 → Id. § 1983(c) → Id.` → bare `Id.` inherits `§ 1983(c)`
+- Footnote-vs-body: chain across a footnote boundary respects the existing `"footnote"` scope strategy
+
+---
+
+## 1. Bluebook Rule 4.1 — exact semantics
+
+### 1.1 The core rule
+
+Rule 4.1 of the 21st edition of *The Bluebook: A Uniform System of Citation* governs `Id.` It cannot be quoted verbatim here (the official online edition at `legalbluebook.com/bluebook/v21/rules/4-short-citation-forms/4-1-id` is paywalled), but the rule is uniformly summarized across every authoritative law-school guide consulted:
+
+> "_Id._ always refers to the immediately preceding cited authority, either in the same footnote or the previous footnote so long as it is the only authority cited in the preceding footnote."
+> — Tarlton Law Library, *Short form: Id., Infra, Supra, Hereinafter* (paraphrasing Rule 4.1) ([tarlton.law.utexas.edu](https://tarlton.law.utexas.edu/bluebook-legal-citation/short-form))
+
+> "Use _Id._ when citing the immediately preceding authority, either: within the same footnote, or in the footnote directly above, provided that footnote includes only one authority."
+> — UC Davis, *Short Citation Forms* ([libguides.law.ucdavis.edu](https://libguides.law.ucdavis.edu/c.php?g=1014499&p=7370559))
+
+> "_Id._ can only be used when the immediately preceding citation contains only one authority."
+> — Hawaii Law Library, *Weird Bluebook Rules* ([law-hawaii.libguides.com](https://law-hawaii.libguides.com/c.php?g=125486&p=821513))
+
+### 1.2 Plain `Id.` vs. `Id. at [page]`
+
+Two-form structure, universally agreed:
+
+- **Plain `Id.`** → same source **and** same page/section as immediately preceding.
+- **`Id. at [page]`** → same source, **different** page/section.
+
+> "When citing to the same authority but a different page, use _id._ at [new page]."
+> — UC Davis Bluebook Guide
+
+> "If the page number has changed, indicate that with 'at' and the page number."
+> — Loyola Chicago Bluebook Guide ([lawlibguides.luc.edu](https://lawlibguides.luc.edu/bluebook/short_form))
+
+### 1.3 What "same page as the immediately preceding citation" means in a chain
+
+This is the load-bearing question for the proposed algorithm. From a web search synthesis of multiple Bluebook guides:
+
+> "The page number should only appear if it is a different page number from the previous citation. This means that when using 'Id. at' to cite a different page, that pincite does **not** automatically carry forward to subsequent citations — each citation must independently specify which page is being cited, whether through 'Id.' alone (same page) or 'Id. at [page]' (different page)."
+> — synthesized from Tarlton, UC Davis, AllCitations, TypeLaw, Casebriefly
+
+Read carefully, the negative ("does not automatically carry forward") is about **the writer's obligation when authoring**: the writer must restate `at NNN` whenever the page changes. It is **not** a statement about parser semantics. For a parser consuming a finished document, the bare `Id.` is unambiguous: it means "same page as the citation I'm immediately following." If that predecessor was `Id. at 115`, then "same page" = **115**.
+
+This is precisely the proposed algorithm.
+
+### 1.4 What breaks the `Id.` chain
+
+The chain is broken by an **intervening authority** (a citation to a different source). The Bluebook carves out two explicit exceptions:
+
+> "Sources cited in explanatory parentheticals or phrases or as part of a case prior or subsequent history are **not** counted as intervening authorities preventing the use of _Id._"
+> — Tarlton (paraphrasing Rule 4.1)
+
+So `Smith, 1 U.S. 1, 100 (citing Other, 3 U.S. 1, 2) → Id.` is a valid `Id.` referring to `Smith` (not `Other`), and the parenthetical `Other` does not break the chain.
+
+Signals (`see`, `see also`, `cf.`, `but see`) attach to citations; they don't break the chain by themselves. What breaks the chain is the *citation* the signal introduces being to a **different authority**. If two consecutive `see` citations point at the same `Smith`, the chain is intact.
+
+### 1.5 Footnotes vs. body
+
+In law-review/footnote-heavy work, `Id.` can cross a footnote boundary only if the preceding footnote contains **exactly one** authority. The proposed algorithm doesn't need to enforce this — eyecite-ts's existing `"footnote"` scope strategy already isolates `Id.` to its zone (strict). Pincite inheritance happens **after** scope resolution, so whatever the resolver decided about the antecedent is what we walk.
+
+---
+
+## 2. Python `eyecite` reference implementation
+
+### 2.1 What `resolve.py` actually does
+
+Reviewed at commit `main` HEAD on 2026-05-19:
+[`eyecite/resolve.py`](https://github.com/freelawproject/eyecite/blob/main/eyecite/resolve.py).
+
+`_resolve_id_citation` (line ~228) is the entire `Id.` resolution path:
+
+```python
+def _resolve_id_citation(
+    id_citation: IdCitation,
+    last_resolution: ResourceType,
+    resolutions: Resolutions,
+) -> ResourceType | None:
+    # if last resolution failed, id. cite should also fail
+    if not last_resolution:
+        return None
+
+    # filter out citations based on pin cite
+    full_cite = cast(FullCitation, resolutions[last_resolution][0])
+    if _has_invalid_pin_cite(full_cite, id_citation):
+        return None
+
+    return last_resolution
+```
+
+**No pincite inheritance.** Resolution is "stick to the last resolution" plus a sanity check.
+
+`_has_invalid_pin_cite` (line ~102) parses the pincite the `IdCitation` already carries from `find.py`'s `extract_pin_cite`, and rejects values outside `[page, page + 150]` of the resolution's full citation. The constant `MAX_OPINION_PAGE_COUNT = 150` is debated upstream — see [issue #104](https://github.com/freelawproject/eyecite/issues/104), citing cases like *McConnell v. FEC* that exceed 750 pages — but it's still the live cutoff.
+
+### 2.2 What `find.py` does with `Id.`
+
+[`_extract_id_citation`](https://github.com/freelawproject/eyecite/blob/main/eyecite/find.py#L356):
+
+```python
+def _extract_id_citation(words, index) -> IdCitation:
+    pin_cite, span_end, parenthetical = extract_pin_cite(words, index)
+    return IdCitation(
+        cast(IdToken, words[index]), index,
+        span_end=span_end,
+        metadata={"pin_cite": pin_cite, "parenthetical": parenthetical},
+    )
+```
+
+It reads `at NNN` (or `¶ NNN`, `§ NNN`) from the text after `Id.` and stores it. If the text has bare `Id.`, `pin_cite` is `None`. **Nothing ever fills it in from an antecedent.**
+
+### 2.3 What the test suite confirms
+
+[`tests/test_ResolveTest.py`](https://github.com/freelawproject/eyecite/blob/main/tests/test_ResolveTest.py) line ~262:
+
+```python
+self.checkResolution(
+    (0, "Foo v. Bar, 1 U.S. 1."),
+    (0, "Id."),
+    (0, "Id. at 2."),
+)
+```
+
+The test verifies **clustering** (`0`, `0`, `0` = same resource) but does not check pincite values on the `Id.` objects. The `Id.` between full and `Id. at 2.` has no pincite in eyecite, and that is considered correct.
+
+Later in the same test (lines ~322-326):
+
+```python
+(0, "Foo v. Bar, 1 U.S. 1."),
+(0, "Id. at 2."),
+(1, "Mass. Gen. Laws ch. 1, § 2"),
+(1, "Id."),
+(0, "Foo, supra, at 2."),
+```
+
+The bare `Id.` at index 3 attaches to the `Mass. Gen. Laws` resource — authority boundary respected — but again no pincite is propagated from `§ 2`.
+
+### 2.4 Open issues / PRs about pincite propagation
+
+- [#74 (CLOSED)](https://github.com/freelawproject/eyecite/issues/74) — uses pincite range to filter cluster matches, not to propagate.
+- [#104 (CLOSED)](https://github.com/freelawproject/eyecite/issues/104) — discusses the 150-page cap on `MAX_OPINION_PAGE_COUNT`.
+
+A `gh search issues` for `pincite OR pin_cite` in `freelawproject/eyecite` returns only these two. **There is no upstream conversation about inheritance.** eyecite-ts is doing novel work here.
+
+### 2.5 What eyecite-ts already does
+
+[`src/resolve/DocumentResolver.ts`](file:///Users/medelman/Projects/OSS/eyecite-ts/src/resolve/DocumentResolver.ts) lines 280–318 already implement single-hop inheritance:
+
+```ts
+// Pincite inheritance (when Id. has none explicit).
+if (
+  idOut.pincite === undefined &&
+  "pincite" in antecedent &&
+  typeof antecedent.pincite === "number"
+) {
+  idOut.pincite = antecedent.pincite
+  if ("pinciteInfo" in antecedent && antecedent.pinciteInfo) {
+    idOut.pinciteInfo = antecedent.pinciteInfo
+  }
+}
+```
+
+The bug the design fixes: `antecedent = this.citations[resolution.resolvedTo]`. `resolvedTo` is the **terminal full citation** (`Smith`), so any pincite on the intermediate `Id. at 115` is never seen. The fix walks the citation array directly instead of dereferencing `resolvedTo`.
+
+---
+
+## 3. Other reference implementations
+
+### 3.1 CourtListener citator
+
+CourtListener (also FreeLawProject) consumes eyecite. Its citation linking code lives in [`courtlistener/cl/citations/`](https://github.com/freelawproject/courtlistener/tree/main/cl/citations) and does not add a pincite-inheritance layer on top of eyecite. Pincite is used for deep-linking to opinion pages on CourtListener (e.g., `?q=...&page=115`), but always from the pincite the citation already carries — never inherited.
+
+### 3.2 Caselaw Access Project (Harvard)
+
+The CAP citator (now archived; logic absorbed into Harvard Library Innovation Lab's [cap-tools](https://github.com/harvard-lil) repos) extracts citations via a different pipeline rooted in `reporters_db` and does not perform short-form inheritance. CAP's published case data carries explicit pincites where present, and downstream consumers do their own resolution.
+
+### 3.3 citeproc / CSL
+
+Citeproc-CSL is designed for academic citation styles (APA, MLA, Chicago, Bluebook-as-CSL). Its `ibid.` handling (`"after": {"position": "ibid"}`) does carry the pincite forward from the immediate predecessor — this is the closest external precedent for the proposed algorithm. See the [CSL spec on "Disambiguation and Substitution"](https://docs.citationstyles.org/en/stable/specification.html#choose) and Zotero's Bluebook style implementations, which model `Id.` as a CSL "ibid" with locator chaining. The chaining is single-hop-immediate-predecessor, exactly what we're proposing.
+
+### 3.4 Practical conclusion
+
+No mainstream open-source legal citation parser propagates pincite through `Id.` chains the way we're proposing. The closest analog is citeproc's `ibid` semantics, which validates the design conceptually but isn't a code reference. eyecite-ts is staking out novel correctness here; that's why nailing the Bluebook reading matters.
+
+---
+
+## 4. Validation: does the proposed algorithm match?
+
+**The proposed algorithm:**
+
+> For each short-form citation with an undefined pincite and a successful resolution, scan backward. For each prior citation:
+> - Determine its "primary" — itself if full, or `resolutions[j].resolvedTo` if short-form.
+> - If different primary than current → **break** (authority boundary).
+> - If it has a defined pincite → **inherit it**, record `pinciteInheritedFrom: j`, break.
+
+### 4.1 Matches the Bluebook on:
+
+| Bluebook requirement | Algorithm behavior | Match? |
+|---|---|---|
+| "Same source as immediately preceding citation" | Resolution already establishes same `resolvedTo` | YES |
+| "Same page as immediately preceding citation" | Backward scan finds nearest predecessor's pincite | YES |
+| Intermediate `Id. at X` should propagate `X` forward | Walks to `j` where pincite is defined; uses **its** value, not the terminal full citation's | YES |
+| Different authority breaks chain | Primary mismatch → break before inheriting | YES |
+| Parentheticals/prior history don't break the chain | Parentheticals appear in citation array but resolve to **same** primary (or are filtered out as nested cites) — they don't trip the authority-boundary break | YES (relies on resolver behavior, see §5.1) |
+| Signals don't break the chain | Signals are not citations; the algorithm walks citations, not text tokens | YES |
+| Footnote boundary respected | Inheritance runs *after* scope-aware resolution; if scope said no, there's no `resolvedTo` to inherit from | YES |
+
+### 4.2 Matches the Python eyecite reference on:
+
+- Eyecite doesn't inherit at all → eyecite-ts adds correct behavior eyecite lacks. No conflict with upstream semantics.
+- The `_has_invalid_pin_cite` 150-page range check should be **applied to the inherited pincite too**, otherwise we could silently propagate an obviously-wrong pincite. The current eyecite-ts inheritance doesn't run that validation; the new linear-walk version should optionally validate the inherited number against the terminal full citation's page range. (Optional refinement — see §5.3.)
+
+### 4.3 Where the algorithm could be wrong
+
+**Edge case: short-form case citation as intermediate.**
+
+Consider: `Smith v. Jones, 1 U.S. 1, 100 → Jones, 1 U.S. at 115 → Id.`
+
+The second citation is a *short-form case* (not `Id.`), but it shares a primary with `Smith` and has its own explicit pincite `115`. The trailing bare `Id.` should inherit `115`. The proposed algorithm: walks back, finds the short-form's primary == current's primary, finds pincite `115`, inherits. **Correct.**
+
+**Edge case: `supra` as intermediate.**
+
+`Smith → Other, 2 F.3d 1 → Smith, supra, at 50 → Id.`
+
+The bare `Id.` resolves to `Smith` (via the `supra`). Walking back from the `Id.`: predecessor is `Smith, supra, at 50`. Same primary, pincite `50`. **Inherits 50. Correct.**
+
+**Edge case: chained `Id.` with mixed pincite presence.**
+
+`Smith, 1 U.S. 1, 100 → Id. at 115 → Id. → Id. at 200 → Id.`
+
+Walking back from the final `Id.`: predecessor is `Id. at 200` (same primary, pincite 200) → inherit `200`. **Correct.**
+
+Walking back from the middle `Id.` (the second one): predecessor is `Id. at 115` → inherit `115`. **Correct.**
+
+**Edge case: section-style pincites.**
+
+`42 U.S.C. § 1983 → Id. § 1983(c) → Id.`
+
+The middle `Id.` has a section-style pincite (`§ 1983(c)`). The trailing `Id.`: walks back, finds same primary, pincite info structured as section-style → inherit `§ 1983(c)`. **Correct, provided the inheritance code preserves the full `pinciteInfo` structure**, which the current eyecite-ts code does via `idOut.pinciteInfo = antecedent.pinciteInfo` — keep that for the array-walk version.
+
+---
+
+## 5. Refinements and gotchas
+
+### 5.1 Parentheticals: rely on the resolver, not on text scanning
+
+eyecite-ts's resolver already places nested-parenthetical citations into the `parenDepths` array and treats them as scope-restricted. Two cases:
+
+- **Parenthetical citation has its own resolution to a different authority** → it lives in the citation array, the algorithm sees it, **breaks** the chain. This is **wrong** by the Bluebook — parenthetical cites are not intervening authorities.
+- **Parenthetical citation is a `cf./citing/quoting` cite to a different source** → same problem.
+
+**Fix:** when walking backward, skip citations whose `parenDepth > parenDepth_of_current`. They're inside an explanatory parenthetical and don't count as intervening. The `parenDepths` array is already computed in `DocumentResolver` (line ~339 `computeParenDepths`), so the data is there. This is a small adjustment to the proposed scan loop:
+
+```ts
+for (let j = i - 1; j >= 0; j--) {
+  const prior = this.citations[j]
+  // Bluebook: nested parenthetical cites don't count as intervening.
+  if (this.parenDepths[j] > this.parenDepths[i]) continue
+  // ... primary comparison + pincite check
+}
+```
+
+### 5.2 Signals: zero work needed
+
+Signals are part of the surrounding text, not separate citation tokens. They don't appear in `this.citations`. The algorithm walks `this.citations` only, so signals are invisible to it — which is exactly the right behavior, because the Bluebook treats a `see Smith → see Smith` chain as a valid `Id.` chain.
+
+### 5.3 Validate inherited pincites (optional but worthwhile)
+
+Mirror eyecite's `_has_invalid_pin_cite` against the terminal full citation when inheritance happens. If `inheritedPincite > fullPage + 150` (or `< fullPage`), don't inherit. This guards against weird data — e.g., `Smith, 1 U.S. 1` followed by `Id. at 500.` where the `500` is a typo or actually a different case mis-clustered. eyecite would already drop the `Id.` resolution in that scenario, but a defensive check on inheritance is cheap insurance.
+
+Recommendation: apply the same `MAX_OPINION_PAGE_COUNT` check (probably 150 to match eyecite, possibly higher per [#104](https://github.com/freelawproject/eyecite/issues/104) for long opinions). Make it a parameter.
+
+### 5.4 Footnote scope strategy
+
+Already correct. The `"footnote"` scope is applied in `scopeBoundary.ts` **before** pincite inheritance runs, so by the time the algorithm walks backward, the `Id.` has already been told what its valid antecedents are. If a strict-footnote `Id.` couldn't see an out-of-zone predecessor, the predecessor isn't in its resolution lineage and the algorithm won't even consider walking that far — because the walk terminates at the first authority-boundary, and a cross-zone predecessor will have either no resolution or a different `resolvedTo`.
+
+That said, **be explicit**: the algorithm's authority-boundary primitive is "primary differs," not "scope boundary." That's fine for inheritance purposes — same authority means same correct pincite source, regardless of zone — but document the invariant.
+
+### 5.5 Don't propagate pincite types across categories
+
+eyecite-ts already has the right idea: pincites on case-family citations are numeric (or `pinciteInfo` for `at *2` star pages, paragraph `¶`, etc.); statute pincites are section-style. The existing inheritance code at line 294 (`typeof antecedent.pincite === "number"`) gates on numeric. The new array walk should preserve this discipline: only inherit a pincite when its **type** matches the inheriting citation's expected pincite shape (numeric for case, section for statute). The existing implementation copies `pinciteInfo` wholesale; make sure the walk-based version does the same and doesn't accidentally splice a statute section into an `Id.` that resolves to a case.
+
+---
+
+## 6. Edge cases to test
+
+The regression tests should cover these. Numbered for easy reference in PR review.
+
+| # | Input | Expected `Id.` pincite |
+|---|---|---|
+| 1 | `Smith, 1 U.S. 1, 100 → Id.` | `100` (inherits from full) |
+| 2 | `Smith, 1 U.S. 1, 100 → Id. at 115 → Id.` | `115` (the regression case) |
+| 3 | `Smith, 1 U.S. 1, 100 → Id. at 115 → Id. at 200 → Id.` | `200` |
+| 4 | `Smith, 1 U.S. 1, 100 → Id. at 115 → Id. → Id.` | `115` for both bare `Id.`s |
+| 5 | `Smith, 1 U.S. 1, 100 → Id. at 115 → Jones, 2 F.3d 1, 50 → Id.` | `50` (new authority) |
+| 6 | `Smith, 1 U.S. 1, 100 → Id. at 115 → Id. → Jones, 2 F.3d 1 → Id.` | `Id.` after `Jones` has no explicit pincite to inherit (Jones has none); should fall through cleanly with `undefined` |
+| 7 | `Smith, 1 U.S. 1, 100 (citing Other, 3 U.S. 1, 5) → Id.` | `100` (parenthetical doesn't break chain — requires §5.1 refinement) |
+| 8 | `Smith, 1 U.S. 1, 100 → Smith, 1 U.S. at 115 → Id.` (short-form case, not `Id.`) | `115` |
+| 9 | `Smith, 1 U.S. 1, 100 → Jones, 2 F.3d 1 → Smith, supra, at 50 → Id.` | `50` (inherit from supra) |
+| 10 | `42 U.S.C. § 1983 → Id. § 1983(c) → Id.` | `§ 1983(c)` (preserve `pinciteInfo`) |
+| 11 | `Smith, 1 U.S. 1, 100 → see also Id. at 115 → see Id.` | `115` (signals don't break chain) |
+| 12 | Footnote 1: `Smith, 1 U.S. 1, 100.` Footnote 2: `Id. at 115.` Footnote 3: `Id.` | `115` (cross-footnote allowed since each footnote has single authority; honor existing scope strategy) |
+| 13 | `Smith, 1 U.S. 1, 100 → Id. at 9999.` | depending on validation (§5.3): either inherit nothing or reject the `9999` outright |
+| 14 | `Smith, 1 U.S. 1, 100 → Id. at 115 → Id. (citing Other, 3 U.S. 1, 5) → Id.` | First bare `Id.` inherits 115; second bare `Id.` inherits 115 too (nested cite to `Other` is parenthetical) |
+
+Cases 7 and 14 require the §5.1 parenthetical-depth refinement. Cases 11 is free if the algorithm only walks citation objects.
+
+---
+
+## 7. Recommendations
+
+**Priority order, all actionable:**
+
+1. **Ship the proposed linear-backward-scan-stop-at-authority-boundary algorithm.** It matches Rule 4.1 and corrects a real bug. (Cases 1–6, 8–10, 12)
+2. **Add parenthetical-depth skipping in the backward walk** using existing `parenDepths`. This is a 2-line change that captures the Bluebook's explicit exception. (Cases 7, 14)
+3. **Add the `MAX_OPINION_PAGE_COUNT` sanity check on inherited pincites**, mirroring eyecite. Make it configurable (default 150 to match upstream, with awareness of [#104](https://github.com/freelawproject/eyecite/issues/104)). (Case 13)
+4. **Preserve `pinciteInfo` wholesale** when inheriting, and gate on type compatibility (numeric ↔ case, section ↔ statute), as the current implementation already does. (Case 10)
+5. **Record `pinciteInheritedFrom: j`** on the inheriting citation. This is provenance metadata for the migration guide and consumers; matches the project's existing `confidence` and `processTimeMs` pattern of "we explain why."
+6. **Test all 14 cases above.** Cases 4, 5, 6, 14 are the highest-value because they exercise the algorithm's invariants directly.
+
+**Do NOT:**
+
+- Walk text tokens (signals, surrounding prose) — only walk the `citations` array.
+- Try to disambiguate between "writer omitted explicit pincite because same as predecessor" vs. "writer forgot to add a pincite." The Bluebook treats them as identical; the parser should too.
+- Look for `resolvedTo` to be a short-form (it won't be — `resolvedTo` always points to a full citation). The walk is over `citations[]` directly; that's how we sidestep the existing bug.
+
+---
+
+## Sources
+
+**Bluebook authoritative summaries** (Rule 4.1):
+
+- [Tarlton Law Library — Short form: Id., Infra, Supra, Hereinafter](https://tarlton.law.utexas.edu/bluebook-legal-citation/short-form) — Rule 4.1 paraphrase; "immediately preceding cited authority"; parenthetical/history exception.
+- [UC Davis Mabie Law Library — Short Citation Forms](https://libguides.law.ucdavis.edu/c.php?g=1014499&p=7370559) — "Use Id. when citing the immediately preceding authority" + single-authority requirement.
+- [Hawaii Law Library — Weird Bluebook Rules](https://law-hawaii.libguides.com/c.php?g=125486&p=821513) — Four explicit Id. rules; single-authority requirement.
+- [Loyola Chicago — Short Citation Forms](https://lawlibguides.luc.edu/bluebook/short_form) — "If the page number has changed, indicate that with 'at'".
+- [Suffolk Law — Advanced Bluebook](https://lawguides.suffolk.edu/bluebook/advanced) — Rule 4.1 reference; pinpoint-cite variations.
+- [Tarlton — Intro Signals](https://tarlton.law.utexas.edu/bluebook-legal-citation/intro-signals) — signals' interaction with citations.
+- [Casebriefly — Id. Citation Rules](https://www.casebriefly.com/bluebook-citation-generator/id-citation) — "Id. always refers to the immediately preceding cited authority."
+- [TypeLaw — Id. vs ibid.](https://www.typelaw.com/blog/when-to-use-id-versus-ibid-in-legal-brief-citations/) — "If there's any interruption with a different source, don't use Id."
+- [AllCitations — Bluebook Short Form](https://www.allcitations.com/blog/bluebook-short-form-citations-id-supra) — synthesizes Rule 4.1.
+
+**Python eyecite reference** (commit `main` HEAD, 2026-05-19):
+
+- [`eyecite/resolve.py`](https://github.com/freelawproject/eyecite/blob/main/eyecite/resolve.py) — `_resolve_id_citation`, `_has_invalid_pin_cite`, `MAX_OPINION_PAGE_COUNT = 150`. No inheritance.
+- [`eyecite/find.py`](https://github.com/freelawproject/eyecite/blob/main/eyecite/find.py#L356) — `_extract_id_citation` extracts only what the `Id.` text contains.
+- [`eyecite/models.py`](https://github.com/freelawproject/eyecite/blob/main/eyecite/models.py) — `CitationBase.Metadata.pin_cite: str | None`; never written from elsewhere.
+- [`tests/test_ResolveTest.py`](https://github.com/freelawproject/eyecite/blob/main/tests/test_ResolveTest.py) — `test_id_resolution`, `test_non_case_resolution` — verifies clustering, not inheritance.
+- [Issue #74 (closed)](https://github.com/freelawproject/eyecite/issues/74) — pincite used for cluster filtering only.
+- [Issue #104 (closed)](https://github.com/freelawproject/eyecite/issues/104) — discusses `MAX_OPINION_PAGE_COUNT = 150` and long opinions.
+
+**eyecite-ts current state**:
+
+- [`src/resolve/DocumentResolver.ts`](file:///Users/medelman/Projects/OSS/eyecite-ts/src/resolve/DocumentResolver.ts) lines 280–318 — current single-hop inheritance from `resolvedTo`; the bug origin.
+
+**Related implementations**:
+
+- [Citation Style Language (CSL) spec](https://docs.citationstyles.org/en/stable/specification.html) — "ibid" semantics chain locators; conceptual precedent (not code).

--- a/docs/superpowers/plans/2026-05-19-pincite-inheritance.md
+++ b/docs/superpowers/plans/2026-05-19-pincite-inheritance.md
@@ -1,0 +1,798 @@
+# Pincite Inheritance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Bluebook Rule 4.1-correct pincite inheritance for bare `Id.` / `supra` / short-form-case citations: each inherits the pincite of its *immediately preceding same-authority* citation, not the terminal full citation. Fixes the bug where intermediate `Id. at X` pincites are dropped.
+
+**Architecture:** A single post-resolution pass on `DocumentResolver` walks each short-form citation's predecessors backward, stops at authority boundaries (different `resolvedTo`) or successful inheritance, skips citations nested in explanatory parentheticals (Rule 4.1 explicit exception), and copies pincite + pinciteInfo from the first eligible predecessor. Two new optional fields (`pinciteInherited`, `pinciteInheritedFrom`) carry provenance.
+
+**Tech Stack:** TypeScript, Vitest 4, pnpm 10, Biome 2. Zero new runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md`
+**Research:** `docs/research/2026-05-19-pincite-inheritance.md`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/types/citation.ts` | Modify | Add `pinciteInherited?` + `pinciteInheritedFrom?` to `IdCitation`, `SupraCitation`, `ShortFormCaseCitation` |
+| `src/resolve/DocumentResolver.ts` | Modify | Remove pincite/pinciteInfo lines from the existing inline `if (citation.type === "id" && resolution?.resolvedTo !== undefined)` block. Add `private inheritPincites(resolved)` method. Call it once at the end of `resolve()`. |
+| `tests/resolve/idInheritsPincite.test.ts` | Modify + extend | Flip the codified-bug test expectation (line ~88-103) to Bluebook-correct behavior. Add new `describe` blocks for chains, parentheticals, authority boundaries, supra/short-form intermediates, statute chains, signals, footnotes. |
+| `.changeset/pincite-inheritance.md` | Create | Minor bump describing the inheritance fix and the two new optional fields. |
+
+No changes to `src/index.ts` (new fields ride on already-exported interfaces).
+
+---
+
+## Pre-flight: Branch & Workspace
+
+The work happens on `feat/confidence-scoring-phase-1-2` (the spec and research already live there). Verify:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+# Expected: feat/confidence-scoring-phase-1-2
+
+git status
+# Expected: modified package.json + pnpm-lock.yaml (persistent drift — leave alone),
+#           plus untracked dev scripts. No staged changes.
+```
+
+If you're on a different branch, switch back and pop the lock-file stash if present (see project memory `feedback_feature_branches.md` and `project_persistent_drift.md`).
+
+---
+
+## Task 1: Add Type Fields
+
+**Files:**
+- Modify: `src/types/citation.ts` (three interfaces: `IdCitation` ~line 721, `SupraCitation` ~line 763, `ShortFormCaseCitation` ~line 787)
+
+- [ ] **Step 1.1: Add fields to `IdCitation`**
+
+Find the existing `pinciteInfo?:` line inside `IdCitation` (~line 725). Insert these two field declarations immediately after it:
+
+```ts
+  /**
+   * True if `pincite` was inherited from a preceding same-authority citation
+   * per Bluebook Rule 4.1. Undefined when `pincite` was extracted directly
+   * from this citation's text or when no pincite was set.
+   */
+  pinciteInherited?: boolean
+  /**
+   * Array index of the citation from which `pincite` was inherited.
+   * Indexes into the same array this citation appears in — i.e., the
+   * output of `extractCitations(...).citations` (or
+   * `DocumentResolver.resolve()`'s output, which preserves input order).
+   * Set only when `pinciteInherited` is true. Records the immediate
+   * predecessor; follow transitively for the chain's originator.
+   */
+  pinciteInheritedFrom?: number
+```
+
+- [ ] **Step 1.2: Add the same two fields to `SupraCitation`**
+
+Find `SupraCitation`'s `pinciteInfo?:` line (~line 770). Insert the same two declarations after it (copy verbatim — the JSDoc applies identically).
+
+- [ ] **Step 1.3: Add the same two fields to `ShortFormCaseCitation`**
+
+Find `ShortFormCaseCitation`'s `pinciteInfo?:` line (~line 794). Insert the same two declarations after it.
+
+- [ ] **Step 1.4: Run typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: passes with zero errors. The new fields are optional and don't affect existing consumers.
+
+- [ ] **Step 1.5: Run lint**
+
+```bash
+pnpm lint
+```
+
+Expected: passes.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/types/citation.ts
+git commit -m "$(cat <<'EOF'
+types: add pinciteInherited/pinciteInheritedFrom to short-form citations
+
+Adds two optional provenance fields to IdCitation, SupraCitation, and
+ShortFormCaseCitation in preparation for Bluebook Rule 4.1 pincite
+inheritance. No runtime change in this commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Flip the Codified-Bug Test (TDD Red)
+
+The existing test at `tests/resolve/idInheritsPincite.test.ts` lines ~88-103 asserts buggy behavior (`ids[1].pincite === 55`) where Bluebook Rule 4.1 actually requires `62`. We flip the expectation first so it becomes our failing test.
+
+**Files:**
+- Modify: `tests/resolve/idInheritsPincite.test.ts`
+
+- [ ] **Step 2.1: Update the test expectations and comment**
+
+Find the existing `it("\`Id. at 62.\` then \`Id.\` — second Id. inherits 62 from chain root's pincite", ...)` block. Replace the entire `it(...)` block with:
+
+```ts
+    it("`Id. at 62.` then `Id.` — second Id. inherits 62 from immediate predecessor (Rule 4.1)", () => {
+      // Bluebook Rule 4.1: `Id.` refers to the immediately preceding cited
+      // authority. A bare `Id.` after `Id. at 62.` inherits the pincite of
+      // that immediate predecessor (62), NOT the terminal full citation's
+      // pincite (55). See docs/research/2026-05-19-pincite-inheritance.md.
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 62. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      expect(ids[0].pincite).toBe(62)
+      expect(ids[1].pincite).toBe(62)
+      expect(ids[1].pinciteInherited).toBe(true)
+      expect(ids[1].pinciteInheritedFrom).toBe(/* index of ids[0] in cites */ 1)
+    })
+```
+
+Note the `pinciteInheritedFrom` assertion: in the citation array, the full `Smith` is index 0, the `Id. at 62` is index 1, the bare `Id.` is index 2. So `ids[1]` (the bare `Id.`) inherited from index 1.
+
+- [ ] **Step 2.2: Run just this test to see it fail**
+
+```bash
+pnpm exec vitest run tests/resolve/idInheritsPincite.test.ts -t "second Id. inherits 62 from immediate predecessor"
+```
+
+Expected: **FAIL.** The current implementation produces `ids[1].pincite === 55` (chases to Smith), but we now expect `62`. The `pinciteInherited` and `pinciteInheritedFrom` assertions also fail because those fields don't exist yet at runtime.
+
+- [ ] **Step 2.3: Do NOT commit**
+
+Stay red. The commit happens at end of Task 3 once the implementation makes the test green.
+
+---
+
+## Task 3: Implement `inheritPincites` (TDD Green)
+
+This task adds the new pass and calls it. We do NOT yet remove the existing inline inheritance — that comes in Task 4. The new pass runs *after* the inline block, so for the test from Task 2 the new pass overwrites whatever the inline block produced.
+
+**Files:**
+- Modify: `src/resolve/DocumentResolver.ts`
+
+- [ ] **Step 3.1: Add the helper to determine pincite family**
+
+At the top of `src/resolve/DocumentResolver.ts`, find the existing `import { isFullCitation } from "../types/guards"` line. After it, add (or extend) imports so the resolver can name the types it inspects:
+
+```ts
+import type { Citation, FullCitation } from "../types/citation"
+```
+
+(Skip any types already imported — Biome will flag duplicates.)
+
+Then, near the other private helpers in the class (look for `computeParenDepths` around line 361), add this private static-style helper as a method:
+
+```ts
+  /**
+   * Returns the expected pincite shape ("numeric" | "string") for the
+   * given full citation. Case-family citations carry numeric pincites;
+   * statute-family citations carry string pincites. Returns "unknown"
+   * if the type doesn't carry a pincite.
+   */
+  private pinciteFamily(cit: FullCitation): "numeric" | "string" | "unknown" {
+    switch (cit.type) {
+      case "case":
+      case "journal":
+      case "neutral":
+        return "numeric"
+      case "statute":
+        return "string"
+      default:
+        return "unknown"
+    }
+  }
+```
+
+- [ ] **Step 3.2: Add the `inheritPincites` private method**
+
+Immediately after the new `pinciteFamily` helper, add:
+
+```ts
+  /**
+   * Post-resolution pass: propagate pincite from the immediately preceding
+   * same-authority citation per Bluebook Rule 4.1. Mutates `resolved` in
+   * place. Idempotent — re-running is a no-op since already-inherited
+   * pincites are skipped by the eligibility gate.
+   *
+   * See docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md.
+   */
+  private inheritPincites(resolved: ResolvedCitation[]): void {
+    for (let i = 0; i < resolved.length; i++) {
+      const cit = resolved[i]
+
+      // Eligibility: only short-forms with a successful resolution and no
+      // explicit pincite/pinciteInfo of their own.
+      if (cit.type !== "id" && cit.type !== "supra" && cit.type !== "shortFormCase") continue
+      const myResolution = this.resolutions[i]
+      if (!myResolution || myResolution.resolvedTo === undefined) continue
+      if (cit.pincite !== undefined || cit.pinciteInfo !== undefined) continue
+
+      const targetPrimary = myResolution.resolvedTo
+      const currentParenDepth = this.parenDepths[i] ?? 0
+
+      // Family lookup uses the terminal full citation (where pincite shape
+      // is unambiguous). resolved[targetPrimary] is guaranteed full because
+      // resolvedTo always points at a full citation.
+      const targetFull = resolved[targetPrimary] as FullCitation
+      const targetFamily = this.pinciteFamily(targetFull)
+      if (targetFamily === "unknown") continue
+
+      for (let j = i - 1; j >= 0; j--) {
+        // Rule 4.1 explicit exception: explanatory-parenthetical cites
+        // are not "intervening authorities."
+        if ((this.parenDepths[j] ?? 0) > currentParenDepth) continue
+
+        const cand = resolved[j]
+        const candPrimary = isFullCitation(cand)
+          ? j
+          : this.resolutions[j]?.resolvedTo
+
+        // Authority boundary: stop scanning at any prior cite that resolves
+        // to a different primary (or fails to resolve).
+        if (candPrimary !== targetPrimary) break
+
+        // Skip candidates without a pincite to inherit. Continue scanning —
+        // earlier same-authority cites may still carry one.
+        if (cand.pincite === undefined) continue
+
+        // Type compatibility: numeric pincite for case-family; string for
+        // statute. Wrong family means a parser oddity; stop rather than
+        // silently mismatching.
+        const candIsNumeric = typeof cand.pincite === "number"
+        const candIsString = typeof cand.pincite === "string"
+        if (targetFamily === "numeric" && !candIsNumeric) break
+        if (targetFamily === "string" && !candIsString) break
+
+        // Inherit. Cast through `as` because the discriminated union'd
+        // pincite types are interface-specific. Runtime check above gates it.
+        ;(cit as IdCitation | SupraCitation | ShortFormCaseCitation).pincite =
+          cand.pincite as never
+        ;(cit as IdCitation | SupraCitation | ShortFormCaseCitation).pinciteInfo =
+          cand.pinciteInfo
+        ;(cit as IdCitation | SupraCitation | ShortFormCaseCitation).pinciteInherited = true
+        ;(cit as IdCitation | SupraCitation | ShortFormCaseCitation).pinciteInheritedFrom = j
+        break
+      }
+    }
+  }
+```
+
+If `IdCitation`, `SupraCitation`, or `ShortFormCaseCitation` aren't already imported, add them to the existing type import block (search for `import type {` near the top — the file already imports several types from `../types/citation`).
+
+- [ ] **Step 3.3: Call `inheritPincites` from `resolve()`**
+
+Find the end of the `resolve()` method (around line 350, the `return resolved` line). Insert a call to the new pass on the line immediately before `return resolved`:
+
+```ts
+    this.inheritPincites(resolved)
+    return resolved
+```
+
+- [ ] **Step 3.4: Run the test from Task 2 to verify it passes**
+
+```bash
+pnpm exec vitest run tests/resolve/idInheritsPincite.test.ts -t "second Id. inherits 62 from immediate predecessor"
+```
+
+Expected: PASS. Both `ids[1].pincite === 62` and the new provenance fields are populated.
+
+- [ ] **Step 3.5: Run the whole test suite**
+
+```bash
+pnpm exec vitest run
+```
+
+Expected: ALL TESTS PASS. The new pass runs after the existing inline block, so any test that depended on the inline block's single-hop inheritance still gets the same result (the new pass either does the same thing or is a no-op when the inline block already set `pincite`).
+
+If any test fails, **stop and investigate.** Likely candidates: a test asserting `pinciteInherited === undefined` on a citation that now has the flag set, or a previously-passing assertion that the bug-codifying test was the only canary for.
+
+- [ ] **Step 3.6: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint
+```
+
+Expected: both pass.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add src/resolve/DocumentResolver.ts tests/resolve/idInheritsPincite.test.ts
+git commit -m "$(cat <<'EOF'
+fix(resolve): inherit pincite from immediate same-authority predecessor (Rule 4.1)
+
+Bluebook Rule 4.1 anchors a bare Id./supra/shortFormCase to the
+immediately preceding cited authority — including its pincite. The
+existing inline inheritance only inherits from the terminal full
+citation (resolvedTo), dropping any pincite introduced mid-chain by
+an intermediate Id. at X or supra, at X.
+
+Adds DocumentResolver.inheritPincites: post-resolution backward walk
+stopping at authority boundaries, skipping parenthetical-nested cites
+per Rule 4.1's explicit exception, with a family-shape gate so
+numeric pincites never propagate to statutes and vice versa.
+
+Flips the bug-codifying test in idInheritsPincite.test.ts to match
+the correct Rule 4.1 semantics.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Remove the Now-Redundant Inline Inheritance
+
+Now that `inheritPincites` handles every case the inline block handled (and more), remove the inline pincite/pinciteInfo lines. Keep the case-name inheritance and the re-scoring — those remain correct and in-scope.
+
+**Files:**
+- Modify: `src/resolve/DocumentResolver.ts`
+
+- [ ] **Step 4.1: Locate the inline block**
+
+Inside `DocumentResolver.resolve()`, find the block:
+
+```ts
+      let citationOut: Citation = citation
+      if (citation.type === "id" && resolution?.resolvedTo !== undefined) {
+        const antecedent = this.citations[resolution.resolvedTo]
+        if (antecedent) {
+          const idOut: IdCitation = { ...(citation as IdCitation) }
+
+          // Pincite inheritance (when Id. has none explicit).
+          if (
+            idOut.pincite === undefined &&
+            "pincite" in antecedent &&
+            typeof antecedent.pincite === "number"
+          ) {
+            idOut.pincite = antecedent.pincite
+            if ("pinciteInfo" in antecedent && antecedent.pinciteInfo) {
+              idOut.pinciteInfo = antecedent.pinciteInfo
+            }
+          }
+
+          // Case-name inheritance (only when antecedent is a `case`).
+          if (antecedent.type === "case") {
+            // ... keep this block intact ...
+          }
+
+          citationOut = idOut
+        }
+      }
+```
+
+- [ ] **Step 4.2: Remove only the pincite-inheritance lines**
+
+Delete the entire `// Pincite inheritance (when Id. has none explicit).` comment and the `if (idOut.pincite === undefined && ...)` block (the ~10 lines that set `idOut.pincite` and `idOut.pinciteInfo`). **Leave the surrounding structure intact:** the `idOut = { ...citation }` spread, the case-name inheritance block, the `citationOut = idOut` assignment.
+
+After the removal, the relevant section should look like:
+
+```ts
+      let citationOut: Citation = citation
+      if (citation.type === "id" && resolution?.resolvedTo !== undefined) {
+        const antecedent = this.citations[resolution.resolvedTo]
+        if (antecedent) {
+          const idOut: IdCitation = { ...(citation as IdCitation) }
+
+          // Case-name inheritance (only when antecedent is a `case`).
+          if (antecedent.type === "case") {
+            // ... unchanged ...
+          }
+
+          citationOut = idOut
+        }
+      }
+```
+
+- [ ] **Step 4.3: Run the full test suite**
+
+```bash
+pnpm exec vitest run
+```
+
+Expected: ALL TESTS PASS. `inheritPincites` now handles every single-hop case that the inline block used to handle, so the behavior is preserved for existing tests.
+
+If any test fails, the most likely cause is that `inheritPincites`'s eligibility/family gate is stricter than the inline block was. Investigate before re-trying: re-read the failing test, check whether the citation type or pincite shape falls through the new gate.
+
+- [ ] **Step 4.4: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint
+```
+
+Expected: both pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/resolve/DocumentResolver.ts
+git commit -m "$(cat <<'EOF'
+refactor(resolve): remove inline pincite inheritance superseded by inheritPincites
+
+The inline block inside DocumentResolver.resolve() inherited pincite
+only from the terminal full citation (resolvedTo). That behavior is
+now subsumed by inheritPincites, which does the same for the
+single-hop case plus the correct multi-hop walk. Keeps the inline
+case-name inheritance and re-scoring untouched — those remain
+correct and in-scope.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Parenthetical Exception + Test
+
+The algorithm already implements the parenthetical-depth skip (Step 3.2, `if ((this.parenDepths[j] ?? 0) > currentParenDepth) continue`). Add a regression test to lock it in.
+
+**Files:**
+- Modify: `tests/resolve/idInheritsPincite.test.ts`
+
+- [ ] **Step 5.1: Add a new `describe` block for parenthetical-exception tests**
+
+Inside the top-level `describe("Id. inherits pincite from antecedent (Bluebook 4.1)", ...)` block, add a new nested `describe` (place it after the `chained Id. citations` block):
+
+```ts
+  describe("Rule 4.1 parenthetical exception", () => {
+    it("`Id.` after `Smith, at 100 (citing Other, 2 F.3d 1, 5)` inherits Smith's 100", () => {
+      // Bluebook Rule 4.1 explicitly excludes parenthetical-nested cites
+      // ("citing", "quoting", etc.) from the "intervening authority" rule.
+      // The Id. inherits from Smith (the host citation), not from Other.
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 100 (1990) (citing Other v. Else, 2 F.3d 1, 5). Id."
+      const cites = extractCitations(text, { resolve: true })
+      const id = cites.find((c): c is IdCitation => c.type === "id")
+      expect(id?.pincite).toBe(100)
+      expect(id?.pinciteInherited).toBe(true)
+    })
+  })
+```
+
+- [ ] **Step 5.2: Run the test**
+
+```bash
+pnpm exec vitest run tests/resolve/idInheritsPincite.test.ts -t "Rule 4.1 parenthetical exception"
+```
+
+Expected: PASS. The parenDepth skip is already in `inheritPincites`, so the test should pass on the first run.
+
+If it fails (the parenthetical isn't actually detected as `parenDepths[j] > 0`, or `Other` somehow shares Smith's primary), investigate `computeParenDepths` and confirm `parenDepths` is correctly tagging the inner citation. The fallback is to debug by logging `this.parenDepths` for that input.
+
+- [ ] **Step 5.3: Run full suite to confirm nothing regressed**
+
+```bash
+pnpm exec vitest run
+```
+
+Expected: ALL TESTS PASS.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add tests/resolve/idInheritsPincite.test.ts
+git commit -m "$(cat <<'EOF'
+test(resolve): cover Rule 4.1 parenthetical exception for pincite inheritance
+
+Locks in the behavior that parenthetical-nested citations
+("citing X", "quoting Y") do not break an Id. chain — the Id.
+correctly inherits from the host citation rather than the nested one.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add Remaining Regression Tests (Chains, Boundaries, Supra, Statute, Signals)
+
+Batch the rest of the spec's test cases into focused `describe` blocks. The algorithm already covers them; this task locks them in as regression tests.
+
+**Files:**
+- Modify: `tests/resolve/idInheritsPincite.test.ts`
+
+- [ ] **Step 6.1: Add the chains describe block**
+
+After the existing `chained Id. citations` block (or after the parenthetical block from Task 5), add:
+
+```ts
+  describe("chains with intermediate pincite changes (Rule 4.1)", () => {
+    it("Smith, at 55 → Id. at 115 → Id. at 200 → bare Id. inherits 200", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Id. at 200. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(3)
+      expect(ids[0].pincite).toBe(115)
+      expect(ids[1].pincite).toBe(200)
+      expect(ids[2].pincite).toBe(200)
+      expect(ids[2].pinciteInherited).toBe(true)
+    })
+
+    it("Smith, at 55 → Id. at 115 → bare Id. → bare Id. both inherit 115", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Id. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(3)
+      expect(ids[0].pincite).toBe(115)
+      expect(ids[1].pincite).toBe(115)
+      expect(ids[1].pinciteInherited).toBe(true)
+      expect(ids[2].pincite).toBe(115)
+      expect(ids[2].pinciteInherited).toBe(true)
+      // Provenance: third Id. inherited from the second (which itself
+      // inherited from `Id. at 115`).
+      expect(ids[2].pinciteInheritedFrom).toBe(ids[1].pinciteInheritedFrom! + 1)
+    })
+  })
+```
+
+- [ ] **Step 6.2: Add the authority-boundary describe block**
+
+```ts
+  describe("authority boundaries break the chain", () => {
+    it("Smith → Id. at 115 → Jones, at 50 → Id. inherits 50 (Jones is new authority)", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Other v. Else, 200 F.3d 1, 50 (1991). Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      // ids[0] is the `Id. at 115` referring to Smith — keeps its explicit 115.
+      expect(ids[0].pincite).toBe(115)
+      // ids[1] is the bare `Id.` referring to the Other v. Else citation —
+      // inherits Other's pincite 50, not Smith's 55 nor the intermediate 115.
+      expect(ids[1].pincite).toBe(50)
+      expect(ids[1].pinciteInherited).toBe(true)
+    })
+
+    it("Smith → Id. at 115 → Other (no pincite) → Id. → undefined (Other has none)", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Other v. Else, 200 F.3d 1 (1991). Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      expect(ids[0].pincite).toBe(115)
+      // Bare Id. after Other (which has no pincite) → no inheritance; chain
+      // cannot cross back to Smith because Other is an authority boundary.
+      expect(ids[1].pincite).toBeUndefined()
+      expect(ids[1].pinciteInherited).toBeUndefined()
+    })
+  })
+```
+
+- [ ] **Step 6.3: Add the supra/short-form intermediate describe block**
+
+```ts
+  describe("supra and short-form-case as intermediates", () => {
+    it("Smith → Other → Smith, supra, at 50 → Id. inherits 50 from supra", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Other v. Else, 200 F.3d 1 (1991). Smith, supra, at 50. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const id = cites.find((c): c is IdCitation => c.type === "id")
+      expect(id?.pincite).toBe(50)
+      expect(id?.pinciteInherited).toBe(true)
+    })
+
+    it("Smith → Smith, 100 F.2d at 115 → Id. inherits 115 from short-form", () => {
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Smith, 100 F.2d at 115. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const id = cites.find((c): c is IdCitation => c.type === "id")
+      expect(id?.pincite).toBe(115)
+      expect(id?.pinciteInherited).toBe(true)
+    })
+  })
+```
+
+- [ ] **Step 6.4: Add the statute-chain describe block**
+
+```ts
+  describe("statute section-style chain", () => {
+    it("28 U.S.C. § 1331 → Id. § 1331(a) → bare Id. inherits § 1331(a)", () => {
+      const text = "See 28 U.S.C. § 1331. Id. § 1331(a). Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      // ids[0] has explicit subsection — keeps it.
+      expect(ids[0].pincite).toBe("(a)")
+      // ids[1] inherits the string-style pincite from the immediate
+      // predecessor. Family-compat gate accepts string for statute family.
+      expect(ids[1].pincite).toBe("(a)")
+      expect(ids[1].pinciteInherited).toBe(true)
+    })
+  })
+```
+
+Note on the assertion `expect(ids[0].pincite).toBe("(a)")`: statute-pincite shape is determined by the eyecite-ts extractor; the exact string value (`"(a)"` vs `"1331(a)"` vs `"§ 1331(a)"`) depends on how the statute extractor structures it. If this assertion fails, first run the test, inspect the actual value, and update both `ids[0]` and `ids[1]` expectations to match. The point of the test is provenance — that `ids[1]` carries the same string `ids[0]` does, plus `pinciteInherited === true`.
+
+- [ ] **Step 6.5: Add the signals-don't-break-chains describe block**
+
+```ts
+  describe("signals do not break Id. chains", () => {
+    it("Smith → see also Id. at 115 → see Id. inherits 115", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). See also Id. at 115. See Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      expect(ids[0].pincite).toBe(115)
+      expect(ids[1].pincite).toBe(115)
+      expect(ids[1].pinciteInherited).toBe(true)
+    })
+  })
+```
+
+- [ ] **Step 6.6: Add the footnotes describe block**
+
+```ts
+  describe("footnote-bounded chains", () => {
+    it("cross-footnote chain with single-authority footnotes inherits correctly", () => {
+      // Each footnote carries exactly one citation, so Rule 4.1's
+      // single-authority cross-footnote rule applies. The existing
+      // "footnote" scope strategy allows Id. to cross into the body
+      // for supra/short-form but is strict for Id. — for this test we
+      // place all three citations in a single contiguous body region
+      // since footnote detection requires specific markup.
+      // (Equivalent semantics test without footnote markup.)
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Id."
+      const cites = extractCitations(text, {
+        resolve: true,
+        detectFootnotes: true,
+      })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      expect(ids[1].pincite).toBe(115)
+      expect(ids[1].pinciteInherited).toBe(true)
+    })
+  })
+```
+
+Note: if the eyecite-ts test fixtures include actual footnote-markup samples (e.g., HTML with `<footnote>` tags), prefer adapting one of those over the inline-body equivalent. Search `tests/footnotes/` for examples. The minimum bar for this test is that `inheritPincites` works correctly when `detectFootnotes: true` is enabled — not whether the footnote-detector itself is right (that's covered by its own tests).
+
+- [ ] **Step 6.7: Run the full pincite-inheritance file**
+
+```bash
+pnpm exec vitest run tests/resolve/idInheritsPincite.test.ts
+```
+
+Expected: ALL TESTS PASS, including the new blocks from Tasks 5 and 6.
+
+If a test fails, investigate the **actual** value the algorithm produced — most likely an off-by-one on indices, an unexpected family-gate stop, or (for the statute test) a different pincite-string shape than guessed. Adjust the test to match the algorithm's actual (Bluebook-correct) output, OR fix the algorithm if the test reveals a real bug.
+
+- [ ] **Step 6.8: Run the entire test suite**
+
+```bash
+pnpm exec vitest run
+```
+
+Expected: ALL TESTS PASS.
+
+- [ ] **Step 6.9: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint
+```
+
+Expected: both pass.
+
+- [ ] **Step 6.10: Commit**
+
+```bash
+git add tests/resolve/idInheritsPincite.test.ts
+git commit -m "$(cat <<'EOF'
+test(resolve): lock in pincite inheritance across chains, authorities, statutes, signals, footnotes
+
+Adds regression tests for every case enumerated in the design spec:
+- Multi-hop chains with mid-chain pincite changes
+- Authority boundaries (different resolvedTo) breaking the chain
+- Supra and short-form-case as intermediates
+- Statute section-style pincite inheritance (preserves string shape)
+- Signals (see, see also, cf.) do not break Id. chains
+- Footnote-aware chains via detectFootnotes: true
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Add Changeset
+
+**Files:**
+- Create: `.changeset/pincite-inheritance.md`
+
+- [ ] **Step 7.1: Write the changeset file**
+
+Create the file with this content:
+
+```markdown
+---
+"eyecite-ts": minor
+---
+
+fix(resolve): inherit pincite from immediate same-authority predecessor (Bluebook Rule 4.1)
+
+`Id.`, `supra`, and short-form-case citations now inherit their pincite from the **immediately preceding same-authority citation** — including from intermediate `Id. at X` or `supra, at X` predecessors — rather than only from the terminal full citation. This matches Bluebook Rule 4.1 and fixes a real bug.
+
+**Behavior changes:**
+
+- `Smith → Id. at 115 → bare Id.` now produces `pincite = 115` on the bare `Id.` (previously `undefined`).
+- `Smith → Jones → Smith, supra, at 50 → bare Id.` now produces `pincite = 50` (previously `undefined`).
+- `Smith, at 100 → Id. at 115 → Id. → Id.` — all three trailing citations now correctly inherit `115`.
+- `Supra` and `ShortFormCaseCitation` gain pincite inheritance for the first time. Previously only `Id.` inherited.
+
+**New optional fields on `IdCitation`, `SupraCitation`, `ShortFormCaseCitation`:**
+
+- `pinciteInherited?: boolean` — true when `pincite` was inherited per Rule 4.1.
+- `pinciteInheritedFrom?: number` — array index (in `extractCitations(...).citations`) of the immediate predecessor that supplied the pincite. Follow transitively for the chain's originator.
+
+**Migration:** No code changes required for consumers reading `pincite`. The inherited value is semantically equivalent to one extracted directly (Rule 4.1 makes them identical). Consumers wanting to distinguish "explicit in text" from "inherited per rule" should branch on `pinciteInherited`.
+
+**Non-goals (future work):** `MAX_OPINION_PAGE_COUNT`-style range validation on inherited pincites; expanding case-name inheritance to `Supra` and `ShortFormCaseCitation`.
+
+See `docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md` for the full design and `docs/research/2026-05-19-pincite-inheritance.md` for the Bluebook + Python eyecite reference validation.
+```
+
+- [ ] **Step 7.2: Commit**
+
+```bash
+git add .changeset/pincite-inheritance.md
+git commit -m "$(cat <<'EOF'
+chore: changeset for pincite inheritance fix
+
+Minor bump — adds two optional provenance fields and a Bluebook
+Rule 4.1-correct behavior change for short-form pincite inheritance.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Final Verification
+
+- [ ] **Step 8.1: Full test suite, typecheck, lint, build**
+
+```bash
+pnpm exec vitest run && pnpm typecheck && pnpm lint && pnpm build
+```
+
+Expected: all four pass.
+
+- [ ] **Step 8.2: Run the size check**
+
+```bash
+pnpm size
+```
+
+Expected: within configured limits. The new code is small (~50 lines in `DocumentResolver.ts`); should be well within budget.
+
+- [ ] **Step 8.3: Review the diff one last time**
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+Expected: ~5 commits (Tasks 1, 3, 4, 5, 6, 7) plus the spec/research commits that were already on the branch. Stat should show changes to `src/types/citation.ts`, `src/resolve/DocumentResolver.ts`, `tests/resolve/idInheritsPincite.test.ts`, `.changeset/pincite-inheritance.md`, and the docs files.
+
+- [ ] **Step 8.4: Hand off**
+
+Implementation complete. Open a PR (don't push automatically — confirm with the user first per project conventions). Suggested PR title: **"fix(resolve): inherit pincite from immediate same-authority predecessor (Bluebook Rule 4.1)"**.

--- a/docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md
+++ b/docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md
@@ -10,7 +10,7 @@ Bluebook Rule 4.1 says a bare `Id.` (no explicit `at NNN`) refers to "the same s
 
 ### The bug
 
-`DocumentResolver.ts:285-302` already inherits pincite when `Id.` has none — but only from the citation at `resolution.resolvedTo`. Because `resolvedTo` is **flat** (every short-form points directly to the terminal full citation, never to an intermediate), the inheritance silently misses any pincite introduced mid-chain:
+The existing inline inheritance block in `DocumentResolver.ts` — the `if (citation.type === "id" && resolution?.resolvedTo !== undefined)` branch inside the main `resolve()` loop — already inherits pincite when `Id.` has none, but only from the citation at `resolution.resolvedTo`. Because `resolvedTo` is **flat** (every short-form points directly to the terminal full citation, never to an intermediate), the inheritance silently misses any pincite introduced mid-chain:
 
 | Input | Expected (Bluebook) | Current behavior |
 |---|---|---|
@@ -47,9 +47,13 @@ for each i in 0..resolved.length-1:
     candPrimary = isFullCitation(cand) ? j : resolutions[j]?.resolvedTo
     if candPrimary !== targetPrimary: break   // authority boundary
 
+    // Require a numeric or string pincite directly on the candidate.
+    // (pinciteInfo-only candidates, e.g. paragraph-only or star-only, are
+    // not inherited from — mirrors the existing inline block's
+    // `typeof antecedent.pincite === "number"` discipline. See §"Type
+    // compatibility" below for the family-shape gate.)
     if cand.pincite !== undefined:
-      if !pinciteTypeCompatible(cit, cand): break       // numeric ↔ string mismatch
-      if !pinciteWithinRange(targetPrimary, cand.pincite): break  // MAX_OPINION_PAGE_COUNT
+      if !pinciteTypeCompatible(cit, cand): break
 
       cit.pincite              = cand.pincite
       cit.pinciteInfo          = cand.pinciteInfo
@@ -65,8 +69,8 @@ for each i in 0..resolved.length-1:
 - **Provenance = immediate predecessor.** `pinciteInheritedFrom` records the citation index the pincite was copied *from*, not the chain's originator. Consumers wanting the originator transitively follow `pinciteInheritedFrom` until they hit a citation where `pinciteInherited` is false.
 - **Walks backward, stops at boundaries.** Stops on (a) authority mismatch (different `resolvedTo`), (b) successful inheritance, (c) reaching index `-1`. Bounded; no cycles possible.
 - **Parenthetical-depth skip.** Mirrors Bluebook Rule 4.1's explicit exclusion of explanatory-parenthetical cites from the "intervening authority" rule. Uses existing `DocumentResolver.parenDepths[]`.
-- **Type compatibility gate.** Mirrors the existing inline block's `typeof antecedent.pincite === "number"` check — a numeric pincite never propagates to a statute, a string section never propagates to a case.
-- **MAX_OPINION_PAGE_COUNT validation.** Inherited pincite must fall within `[fullPage, fullPage + MAX_OPINION_PAGE_COUNT)` of the terminal full citation. Default `150`, matches Python eyecite. Configurable via resolver options for long opinions (cf. eyecite issue #104).
+- **Type compatibility gate (`pinciteTypeCompatible`).** Defined as: compatible iff `cit`'s family expects the same pincite shape as `cand`'s. Case-family (`case`, `journal`, `neutral`, `id`-resolving-to-case, `supra`-resolving-to-case, `shortFormCase`) expects `number | undefined`. Statute-family (`statute`, `id`-resolving-to-statute) expects `string | undefined`. Inheriting a `string` into a case-family citation or a `number` into a statute is always wrong; the check returns `false` and the walk stops. Implementation can derive family by inspecting the terminal full citation at `targetPrimary`.
+- **No range/sanity validation in this PR.** A `MAX_OPINION_PAGE_COUNT`-style check (mirroring Python eyecite's `_has_invalid_pin_cite`) was recommended in the research but is **out of scope** here — eyecite-ts has no such validation today, and adding it now would be a separate, measurable behavior change. Tracked as future work; see Non-Goals.
 
 ## Type Changes
 
@@ -84,9 +88,12 @@ export interface IdCitation extends CitationBase {
   pinciteInherited?: boolean
 
   /**
-   * Array index (in the resolved-citations output) of the citation from
-   * which `pincite` was inherited. Set only when `pinciteInherited` is true.
-   * Records the immediate predecessor; follow transitively for the originator.
+   * Array index of the citation from which `pincite` was inherited.
+   * Indexes into the same array this citation appears in — i.e., the
+   * output of `extractCitations(...).citations` (equivalently
+   * `DocumentResolver.resolve()`'s output, which preserves input order).
+   * Set only when `pinciteInherited` is true. Records the immediate
+   * predecessor; follow transitively for the chain's originator.
    */
   pinciteInheritedFrom?: number
 }
@@ -123,18 +130,18 @@ resolve(citations: Citation[]): ResolvedCitation[] {
 
 ### What changes in the existing main-loop inheritance block
 
-`DocumentResolver.ts:285-302` (the existing inline inheritance block) is split:
+The inline inheritance block inside `DocumentResolver.resolve()` (the `if (citation.type === "id" && resolution?.resolvedTo !== undefined)` branch) is split:
 
-- **Removed:** the pincite/pinciteInfo propagation (lines 290-303). Replaced by `inheritPincites`.
-- **Kept:** the case-name/plaintiff/defendant/proceduralPrefix propagation (lines 305-313). Case names belong to the *terminal authority*, not to intermediate Id.s, so the existing `antecedent = this.citations[resolution.resolvedTo]` lookup remains correct.
-- **Kept:** the re-scoring via `scoreCitation` (lines 322-338). The new pass does **not** re-score — pincite presence isn't an input to current confidence axes. If a future change makes scoring pincite-sensitive, a re-score call gets added in a follow-up PR.
+- **Removed:** the pincite/pinciteInfo propagation. Replaced by `inheritPincites`.
+- **Kept:** the case-name/plaintiff/defendant/proceduralPrefix propagation. Case names belong to the *terminal authority*, not to intermediate Id.s, so the existing `antecedent = this.citations[resolution.resolvedTo]` lookup remains correct.
+- **Kept:** the re-scoring via `scoreCitation` further down in the loop. The new pass does **not** re-score — pincite presence isn't an input to current confidence axes. If a future change makes scoring pincite-sensitive, a re-score call gets added in a follow-up PR.
 
 ### What `inheritPincites` reads
 
 - `resolved` (input/output, mutated in place) — used for both the walk and `isFullCitation` checks. Resolved entries preserve the `type` discriminant, so no need to cross-reference `this.citations`.
 - `this.resolutions[]` — for `candPrimary` lookup when a walked predecessor is a short-form.
 - `this.parenDepths[]` — for the parenthetical-exception check.
-- A small helper to fetch the terminal full citation given `resolvedTo` (for `pinciteWithinRange`).
+- A small helper to fetch the terminal full citation given a `resolvedTo` index (for the type-compatibility family lookup).
 
 ## Testing
 
@@ -176,14 +183,15 @@ describe("pincite inheritance — signals don't break chains")
 
 describe("pincite inheritance — footnotes")
   Case 12: fn1: Smith, at 100. fn2: Id. at 115. fn3: Id.  → 115
-           (respects existing "footnote" scope strategy)
-
-describe("pincite inheritance — validation guard")
-  Case 13: Smith, 1 U.S. 1 → Id. at 9999                  → 9999 rejected on
-           the explicit Id. (existing behavior); subsequent bare Id. → undefined
+           (use `extractCitations(text, { resolve: true, detectFootnotes: true })`;
+            respects existing "footnote" scope strategy)
 ```
 
+(Case 13 — range/MAX_OPINION_PAGE_COUNT validation — is **deferred** along with the validation itself. See Non-Goals.)
+
 ### Assertion shape
+
+Single-citation case:
 
 ```ts
 const cites = extractCitations(text, { resolve: true })
@@ -192,6 +200,18 @@ expect(idCit.type).toBe("id")
 expect(idCit.pincite).toBe(115)
 expect(idCit.pinciteInherited).toBe(true)
 expect(idCit.pinciteInheritedFrom).toBe(M)
+```
+
+Multi-citation case (cases 4, 14, where multiple bare Id.s in the same chain must each be checked):
+
+```ts
+const cites = extractCitations(text, { resolve: true })
+const ids = cites.filter((c): c is IdCitation => c.type === "id")
+expect(ids).toHaveLength(2)
+expect(ids[0].pincite).toBe(115)
+expect(ids[0].pinciteInheritedFrom).toBe(/* index of `Id. at 115` */)
+expect(ids[1].pincite).toBe(115)
+expect(ids[1].pinciteInheritedFrom).toBe(/* index of ids[0] in cites[] */)
 ```
 
 ### What is NOT tested in this PR
@@ -205,7 +225,7 @@ expect(idCit.pinciteInheritedFrom).toBe(M)
 | File | Change |
 |---|---|
 | `src/types/citation.ts` | Add `pinciteInherited?: boolean` and `pinciteInheritedFrom?: number` to `IdCitation`, `SupraCitation`, `ShortFormCaseCitation` |
-| `src/resolve/DocumentResolver.ts` | Remove pincite-inheritance lines from the existing inline block (~lines 290-303). Add `private inheritPincites(resolved)` method. Call it once at end of `resolve()`. |
+| `src/resolve/DocumentResolver.ts` | Remove the pincite/pinciteInfo propagation from the existing inline `if (citation.type === "id" && resolution?.resolvedTo !== undefined)` block. Keep case-name propagation and re-scoring in that block. Add `private inheritPincites(resolved)` method. Call it once at end of `resolve()`. |
 | `tests/resolve/idInheritsPincite.test.ts` | **Extend** with the new chained/intermediate/parenthetical/supra/statute test groups. Existing single-hop tests stay (and continue to pass under the new pass). |
 | `.changeset/<random>.md` | New changeset describing the inheritance fix (minor bump — new optional fields, behavior change for short-form pincites) |
 
@@ -215,7 +235,8 @@ No changes needed to `src/index.ts` (the new fields are properties on already-ex
 
 - **Re-scoring inheriting citations.** Out of scope until a confidence axis depends on pincite.
 - **Case-name inheritance for `Supra` and `ShortFormCaseCitation`.** Currently only `Id.` gets case-name inheritance. Expanding that is a separate concern.
-- **Removing the MAX_OPINION_PAGE_COUNT validation entirely.** Default stays at 150, configurable; making it dynamic per-volume is a separate ticket.
+- **`MAX_OPINION_PAGE_COUNT`-style range validation.** Recommended by research §5.3, but eyecite-ts has no such validation today (verified — no matches for `MAX_OPINION_PAGE_COUNT`/`invalid_pin_cite` in `src/`). Adding it now would be a separate, measurable behavior change for both single-hop and multi-hop inheritance. Tracked as future work — own PR, own benchmarks, default likely `150` matching upstream eyecite with an opt-out for long opinions (cf. eyecite issue #104).
+- **Inheriting from `pinciteInfo`-only candidates.** If a candidate has structured `pinciteInfo` but no numeric/string `pincite`, we don't inherit. Mirrors the existing inline block's discipline. Revisit when a real-world case shows this matters.
 - **Validating pincite type compatibility for *all* cross-type chains.** The gate is "don't propagate a numeric to a statute and vice versa." Finer distinctions (e.g., page vs. paragraph vs. star-pagination within case-family) are not in scope; they share `PinciteInfo` shape.
 
 ## Open Questions

--- a/docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md
+++ b/docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md
@@ -1,0 +1,230 @@
+# Design: Pincite Inheritance for Short-Form Citations
+
+**Date:** 2026-05-19
+**Status:** Approved by user, ready for implementation plan
+**Related research:** [`docs/research/2026-05-19-pincite-inheritance.md`](../../research/2026-05-19-pincite-inheritance.md)
+
+## Background
+
+Bluebook Rule 4.1 says a bare `Id.` (no explicit `at NNN`) refers to "the same source and same page as the immediately preceding citation." When the preceding citation is itself an `Id. at X`, the bare `Id.` inherits `X`. Today, `eyecite-ts` does **not** propagate pincites correctly through chains that contain intermediate pincite changes.
+
+### The bug
+
+`DocumentResolver.ts:285-302` already inherits pincite when `Id.` has none — but only from the citation at `resolution.resolvedTo`. Because `resolvedTo` is **flat** (every short-form points directly to the terminal full citation, never to an intermediate), the inheritance silently misses any pincite introduced mid-chain:
+
+| Input | Expected (Bluebook) | Current behavior |
+|---|---|---|
+| `Smith, 1 U.S. 1, 100 → Id. at 115 → Id.` | bare Id. pincite = `115` | bare Id. pincite = `undefined` (chases past `Id. at 115` to `Smith`, which has its own `100`, not `115`) |
+| `Smith → Jones → Smith, supra, at 50 → Id.` | bare Id. pincite = `50` | bare Id. pincite = `undefined` (chases past `supra` to `Smith`) |
+
+The bug doesn't affect the simple case `Smith, at 100 → Id. → Id.`, because both Id.s correctly resolve to `Smith` and inherit `Smith.pincite = 100`.
+
+### Why this hasn't been done upstream
+
+The Python `eyecite` reference does no inheritance at all — it stores whatever pincite the `Id.` token captured and validates it against the full citation's page range (see [research §2](../../research/2026-05-19-pincite-inheritance.md)). `eyecite-ts` already exceeds upstream by propagating pincite from the terminal antecedent; this work extends that propagation to the Bluebook-correct intermediate antecedent.
+
+## Algorithm
+
+After the main `resolve()` loop has populated `resolutions[]` and built `resolved[]`, run a **single post-resolution pass** that walks each short-form citation's predecessors and inherits the first eligible pincite.
+
+```
+for each i in 0..resolved.length-1:
+  cit = resolved[i]
+  if !isShortFormCitation(cit): continue
+  if resolutions[i]?.resolvedTo === undefined: continue
+  if cit.pincite !== undefined || cit.pinciteInfo !== undefined: continue
+
+  targetPrimary = resolutions[i].resolvedTo
+  currentParenDepth = parenDepths[i]
+
+  for j from i-1 down to 0:
+    cand = resolved[j]
+
+    // Bluebook 4.1 explicit exception: parenthetical-nested cites
+    // are NOT intervening authorities.
+    if parenDepths[j] > currentParenDepth: continue
+
+    candPrimary = isFullCitation(cand) ? j : resolutions[j]?.resolvedTo
+    if candPrimary !== targetPrimary: break   // authority boundary
+
+    if cand.pincite !== undefined:
+      if !pinciteTypeCompatible(cit, cand): break       // numeric ↔ string mismatch
+      if !pinciteWithinRange(targetPrimary, cand.pincite): break  // MAX_OPINION_PAGE_COUNT
+
+      cit.pincite              = cand.pincite
+      cit.pinciteInfo          = cand.pinciteInfo
+      cit.pinciteInherited     = true
+      cit.pinciteInheritedFrom = j
+      break
+```
+
+### Key invariants
+
+- **Single left-to-right pass.** Each citation only inherits from prior indices, so one pass suffices — no fixpoint iteration.
+- **Operates on `resolved`, not `this.citations`.** Earlier iterations' inherited pincites are visible to later iterations, which is required for chains like `Smith → Id. at 115 → Id. → Id.` (last Id. inherits from the middle Id., which was itself inherited).
+- **Provenance = immediate predecessor.** `pinciteInheritedFrom` records the citation index the pincite was copied *from*, not the chain's originator. Consumers wanting the originator transitively follow `pinciteInheritedFrom` until they hit a citation where `pinciteInherited` is false.
+- **Walks backward, stops at boundaries.** Stops on (a) authority mismatch (different `resolvedTo`), (b) successful inheritance, (c) reaching index `-1`. Bounded; no cycles possible.
+- **Parenthetical-depth skip.** Mirrors Bluebook Rule 4.1's explicit exclusion of explanatory-parenthetical cites from the "intervening authority" rule. Uses existing `DocumentResolver.parenDepths[]`.
+- **Type compatibility gate.** Mirrors the existing inline block's `typeof antecedent.pincite === "number"` check — a numeric pincite never propagates to a statute, a string section never propagates to a case.
+- **MAX_OPINION_PAGE_COUNT validation.** Inherited pincite must fall within `[fullPage, fullPage + MAX_OPINION_PAGE_COUNT)` of the terminal full citation. Default `150`, matches Python eyecite. Configurable via resolver options for long opinions (cf. eyecite issue #104).
+
+## Type Changes
+
+Add two optional fields to `IdCitation`, `SupraCitation`, and `ShortFormCaseCitation` in `src/types/citation.ts`. Parallel additions — these three interfaces don't share a discriminated subtype below `CitationBase`, and the fields don't belong on `CitationBase` (full citations never inherit pincites).
+
+```ts
+export interface IdCitation extends CitationBase {
+  // ...existing fields...
+
+  /**
+   * True if `pincite` was inherited from a preceding same-authority citation
+   * per Bluebook Rule 4.1. Absent (undefined) when pincite was extracted
+   * directly from this citation's text or when no pincite was set.
+   */
+  pinciteInherited?: boolean
+
+  /**
+   * Array index (in the resolved-citations output) of the citation from
+   * which `pincite` was inherited. Set only when `pinciteInherited` is true.
+   * Records the immediate predecessor; follow transitively for the originator.
+   */
+  pinciteInheritedFrom?: number
+}
+```
+
+Same two fields repeated on `SupraCitation` and `ShortFormCaseCitation`.
+
+**Spans:** `spans.pincite` is **not** set on inheriting citations. The inherited pincite has no text span in the descendant's own text; the span belongs to the citation referenced by `pinciteInheritedFrom`.
+
+**No new exports.** Both fields are optional properties on already-exported interfaces.
+
+## Pipeline Placement
+
+A new private method on `DocumentResolver`:
+
+```ts
+private inheritPincites(resolved: ResolvedCitation[]): void { ... }
+```
+
+Called once at the end of `resolve()`, after the main loop builds `resolved[]`, before returning:
+
+```ts
+resolve(citations: Citation[]): ResolvedCitation[] {
+  // ... existing setup: parenDepths, scope, etc.
+  const resolved: ResolvedCitation[] = []
+  for (let i = 0; i < citations.length; i++) {
+    // resolve antecedent, build resolutions[i], push to resolved[]
+  }
+
+  this.inheritPincites(resolved)   // NEW
+  return resolved
+}
+```
+
+### What changes in the existing main-loop inheritance block
+
+`DocumentResolver.ts:285-302` (the existing inline inheritance block) is split:
+
+- **Removed:** the pincite/pinciteInfo propagation (lines 290-303). Replaced by `inheritPincites`.
+- **Kept:** the case-name/plaintiff/defendant/proceduralPrefix propagation (lines 305-313). Case names belong to the *terminal authority*, not to intermediate Id.s, so the existing `antecedent = this.citations[resolution.resolvedTo]` lookup remains correct.
+- **Kept:** the re-scoring via `scoreCitation` (lines 322-338). The new pass does **not** re-score — pincite presence isn't an input to current confidence axes. If a future change makes scoring pincite-sensitive, a re-score call gets added in a follow-up PR.
+
+### What `inheritPincites` reads
+
+- `resolved` (input/output, mutated in place) — used for both the walk and `isFullCitation` checks. Resolved entries preserve the `type` discriminant, so no need to cross-reference `this.citations`.
+- `this.resolutions[]` — for `candPrimary` lookup when a walked predecessor is a short-form.
+- `this.parenDepths[]` — for the parenthetical-exception check.
+- A small helper to fetch the terminal full citation given `resolvedTo` (for `pinciteWithinRange`).
+
+## Testing
+
+**Extend the existing test file:** `tests/resolve/idInheritsPincite.test.ts` already covers single-hop inheritance (cases that work today via the inline block). The new chained/intermediate/supra/statute cases get added as new `describe` blocks in that file. Same convention, single source of truth for pincite-inheritance tests.
+
+Tests use `extractCitations(text, { resolve: true })` end-to-end (the existing pattern).
+
+### Test groups
+
+```
+describe("pincite inheritance — basic")
+  Case 1:  Smith, 1 U.S. 1, 100 → Id.                     → 100
+  Case 2:  Smith → Id. at 115 → Id.                        → 115  (regression)
+  Negative: Id. at 42 after anything                       → 42, pinciteInherited undefined
+  Negative: bare Id. after cite with no pincite            → undefined, no inheritance
+
+describe("pincite inheritance — chains")
+  Case 3:  Smith → Id. at 115 → Id. at 200 → Id.          → 200
+  Case 4:  Smith, at 100 → Id. at 115 → Id. → Id.         → both inherit 115
+  Provenance: last Id. in case 4 has pinciteInheritedFrom = index of middle Id.
+
+describe("pincite inheritance — authority boundaries")
+  Case 5:  Smith → Id. at 115 → Jones, at 50 → Id.        → 50
+  Case 6:  Smith → Id. at 115 → Id. → Jones → Id.         → undefined (Jones has no pincite)
+
+describe("pincite inheritance — parenthetical exception")
+  Case 7:  Smith, at 100 (citing Other, at 5) → Id.       → 100  (skips parenthetical)
+  Case 14: Smith → Id. at 115 → Id. (citing Other) → Id.  → 115 for both bare Id.s
+
+describe("pincite inheritance — short-form & supra intermediates")
+  Case 8:  Smith → Smith, 1 U.S. at 115 → Id.             → 115
+  Case 9:  Smith → Jones → Smith, supra, at 50 → Id.      → 50
+
+describe("pincite inheritance — statute (section-style)")
+  Case 10: 42 U.S.C. § 1983 → Id. § 1983(c) → Id.         → § 1983(c)  (preserves pinciteInfo)
+
+describe("pincite inheritance — signals don't break chains")
+  Case 11: Smith → see also Id. at 115 → see Id.          → 115
+
+describe("pincite inheritance — footnotes")
+  Case 12: fn1: Smith, at 100. fn2: Id. at 115. fn3: Id.  → 115
+           (respects existing "footnote" scope strategy)
+
+describe("pincite inheritance — validation guard")
+  Case 13: Smith, 1 U.S. 1 → Id. at 9999                  → 9999 rejected on
+           the explicit Id. (existing behavior); subsequent bare Id. → undefined
+```
+
+### Assertion shape
+
+```ts
+const cites = extractCitations(text, { resolve: true })
+const idCit = cites[N]   // or use a `findId(cites)` helper as the existing file does
+expect(idCit.type).toBe("id")
+expect(idCit.pincite).toBe(115)
+expect(idCit.pinciteInherited).toBe(true)
+expect(idCit.pinciteInheritedFrom).toBe(M)
+```
+
+### What is NOT tested in this PR
+
+- **Fixture-level integration regression.** Unit-style tests above cover the algorithm. If a regression surfaces in eval scripts later, we add a fixture case then.
+- **Cycle guard.** The walk is bounded (`j >= 0`, strictly decreasing); cycles aren't representable. A code comment notes the invariant — no test needed.
+- **Pincite-affected confidence scoring.** This PR does not change scoring inputs; no rescore tests required.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `src/types/citation.ts` | Add `pinciteInherited?: boolean` and `pinciteInheritedFrom?: number` to `IdCitation`, `SupraCitation`, `ShortFormCaseCitation` |
+| `src/resolve/DocumentResolver.ts` | Remove pincite-inheritance lines from the existing inline block (~lines 290-303). Add `private inheritPincites(resolved)` method. Call it once at end of `resolve()`. |
+| `tests/resolve/idInheritsPincite.test.ts` | **Extend** with the new chained/intermediate/parenthetical/supra/statute test groups. Existing single-hop tests stay (and continue to pass under the new pass). |
+| `.changeset/<random>.md` | New changeset describing the inheritance fix (minor bump — new optional fields, behavior change for short-form pincites) |
+
+No changes needed to `src/index.ts` (the new fields are properties on already-exported interfaces).
+
+## Non-Goals
+
+- **Re-scoring inheriting citations.** Out of scope until a confidence axis depends on pincite.
+- **Case-name inheritance for `Supra` and `ShortFormCaseCitation`.** Currently only `Id.` gets case-name inheritance. Expanding that is a separate concern.
+- **Removing the MAX_OPINION_PAGE_COUNT validation entirely.** Default stays at 150, configurable; making it dynamic per-volume is a separate ticket.
+- **Validating pincite type compatibility for *all* cross-type chains.** The gate is "don't propagate a numeric to a statute and vice versa." Finer distinctions (e.g., page vs. paragraph vs. star-pagination within case-family) are not in scope; they share `PinciteInfo` shape.
+
+## Open Questions
+
+None outstanding. Algorithm validated against Bluebook Rule 4.1 (research §1) and Python eyecite reference (research §2); approach approved by user.
+
+## Migration Notes (for the eventual changeset)
+
+- **Behavior change — `Id.`:** `Id.` already inherited pincite from its terminal antecedent (the full citation at `resolvedTo`). It now *additionally* inherits from intermediate `Id. at X` and `supra, at X` predecessors when they share the same authority. This is the Bluebook-correct semantic and fixes a real bug — see the spec body for the failure modes.
+- **Behavior change — `Supra` and `ShortFormCaseCitation`:** these gain pincite inheritance for the first time. Previously, bare `supra` (no `at NNN`) and bare short-form-case never inherited; they now do, scoped to the same authority chain.
+- **New fields:** `pinciteInherited` and `pinciteInheritedFrom` are optional. Consumers reading `pincite` without checking provenance see the inherited value as if it were extracted directly — which is the Bluebook-correct semantic.
+- **Provenance:** consumers wanting to distinguish "writer explicitly wrote `at NNN`" from "inherited per Rule 4.1" should branch on `pinciteInherited`. Consumers wanting the originating citation should follow `pinciteInheritedFrom` transitively until they hit a citation where `pinciteInherited` is false/undefined.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -14,6 +14,7 @@ import type {
   Citation,
   CitationSignal,
   FullCaseCitation,
+  FullCitation,
   IdCitation,
   ShortFormCaseCitation,
   SupraCitation,
@@ -277,29 +278,18 @@ export class DocumentResolver {
       // follow short-form chains (shortForm/supra/Id. → full antecedent).
       this.resolutions[i] = resolution
 
-      // Bluebook Rule 4.1: an `Id.` refers to the same authority and page(s)
-      // cited in the antecedent. When the antecedent is a case citation,
+      // Bluebook Rule 4.1: when the antecedent is a case citation,
       // propagate its caption (caseName, plaintiff, defendant, procedural
-      // prefix). When the Id. lacks an explicit `at NNN`, also propagate
-      // pincite from the antecedent. Consumers can then use the Id.
-      // directly without walking `resolution.resolvedTo`.
+      // prefix) onto the Id. so consumers can use it directly without
+      // walking `resolution.resolvedTo`. Pincite inheritance lives in the
+      // post-resolution `inheritPincites` pass below (it has to walk the
+      // citation array to honor the "immediately preceding citation"
+      // rule when intermediate `Id. at X` introduces a new pincite).
       let citationOut: Citation = citation
       if (citation.type === "id" && resolution?.resolvedTo !== undefined) {
         const antecedent = this.citations[resolution.resolvedTo]
         if (antecedent) {
           const idOut: IdCitation = { ...(citation as IdCitation) }
-
-          // Pincite inheritance (when Id. has none explicit).
-          if (
-            idOut.pincite === undefined &&
-            "pincite" in antecedent &&
-            typeof antecedent.pincite === "number"
-          ) {
-            idOut.pincite = antecedent.pincite
-            if ("pinciteInfo" in antecedent && antecedent.pinciteInfo) {
-              idOut.pinciteInfo = antecedent.pinciteInfo
-            }
-          }
 
           // Case-name inheritance (only when antecedent is a `case`).
           if (antecedent.type === "case") {
@@ -325,7 +315,80 @@ export class DocumentResolver {
       } as ResolvedCitation)
     }
 
+    this.inheritPincites(resolved)
     return resolved
+  }
+
+  /**
+   * Returns true if the given full citation carries a numeric pincite
+   * (case-family: case, journal, neutral). Short-form citation types
+   * (IdCitation, SupraCitation, ShortFormCaseCitation) all type `pincite`
+   * as `number` only, so they can only inherit from numeric-pincite
+   * authorities. Statute-family inheritance is blocked by the type system
+   * today; revisit if/when short-forms gain `string` pincite support.
+   */
+  private hasNumericPinciteFamily(cit: FullCitation): boolean {
+    return cit.type === "case" || cit.type === "journal" || cit.type === "neutral"
+  }
+
+  /**
+   * Post-resolution pass: propagate pincite from the immediately preceding
+   * same-authority citation per Bluebook Rule 4.1 / Indigo Book R6.2.2.
+   * Mutates `resolved` in place. Walks backward from each short-form,
+   * stopping at authority boundaries (different `resolvedTo`) or successful
+   * inheritance, skipping citations nested in explanatory parentheticals
+   * (Rule 4.1 explicit exception). Only inherits numeric pincites — see
+   * `hasNumericPinciteFamily` for why.
+   *
+   * See docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md.
+   */
+  private inheritPincites(resolved: ResolvedCitation[]): void {
+    for (let i = 0; i < resolved.length; i++) {
+      const cit = resolved[i]
+
+      // Eligibility: only short-forms with a successful resolution and no
+      // explicit pincite/pinciteInfo of their own.
+      if (cit.type !== "id" && cit.type !== "supra" && cit.type !== "shortFormCase") continue
+      const myResolution = this.resolutions[i]
+      if (!myResolution || myResolution.resolvedTo === undefined) continue
+      if (cit.pincite !== undefined || cit.pinciteInfo !== undefined) continue
+
+      const targetPrimary = myResolution.resolvedTo
+      const currentParenDepth = this.parenDepths[i] ?? 0
+
+      // Family check uses the terminal full citation. resolvedTo always
+      // points at a full citation by construction in
+      // resolveId/resolveSupra/resolveShortFormCase.
+      const targetFull = resolved[targetPrimary] as unknown as FullCitation
+      if (!this.hasNumericPinciteFamily(targetFull)) continue
+
+      for (let j = i - 1; j >= 0; j--) {
+        // Rule 4.1 explicit exception: explanatory-parenthetical cites
+        // are not "intervening authorities."
+        if ((this.parenDepths[j] ?? 0) > currentParenDepth) continue
+
+        const cand = resolved[j]
+        const candPrimary = isFullCitation(cand) ? j : this.resolutions[j]?.resolvedTo
+
+        // Authority boundary: stop scanning at any prior cite that resolves
+        // to a different primary (or fails to resolve).
+        if (candPrimary !== targetPrimary) break
+
+        // Candidate must carry a numeric pincite to inherit. Skip non-numeric
+        // (statute-shape) candidates by continuing — a more eligible candidate
+        // may exist further back. Skip pinciteInfo-only candidates similarly.
+        const candPincite = (cand as { pincite?: number | string }).pincite
+        if (typeof candPincite !== "number") continue
+
+        const target = cit as IdCitation | SupraCitation | ShortFormCaseCitation
+        target.pincite = candPincite
+        const candPinciteInfo = (cand as { pinciteInfo?: IdCitation["pinciteInfo"] }).pinciteInfo
+        if (candPinciteInfo) target.pinciteInfo = candPinciteInfo
+        target.pinciteInherited = true
+        target.pinciteInheritedFrom = j
+        break
+      }
+    }
   }
 
   /**

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -724,6 +724,21 @@ export interface IdCitation extends CitationBase {
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
   /**
+   * True if `pincite` was inherited from a preceding same-authority citation
+   * per Bluebook Rule 4.1 / Indigo Book R6.2.2. Undefined when `pincite` was
+   * extracted directly from this citation's text or when no pincite was set.
+   */
+  pinciteInherited?: boolean
+  /**
+   * Array index of the citation from which `pincite` was inherited.
+   * Indexes into the same array this citation appears in — i.e., the
+   * output of `extractCitations(...).citations` (or
+   * `DocumentResolver.resolve()`'s output, which preserves input order).
+   * Set only when `pinciteInherited` is true. Records the immediate
+   * predecessor; follow transitively for the chain's originator.
+   */
+  pinciteInheritedFrom?: number
+  /**
    * Trailing parenthetical content (text between the parens, excluding the
    * parens themselves) captured from `Id. at N (...)` forms. Common values
    * include drop-citation markers (`citation omitted`, `internal quotation
@@ -769,6 +784,21 @@ export interface SupraCitation extends CitationBase {
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
   /**
+   * True if `pincite` was inherited from a preceding same-authority citation
+   * per Bluebook Rule 4.1 / Indigo Book R6.2.2. Undefined when `pincite` was
+   * extracted directly from this citation's text or when no pincite was set.
+   */
+  pinciteInherited?: boolean
+  /**
+   * Array index of the citation from which `pincite` was inherited.
+   * Indexes into the same array this citation appears in — i.e., the
+   * output of `extractCitations(...).citations` (or
+   * `DocumentResolver.resolve()`'s output, which preserves input order).
+   * Set only when `pinciteInherited` is true. Records the immediate
+   * predecessor; follow transitively for the chain's originator.
+   */
+  pinciteInheritedFrom?: number
+  /**
    * Trailing parenthetical content (text between the parens, excluding the
    * parens themselves). See `IdCitation.parenthetical` for common shapes
    * and rationale. #303
@@ -792,6 +822,21 @@ export interface ShortFormCaseCitation extends CitationBase {
   pincite?: number
   /** Structured pincite information (page, range, footnote, star-pagination). */
   pinciteInfo?: import("../extract/pincite").PinciteInfo
+  /**
+   * True if `pincite` was inherited from a preceding same-authority citation
+   * per Bluebook Rule 4.1 / Indigo Book R6.2.2. Undefined when `pincite` was
+   * extracted directly from this citation's text or when no pincite was set.
+   */
+  pinciteInherited?: boolean
+  /**
+   * Array index of the citation from which `pincite` was inherited.
+   * Indexes into the same array this citation appears in — i.e., the
+   * output of `extractCitations(...).citations` (or
+   * `DocumentResolver.resolve()`'s output, which preserves input order).
+   * Set only when `pinciteInherited` is true. Records the immediate
+   * predecessor; follow transitively for the chain's originator.
+   */
+  pinciteInheritedFrom?: number
   /** Component-level spans (currently just `pincite`; extend when needed). */
   spans?: import("./componentSpans").ShortFormCaseComponentSpans
   /** Back-reference party name when the short-form includes one (Bluebook

--- a/tests/resolve/idInheritsPincite.test.ts
+++ b/tests/resolve/idInheritsPincite.test.ts
@@ -89,19 +89,21 @@ describe("Id. inherits pincite from antecedent (Bluebook 4.1)", () => {
       expect(ids[1].pincite).toBe(55)
     })
 
-    it("`Id. at 62.` then `Id.` — second Id. inherits 62 from chain root's pincite", () => {
-      // Bluebook semantics: the second Id. refers to the antecedent, which
-      // resolves transitively to the full citation (pincite=55). The
-      // explicit `at 62` on the first Id. is local to that Id. only —
-      // the second Id. inherits from the full citation's pincite=55, not
-      // the local override 62.
+    it("`Id. at 62.` then `Id.` — second Id. inherits 62 from immediate predecessor (Rule 4.1)", () => {
+      // Bluebook Rule 4.1 / Indigo Book R6.2.2: `Id.` refers to the
+      // immediately preceding cited authority. A bare `Id.` after
+      // `Id. at 62.` inherits the pincite of that immediate predecessor
+      // (62), NOT the terminal full citation's pincite (55).
+      // See docs/research/2026-05-19-pincite-inheritance.md.
       const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 62. Id."
       const cites = extractCitations(text, { resolve: true })
       const ids = cites.filter((c): c is IdCitation => c.type === "id")
       expect(ids).toHaveLength(2)
       expect(ids[0].pincite).toBe(62)
-      // Documents transitive-to-full-citation inheritance behavior.
-      expect(ids[1].pincite).toBe(55)
+      expect(ids[1].pincite).toBe(62)
+      expect(ids[1].pinciteInherited).toBe(true)
+      // Index of ids[0] in cites[]: full citation is index 0, ids[0] is index 1.
+      expect(ids[1].pinciteInheritedFrom).toBe(1)
     })
   })
 

--- a/tests/resolve/idInheritsPincite.test.ts
+++ b/tests/resolve/idInheritsPincite.test.ts
@@ -129,4 +129,112 @@ describe("Id. inherits pincite from antecedent (Bluebook 4.1)", () => {
       expect(id?.pinciteInherited).toBe(true)
     })
   })
+
+  describe("chains with intermediate pincite changes (Rule 4.1)", () => {
+    it("Smith, at 55 → Id. at 115 → Id. at 200 → bare Id. inherits 200", () => {
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Id. at 200. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(3)
+      expect(ids[0].pincite).toBe(115)
+      expect(ids[1].pincite).toBe(200)
+      expect(ids[2].pincite).toBe(200)
+      expect(ids[2].pinciteInherited).toBe(true)
+    })
+
+    it("Smith, at 55 → Id. at 115 → bare Id. → bare Id. — both bare Id.s inherit 115", () => {
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Id. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(3)
+      expect(ids[0].pincite).toBe(115)
+      expect(ids[1].pincite).toBe(115)
+      expect(ids[1].pinciteInherited).toBe(true)
+      expect(ids[2].pincite).toBe(115)
+      expect(ids[2].pinciteInherited).toBe(true)
+      // Provenance: the third Id. inherits from the second (which itself
+      // inherited from `Id. at 115`). pinciteInheritedFrom values are
+      // adjacent indices in cites[].
+      expect(ids[2].pinciteInheritedFrom).toBe((ids[1].pinciteInheritedFrom ?? 0) + 1)
+    })
+  })
+
+  describe("authority boundaries break the chain", () => {
+    it("Smith → Id. at 115 → Other, at 50 → bare Id. inherits 50 (Other is new authority)", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Other v. Else, 200 F.3d 1, 50 (1991). Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      // ids[0] is `Id. at 115` referring to Smith — keeps its explicit 115.
+      expect(ids[0].pincite).toBe(115)
+      // ids[1] is the bare `Id.` referring to Other — inherits Other's 50.
+      expect(ids[1].pincite).toBe(50)
+      expect(ids[1].pinciteInherited).toBe(true)
+    })
+
+    it("Smith → Id. at 115 → Other (no pincite) → bare Id. — no inheritance", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Other v. Else, 200 F.3d 1 (1991). Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      expect(ids[0].pincite).toBe(115)
+      // Bare Id. after Other (which has no pincite) — no inheritance,
+      // and chain cannot cross back to Smith because Other is an
+      // authority boundary.
+      expect(ids[1].pincite).toBeUndefined()
+      expect(ids[1].pinciteInherited).toBeUndefined()
+    })
+  })
+
+  describe("supra and short-form-case as intermediates", () => {
+    it("Smith → Other → Smith, supra, at 50 → bare Id. inherits 50 from supra", () => {
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 55 (1990). Other v. Else, 200 F.3d 1 (1991). Smith, supra, at 50. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const id = findId(cites)
+      expect(id?.pincite).toBe(50)
+      expect(id?.pinciteInherited).toBe(true)
+    })
+
+    it("Smith → Smith, 100 F.2d at 115 → bare Id. inherits 115 from short-form", () => {
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Smith, 100 F.2d at 115. Id."
+      const cites = extractCitations(text, { resolve: true })
+      const id = findId(cites)
+      expect(id?.pincite).toBe(115)
+      expect(id?.pinciteInherited).toBe(true)
+    })
+  })
+
+  describe("signals do not break Id. chains", () => {
+    it("Smith → see also Id. at 115 → see Id. — bare Id. inherits 115", () => {
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). See also Id. at 115. See Id."
+      const cites = extractCitations(text, { resolve: true })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      expect(ids[0].pincite).toBe(115)
+      expect(ids[1].pincite).toBe(115)
+      expect(ids[1].pinciteInherited).toBe(true)
+    })
+  })
+
+  describe("footnote-aware chains", () => {
+    it("chain with detectFootnotes enabled still inherits correctly", () => {
+      // The footnote scope strategy gates resolution boundaries; inheritance
+      // runs after resolution, so any chain that the resolver accepts also
+      // inherits correctly. This test exercises the option compatibility
+      // (no crash, behavior preserved) more than footnote-specific semantics
+      // — those live in tests/footnotes/.
+      const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. at 115. Id."
+      const cites = extractCitations(text, {
+        resolve: true,
+        detectFootnotes: true,
+      })
+      const ids = cites.filter((c): c is IdCitation => c.type === "id")
+      expect(ids).toHaveLength(2)
+      expect(ids[1].pincite).toBe(115)
+      expect(ids[1].pinciteInherited).toBe(true)
+    })
+  })
 })

--- a/tests/resolve/idInheritsPincite.test.ts
+++ b/tests/resolve/idInheritsPincite.test.ts
@@ -115,4 +115,18 @@ describe("Id. inherits pincite from antecedent (Bluebook 4.1)", () => {
       expect(id?.pincite).toBeUndefined()
     })
   })
+
+  describe("Rule 4.1 parenthetical exception", () => {
+    it("`Id.` after `Smith, at 100 (citing Other, 2 F.3d 1, 5)` inherits Smith's 100", () => {
+      // Bluebook Rule 4.1 explicitly excludes parenthetical-nested cites
+      // ("citing", "quoting", etc.) from the "intervening authority" rule.
+      // The Id. inherits from Smith (the host citation), not from Other.
+      const text =
+        "Smith v. Jones, 100 F.2d 50, 100 (1990) (citing Other v. Else, 2 F.3d 1, 5). Id."
+      const cites = extractCitations(text, { resolve: true })
+      const id = findId(cites)
+      expect(id?.pincite).toBe(100)
+      expect(id?.pinciteInherited).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- `Id.`, `supra`, and short-form-case citations now inherit their pincite from the **immediately preceding same-authority citation** — including from intermediate `Id. at X` or `supra, at X` predecessors — rather than only from the terminal full citation. This matches **Bluebook Rule 4.1** / **Indigo Book R6.2.2** and fixes a real bug where `Smith → Id. at 115 → bare Id.` produced `pincite = 55` (chasing past the intermediate to Smith) instead of the correct `115`.
- Replaces the inline pincite-inheritance block in `DocumentResolver.resolve()` with a post-resolution pass (`inheritPincites`): backward walk stopping at authority boundaries, skipping parenthetical-nested cites per Rule 4.1's explicit exception. Adds two optional provenance fields (`pinciteInherited`, `pinciteInheritedFrom`) on `IdCitation`, `SupraCitation`, `ShortFormCaseCitation`.
- `Supra` and `ShortFormCaseCitation` gain pincite inheritance for the first time. Previously only `Id.` inherited. Statute-chain inheritance is deferred — short-form pincite types are `number` only, so statute-shape inheritance is blocked by the type system today.

**Design + research** (in-repo): `docs/superpowers/specs/2026-05-19-pincite-inheritance-design.md`, `docs/research/2026-05-19-pincite-inheritance.md`. The research cites Indigo Book R6.2.2 as the primary source; the Bluebook proper (Rule 4.1) is paywalled.

**Changeset:** `.changeset/pincite-inheritance.md` (minor bump).

## Test Plan

- [x] `pnpm exec vitest run` — 2975 tests pass (10 new + flipped 1 bug-codifying test in `tests/resolve/idInheritsPincite.test.ts`)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (234 pre-existing warnings unrelated to this PR)
- [x] `pnpm build` — succeeds, 24 files in `dist/`
- [x] `pnpm size` — within budget (34.53 / 50 kB main; 1.8 / 3 kB utils)
- [ ] Reviewer: confirm the flipped test at `tests/resolve/idInheritsPincite.test.ts` (second `Id.` after `Id. at 62.` inheriting `62`, previously asserted `55`) reflects the Bluebook-correct semantic — see Indigo Book R6.2.2 quoted in the research doc §1.1.

## What's NOT in this PR (deferred to future work)

- `MAX_OPINION_PAGE_COUNT`-style range validation on inherited pincites (recommended by research §5.3; deferred because eyecite-ts has no such validation today and bundling that change would conflate two behavior shifts).
- Statute-chain inheritance (blocked by short-form pincite type being `number` only).
- Expanding case-name inheritance to `Supra` and `ShortFormCaseCitation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)