### PR TITLE
fix(resolve): Id. clusters with immediately preceding citation (Rule 4.1)

### DIFF
--- a/.changeset/id-clusters-with-unresolved-antecedent.md
+++ b/.changeset/id-clusters-with-unresolved-antecedent.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": minor
+---
+
+fix(resolve): Id. clusters with immediately preceding citation per Bluebook Rule 4.1, even when predecessor is an unresolved short-form
+
+Three coordinated fixes resolve a class of bugs where `Id.` referred to the wrong authority when the immediately preceding short-form had no extractable full-citation antecedent (typically because the author introduced the case name in prose rather than as a structured citation).
+
+**Behavior changes:**
+
+- **`Id.` now clusters with the immediately preceding citation regardless of resolution state** (Bluebook Rule 4.1 / Indigo Book R6.2.2). Previously, `Id.` would chase past an unresolved short-form to the previous full citation — wrong authority. The bug surfaced in passages like `Leach v. Anderl, 218 N.J. Super. 18 (1987). In Yellen v. Kassin, ... Yellen, 416 N.J. Super. at 590-91, 3 A.3d at 590-91. ... Id. at 590.` where `Id. at 590` now correctly clusters with the Yellen short-form (whose case name was inferred from the prose mention) rather than resolving to Leach.
+- **Short-form citations now carry `inferredCaseName`** when their case name was found in preceding prose (within ~400 chars) and their vol+reporter has no full-citation match in the array. The short-form remains formally unresolved (`resolvedTo` undefined), but consumers can render the case name via `caseName ?? inferredCaseName ?? partyName`.
+- **Quote-zone detection is more robust** for mid-document text inputs. The previous greedy ASCII-quote pairing mistook orphan close-quotes (from snippets starting mid-sentence) for opens, creating phantom zones that broke `Id.` resolution. The new context-based classifier handles both typographic (`"` `"`) and ASCII (`"`) quotes correctly.
+
+**New optional fields:**
+
+- `ResolutionResult.antecedentIndex?: number` — chain pointer to the immediately preceding cited authority, regardless of resolution state. Same shape as the existing `ShortFormCaseCitation.pinciteInheritedFrom` from 0.19.0. Walk transitively for the chain's originator.
+- `ShortFormCaseCitation.inferredCaseName?: string` — case name recovered from preceding prose when vol+reporter lookup fails.
+- `ShortFormCaseCitation.inferredPlaintiff?: string`, `inferredDefendant?: string`, `inferredCaseNameSpan?: Span` — supporting fields for the inferred name.
+- Same four `inferred*` fields on `SupraCitation`.
+
+**Migration:**
+
+- No breaking changes. All new fields are optional; `resolvedTo` semantics unchanged.
+- Consumers wanting to follow the new chain pointer use `let cur = id.resolution.antecedentIndex; while (cur !== undefined) { /* inspect cites[cur]; advance cur = cites[cur].resolution?.antecedentIndex */ }`.
+- Consumers rendering case names should fall back: `caseName ?? inferredCaseName ?? partyName`.
+- The `Id.` resolution outcome for the unresolved-short-form-predecessor scenario changes from "resolves to previous full cite" (incorrect) to "antecedentIndex set, resolvedTo undefined" (Bluebook-correct). If any test was relying on the previous behavior, update it to use `antecedentIndex` for the chain walk.
+
+See `docs/superpowers/specs/2026-05-19-id-resolves-past-unresolved-shortform-design.md` for the full design and `docs/research/2026-05-19-id-unresolved-antecedent.md` for the Bluebook + Python eyecite + CSL/citeproc reference validation.

--- a/.changeset/id-clusters-with-unresolved-antecedent.md
+++ b/.changeset/id-clusters-with-unresolved-antecedent.md
@@ -17,7 +17,6 @@ Three coordinated fixes resolve a class of bugs where `Id.` referred to the wron
 - `ResolutionResult.antecedentIndex?: number` — chain pointer to the immediately preceding cited authority, regardless of resolution state. Same shape as the existing `ShortFormCaseCitation.pinciteInheritedFrom` from 0.19.0. Walk transitively for the chain's originator.
 - `ShortFormCaseCitation.inferredCaseName?: string` — case name recovered from preceding prose when vol+reporter lookup fails.
 - `ShortFormCaseCitation.inferredPlaintiff?: string`, `inferredDefendant?: string`, `inferredCaseNameSpan?: Span` — supporting fields for the inferred name.
-- Same four `inferred*` fields on `SupraCitation`.
 
 **Migration:**
 

--- a/docs/research/2026-05-19-id-unresolved-antecedent.md
+++ b/docs/research/2026-05-19-id-unresolved-antecedent.md
@@ -1,0 +1,306 @@
+# Research: `Id.` Resolution When Predecessor Is an Unresolved Short-Form
+
+**Date:** 2026-05-19
+**Query:** When `Id.` follows a short-form citation whose own antecedent cannot be located (because the case name was introduced in prose rather than as a structured full citation), what should the resolver do? Is the right answer to (A) relax `resolvedTo` to accept short-forms, (B) add a separate `clusterId`, or (C) add an `antecedentIndex` pointer alongside `resolvedTo`?
+**Depth:** deep
+
+---
+
+## TL;DR Recommendation
+
+**Adopt Option C (`antecedentIndex`) as the data-model change, paired with a narrow extension to `resolveId` and forward-looking prose case-name extraction.**
+
+The Bluebook is explicit that `Id.` anchors to the **immediately preceding cited authority**, not to its resolved bibliography entry. CSL/citeproc treats `ibid` the same way — purely positional. Python eyecite's choice to drop the `Id.` is a documented limitation of its bibliographic resolver model (it can't represent "this is a chained citation but the underlying authority is unknown"), and the eyecite team has been actively shipping patches in that exact area (`ReferenceCitation`, PRs #191/#200/#202/#247, Jan–May 2025) precisely because the model can't grow.
+
+`antecedentIndex` is the smallest surgical fix that:
+
+1. Matches Bluebook semantics — `Id.` always points to the preceding citation, full stop, regardless of whether that citation has a deeper authority resolved.
+2. Has prior art *inside this very codebase*: `ShortFormCaseCitation.pinciteInheritedFrom` is already a `number` chain pointer with the same shape, documented as "Records the immediate predecessor; follow transitively for the chain's originator" (`src/types/citation.ts:832-838`).
+3. Is additive — no downstream consumer breaks. Existing `resolvedTo` semantics stay strict ("points to a successfully resolved full cite").
+4. Naturally generalizes: short-forms also get `antecedentIndex` if we want to expose their position-chain.
+
+Option A (relax `resolvedTo`) silently changes the contract for every existing consumer — they get a short-form back from what they thought was a guaranteed-full-cite pointer. Option B (`clusterId`) solves a different problem (post-hoc grouping for UI) and answers neither "where do I look up the page?" nor "what's the predecessor?" in O(1).
+
+A modest follow-on (independent of the data model) is to **extend prose case-name extraction** so the `Leach …` / "In Yellen v. Kassin" / "Yellen, 416 N.J. Super. at 590" sequence resolves Yellen's short-form properly via the prose-introduced name. eyecite-ts already extracts `partyName` on `ShortFormCaseCitation` (`src/types/citation.ts:848`), and Python eyecite added a `ReferenceCitation` path in PR #191 to harvest forward references — the missing piece is a **backward** sweep when a short-form's vol+reporter has no in-history match.
+
+---
+
+## The Specific Bug
+
+User input (real brief):
+
+> Leach v. Anderl, 218 N.J. Super. 18, 30–31 (App. Div. 1987). **In Yellen v. Kassin**, the Appellate Division squarely held that … **Yellen, 416 N.J. Super. at 590–91**, **3 A.3d at 590–91**. The court reversed … **Id. at 590.**
+
+Author intent: `Id.` → Yellen. Bluebook compliant.
+
+Current behavior (`src/resolve/DocumentResolver.ts:452-465`):
+
+```ts
+for (let i = currentIndex - 1; i >= 0; i--) {
+  const c = this.citations[i]
+  let primaryIdx: number
+
+  if (isFullCitation(c)) {
+    primaryIdx = i
+  } else {
+    // shortForm/Id./supra — follow the resolution chain. If it failed to
+    // resolve we skip it: a broken short-form shouldn't pin Id. to a
+    // citation the writer didn't successfully cite.
+    const prev = this.resolutions[i]
+    if (!prev || prev.resolvedTo === undefined) continue
+    primaryIdx = prev.resolvedTo
+  }
+  ...
+```
+
+Because the Yellen short-form has `resolution.resolvedTo === undefined` (eyecite-ts has no full Yellen citation in `citations[]` to match against — only the prose mention), the walk skips it and lands on **Leach**. Wrong authority.
+
+This is the *exact* failure mode the docstring above worries about ("a broken short-form shouldn't pin Id. to a citation the writer didn't successfully cite"), but the cure is worse than the disease — it pins `Id.` to a citation the writer **deliberately walked past**.
+
+---
+
+## Finding 1 — Bluebook Rule 4.1 / Indigo Book R6.2.2: `Id.` is Positional, Not Bibliographic
+
+### Convergent authority
+
+Every secondary source the search surfaced says the same thing:
+
+> `Id.` always refers to the **immediately preceding cited authority**.
+> ([Bluebook v21 R4.1](https://www.legalbluebook.com/bluebook/v21/rules/4-short-citation-forms/4-1-id), via [Tarlton Law Library](https://tarlton.law.utexas.edu/bluebook-legal-citation/short-form))
+
+Indigo Book R15.3.1 phrases the same rule:
+
+> _Id._ should be used only if the preceding citation cites to one source.
+> ([Indigo Book §R15.3](https://law.resource.org/pub/us/code/blue/IndigoBook.html))
+
+The Bluebook's only constraints on `Id.` are positional (immediately preceding) and disambiguation-based (preceding citation must cite only one source; intervening string-cites or multi-authority sentences kill `Id.`). **There is no Bluebook rule that conditions `Id.` on the preceding citation being a full citation, nor on the preceding citation being "resolvable" in any bibliographic sense.** The Bluebook predates structured citation databases by 70 years; it speaks of typographical adjacency, not graph edges.
+
+### What the Bluebook actually requires of the writer
+
+The writer's duty is satisfied when **the reader can identify the cited authority from context**. Bluebook R10.9 (short form for cases) says the short form is permissible "if it will be clear from context to the reader what is being referenced." A case name introduced narratively in prose — "In _Yellen v. Kassin_, the Appellate Division held…" — does in fact establish the authority for a reader, and the Bluebook explicitly permits a subsequent short-form citation under R10.9. So the writer here is doing nothing wrong; the parser, not the brief, is short of state.
+
+### Implication for the resolver
+
+`Id.` resolution should ask *"what authority did the writer just talk about?"*, not *"what authority did my full-citation database successfully match?"* The current eyecite-ts model fuses those two questions. Splitting them is the design move.
+
+---
+
+## Finding 2 — Python Eyecite Drops the `Id.` Entirely (and Knows This Is a Limitation)
+
+### Verbatim reference behavior
+
+From [`eyecite/resolve.py`](https://github.com/freelawproject/eyecite/blob/main/eyecite/resolve.py) (base64-decoded):
+
+```python
+def _resolve_id_citation(
+    id_citation: IdCitation,
+    last_resolution: ResourceType,
+    resolutions: Resolutions,
+) -> ResourceType | None:
+    """Resolve id citations to the resource of the previously resolved citation."""
+    # if last resolution failed, id. cite should also fail
+    if not last_resolution:
+        return None
+    ...
+```
+
+And from the main loop:
+
+```python
+last_resolution = resolution  # only set when the cite resolved
+if resolution:
+    resolutions[resolution].append(citation)
+# else: citation is silently dropped from the resolutions dict
+```
+
+`last_resolution` is updated on **every** iteration to the current cite's `resolution`. If the current cite is a short-form that returns `None`, `last_resolution = None` and the next `Id.` also returns `None` and is dropped. The `tests/test_ResolveTest.py` test suite confirms this with a fixture (`"Foo v. Bar, 1 U.S. 1." → "2 F.2d, at 2." → "Id. at 2."`) expecting all three of `(0, None, None)`.
+
+### Why this is a model limit, not a design choice
+
+Python eyecite's `Resolutions` is `dict[ResourceType, list[CitationBase]]` — a one-to-many index keyed by *resolved authority*. There is no native shape for "this short-form and this `Id.` are clustered together but the underlying `Resource` is unknown." The data structure forces "drop on failure."
+
+### eyecite has been actively patching around this
+
+Beginning January 2025, eyecite added `ReferenceCitation` ([PR #191](https://github.com/freelawproject/eyecite/pull/191)) — a wholly new citation class for the "[NAME] at [PAGE]" prose pattern that appears *after* a full citation. Follow-ups #200, #202, #203, #207, #214, #241, #247, #251, #260, #263 (Jan–May 2025) all expand prose-name extraction. Crucially, `ReferenceCitation` is **forward-only**: it scans text after a known full citation looking for `Smith at 240`, but **does not handle the reverse case** where the prose mention precedes the structured short-form. eyecite's WebFetch'd `find_case_name(short=True)` path only looks at HTML emphasis tags adjacent to the short-form, not at preceding prose.
+
+So: Python eyecite (a) cannot resolve the Yellen short-form, (b) drops the chained `Id.`, and (c) is the upstream reference implementation but has an active open gap in this area. eyecite-ts can do better here without diverging from upstream's *philosophy* — just from upstream's *data shape*.
+
+### Issues to watch
+
+- [#75 (open)](https://github.com/freelawproject/eyecite/issues/75) — Skip supra cites to current document
+- [#299 (open)](https://github.com/freelawproject/eyecite/issues/299) — `Id.` doesn't capture pin cite with § references
+- No open issue specifically about "Id. after unresolved short-form" (checked all open & closed issues), suggesting upstream considers the current behavior a known constraint of the bibliographic model.
+
+---
+
+## Finding 3 — CourtListener Citator Adds an Outer Resolution Layer
+
+[CourtListener](https://www.courtlistener.com/help/api/rest/citation-lookup/) consumes eyecite output and adds a **post-extraction reverse-matching layer**: when a citation is ambiguous (matches multiple opinions in their database), they "search the case name from each potential match in the original document and if there is only one match, then that becomes the linked citation." They explicitly call out that "Reference citations lacking a full case name can be difficult to extract accurately" and that "Eyecite allows for an initial citation extraction, followed by a secondary reference resolution step. If you have an external database that provides resolved case names, you can use this feature."
+
+This validates the architectural separation Option C creates: **antecedent linking (parser concern) is distinct from authority resolution (citator/database concern).** A library can confidently say "these citations are part of the same chain" without committing to "and they all refer to record `xyz` in your database."
+
+---
+
+## Finding 4 — CSL / citeproc `ibid` Is Purely Positional
+
+The [CSL 1.0.2 spec](https://docs.citationstyles.org/en/stable/specification.html) defines `ibid` strictly by sequence position relative to the previous cite — *not* by whether the previous cite successfully matched a bibliography entry:
+
+> The "ibid"/"ibid-with-locator"/"subsequent" positions apply to cites referencing previously cited items, which have the "subsequent" position.
+> When the preceding cite does not have a locator … the position of the current cite is "ibid".
+
+The position assignment runs against the **citation stream**, independent of bibliography resolution. citeproc-js's later refactor (`processCites` returning `[[(Cite, Maybe Reference)]]`) institutionalized this separation: a citation can have a position-context (ibid) and an *unresolved* reference simultaneously. That is exactly the shape we need.
+
+[pandoc-citeproc issue #53](https://github.com/jgm/pandoc-citeproc/issues/53) and the [Hayagriva position bug](https://github.com/typst/hayagriva/issues/122) both wrestle with the same problem from the other side — sequence-vs-resolution is so canonically separable that bugs arise when implementations conflate them.
+
+---
+
+## Finding 5 — `antecedentIndex` Already Has Prior Art Inside `eyecite-ts`
+
+`ShortFormCaseCitation.pinciteInheritedFrom: number` (added for #303-class inheritance work) is documented in `src/types/citation.ts:832-838`:
+
+```ts
+/**
+ * Array index of the citation from which `pincite` was inherited.
+ * Indexes into the same array this citation appears in — i.e., the
+ * output of `extractCitations(...).citations` (or
+ * `DocumentResolver.resolve()`'s output, which preserves input order).
+ * Set only when `pinciteInherited` is true. Records the immediate
+ * predecessor; follow transitively for the chain's originator.
+ */
+pinciteInheritedFrom?: number
+```
+
+Same shape (`number` index into the citation array), same semantics ("records the immediate predecessor; follow transitively for the chain's originator"), same backward-compat story (additive, optional). Adopting `antecedentIndex` on the resolution object is internally consistent with how the codebase already models predecessor links.
+
+Note also that `SupraCitation` carries the **same** `pinciteInheritedFrom` field (`src/types/citation.ts:793-800`) — chain pointers are not a novel concept here.
+
+---
+
+## Finding 6 — Prose Case-Name Extraction is Half-Built
+
+`extractCaseName` already exists in `src/extract/extractCase.ts:1150` and is invoked from full-citation extraction (`extractCase.ts:2615+`). It does a structured backward walk for `Party v. Party` patterns within a bounded window.
+
+`extractShortForms.ts:443-488` already extracts a `partyName` from text *embedded in the short-form itself* (`Yellen, 416 N.J. Super. at 590` → `partyName = "Yellen"`). And the resolver at `DocumentResolver.ts:809-826` already uses `partyName` to disambiguate when multiple full cites match `416 N.J. Super.`.
+
+The missing capability — adapting `extractCaseName` (or a sibling) to scan **backward from a short-form** when no in-history full citation matches the short-form's vol+reporter — would not be a new architectural axis. It's a forward extension of work already in flight.
+
+---
+
+## The Three Candidate Fixes — Trade-Off Matrix
+
+| Dimension | A: Relax `resolvedTo` to accept short-forms | B: Add `clusterId` field | **C: Add `antecedentIndex` field** |
+|---|---|---|---|
+| **Bluebook fidelity** | Partial — `Id.` finds something, but consumers still have to chase pointers to get the actual authority | Weak — `clusterId` says "same group" but doesn't preserve adjacency / direction | **Strong — directly encodes "immediately preceding" semantic** |
+| **Python eyecite prior art** | None — they don't do this | None — they don't do this either | Closest: `Resolutions` keyed by `Resource` is the same idea inverted; CSL `position=ibid` is the same idea |
+| **In-repo prior art** | None — would invert the existing strict-full contract | None | **Strong: `pinciteInheritedFrom`** is the same field shape, same semantics |
+| **Breaking change** | **Yes** — every consumer expecting `citations[resolvedTo]` to be a `FullCitation` breaks (type narrowing, UI rendering, downstream resolvers) | No — additive | **No — additive** |
+| **Type system cost** | `resolvedTo: number` becomes `resolvedTo: number /* may be short-form */` and the discriminated union loses a guarantee | Trivial: `clusterId?: string` | Trivial: `antecedentIndex?: number` |
+| **Solves the real bug?** | Yes — `Id.` would chain through unresolved short-forms | **No** — consumer still has to ask "what's `Id.`'s real predecessor?" — `clusterId` alone gives you the set but not the order | **Yes — `Id.` writes its `antecedentIndex` to the unresolved short-form, and the chain is walkable** |
+| **Handles the wider class of clustering needs (UI grouping, parallel cites)?** | No | **Yes** — but at the cost of being a parallel solution to a different problem | Partial — `antecedentIndex` is a chain pointer, so transitive closure gives you the cluster |
+| **Effort estimate** | Tiny code change, huge consumer-facing fallout | Small, but unclear payoff for the actual bug | Small — single field add + resolver tweak + tests |
+
+### A's failure mode in detail
+
+If we relax `resolvedTo`, consider what `citations[id.resolution.resolvedTo]` returns: a `ShortFormCaseCitation` with no full case-name fields, no court, no year. Every existing consumer that does `if (target.type === "case") { render(target.caseName) }` silently produces empty strings. This is the most expensive option *because* it looks cheap.
+
+### B's mismatch with the question
+
+`clusterId` is the right answer to a *different* question — "give me all the citations to authority X for de-duping in a UI." It's a worthwhile field on its own. But it doesn't tell `Id.` who its immediate predecessor is, and it doesn't preserve sequence. You'd still need either A's relaxation or C's chain pointer to make the resolver work; `clusterId` would always sit alongside one of them.
+
+### C's strengths
+
+- The resolver writes a small change: when the walk finds a non-full citation at index `i` whose `resolvedTo` is undefined, it **stops** there and records `antecedentIndex = i` (instead of skipping). The strict `resolvedTo` contract for full-cite resolution is preserved by leaving `resolvedTo` undefined in that case.
+- Consumers who want to walk the chain do `while (antecedentIndex !== undefined) { ... }` and get the originator — the same idiom the codebase already documents for `pinciteInheritedFrom`.
+- Consumers who only care about the resolved authority continue to use `resolvedTo` and get back a guaranteed `FullCitation` — the existing contract.
+- Annotators that just want to render `Id. → "Yellen"` use `citations[antecedentIndex].partyName ?? citations[antecedentIndex].text` — no full-cite lookup required.
+
+---
+
+## Recommended Implementation Sketch
+
+> **Not implementation — scope-of-change estimate to inform the decision.**
+
+### Data-model change (`src/resolve/types.ts`)
+
+```ts
+export interface ResolutionResult {
+  /** Index of the FULL citation this resolves to. Unchanged contract. */
+  resolvedTo?: number
+  /**
+   * Index of the immediately preceding cited authority in document order,
+   * regardless of whether that citation itself resolved to a full cite.
+   * Always set when the resolver could anchor `Id.`/short-form to *some*
+   * preceding citation. May equal `resolvedTo` for clean chains; differs
+   * when the predecessor is itself an unresolved short-form (Bluebook R4.1
+   * compliance for prose-introduced authorities).
+   */
+  antecedentIndex?: number
+  failureReason?: string
+  warnings?: string[]
+  confidence: number
+}
+```
+
+### Resolver change (`src/resolve/DocumentResolver.ts:452-465`)
+
+Two-pass walk: prefer the closest full-cite-resolved candidate (current behavior), but if **no candidate at all is found**, fall back to the most recent non-full citation and set `antecedentIndex` (leaving `resolvedTo` undefined). Confidence drops to ~0.7. Add a warning: `"Id. antecedent has unresolved authority; chained by position only"`.
+
+### Optional follow-on: backward prose-name extraction
+
+When a short-form fails vol+reporter lookup, run `extractCaseName` on the preceding ~200 chars of prose. If it finds `Party v. Party` and the short-form's `partyName` matches either side, **promote** the prose mention to an implicit full-citation anchor (or attach it to the short-form's metadata so downstream consumers can do the lookup). This addresses the upstream gap eyecite hasn't filled, would close out a real class of brief-writing styles, and is independent of the data-model change.
+
+### Test cases to add
+
+1. The literal Leach/Yellen fixture from the bug report — `Id.` must land on Yellen's short-form, not Leach.
+2. `Id.` after an unresolved short-form whose vol+reporter has no match anywhere — `antecedentIndex` set, `resolvedTo` undefined, warning emitted.
+3. `Id.` after a resolved short-form — `resolvedTo` and `antecedentIndex` both point through to the originating full cite (or `antecedentIndex` to the short-form, `resolvedTo` to the full cite — pick one and document it; the latter is more consistent with "immediately preceding").
+4. Chain of two `Id.`s after an unresolved short-form — both anchor, no drift.
+5. Regression: confirm existing tests around quote zones, footnote scope, parenthetical-child, and weak-signal filtering still produce identical `resolvedTo` values (the strict contract is untouched).
+
+---
+
+## Open Questions for the Implementer
+
+1. **Should `antecedentIndex` point at the immediately preceding citation always, or at the most recent "primary" citation (skipping parenthetical children and weak-signal asides)?** The Bluebook says strictly immediately preceding (excluding string-cite members and parentheticals — see R4.1 carve-outs). Recommend: mirror the existing filters but allow short-forms regardless of resolution state.
+2. **For resolved chains, does `antecedentIndex` point at the predecessor cite (one step back) or transitively at the originator?** Recommend: one step back. Transitive walk is the consumer's job, and that's how `pinciteInheritedFrom` is already documented.
+3. **Should the resolver emit an `Id.` resolution with `resolvedTo` populated by *following* the antecedent's own `antecedentIndex` chain to find a full cite, if one is upstream?** I.e., if `Id. → unresolved short-form → some earlier full cite (because the short-form had a different unresolved name)`. Recommend: no, at least for v1. The Bluebook says `Id.` is anchored to the *immediately* preceding authority; if the writer chained short-forms to two different authorities through a prose name, only the predecessor authority is what `Id.` actually means.
+4. **Naming.** `antecedentIndex` is clear but verbose; `predecessorIndex` and `priorCiteIndex` are alternatives. Whatever name is picked should differ from `resolvedTo` enough that the distinction is hard to miss.
+
+---
+
+## Sources
+
+### Bluebook & Indigo Book
+- [Bluebook v21 R4.1 "Id."](https://www.legalbluebook.com/bluebook/v21/rules/4-short-citation-forms/4-1-id) — primary rule; "Id. always refers to the immediately preceding cited authority."
+- [Indigo Book §R15.3 (R6.2.2 in earlier numbering)](https://law.resource.org/pub/us/code/blue/IndigoBook.html) — "Id. should be used only if the preceding citation cites to one source."
+- [Tarlton Law Library — Short form: Id., Infra, Supra, Hereinafter](https://tarlton.law.utexas.edu/bluebook-legal-citation/short-form) — secondary summary, confirms positional rule.
+- [UC Davis Bluebook Guide — Short Citation Forms](https://libguides.law.ucdavis.edu/c.php?g=1014499&p=7370559) — ambiguity-avoidance gloss.
+- [Bluebook R10.9 — Short Forms for Cases](https://guides.ll.georgetown.edu/c.php?g=261289&p=2339389) — "clear from context to the reader."
+
+### Python Eyecite (Reference Implementation)
+- [`eyecite/resolve.py` (main)](https://github.com/freelawproject/eyecite/blob/main/eyecite/resolve.py) — `_resolve_id_citation` source; "if last resolution failed, id. cite should also fail."
+- [`eyecite/find.py` (main)](https://github.com/freelawproject/eyecite/blob/main/eyecite/find.py) — `find_case_name(short=True)` only looks at HTML emphasis tags, not prose.
+- [`eyecite/models.py` (main)](https://github.com/freelawproject/eyecite/blob/main/eyecite/models.py) — no chain pointer field on `IdCitation`/`ShortCaseCitation`; `Resolutions` is `dict[ResourceType, list[CitationBase]]`.
+- [PR #191 — Add Reference Citation Extractor](https://github.com/freelawproject/eyecite/pull/191) (Jan 2025) — introduces forward-only prose-name extraction; 1,188 new references in 1% sample.
+- [PR #200 — feat(ReferenceCitation): use resolved_case_name](https://github.com/freelawproject/eyecite/pull/200) (Feb 2025) — `ReferenceCitation` integrated with resolved case names.
+- [PR #202 / #203 / #207 / #214 / #241 / #247 / #251 / #260 / #263](https://github.com/freelawproject/eyecite/pulls?q=is%3Apr+is%3Aclosed+reference) — successive reference-citation refinements through May 2025.
+- [Issue #299 (open) — Id. doesn't capture pin cite with § references](https://github.com/freelawproject/eyecite/issues/299) — adjacent `Id.` resolution edge case.
+- [Issue #75 (open) — Skip supra cites to current document](https://github.com/freelawproject/eyecite/issues/75) — confirms upstream openness to refining short-form semantics.
+
+### CourtListener (Downstream Consumer)
+- [Citation Lookup and Verification API](https://www.courtlistener.com/help/api/rest/citation-lookup/) — outer reverse-matching layer atop eyecite; "Reference citations lacking a full case name can be difficult to extract accurately."
+- [CourtListener FAQ — Citator](https://www.courtlistener.com/faq/) — describes the reverse-matching strategy for ambiguous citations.
+
+### CSL / citeproc (Cross-Domain Reference)
+- [CSL 1.0.2 Specification — Position](https://docs.citationstyles.org/en/stable/specification.html) — `ibid` defined purely by stream position, independent of bibliography resolution.
+- [pandoc-citeproc Issue #53 — Disambiguation problems in ibid styles](https://github.com/jgm/pandoc-citeproc/issues/53) — illustrates the value of separating position from resolution.
+- [Hayagriva Issue #122 — CSL position "ibid" isn't tested well](https://github.com/typst/hayagriva/issues/122) — same separation surfacing in a different impl.
+- [pandoc-citeproc 0.16+ changelog](https://hackage.haskell.org/package/pandoc-citeproc-0.16.0.1/changelog) — `processCites` type evolved to `[[(Cite, Maybe Reference)]]` to permit position-without-resolution.
+
+### eyecite-ts Internal Prior Art
+- `src/types/citation.ts:783-800` — `SupraCitation.pinciteInheritedFrom: number` — existing chain-pointer field.
+- `src/types/citation.ts:817-852` — `ShortFormCaseCitation` already carries `partyName`/`partyNameNormalized` and `pinciteInheritedFrom`.
+- `src/resolve/DocumentResolver.ts:452-528` — current `resolveId` algorithm where the skip-on-unresolved happens.
+- `src/resolve/DocumentResolver.ts:604-705` — `applyCaseNameWindowCheck` already detects prose names near `Id.` and downgrades confidence; logical extension point for `antecedentIndex` warnings.
+- `src/extract/extractCase.ts:1150` — `extractCaseName` backward search, candidate for adaptation to short-form backward prose extraction.
+- `src/extract/extractShortForms.ts:443-488` — short-form `partyName` extraction already in place.

--- a/docs/superpowers/plans/2026-05-19-id-resolves-past-unresolved-shortform.md
+++ b/docs/superpowers/plans/2026-05-19-id-resolves-past-unresolved-shortform.md
@@ -1,0 +1,1102 @@
+# `Id.` Clusters With Unresolved Short-Form Predecessor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the resolver bug where `Id.` chases past an unresolved short-form (like `Yellen, 416 N.J. Super. at 590-91` whose case name appears only in prose) to the previous full citation (Leach), instead of clustering with the immediately preceding citation per Bluebook Rule 4.1 / Indigo Book R6.2.2.
+
+**Architecture:** Three coordinated changes. (1) Add an additive `antecedentIndex` field on `ResolutionResult` — same chain-pointer shape as the existing `pinciteInheritedFrom`. (2) Make `resolveShortFormCase` enrich short-forms with `inferredCaseName` via backward prose scan when vol+reporter lookup fails. (3) Replace the greedy quote-pairing in `detectQuoteZones` with a context-based open/close classifier so mid-document text snippets don't produce phantom zones.
+
+**Tech Stack:** TypeScript, Vitest 4, pnpm 10, Biome 2. Zero new runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-id-resolves-past-unresolved-shortform-design.md`
+**Research:** `docs/research/2026-05-19-id-unresolved-antecedent.md`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/resolve/types.ts` | Modify | Add `antecedentIndex?: number` to `ResolutionResult` |
+| `src/types/citation.ts` | Modify | Add `inferredCaseName?`, `inferredPlaintiff?`, `inferredDefendant?`, `inferredCaseNameSpan?` to `ShortFormCaseCitation` and `SupraCitation` |
+| `src/resolve/DocumentResolver.ts` | Modify | (a) Rewrite `detectQuoteZones` with context classifier. (b) Add `findImmediatePredecessor` helper. (c) Modify `resolveId` to two-pass. (d) Populate `antecedentIndex` in `resolveSupra` and `resolveShortFormCase`. (e) Add `extractInferredCaseName` fallback inside `resolveShortFormCase`. |
+| `tests/resolve/quoteZoneRobustness.test.ts` | Create | Quote-zone classifier tests (Section 4 of spec) |
+| `tests/resolve/idWalksToUnresolvedAntecedent.test.ts` | Create | `antecedentIndex` chain tests (Section 2 of spec) |
+| `tests/resolve/shortFormProseNameFallback.test.ts` | Create | Backward prose extraction tests (Section 3 of spec) |
+| `tests/resolve/yellenFixture.test.ts` | Create | End-to-end fixture from bug report |
+| `.changeset/id-clusters-with-unresolved-antecedent.md` | Create | Minor bump |
+
+---
+
+## Pre-flight
+
+Verify you're on the right branch with the spec/research already present:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+# Expected: fix/id-resolves-past-unresolved-shortform
+
+ls docs/superpowers/specs/2026-05-19-id-resolves-past-unresolved-shortform-design.md
+ls docs/research/2026-05-19-id-unresolved-antecedent.md
+# Both should exist.
+```
+
+If you're elsewhere, switch back and pop any lock-file stash (per `project_persistent_drift` memory: `package.json` + `pnpm-lock.yaml` are expected to show as modified — leave alone or stash during branch switches).
+
+---
+
+## Task 1: Type Additions
+
+Pure type changes. Nothing runtime in this task.
+
+**Files:**
+- Modify: `src/resolve/types.ts` (~line 72, `ResolutionResult` interface)
+- Modify: `src/types/citation.ts` (~line 787 for `ShortFormCaseCitation`, ~line 763 for `SupraCitation`)
+
+- [ ] **Step 1.1: Add `antecedentIndex` to `ResolutionResult`**
+
+Open `src/resolve/types.ts`. Find the `export interface ResolutionResult {` block. After the existing `resolvedTo?: number` declaration (and its JSDoc), insert this field declaration immediately before `failureReason`:
+
+```ts
+  /**
+   * Index of the immediately preceding cited authority in document order,
+   * regardless of whether *that* citation itself resolved to a full cite.
+   * Bluebook Rule 4.1 / Indigo Book R6.2.2: `Id.` anchors here.
+   *
+   * - When the predecessor is a full citation or successfully-resolved
+   *   short-form, this points one step back (may equal `resolvedTo`).
+   * - When the predecessor is an unresolved short-form (e.g. because the
+   *   case name appears only in prose), this still points at it; the
+   *   `resolvedTo` field stays undefined.
+   * - Records the immediate predecessor only; follow transitively via
+   *   `resolutions[antecedentIndex].antecedentIndex` for the originator.
+   *   Same idiom as `ShortFormCaseCitation.pinciteInheritedFrom`.
+   */
+  antecedentIndex?: number
+```
+
+- [ ] **Step 1.2: Add inferred-case-name fields to `ShortFormCaseCitation`**
+
+Open `src/types/citation.ts`. Find `export interface ShortFormCaseCitation extends CitationBase {` (~line 787). After the existing `pinciteInheritedFrom?: number` declaration (added in 0.19.0; should be present), insert these four fields:
+
+```ts
+  /**
+   * Case name inferred from prose preceding this short-form when no full
+   * citation in `citations[]` matched its vol+reporter. Populated by the
+   * resolver fallback for the "In Smith v. Jones... Smith, 100 F.2d at 200"
+   * pattern. Consumers: prefer `caseName ?? inferredCaseName ?? partyName`.
+   */
+  inferredCaseName?: string
+  /** Plaintiff side of the inferred case name. */
+  inferredPlaintiff?: string
+  /** Defendant side of the inferred case name. */
+  inferredDefendant?: string
+  /** Span in original text where the inferred case name was found. */
+  inferredCaseNameSpan?: Span
+```
+
+- [ ] **Step 1.3: Add the same four fields to `SupraCitation`**
+
+Find `export interface SupraCitation extends CitationBase {` (~line 763). After its existing `pinciteInheritedFrom?: number`, insert the same four field declarations (copy verbatim from Step 1.2 — the JSDoc applies identically).
+
+- [ ] **Step 1.4: Verify the `Span` type is already imported**
+
+In `src/types/citation.ts`, look at the imports at the top of the file. `Span` should already be imported from `./span` (used elsewhere in the file). No new import needed.
+
+- [ ] **Step 1.5: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: passes with zero errors.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/resolve/types.ts src/types/citation.ts
+git commit -m "$(cat <<'EOF'
+types: add antecedentIndex + inferredCaseName for Rule 4.1 clustering
+
+Adds:
+- ResolutionResult.antecedentIndex — chain pointer to the immediately
+  preceding citation, regardless of resolution state. Same shape as the
+  existing pinciteInheritedFrom field from 0.19.0.
+- ShortFormCaseCitation/SupraCitation.inferredCaseName + plaintiff/
+  defendant/span — for short-forms whose case name was extracted from
+  preceding prose rather than from a structured full citation.
+
+No runtime change in this commit.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Quote-Zone Robustness Fix
+
+Replace the greedy ASCII-quote pairing with a context-based open/close classifier. Includes typographic-quote (U+201C / U+201D) unambiguous pairing.
+
+**Files:**
+- Modify: `src/resolve/DocumentResolver.ts` (`detectQuoteZones` function at ~line 109)
+- Create: `tests/resolve/quoteZoneRobustness.test.ts`
+
+- [ ] **Step 2.1: Write failing tests**
+
+Create `tests/resolve/quoteZoneRobustness.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { IdCitation } from "@/types/citation"
+
+describe("quote-zone robustness — orphan ASCII quotes", () => {
+  it("orphan leading close-quote (mid-doc paste) does not create phantom zone", () => {
+    // The leading `use."` is a mid-document orphan close. Without the fix,
+    // the existing greedy pairing turns it into a phantom open and engulfs
+    // Smith into a quote zone, which then rejects Smith as Id.'s antecedent.
+    const text = `use." Smith v. Jones, 100 F.2d 50, 55 (1990). Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+    // Resolved to Smith (idx 0).
+    expect(cites[id!.resolution!.resolvedTo!].type).toBe("case")
+  })
+
+  it("orphan trailing open-quote does not create phantom zone", () => {
+    // Trailing orphan open at end-of-text.
+    const text = `Smith v. Jones, 100 F.2d 50, 55 (1990). Id. "and so on`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+})
+
+describe("quote-zone robustness — typographic quotes unambiguous", () => {
+  it("curly quotes pair unambiguously even with adjacent orphan ASCII quote", () => {
+    // Mix: curly quotes around the actual quoted text, plus an orphan ASCII
+    // quote elsewhere. The curly pair should always be a zone; the ASCII
+    // orphan should be ignored.
+    const text = `He said "the rule is clear." use." Smith v. Jones, 100 F.2d 50, 55 (1990). Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+})
+
+describe("quote-zone robustness — well-formed ASCII still works", () => {
+  it("standard balanced ASCII quotes around a quoted passage do not break resolution", () => {
+    const text = `Smith v. Jones, 100 F.2d 50, 55 (1990). The court held "the rule applies." Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+
+  it("apostrophes (single quotes) do not affect double-quote pairing", () => {
+    const text = `Smith's case, 100 F.2d 50, 55 (1990). The court said "it's the rule." Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+})
+```
+
+- [ ] **Step 2.2: Run tests to verify they fail (or pass for the wrong reason)**
+
+```bash
+pnpm exec vitest run tests/resolve/quoteZoneRobustness.test.ts 2>&1 | tail -20
+```
+
+Expected: The "orphan leading close-quote" test FAILS (this is the user-visible bug). Other tests may pass with current code (well-formed text already works). Note the failing assertion before proceeding.
+
+- [ ] **Step 2.3: Replace the inline-quote loop in `detectQuoteZones`**
+
+Open `src/resolve/DocumentResolver.ts`. Find the `detectQuoteZones` function (~line 109). Replace the entire **inline paired double-quotes** section (the comment "Inline paired double-quotes." through its loop) with the context-classifier-based algorithm. Keep the markdown blockquote scan (the `>` lines section) unchanged.
+
+The new section (replace from `// Inline paired double-quotes.` through the closing of the for loop and the `openPos = -1` line):
+
+```ts
+  // Inline paired quotes. Two-step:
+  //   1. Classify each quote-character as open / close / ambiguous based on
+  //      neighboring characters (typographic conventions).
+  //   2. Match opens to closes with a stack, skipping orphans and ambiguous.
+  //
+  // Why not greedy "first quote = open, next = close"? That mispairs when
+  // input starts mid-document with an orphan close (e.g. `use." Smith...`),
+  // creating a phantom zone that engulfs unrelated citations and breaks
+  // Id. resolution. The classifier handles arbitrary text snippets
+  // robustly. Typographic quotes (U+201C / U+201D) are unambiguous and
+  // pair directly.
+  const MAX_INLINE_QUOTE_LEN = 600
+  const opens: number[] = []
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+
+    // Typographic quotes: unambiguous.
+    if (ch === "“") {
+      opens.push(i)
+      continue
+    }
+    if (ch === "”") {
+      if (opens.length === 0) continue // orphan close
+      const openPos = opens.pop()!
+      if (i - openPos + 1 <= MAX_INLINE_QUOTE_LEN) {
+        zones.push({ start: openPos, end: i + 1 })
+      }
+      continue
+    }
+
+    // ASCII straight double-quote: classify by neighbors.
+    if (ch !== '"') continue
+    const cls = classifyAsciiQuote(text, i)
+    if (cls === "open") {
+      opens.push(i)
+    } else if (cls === "close") {
+      if (opens.length === 0) continue // orphan close — discard
+      const openPos = opens.pop()!
+      if (i - openPos + 1 <= MAX_INLINE_QUOTE_LEN) {
+        zones.push({ start: openPos, end: i + 1 })
+      }
+    }
+    // ambiguous → skip
+  }
+```
+
+Right before the existing `function detectQuoteZones(...)` declaration, add the classifier helper as a module-level function:
+
+```ts
+/**
+ * Classify an ASCII `"` at position `pos` as opening, closing, or ambiguous,
+ * based on neighboring characters. English typographic conventions:
+ *
+ *   - Opening: preceded by start/whitespace/punctuation-open (`(`, `[`, `—`)
+ *     AND followed by a letter or `(`.
+ *   - Closing: preceded by a letter/digit/sentence punctuation
+ *     (`.`, `,`, `?`, `!`, `:`, `;`, `)`, `]`) AND followed by end/
+ *     whitespace/punctuation.
+ *   - Ambiguous: everything else (skipped during pairing).
+ */
+function classifyAsciiQuote(text: string, pos: number): "open" | "close" | "ambiguous" {
+  const prev = pos === 0 ? "" : text[pos - 1]
+  const next = pos === text.length - 1 ? "" : text[pos + 1]
+
+  const openPrev =
+    prev === "" || /\s/.test(prev) || prev === "(" || prev === "[" || prev === "—"
+  const openNext = /[A-Za-zÀ-ɏ]/.test(next) || next === "("
+  if (openPrev && openNext) return "open"
+
+  const closePrev = /[A-Za-z0-9À-ɏ.,?!:;)\]]/.test(prev)
+  const closeNext = next === "" || /[\s.,;:)—\]]/.test(next)
+  if (closePrev && closeNext) return "close"
+
+  return "ambiguous"
+}
+```
+
+- [ ] **Step 2.4: Run the new tests**
+
+```bash
+pnpm exec vitest run tests/resolve/quoteZoneRobustness.test.ts 2>&1 | tail -10
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 2.5: Run the full test suite for regressions**
+
+```bash
+pnpm exec vitest run 2>&1 | tail -5
+```
+
+Expected: ALL tests pass. If any pre-existing quote-zone test fails, investigate — the change should preserve behavior for well-formed text. Most likely failure mode is that a test was relying on the orphan-pairing behavior; flip its assertion to match the new (correct) behavior and document the change in the commit.
+
+- [ ] **Step 2.6: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint 2>&1 | tail -5
+```
+
+Expected: both pass.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/resolve/DocumentResolver.ts tests/resolve/quoteZoneRobustness.test.ts
+git commit -m "$(cat <<'EOF'
+fix(resolve): context-based ASCII quote classifier in detectQuoteZones
+
+Replaces greedy "first quote = open, next = close" pairing with a
+context-based open/close classifier (English typographic conventions:
+preceded by whitespace/punctuation-open vs letter/punctuation-close).
+Typographic quotes (U+201C / U+201D) pair unambiguously.
+
+The greedy algorithm produced phantom quote zones when given mid-
+document text snippets (e.g. `use." Smith v. Jones... Id.`), causing
+Id. resolution to fail because Smith was incorrectly placed inside a
+phantom quote zone different from Id.'s.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `antecedentIndex` Population
+
+Add the `findImmediatePredecessor` helper. Modify `resolveId` to fall back to `antecedentIndex`-only when no resolved full-cite candidate exists. Populate `antecedentIndex` in `resolveSupra` and `resolveShortFormCase` for consistency.
+
+**Files:**
+- Modify: `src/resolve/DocumentResolver.ts`
+- Create: `tests/resolve/idWalksToUnresolvedAntecedent.test.ts`
+
+- [ ] **Step 3.1: Write failing tests for `antecedentIndex` chain**
+
+Create `tests/resolve/idWalksToUnresolvedAntecedent.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, IdCitation } from "@/types/citation"
+
+describe("antecedentIndex — Id. clusters with unresolved short-form (Bluebook 4.1)", () => {
+  it("Id. after unresolved Yellen short-form: antecedentIndex points at it, resolvedTo undefined", () => {
+    // Yellen, 416 N.J. Super. at 590 is a shortFormCase. Vol+reporter
+    // (416 N.J. Super.) has no match anywhere in this text → unresolved.
+    // Id. that follows should anchor to the Yellen short-form
+    // (antecedentIndex), NOT chase past it to Smith.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). Yellen, 416 N.J. Super. at 590. Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id).toBeDefined()
+    expect(id?.resolution?.resolvedTo).toBeUndefined()
+    // Antecedent is the Yellen short-form (idx 1).
+    expect(id?.resolution?.antecedentIndex).toBe(1)
+  })
+
+  it("antecedentIndex set even when resolvedTo is also set (one step back)", () => {
+    // Smith full at idx 0, Id. at idx 1, second Id. at idx 2.
+    // The second Id. resolves to Smith (resolvedTo=0) AND has
+    // antecedentIndex=1 (one step back, the first Id.).
+    const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. Id."
+    const cites = extractCitations(text, { resolve: true })
+    const ids = cites.filter((c): c is IdCitation => c.type === "id")
+    expect(ids).toHaveLength(2)
+    expect(ids[1].resolution?.resolvedTo).toBe(0)
+    expect(ids[1].resolution?.antecedentIndex).toBe(1)
+  })
+
+  it("Id. immediately after a full cite: antecedentIndex equals resolvedTo", () => {
+    const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBe(0)
+    expect(id?.resolution?.antecedentIndex).toBe(0)
+  })
+
+  it("chain via antecedentIndex: parallel unresolved short-forms cluster", () => {
+    // Yellen short-form (idx 1) and 3 A.3d parallel (idx 2) both fail
+    // vol+reporter lookup. The parallel's antecedentIndex points at the
+    // Yellen short-form. Id. (idx 3) clusters with the parallel.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). Yellen, 416 N.J. Super. at 590, 3 A.3d at 590. Id."
+    const cites = extractCitations(text, { resolve: true })
+    expect(cites).toHaveLength(4)
+    const shortFormCaseCount = cites.filter(
+      (c: Citation) => c.type === "shortFormCase",
+    ).length
+    expect(shortFormCaseCount).toBe(2)
+
+    // Walk: Id (3).antecedentIndex → 2 → antecedentIndex → 1.
+    const id = cites[3] as IdCitation
+    expect(id.type).toBe("id")
+    expect(id.resolution?.antecedentIndex).toBe(2)
+    expect(id.resolution?.resolvedTo).toBeUndefined()
+
+    const parallel = cites[2]
+    expect(parallel.type).toBe("shortFormCase")
+    expect(
+      (parallel as { resolution?: { antecedentIndex?: number } }).resolution
+        ?.antecedentIndex,
+    ).toBe(1)
+  })
+
+  it("no prior citation: antecedentIndex undefined", () => {
+    const text = "Id. at 100."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.antecedentIndex).toBeUndefined()
+    expect(id?.resolution?.resolvedTo).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+```bash
+pnpm exec vitest run tests/resolve/idWalksToUnresolvedAntecedent.test.ts 2>&1 | tail -20
+```
+
+Expected: tests FAIL — the `antecedentIndex` field is on the type but never populated by any resolver.
+
+- [ ] **Step 3.3: Add `findImmediatePredecessor` helper**
+
+Open `src/resolve/DocumentResolver.ts`. Inside the `DocumentResolver` class, near `resolveId` (~line 439), add this private method. Place it immediately *before* `resolveId`:
+
+```ts
+  /**
+   * Find the immediate-preceding citation index for `antecedentIndex`
+   * purposes. Bluebook Rule 4.1: `Id.` anchors to "the immediately
+   * preceding cited authority" — unlike `resolveId`'s primary chase
+   * (which only accepts resolved full antecedents), this lookup accepts
+   * any prior citation that passes the existing scope / parenthetical /
+   * weak-signal / quote-zone filters, regardless of resolution state.
+   *
+   * Returns the index of the immediately-preceding eligible citation,
+   * or `undefined` if none.
+   */
+  private findImmediatePredecessor(citation: IdCitation): number | undefined {
+    const currentIndex = this.context.citationIndex
+    const citationZone = isInZone(citation.span.originalStart, this.quoteZones)
+
+    for (let i = currentIndex - 1; i >= 0; i--) {
+      // Apply the same filters as resolveId's main chase.
+      if (this.isParentheticalChild(i)) continue
+      if (!this.isWithinScope(i, currentIndex)) continue
+      const candidateZone = isInZone(this.citations[i].span.originalStart, this.quoteZones)
+      if (candidateZone && candidateZone !== citationZone) continue
+      // Accept regardless of resolution state.
+      return i
+    }
+    return undefined
+  }
+```
+
+The signature uses `IdCitation` but the same logic is needed for `supra` and `shortFormCase`. Generalize the parameter type so it can be called from those resolvers too. Change the signature to:
+
+```ts
+  private findImmediatePredecessor(
+    citation: IdCitation | SupraCitation | ShortFormCaseCitation,
+  ): number | undefined {
+```
+
+The body is unchanged.
+
+- [ ] **Step 3.4: Modify `resolveId` to two-pass**
+
+Open `src/resolve/DocumentResolver.ts`. Find the existing `resolveId` method (~line 439). At the point in the function where it currently returns `this.createFailureResult("Antecedent citation outside scope boundary")` (when `candidates.length === 0`, ~line 491), insert a fallback pass before the failure return. Find this block:
+
+```ts
+    if (candidates.length === 0) {
+      // Diagnose: did we have any preceding citation at all? If not, the
+      // legacy failure message helps consumers debug "Id. before any cite".
+      const anyPrior = currentIndex > 0
+      return this.createFailureResult(
+        anyPrior ? "Antecedent citation outside scope boundary" : "No preceding citation found",
+      )
+    }
+```
+
+Replace with:
+
+```ts
+    if (candidates.length === 0) {
+      // No resolved full-cite candidate. Pass 2: try the immediate
+      // predecessor regardless of resolution state — Bluebook Rule 4.1
+      // anchors `Id.` to the immediately preceding cited authority, not
+      // just to resolved ones. The chain pointer is recorded in
+      // `antecedentIndex`; `resolvedTo` stays undefined.
+      const antecedentIndex = this.findImmediatePredecessor(citation)
+      if (antecedentIndex !== undefined) {
+        return {
+          resolvedTo: undefined,
+          antecedentIndex,
+          confidence: 0.7,
+          warnings: [
+            "Id. antecedent has unresolved authority; chained by position only",
+          ],
+        }
+      }
+      const anyPrior = currentIndex > 0
+      return this.createFailureResult(
+        anyPrior ? "Antecedent citation outside scope boundary" : "No preceding citation found",
+      )
+    }
+```
+
+Then find the successful-resolution return at the bottom of `resolveId` (~line 521-527):
+
+```ts
+    // Case-name window check: ...
+    const { confidence, warnings } = this.applyCaseNameWindowCheck(best.index, citation)
+
+    return {
+      resolvedTo: best.index,
+      confidence,
+      warnings,
+    }
+```
+
+Add `antecedentIndex` to the return:
+
+```ts
+    return {
+      resolvedTo: best.index,
+      antecedentIndex: this.findImmediatePredecessor(citation),
+      confidence,
+      warnings,
+    }
+```
+
+- [ ] **Step 3.5: Populate `antecedentIndex` in `resolveSupra`**
+
+Find `resolveSupra` (~line 700+). Find its successful return path (`return { resolvedTo: ..., confidence: ... }`) and add `antecedentIndex: this.findImmediatePredecessor(citation),` to the return object. Do not modify failure paths.
+
+- [ ] **Step 3.6: Populate `antecedentIndex` in `resolveShortFormCase`**
+
+Find `resolveShortFormCase` (~line 770+). Find its successful return path and add `antecedentIndex: this.findImmediatePredecessor(citation),`. Also add to the FAILURE return path — when vol+reporter lookup fails, we still want to record the immediate predecessor for chain walks. So both returns get `antecedentIndex`.
+
+For the failure return specifically, replace:
+
+```ts
+      return this.createFailureResult("No matching full case citation found")
+```
+
+with:
+
+```ts
+      const antecedentIndex = this.findImmediatePredecessor(citation)
+      if (antecedentIndex !== undefined) {
+        return {
+          resolvedTo: undefined,
+          antecedentIndex,
+          confidence: 0.5,
+          warnings: ["No matching full case citation found; chained by position only"],
+        }
+      }
+      return this.createFailureResult("No matching full case citation found")
+```
+
+- [ ] **Step 3.7: Run the antecedentIndex tests**
+
+```bash
+pnpm exec vitest run tests/resolve/idWalksToUnresolvedAntecedent.test.ts 2>&1 | tail -10
+```
+
+Expected: ALL 5 tests pass.
+
+- [ ] **Step 3.8: Run the full test suite for regressions**
+
+```bash
+pnpm exec vitest run 2>&1 | tail -5
+```
+
+Expected: ALL tests pass. The `antecedentIndex` additions are purely additive on `ResolutionResult`; existing consumers don't read the new field.
+
+- [ ] **Step 3.9: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint 2>&1 | tail -5
+```
+
+Expected: both pass.
+
+- [ ] **Step 3.10: Commit**
+
+```bash
+git add src/resolve/DocumentResolver.ts tests/resolve/idWalksToUnresolvedAntecedent.test.ts
+git commit -m "$(cat <<'EOF'
+fix(resolve): populate antecedentIndex per Bluebook Rule 4.1
+
+Adds findImmediatePredecessor helper that walks back applying the
+existing scope / parenthetical / weak-signal / quote-zone filters
+but accepts citations regardless of resolution state.
+
+resolveId now has a two-pass structure: try the existing resolved-
+full-cite chase first, then fall back to antecedentIndex-only when
+no resolved candidate exists. This fixes the bug where Id. chased
+past an unresolved short-form (case name in prose) to the previous
+full citation — wrong authority.
+
+resolveSupra and resolveShortFormCase populate antecedentIndex for
+consistency, so consumers can walk the chain regardless of citation
+type. shortFormCase also records antecedentIndex on failed lookups
+so subsequent Id. can cluster with the unresolved short-form.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Backward Prose Case-Name Extraction
+
+Add `extractInferredCaseName` method on `DocumentResolver`. Wire it into `resolveShortFormCase` as a fallback when vol+reporter lookup fails.
+
+**Files:**
+- Modify: `src/resolve/DocumentResolver.ts`
+- Create: `tests/resolve/shortFormProseNameFallback.test.ts`
+
+- [ ] **Step 4.1: Write failing tests**
+
+Create `tests/resolve/shortFormProseNameFallback.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, ShortFormCaseCitation } from "@/types/citation"
+
+describe("backward prose case-name extraction", () => {
+  it("extracts case name from prose preceding a short-form when vol+reporter has no full match", () => {
+    // "In Yellen v. Kassin" is the prose mention; the short-form has
+    // partyName="Yellen". Vol+reporter (416 N.J. Super.) has no full match.
+    // After this PR, the short-form should be enriched with inferredCaseName.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). In Yellen v. Kassin, the court held. Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find(
+      (c): c is ShortFormCaseCitation =>
+        c.type === "shortFormCase" && c.partyName === "Yellen",
+    )
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBe("Yellen v. Kassin")
+    expect(yellenShort?.inferredPlaintiff?.toLowerCase()).toContain("yellen")
+    expect(yellenShort?.inferredDefendant?.toLowerCase()).toContain("kassin")
+  })
+
+  it("does not infer when short-form has no partyName", () => {
+    // Bare short-form `416 N.J. Super. at 590` — no party prefix.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). In Yellen v. Kassin, the court held. 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const bareShort = cites.find(
+      (c): c is ShortFormCaseCitation =>
+        c.type === "shortFormCase" && !c.partyName,
+    )
+    expect(bareShort).toBeDefined()
+    expect(bareShort?.inferredCaseName).toBeUndefined()
+  })
+
+  it("does not infer when prose case name does not match partyName", () => {
+    // Prose mentions Smith v. Jones, but the short-form's partyName is
+    // Yellen. No match → no inference.
+    const text =
+      "In Smith v. Jones, the court held. Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find(
+      (c): c is ShortFormCaseCitation => c.type === "shortFormCase",
+    )
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBeUndefined()
+  })
+
+  it("vol+reporter match still wins over prose inference (no fallback when resolved)", () => {
+    // Provide a full Yellen citation, then a short-form. Resolution
+    // succeeds via vol+reporter; the prose-extraction fallback never runs.
+    const text =
+      "Yellen v. Kassin, 416 N.J. Super. 580 (App. Div. 2009). Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find(
+      (c): c is ShortFormCaseCitation =>
+        c.type === "shortFormCase" && c.partyName === "Yellen",
+    )
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.resolution?.resolvedTo).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```bash
+pnpm exec vitest run tests/resolve/shortFormProseNameFallback.test.ts 2>&1 | tail -20
+```
+
+Expected: tests FAIL — `inferredCaseName` is never populated.
+
+- [ ] **Step 4.3: Add `extractInferredCaseName` method**
+
+Open `src/resolve/DocumentResolver.ts`. Add this import at the top alongside other extract imports (find any existing `from "../extract/..."` import; if none, add a new one):
+
+```ts
+import { extractCaseName } from "../extract/extractCase"
+```
+
+Add this private method on `DocumentResolver`. Place it near `resolveShortFormCase` for proximity:
+
+```ts
+  /**
+   * Backward prose scan for "Party v. Party" patterns preceding a
+   * short-form citation whose vol+reporter lookup failed. Used to recover
+   * a case name when the author introduced the authority in prose (e.g.
+   * "In Yellen v. Kassin, ...") and used a short-form that didn't carry
+   * an extractable full citation.
+   *
+   * Returns the inferred case name + spans, or `undefined` if no
+   * acceptable match is found within `LOOKBACK` chars.
+   */
+  private extractInferredCaseName(
+    citation: ShortFormCaseCitation,
+  ):
+    | {
+        caseName: string
+        plaintiff: string
+        defendant: string
+        span: Span
+      }
+    | undefined {
+    const LOOKBACK = 200
+    if (!citation.partyName) return undefined
+
+    const result = extractCaseName(this.text, citation.span.cleanStart, LOOKBACK)
+    if (!result) return undefined
+
+    // Parse the case name into plaintiff/defendant via " v. " split.
+    const vMatch = result.caseName.match(/^(.+?)\s+v\.\s+(.+)$/i)
+    if (!vMatch) return undefined
+    const plaintiff = vMatch[1].trim()
+    const defendant = vMatch[2].trim()
+
+    // Require the short-form's partyName to match one side (case-insensitive).
+    const shortName = this.normalizePartyName(citation.partyName)
+    const plaintiffNorm = this.normalizePartyName(plaintiff)
+    const defendantNorm = this.normalizePartyName(defendant)
+    if (shortName !== plaintiffNorm && shortName !== defendantNorm) return undefined
+
+    return {
+      caseName: result.caseName,
+      plaintiff,
+      defendant,
+      // Span covers the case name in clean coordinates; map to original via
+      // the citation's existing transformation. For now, store the clean
+      // span shape; consumers can use it as an offset reference.
+      span: {
+        cleanStart: result.nameStart,
+        cleanEnd: result.nameStart + result.caseName.length,
+        originalStart: result.nameStart,
+        originalEnd: result.nameStart + result.caseName.length,
+      },
+    }
+  }
+```
+
+- [ ] **Step 4.4: Wire the fallback into `resolveShortFormCase`**
+
+Find `resolveShortFormCase`. Locate the existing failure branch — where vol+reporter lookup fails. In Task 3, this branch was modified to populate `antecedentIndex`. Now also call `extractInferredCaseName` and mutate the citation before returning.
+
+Find the failure return added in Task 3.6:
+
+```ts
+      const antecedentIndex = this.findImmediatePredecessor(citation)
+      if (antecedentIndex !== undefined) {
+        return {
+          resolvedTo: undefined,
+          antecedentIndex,
+          confidence: 0.5,
+          warnings: ["No matching full case citation found; chained by position only"],
+        }
+      }
+      return this.createFailureResult("No matching full case citation found")
+```
+
+Insert the prose-extraction call BEFORE the antecedentIndex check (so the enrichment happens regardless of whether an antecedent exists). Replace the block with:
+
+```ts
+      // Backward prose scan: try to recover case name from preceding prose.
+      const inferred = this.extractInferredCaseName(citation)
+      if (inferred) {
+        citation.inferredCaseName = inferred.caseName
+        citation.inferredPlaintiff = inferred.plaintiff
+        citation.inferredDefendant = inferred.defendant
+        citation.inferredCaseNameSpan = inferred.span
+      }
+
+      const antecedentIndex = this.findImmediatePredecessor(citation)
+      if (antecedentIndex !== undefined) {
+        return {
+          resolvedTo: undefined,
+          antecedentIndex,
+          confidence: 0.5,
+          warnings: ["No matching full case citation found; chained by position only"],
+        }
+      }
+      return this.createFailureResult("No matching full case citation found")
+```
+
+- [ ] **Step 4.5: Verify `Span` is imported into DocumentResolver**
+
+Check the imports at the top of `src/resolve/DocumentResolver.ts`. `Span` should already be imported (used by other code). If not, add `import type { Span } from "../types/span"`.
+
+- [ ] **Step 4.6: Run the prose-extraction tests**
+
+```bash
+pnpm exec vitest run tests/resolve/shortFormProseNameFallback.test.ts 2>&1 | tail -15
+```
+
+Expected: 4 tests PASS. If the test "extracts case name from prose..." fails with `inferredCaseName === undefined`, debug:
+- Add a `console.log("extractCaseName result:", result)` temporarily inside `extractInferredCaseName` to see what `extractCaseName` returns for the Yellen text.
+- The most likely cause: `extractCaseName` walks back from the short-form and may not pick up "Yellen v. Kassin" because that case name is too far back (more than 200 chars) or the function's internal boundary logic excludes it.
+- If the function's defaults don't cover this case, increase `LOOKBACK` to 250 or 300 and retry. The spec specifies "~200 chars" as guidance, not strict.
+
+- [ ] **Step 4.7: Run the full test suite**
+
+```bash
+pnpm exec vitest run 2>&1 | tail -5
+```
+
+Expected: all tests pass. The prose-extraction fallback only fires when vol+reporter lookup fails; successful resolutions are unchanged.
+
+- [ ] **Step 4.8: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint 2>&1 | tail -5
+```
+
+Expected: both pass.
+
+- [ ] **Step 4.9: Commit**
+
+```bash
+git add src/resolve/DocumentResolver.ts tests/resolve/shortFormProseNameFallback.test.ts
+git commit -m "$(cat <<'EOF'
+fix(resolve): backward prose extraction for short-form case names
+
+When a ShortFormCaseCitation's vol+reporter lookup fails AND the
+short-form carries a partyName, scan ~200 chars of preceding text for
+a "Party v. Party" pattern via the existing extractCaseName helper.
+If found AND one of the matched parties matches the short-form's
+partyName, enrich the short-form with inferredCaseName / inferred
+Plaintiff / inferredDefendant / inferredCaseNameSpan.
+
+This recovers the case name for short-forms whose authority was
+introduced in prose rather than as a structured full citation —
+e.g. "In Yellen v. Kassin, ... Yellen, 416 N.J. Super. at 590" now
+populates inferredCaseName = "Yellen v. Kassin" on the short-form.
+
+No phantom full citation added to citations[]; resolvedTo stays
+undefined for these chains. Consumers walking antecedentIndex from
+a subsequent Id. can reach the enriched short-form to render the
+case name. Consumers preferring caseName: try `caseName ?? inferred
+CaseName ?? partyName`.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: End-to-End Yellen Fixture
+
+The bug report's exact text, now exercising all three sections together.
+
+**Files:**
+- Create: `tests/resolve/yellenFixture.test.ts`
+
+- [ ] **Step 5.1: Write the end-to-end fixture test**
+
+Create `tests/resolve/yellenFixture.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, IdCitation, ShortFormCaseCitation } from "@/types/citation"
+
+describe("Yellen / Leach end-to-end (bug report 2026-05-19)", () => {
+  // The actual passage from the user's brief (HOA-adverse-possession context).
+  const text = `Leach v. Anderl, 218 N.J. Super. 18, 30–31 (App. Div. 1987). In Yellen v. Kassin, the Appellate Division squarely held that where neighbors shared a driveway traversing both properties without objection, the use was "not recognized by the law as hostile to the property rights of the other, but [was] at all times permissive in character and subject to alteration as the needs of both neighbors changed over time." Yellen, 416 N.J. Super. at 590–91, 3 A.3d at 590–91. The court reversed the trial court's finding of mutual prescriptive easements, holding that the evidence "does not establish that the use of the driveways was hostile in the sense that either party considered use of the other's driveway under a claim of right with the intent to claim an interest in the other's property." Id. at 590.`
+
+  it("Id. at 590 does NOT resolve to Leach (the user-reported bug)", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id).toBeDefined()
+    // The bug: id.resolution.resolvedTo used to point at Leach (idx 0).
+    // After this PR, resolvedTo is undefined (no full Yellen citation
+    // in the array — Yellen's name lives in prose).
+    expect(id?.resolution?.resolvedTo).toBeUndefined()
+  })
+
+  it("Yellen short-form has inferredCaseName from prose", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find(
+      (c): c is ShortFormCaseCitation =>
+        c.type === "shortFormCase" && c.partyName === "Yellen",
+    )
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBe("Yellen v. Kassin")
+  })
+
+  it("Id. clusters with the parallel short-form via antecedentIndex", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.antecedentIndex).toBeDefined()
+
+    // Walk: Id → parallel (3 A.3d) → Yellen short → ... → eventually
+    // reaches the enriched short-form with inferredCaseName.
+    let cur: number | undefined = id?.resolution?.antecedentIndex
+    let foundInferred: string | undefined
+    const visited = new Set<number>()
+    while (cur !== undefined && !visited.has(cur)) {
+      visited.add(cur)
+      const c = cites[cur] as Citation & {
+        resolution?: { antecedentIndex?: number }
+        inferredCaseName?: string
+      }
+      if (c.inferredCaseName) {
+        foundInferred = c.inferredCaseName
+        break
+      }
+      cur = c.resolution?.antecedentIndex
+    }
+    expect(foundInferred).toBe("Yellen v. Kassin")
+  })
+})
+```
+
+- [ ] **Step 5.2: Run the fixture test**
+
+```bash
+pnpm exec vitest run tests/resolve/yellenFixture.test.ts 2>&1 | tail -15
+```
+
+Expected: ALL 3 tests pass.
+
+If a test fails:
+- "Id. at 590 does NOT resolve to Leach" failing means Tasks 2 or 3 didn't fully land. Verify by inspecting `id.resolution?.resolvedTo` in a console.log added temporarily.
+- "Yellen short-form has inferredCaseName from prose" failing means Task 4 didn't fully land. Verify by inspecting `yellenShort?.inferredCaseName`.
+- "Id. clusters via antecedentIndex" failing usually means the chain doesn't terminate at the inferred-name citation. Add a console.log to print the walk.
+
+- [ ] **Step 5.3: Run the full test suite for sanity**
+
+```bash
+pnpm exec vitest run 2>&1 | tail -5
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.4: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint 2>&1 | tail -5
+```
+
+Expected: both pass.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add tests/resolve/yellenFixture.test.ts
+git commit -m "$(cat <<'EOF'
+test(resolve): end-to-end Yellen fixture from bug report 2026-05-19
+
+Locks in the user-reported scenario: real legal brief passage with
+"Leach v. Anderl..." full cite, "In Yellen v. Kassin..." prose
+mention, "Yellen, 416 N.J. Super. at 590-91" short-form (vol+reporter
+unresolvable), parallel "3 A.3d at 590-91", and trailing "Id. at 590".
+
+Before this PR's fixes, Id. at 590 resolved to Leach (wrong authority).
+After: Id. has resolvedTo undefined, antecedentIndex pointing into the
+chain, and transitive walk reaches the Yellen short-form with
+inferredCaseName = "Yellen v. Kassin".
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Changeset
+
+**Files:**
+- Create: `.changeset/id-clusters-with-unresolved-antecedent.md`
+
+- [ ] **Step 6.1: Write the changeset**
+
+Create the file with this content:
+
+```markdown
+---
+"eyecite-ts": minor
+---
+
+fix(resolve): Id. clusters with immediately preceding citation per Bluebook Rule 4.1, even when predecessor is an unresolved short-form
+
+Three coordinated fixes resolve a class of bugs where `Id.` referred to the wrong authority when the immediately preceding short-form had no extractable full-citation antecedent (typically because the author introduced the case name in prose rather than as a structured citation).
+
+**Behavior changes:**
+
+- **`Id.` now clusters with the immediately preceding citation regardless of resolution state** (Bluebook Rule 4.1 / Indigo Book R6.2.2). Previously, `Id.` would chase past an unresolved short-form to the previous full citation — wrong authority. The bug surfaced in passages like `Leach v. Anderl, 218 N.J. Super. 18 (1987). In Yellen v. Kassin, ... Yellen, 416 N.J. Super. at 590-91, 3 A.3d at 590-91. ... Id. at 590.` where `Id. at 590` now correctly clusters with the Yellen short-form (whose case name was inferred from the prose mention) rather than resolving to Leach.
+- **Short-form citations now carry `inferredCaseName`** when their case name was found in preceding prose (within ~200 chars) and their vol+reporter has no full-citation match in the array. The short-form remains formally unresolved (`resolvedTo` undefined), but consumers can render the case name via `caseName ?? inferredCaseName ?? partyName`.
+- **Quote-zone detection is more robust** for mid-document text inputs. The previous greedy ASCII-quote pairing mistook orphan close-quotes (from snippets starting mid-sentence) for opens, creating phantom zones that broke `Id.` resolution. The new context-based classifier handles both typographic (`"` `"`) and ASCII (`"`) quotes correctly.
+
+**New optional fields:**
+
+- `ResolutionResult.antecedentIndex?: number` — chain pointer to the immediately preceding cited authority, regardless of resolution state. Same shape as the existing `ShortFormCaseCitation.pinciteInheritedFrom` from 0.19.0. Walk transitively for the chain's originator.
+- `ShortFormCaseCitation.inferredCaseName?: string` — case name recovered from preceding prose when vol+reporter lookup fails.
+- `ShortFormCaseCitation.inferredPlaintiff?: string`, `inferredDefendant?: string`, `inferredCaseNameSpan?: Span` — supporting fields for the inferred name.
+- Same four `inferred*` fields on `SupraCitation`.
+
+**Migration:**
+
+- No breaking changes. All new fields are optional; `resolvedTo` semantics unchanged.
+- Consumers wanting to follow the new chain pointer use `let cur = id.resolution.antecedentIndex; while (cur !== undefined) { /* inspect cites[cur]; advance cur = cites[cur].resolution?.antecedentIndex */ }`.
+- Consumers rendering case names should fall back: `caseName ?? inferredCaseName ?? partyName`.
+- The `Id.` resolution outcome for the unresolved-short-form-predecessor scenario changes from "resolves to previous full cite" (incorrect) to "antecedentIndex set, resolvedTo undefined" (Bluebook-correct). If any test was relying on the previous behavior, update it to use `antecedentIndex` for the chain walk.
+
+See `docs/superpowers/specs/2026-05-19-id-resolves-past-unresolved-shortform-design.md` for the full design and `docs/research/2026-05-19-id-unresolved-antecedent.md` for the Bluebook + Python eyecite + CSL/citeproc reference validation.
+```
+
+- [ ] **Step 6.2: Commit**
+
+```bash
+git add .changeset/id-clusters-with-unresolved-antecedent.md
+git commit -m "$(cat <<'EOF'
+chore: changeset for Id. clustering with unresolved short-form
+
+Minor bump — adds antecedentIndex on ResolutionResult, inferred case-
+name fields on ShortFormCaseCitation/SupraCitation, and corrects Id.
+resolution per Bluebook Rule 4.1 when predecessor is an unresolved
+short-form.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Final Verification
+
+- [ ] **Step 7.1: Full test suite + typecheck + lint + build**
+
+```bash
+pnpm exec vitest run && pnpm typecheck && pnpm lint && pnpm build 2>&1 | tail -10
+```
+
+Expected: all four pass. Tests should show approximately 2975 + ~15 new = ~2990 passing.
+
+- [ ] **Step 7.2: Bundle size check**
+
+```bash
+pnpm size 2>&1 | tail -10
+```
+
+Expected: within budget (main: 36-37 / 50 kB, utils: 1.8 / 3 kB). The new code is small (~80 lines added to `DocumentResolver.ts`, ~4 fields on types); should not move the size needle significantly.
+
+- [ ] **Step 7.3: Review the diff**
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+Expected: 6 commits (Tasks 1, 2, 3, 4, 5, 6) plus the spec + research docs already on the branch. Stat should show changes concentrated in `src/resolve/`, `src/types/`, `tests/resolve/`, plus the changeset.
+
+- [ ] **Step 7.4: Hand off**
+
+Implementation complete. Open a PR (don't push automatically — confirm with the user first per project conventions). Suggested PR title: **"fix(resolve): Id. clusters with immediately preceding citation per Bluebook Rule 4.1"**.

--- a/docs/superpowers/specs/2026-05-19-id-resolves-past-unresolved-shortform-design.md
+++ b/docs/superpowers/specs/2026-05-19-id-resolves-past-unresolved-shortform-design.md
@@ -1,0 +1,413 @@
+# Design: `Id.` Should Cluster With Its Immediately Preceding Citation, Even When the Predecessor Is an Unresolved Short-Form
+
+**Date:** 2026-05-19
+**Status:** Approved by user, ready for implementation plan
+**Related research:** [`docs/research/2026-05-19-id-unresolved-antecedent.md`](../../research/2026-05-19-id-unresolved-antecedent.md)
+
+## Background
+
+A real legal brief contains this passage:
+
+> Leach v. Anderl, 218 N.J. Super. 18, 30–31 (App. Div. 1987). In *Yellen v. Kassin*, the Appellate Division squarely held that ... *Yellen*, 416 N.J. Super. at 590–91, 3 A.3d at 590–91. The court reversed ... *Id.* at 590.
+
+The writer's intent is unambiguous: `Id. at 590` refers to **Yellen**. Per Bluebook Rule 4.1 / Indigo Book R6.2.2, `Id.` anchors to "the immediately preceding cited authority" — which is the `Yellen, 416 N.J. Super. at 590–91` short-form (or its parallel `3 A.3d at 590–91`).
+
+But `eyecite-ts` currently resolves `Id.` to **Leach** — totally wrong authority.
+
+### Root cause
+
+The case name `Yellen v. Kassin` appears in **prose** ("In *Yellen v. Kassin*..."), not as a structured full citation. eyecite-ts doesn't extract case names from arbitrary prose, so it has no `Yellen` full citation to anchor the `Yellen, 416 N.J. Super. at 590–91` short-form against. Vol+reporter lookup fails → the short-form has `resolution.resolvedTo === undefined`.
+
+Then `resolveId` in `DocumentResolver.ts:462-463` walks backward and explicitly *skips* unresolved short-forms:
+
+```ts
+const prev = this.resolutions[i]
+if (!prev || prev.resolvedTo === undefined) continue
+```
+
+So `Id.` chases past both Yellen short-forms and lands on Leach. The author's intent is lost.
+
+### Why this isn't easy to fix in a one-liner
+
+The current resolution model conflates two questions:
+
+1. **"What's the immediately preceding citation?"** — a positional, sequence-based question.
+2. **"What authority does this resolve to?"** — a bibliographic, full-cite lookup question.
+
+Bluebook Rule 4.1 cares about (1). The current model only exposes (2) via `resolvedTo`. The fix has to separate these.
+
+### Research summary
+
+Per [research §"TL;DR"](../../research/2026-05-19-id-unresolved-antecedent.md):
+
+- **Bluebook is purely positional.** Indigo Book R15.3.1 anchors `Id.` to "the immediately preceding cited authority" — no condition on whether that authority has a resolved bibliographic entry.
+- **Python `eyecite` has the same bug** and explicitly can't fix it because its `Resolutions = dict[Resource, list[Cite]]` shape structurally can't represent "clustered with no underlying authority."
+- **CSL/citeproc separates position from resolution** (pandoc-citeproc evolved its type to `[[(Cite, Maybe Reference)]]` for exactly this reason).
+- **In-repo prior art is `pinciteInheritedFrom`** — the chain-pointer field shipped in `0.19.0` for pincite inheritance. Same `number` index shape, same "Records the immediate predecessor; follow transitively" semantic. Adopting the same pattern at the resolution layer is internally consistent.
+
+Recommendation: an additive `antecedentIndex` field on `ResolutionResult`, plus two coordinated changes (prose case-name extraction and quote-zone robustness) so the Yellen example works end-to-end after this PR.
+
+## Architecture
+
+Three coordinated changes:
+
+```
+┌─── 1. Backward prose case-name extraction (Section 3) ───┐
+│  resolveShortFormCase fallback: when vol+reporter lookup  │
+│  fails AND the short-form has partyName, scan ~200 chars  │
+│  of preceding prose for "Party v. Party". Enrich the      │
+│  short-form with `inferredCaseName` / spans.              │
+└──────────────────────────┬────────────────────────────────┘
+                           │
+┌──────────────────────────▼─ 2. antecedentIndex (Section 2) ─┐
+│  New optional field on ResolutionResult. resolveId records  │
+│  it for the immediate preceding citation regardless of      │
+│  resolution state. resolvedTo contract unchanged (still     │
+│  only set for terminal full cite). Mirror shape of          │
+│  pinciteInheritedFrom.                                      │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+┌──────────────────────────▼─ 3. Quote-zone robustness (Section 4) ─┐
+│  detectQuoteZones uses context-based open/close classification    │
+│  for ASCII quotes; typographic quotes are unambiguous. Handles    │
+│  orphan opens/closes from mid-document pastes without producing   │
+│  phantom zones.                                                   │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Each section is independently testable. Composing them makes the Yellen fixture pass end-to-end.
+
+## Section 2: `antecedentIndex` (Resolution-Model Fix)
+
+### Type addition (`src/resolve/types.ts`)
+
+```ts
+export interface ResolutionResult {
+  /**
+   * Index of the FULL citation this short-form resolved to. Contract
+   * UNCHANGED: only set when a same-authority full citation exists in
+   * scope. Consumers can still rely on `resolved[resolvedTo]` being a
+   * full citation.
+   */
+  resolvedTo?: number
+
+  /**
+   * NEW. Index of the immediately preceding cited authority in document
+   * order, regardless of whether that citation itself resolved to a full
+   * cite. Bluebook Rule 4.1 / Indigo Book R6.2.2: `Id.` anchors here.
+   *
+   * - When the predecessor is a full citation or successfully-resolved
+   *   short-form, `antecedentIndex` points one step back.
+   * - When the predecessor is an unresolved short-form (e.g. because the
+   *   case name appears only in prose), `antecedentIndex` still points
+   *   at it; `resolvedTo` stays undefined.
+   * - Records the immediate predecessor only; follow transitively via
+   *   `resolutions[antecedentIndex].antecedentIndex` for the originator.
+   *   Same idiom as `pinciteInheritedFrom`.
+   */
+  antecedentIndex?: number
+
+  // existing fields unchanged: confidence, failureReason, warnings, features
+}
+```
+
+### Antecedent semantics — one step back, not transitive
+
+`antecedentIndex` points at the **immediately preceding citation** in document order, after applying the resolver's existing filters (scope, parenthetical children, weak-signal asides, quote-zone respect). It does **not** chase through to the originator.
+
+Examples (assume idx 0 is Smith full case cite):
+
+| Chain | `Id.` resolvedTo | `Id.` antecedentIndex |
+|---|---|---|
+| `Smith → Id.` | 0 | 0 (Smith is both immediate predecessor and the full cite) |
+| `Smith → Smith, 1 U.S. at 115 (resolved) → Id.` | 0 | 1 (immediate predecessor is the resolved short-form at idx 1, not the full cite at 0) |
+| `Smith → Id. at 115 → Id.` | 0 | 1 (immediate predecessor is `Id. at 115` at idx 1) |
+| `Smith → unresolved short → Id.` | undefined | 1 (the unresolved short-form) |
+| `Smith → unresolved short → unresolved parallel → Id.` | undefined | 2 (the parallel short-form, one step back) |
+| (no prior citation) `Id.` | undefined | undefined |
+
+### `resolveId` algorithm change
+
+```ts
+private resolveId(citation: IdCitation): ResolutionResult | undefined {
+  // Pass 1: existing algorithm — find best full-cite candidate
+  // (filters: scope, parenthetical, weak-signal, quote-zone, family).
+  const fullCandidate = this.findResolvedFullAntecedent(citation)
+  if (fullCandidate !== undefined) {
+    const antecedentIndex = this.findImmediatePredecessor(citation)
+    return {
+      resolvedTo: fullCandidate.index,
+      antecedentIndex,                 // may equal resolvedTo or point one step back
+      confidence: fullCandidate.confidence,  // unchanged from current implementation
+      warnings: fullCandidate.warnings,      // unchanged from current implementation
+    }
+  }
+
+  // Pass 2: NEW — no resolved full cite found, but we may still have an
+  // unresolved short-form predecessor. Bluebook-anchor to it.
+  const antecedentIndex = this.findImmediatePredecessor(citation)
+  if (antecedentIndex !== undefined) {
+    return {
+      resolvedTo: undefined,
+      antecedentIndex,
+      confidence: 0.7,
+      warnings: [{
+        level: "info",
+        message: "Id. antecedent has unresolved authority; chained by position only",
+        position: { start: citation.span.originalStart, end: citation.span.originalEnd },
+      }],
+    }
+  }
+
+  // Pass 3: existing — no preceding citation at all.
+  return this.createFailureResult("No preceding citation found")
+}
+```
+
+`findImmediatePredecessor` is a new helper that applies the same scope/parenthetical/weak-signal/quote filters as the existing chase, but **accepts unresolved short-forms** as the answer rather than continuing past them.
+
+### `resolveSupra` and `resolveShortFormCase` parity
+
+Both also get `antecedentIndex` populated for consistency. Consumers walking the chain need it regardless of citation type. The change is mechanical: for any successful resolution, record `antecedentIndex` alongside `resolvedTo`.
+
+### Why "one step back" and not transitive
+
+Same reason `pinciteInheritedFrom` is one step back: provenance is more useful than originator-only. A consumer walking the chain can always traverse transitively; one that only sees the originator loses the link history. This is also what citeproc-CSL does (`position=ibid` references the immediately prior cite, not the bibliography entry).
+
+## Section 3: Backward Prose Case-Name Extraction
+
+### When it runs
+
+Inside `resolveShortFormCase`, as a **fallback after vol+reporter lookup fails**. Conceptually a resolution-time enrichment, not a parse-time decision — keeps extraction purely syntactic.
+
+```ts
+private resolveShortFormCase(citation: ShortFormCaseCitation): ResolutionResult | undefined {
+  // Existing: try vol+reporter match against prior full citations
+  const resolved = this.findFullCiteByVolumeReporter(citation)
+  if (resolved !== undefined) {
+    return {
+      resolvedTo: resolved.index,
+      antecedentIndex: this.findImmediatePredecessor(citation),
+      confidence: resolved.confidence,   // unchanged from current implementation
+    }
+  }
+
+  // NEW fallback: backward prose scan for "Party v. Party"
+  if (citation.partyName) {
+    const inferred = this.extractInferredCaseName(citation)
+    if (inferred) {
+      // Mutate the short-form in place with inferred metadata. No
+      // synthetic FullCitation added to the citations array.
+      citation.inferredCaseName = inferred.caseName
+      citation.inferredCaseNameSpan = inferred.span
+      if (inferred.plaintiff) citation.inferredPlaintiff = inferred.plaintiff
+      if (inferred.defendant) citation.inferredDefendant = inferred.defendant
+    }
+  }
+
+  return this.createFailureResult("No matching full case citation found")
+}
+```
+
+### Why enrich the short-form, not synthesize a full citation
+
+| Path | Pro | Con |
+|---|---|---|
+| **A. Enrich short-form** (chosen) | Non-invasive; no phantom citations in `citations[]`; consumers walk antecedentIndex to find inferred metadata | Short-form formally "unresolved" (`resolvedTo === undefined`); consumers need `caseName ?? inferredCaseName ?? partyName` fallback |
+| B. Synthesize a `FullCaseCitation` | Resolution succeeds end-to-end; uniform output | Phantom citation has no organic `span`/`matchedText`; breaks "extract = parse, resolve = link" invariant; surprises iteration over `citations.length` |
+
+Going with A. Architectural invariant is preserved; cost is a one-line fallback at consumer sites.
+
+### Prose-scan algorithm
+
+Refactor `extractCaseName` (`src/extract/extractCase.ts:~1150`) to expose its bounded-window backward-search for `Party v. Party` patterns as a reusable helper. New method `extractInferredCaseName` on `DocumentResolver` (or extracted to a sibling utility) calls it with:
+
+- **Search window**: ~200 chars before the short-form's `span.cleanStart`.
+- **Pattern**: existing `Party v. Party` regex from `extractCase.ts`.
+- **Acceptance criteria**:
+  1. Match found within the window.
+  2. At least one matched party name matches `citation.partyName` (case-insensitive, normalized — reuse the same normalization the resolver uses at `DocumentResolver.ts:809-826`).
+  3. Prefer the closest match to the short-form (scan walks backward from the short-form; first matching `Party v. Party` wins).
+
+If no match: return `undefined`. Short-form stays unenriched, resolution still fails, but `antecedentIndex` from Section 2 still does its work.
+
+### New optional fields on `ShortFormCaseCitation` and `SupraCitation`
+
+```ts
+/**
+ * Case name inferred from prose preceding this short-form when no full
+ * citation in `citations[]` matched its vol+reporter. Populated by the
+ * resolver fallback for the "In Smith v. Jones... Smith, 100 F.2d at 200"
+ * pattern. Consumers: prefer `caseName ?? inferredCaseName ?? partyName`.
+ */
+inferredCaseName?: string
+/** Plaintiff side of the inferred case name. */
+inferredPlaintiff?: string
+/** Defendant side. */
+inferredDefendant?: string
+/** Span in original text where the inferred case name was found. */
+inferredCaseNameSpan?: Span
+```
+
+`SupraCitation` gets the same four fields — `Yellen, supra` also benefits from prose inference.
+
+### Composition with Section 2
+
+For the Yellen scenario after both Sections 2 and 3 land:
+
+| idx | citation | resolvedTo | antecedentIndex | inferredCaseName |
+|---|---|---|---|---|
+| 0 | Leach (full) | (n/a) | (n/a) | (n/a) |
+| 1 | Yellen, 416 N.J. Super. at 590–91 | undefined | undefined | `"Yellen v. Kassin"` |
+| 2 | 3 A.3d at 590–91 (parallel, no party) | undefined | 1 | undefined |
+| 3 | Id. at 590 | undefined | 2 | undefined |
+
+Consumer walks: `cites[3].resolution.antecedentIndex → cites[2] → antecedentIndex → cites[1] → inferredCaseName === "Yellen v. Kassin"` ✓
+
+## Section 4: Quote-Zone Robustness
+
+### Current bug
+
+`detectQuoteZones` (`DocumentResolver.ts:109+`) pairs `"` characters greedily — first becomes open, next becomes close, etc. Orphan-close at start (e.g. `use." ...`) gets treated as open and mispairs with the next real-open, creating a phantom zone that engulfs surrounding citations and breaks `Id.`'s quote-boundary check.
+
+### Fix: context-based open/close classification
+
+Replace greedy pair-as-you-go with two-step:
+
+1. **Classify** each `"` as open / close / ambiguous based on neighboring characters.
+2. **Match** opens to closes with a stack, skipping ambiguous quotes and orphans.
+
+Classification rules (English typographic conventions):
+
+| `"` neighbors | Classification |
+|---|---|
+| **prev**: start-of-text \| whitespace \| `(` \| `[` \| `—`<br>**next**: letter or `(` | **open** |
+| **prev**: letter \| digit \| `?` \| `!` \| `.` \| `,` \| `)` \| `]`<br>**next**: end-of-text \| whitespace \| `.` \| `,` \| `;` \| `:` \| `)` \| `—` | **close** |
+| Otherwise | **ambiguous** (skip) |
+
+### Pairing algorithm
+
+```ts
+opens: number[] = []
+zones: Array<{ start: number; end: number }> = []
+
+for (let i = 0; i < text.length; i++) {
+  if (text[i] !== '"' && text[i] !== '“' && text[i] !== '”') continue
+
+  // Typographic quotes are unambiguous.
+  if (text[i] === '“') { opens.push(i); continue }
+  if (text[i] === '”') {
+    if (opens.length === 0) continue  // orphan close
+    const openPos = opens.pop()!
+    if (i - openPos <= MAX_INLINE_QUOTE_LEN) zones.push({ start: openPos, end: i + 1 })
+    continue
+  }
+
+  // ASCII straight quote — classify by context.
+  const cls = classifyAsciiQuote(text, i)
+  if (cls === 'open') {
+    opens.push(i)
+  } else if (cls === 'close') {
+    if (opens.length === 0) continue  // orphan close (e.g. mid-doc paste)
+    const openPos = opens.pop()!
+    if (i - openPos <= MAX_INLINE_QUOTE_LEN) zones.push({ start: openPos, end: i + 1 })
+  }
+  // ambiguous → skip
+}
+```
+
+Apostrophes (`'`) are not double-quotes; ignored by this algorithm regardless. Nested single-quoted text inside double quotes works correctly.
+
+### Why context-classifier, not parity-from-start
+
+The standard "count `"` from start, parity says open/close" approach (used by several legal-text quote detectors) works for well-formed text starting from byte 0, but has the **same orphan-quote bug** when given mid-document input. eyecite-ts's input contract is "arbitrary text snippets" — not "full briefs only" — so parity-from-start is unreliable.
+
+### Markdown block-quotes (lines starting with `>`)
+
+Left unchanged. The existing line-based logic is already correct and unambiguous.
+
+### Bug A vs Bug B priority
+
+This fix targets Bug A (phantom quote zone from orphan quotes) — likely a test-artifact / direct-snippet issue rather than production. Bug B (Section 2: chase-past-unresolved) is the user-visible failure in real briefs. Including Bug A in this PR is defensive — costs are low, robustness gain is real.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `src/resolve/types.ts` | Add `antecedentIndex?: number` to `ResolutionResult` |
+| `src/resolve/DocumentResolver.ts` | (a) Replace `detectQuoteZones` algorithm with context-classifier. (b) Add `findImmediatePredecessor` helper. (c) Modify `resolveId` to two-pass: try full-cite first, fall back to antecedentIndex-only on failure. (d) Add `antecedentIndex` writes to `resolveSupra` and `resolveShortFormCase` for consistency. (e) Add `extractInferredCaseName` method, called as fallback in `resolveShortFormCase`. |
+| `src/extract/extractCase.ts` | Refactor `extractCaseName` to expose its bounded-window backward `Party v. Party` matching as a reusable helper for `extractInferredCaseName`. (Alternative: copy the regex into the resolver helper without refactoring `extractCaseName` — pick during implementation based on how cleanly the existing function decomposes.) |
+| `src/types/citation.ts` | Add `inferredCaseName?`, `inferredPlaintiff?`, `inferredDefendant?`, `inferredCaseNameSpan?` to `ShortFormCaseCitation` and `SupraCitation` |
+| `tests/resolve/idWalksToUnresolvedAntecedent.test.ts` | NEW — Section 2 cases |
+| `tests/resolve/shortFormProseNameFallback.test.ts` | NEW — Section 3 cases |
+| `tests/resolve/quoteZoneRobustness.test.ts` | NEW — Section 4 cases |
+| `tests/resolve/yellenFixture.test.ts` | NEW — end-to-end Yellen fixture verifying all three sections compose |
+| `.changeset/id-clusters-with-unresolved-antecedent.md` | NEW — minor bump |
+
+No changes to `src/index.ts` (all new types are properties on already-exported interfaces or are on the existing `ResolutionResult`).
+
+## Testing
+
+### Section 2 — `antecedentIndex`
+
+`tests/resolve/idWalksToUnresolvedAntecedent.test.ts`:
+
+- Direct: `Smith → unresolved Yellen short-form → Id.` — `Id.antecedentIndex === Yellen short-form index`; `Id.resolvedTo === undefined`; warning present.
+- Chain: `Smith → unresolved short-form → unresolved short-form → Id.` — `Id.antecedentIndex === most-recent short-form` (one step back, not transitive).
+- Both paths work together: `Smith → Id. → Id.` — both Id.s have `resolvedTo === 0` AND `antecedentIndex` set correctly (idx 0 for first Id., idx 1 for second).
+- Transitive walk: consumer follows `antecedentIndex` chain until hitting a citation with `resolvedTo` set, OR `antecedentIndex === undefined`.
+
+### Section 3 — Prose case-name extraction
+
+`tests/resolve/shortFormProseNameFallback.test.ts`:
+
+- Inferred from explicit `Party v. Party` in prose ≤200 chars back.
+- Skipped when short-form has no `partyName`.
+- Skipped when `partyName` doesn't match prose match.
+- Window-bounded: prose mention >200 chars back not picked up.
+- Inferred metadata reachable via `antecedentIndex` walk from a subsequent `Id.`.
+
+### Section 4 — Quote-zone robustness
+
+`tests/resolve/quoteZoneRobustness.test.ts`:
+
+- Mid-doc paste with leading orphan close (`use." Smith, 1 U.S. 1. Id.`) — no phantom zone; citations resolve normally.
+- Mid-doc paste with trailing orphan open (`Smith, 1 U.S. 1 "and so on`) — no phantom zone.
+- Typographic quotes always pair correctly (`U+201C` / `U+201D`).
+- Standard ASCII quotes pair correctly when well-formed.
+- Apostrophes ignored.
+- Markdown block-quote (`> ...`) lines still detected.
+
+### End-to-end fixture
+
+`tests/resolve/yellenFixture.test.ts`:
+
+- Literal Leach / Yellen brief excerpt from the bug report.
+- `Id. at 590` clusters with the Yellen parallel short-form (`antecedentIndex` walk reaches Yellen short-form).
+- Yellen short-form has `inferredCaseName === "Yellen v. Kassin"`.
+- `Id.` does **not** resolve to Leach.
+
+### Regression
+
+Run the existing 2975 tests — none should break. Each section is additive or strictly improves correctness on input shapes existing tests don't cover.
+
+## Non-Goals
+
+- **Synthesizing a `FullCaseCitation` from prose mentions.** We enrich the existing short-form rather than insert a phantom citation. If a future change wants to expose prose mentions as first-class extractable citations, that's a separate design.
+- **Transitive `antecedentIndex` walk by the resolver.** The resolver records one-step-back only; transitive traversal is the consumer's responsibility. Matches `pinciteInheritedFrom` convention.
+- **`clusterId` field for UI grouping.** A `clusterId` answers a different question (set membership without direction). Worth having on its own merits but out of scope here — `antecedentIndex` already supports the cluster question via transitive walk.
+- **String-cite handling for prose extraction.** If the prose match itself is inside a string-cite (rare), we don't try to disambiguate — first matching `Party v. Party` wins.
+- **Foreign-language prose patterns.** English `v.` / `v` only. Matches existing extractCaseName scope.
+- **Parity-from-start quote algorithm.** Considered (used elsewhere in the broader legal-text ecosystem) but ruled out for eyecite-ts because the input contract permits arbitrary text snippets.
+
+## Open Questions
+
+None outstanding. Algorithm validated against Bluebook Rule 4.1 / Indigo R15.3.1 (research §1), Python eyecite reference (research §2), CSL/citeproc precedent (research §4), and in-codebase prior art `pinciteInheritedFrom` (research §5). Approach approved by user.
+
+## Migration Notes (for the eventual changeset)
+
+- **No breaking changes.** All new fields are optional. `resolvedTo` semantics unchanged.
+- **New behavior — `Id.` after unresolved short-form** now clusters with that short-form (via `antecedentIndex`) instead of chasing past to the previous full cite. This is a correctness fix per Bluebook Rule 4.1; consumers reading `resolvedTo` see no change (it stays `undefined` for these chains), but consumers reading `antecedentIndex` see the new clustering.
+- **New behavior — short-forms with prose-introduced authority** now carry `inferredCaseName` when a `Party v. Party` pattern appears in nearby prose. `resolvedTo` still `undefined` for these.
+- **New behavior — orphan-quote inputs** no longer produce phantom quote zones. May change `Id.`/short-form resolution outcomes for tests or production inputs that started mid-document with a stray `"`. Expected impact: previously-failing resolutions now succeed.
+- **For consumers walking provenance:** `resolution.antecedentIndex` is the new chain pointer. Walk transitively: `let cur = id.resolution.antecedentIndex; while (cur !== undefined && cites[cur].resolution.resolvedTo === undefined) cur = cites[cur].resolution.antecedentIndex`. Hits a `resolvedTo`-set citation or runs out.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -487,7 +487,7 @@ export class DocumentResolver {
    * preceding cited authority" — unlike `resolveId`'s primary chase
    * (which only accepts resolved full antecedents), this lookup accepts
    * any prior citation that passes the existing scope / parenthetical /
-   * weak-signal / quote-zone filters, regardless of resolution state.
+   * quote-zone filters, regardless of resolution state.
    *
    * Returns the index of the immediately-preceding eligible citation,
    * or `undefined` if none.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -91,6 +91,33 @@ function citationFamily(citation: Citation): CitationFamily {
 }
 
 /**
+ * Classify an ASCII `"` at position `pos` as opening, closing, or ambiguous,
+ * based on neighboring characters. English typographic conventions:
+ *
+ *   - Opening: preceded by start/whitespace/punctuation-open (`(`, `[`, `—`)
+ *     AND followed by a letter or `(`.
+ *   - Closing: preceded by a letter/digit/sentence punctuation
+ *     (`.`, `,`, `?`, `!`, `:`, `;`, `)`, `]`) AND followed by end/
+ *     whitespace/punctuation.
+ *   - Ambiguous: everything else (skipped during pairing).
+ */
+function classifyAsciiQuote(text: string, pos: number): "open" | "close" | "ambiguous" {
+  const prev = pos === 0 ? "" : text[pos - 1]
+  const next = pos === text.length - 1 ? "" : text[pos + 1]
+
+  const openPrev =
+    prev === "" || /\s/.test(prev) || prev === "(" || prev === "[" || prev === "—"
+  const openNext = /[A-Za-zÀ-ɏ]/.test(next) || next === "("
+  if (openPrev && openNext) return "open"
+
+  const closePrev = /[A-Za-z0-9À-ɏ.,?!:;)\]]/.test(prev)
+  const closeNext = next === "" || /[\s.,;:)—\]]/.test(next)
+  if (closePrev && closeNext) return "close"
+
+  return "ambiguous"
+}
+
+/**
  * Detects block-quote and inline-quote zones in **original** text and
  * returns sorted, non-overlapping `{start, end}` ranges in original-text
  * coordinates. Callers must look up citations via `span.originalStart`,
@@ -101,10 +128,10 @@ function citationFamily(citation: Citation): CitationFamily {
  *   - Markdown blockquotes: contiguous lines whose first non-whitespace
  *     character is `>`. The zone spans from the first such line's start to
  *     the end of the last contiguous line.
- *   - Inline paired double-quotes: greedy `"…"` regions on a single content
- *     stretch. We only accept pairs that are at most ~600 chars apart, which
- *     filters most cases of stray unbalanced quotes; longer "quotes" would
- *     swallow unrelated citations and produce wrong skips.
+ *   - Inline paired quotes: balanced `"…"` or `“…”` regions on a single
+ *     content stretch. We only accept pairs that are at most ~600 chars
+ *     apart, which filters most cases of stray unbalanced quotes; longer
+ *     "quotes" would swallow unrelated citations and produce wrong skips.
  */
 function detectQuoteZones(text: string): Array<{ start: number; end: number }> {
   const zones: Array<{ start: number; end: number }> = []
@@ -129,20 +156,49 @@ function detectQuoteZones(text: string): Array<{ start: number; end: number }> {
   }
   if (zoneStart !== -1) zones.push({ start: zoneStart, end: text.length })
 
-  // Inline paired double-quotes.
+  // Inline paired quotes. Two-step:
+  //   1. Classify each quote-character as open / close / ambiguous based on
+  //      neighboring characters (typographic conventions).
+  //   2. Match opens to closes with a stack, skipping orphans and ambiguous.
+  //
+  // Why not greedy "first quote = open, next = close"? That mispairs when
+  // input starts mid-document with an orphan close (e.g. `use." Smith...`),
+  // creating a phantom zone that engulfs unrelated citations and breaks
+  // Id. resolution. The classifier handles arbitrary text snippets
+  // robustly. Typographic quotes (U+201C / U+201D) are unambiguous and
+  // pair directly.
   const MAX_INLINE_QUOTE_LEN = 600
-  let openPos = -1
+  const opens: number[] = []
   for (let i = 0; i < text.length; i++) {
-    if (text[i] !== '"') continue
-    if (openPos === -1) {
-      openPos = i
-    } else {
-      const length = i - openPos + 1
-      if (length <= MAX_INLINE_QUOTE_LEN) {
+    const ch = text[i]
+
+    // Typographic quotes: unambiguous.
+    if (ch === "“") {
+      opens.push(i)
+      continue
+    }
+    if (ch === "”") {
+      if (opens.length === 0) continue // orphan close
+      const openPos = opens.pop()!
+      if (i - openPos + 1 <= MAX_INLINE_QUOTE_LEN) {
         zones.push({ start: openPos, end: i + 1 })
       }
-      openPos = -1
+      continue
     }
+
+    // ASCII straight double-quote: classify by neighbors.
+    if (ch !== '"') continue
+    const cls = classifyAsciiQuote(text, i)
+    if (cls === "open") {
+      opens.push(i)
+    } else if (cls === "close") {
+      if (opens.length === 0) continue // orphan close — discard
+      const openPos = opens.pop()!
+      if (i - openPos + 1 <= MAX_INLINE_QUOTE_LEN) {
+        zones.push({ start: openPos, end: i + 1 })
+      }
+    }
+    // ambiguous → skip
   }
 
   zones.sort((a, b) => a.start - b.start)

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -105,8 +105,7 @@ function classifyAsciiQuote(text: string, pos: number): "open" | "close" | "ambi
   const prev = pos === 0 ? "" : text[pos - 1]
   const next = pos === text.length - 1 ? "" : text[pos + 1]
 
-  const openPrev =
-    prev === "" || /\s/.test(prev) || prev === "(" || prev === "[" || prev === "—"
+  const openPrev = prev === "" || /\s/.test(prev) || prev === "(" || prev === "[" || prev === "—"
   const openNext = /[A-Za-zÀ-ɏ]/.test(next) || next === "("
   if (openPrev && openNext) return "open"
 
@@ -167,19 +166,26 @@ function detectQuoteZones(text: string): Array<{ start: number; end: number }> {
   // Id. resolution. The classifier handles arbitrary text snippets
   // robustly. Typographic quotes (U+201C / U+201D) are unambiguous and
   // pair directly.
+  //
+  // Two separate stacks isolate ASCII and typographic styles so a mixed
+  // open/close (e.g. ASCII `"` … typographic `”`) cannot cross-pair into
+  // a phantom zone that engulfs intermediate citations.
   const MAX_INLINE_QUOTE_LEN = 600
-  const opens: number[] = []
+  const asciiOpens: number[] = []
+  const typographicOpens: number[] = []
   for (let i = 0; i < text.length; i++) {
     const ch = text[i]
 
     // Typographic quotes: unambiguous.
     if (ch === "“") {
-      opens.push(i)
+      typographicOpens.push(i)
       continue
     }
     if (ch === "”") {
-      if (opens.length === 0) continue // orphan close
-      const openPos = opens.pop()!
+      // Orphan closes are skipped — a leading typographic `”` without a
+      // matching open should not retroactively turn into an open.
+      const openPos = typographicOpens.pop()
+      if (openPos === undefined) continue
       if (i - openPos + 1 <= MAX_INLINE_QUOTE_LEN) {
         zones.push({ start: openPos, end: i + 1 })
       }
@@ -190,10 +196,11 @@ function detectQuoteZones(text: string): Array<{ start: number; end: number }> {
     if (ch !== '"') continue
     const cls = classifyAsciiQuote(text, i)
     if (cls === "open") {
-      opens.push(i)
+      asciiOpens.push(i)
     } else if (cls === "close") {
-      if (opens.length === 0) continue // orphan close — discard
-      const openPos = opens.pop()!
+      // Orphan closes are skipped — same rationale as the typographic branch.
+      const openPos = asciiOpens.pop()
+      if (openPos === undefined) continue
       if (i - openPos + 1 <= MAX_INLINE_QUOTE_LEN) {
         zones.push({ start: openPos, end: i + 1 })
       }

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -981,12 +981,19 @@ export class DocumentResolver {
    *
    * Unlike `extractCaseName` — which performs a boundary-bounded backward
    * walk starting *immediately before* a citation core — this scan looks
-   * anywhere in a ~200-char window before the short-form and accepts the
+   * anywhere in a ~400-char window before the short-form and accepts the
    * closest "Party v. Party" mention whose plaintiff or defendant matches
    * the short-form's `partyName`. Crossing intervening sentence boundaries
    * (e.g., "In Yellen v. Kassin, the court held. Yellen, 416 ...") is
    * required: the prose mention and the short-form are by definition
    * separated by other prose.
+   *
+   * LOOKBACK = 400 chars accommodates real-world legal prose where the
+   * prose mention and short-form are separated by a long quoted passage
+   * (e.g. the bug-report 2026-05-19 Yellen fixture has ~351 chars of
+   * block quote between "In Yellen v. Kassin" and "Yellen, 416 N.J.
+   * Super. at 590"). False-positive risk is bounded by the partyName
+   * acceptance check and the "closest match wins" tie-breaker.
    *
    * Returns the inferred case name + spans, or `undefined` if no
    * acceptable match is found within `LOOKBACK` chars.
@@ -999,7 +1006,7 @@ export class DocumentResolver {
         span: Span
       }
     | undefined {
-    const LOOKBACK = 200
+    const LOOKBACK = 400
     if (!citation.partyName) return undefined
 
     const start = Math.max(0, citation.span.cleanStart - LOOKBACK)

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -1011,6 +1011,10 @@ export class DocumentResolver {
     // side of `v.` / `vs.`, ending at sentence punctuation or a comma.
     // Looser than `V_CASE_NAME_REGEX` from `extractCase.ts`, which is
     // anchored to a citation core — here we're scanning free prose.
+    //
+    // The nested `*` quantifiers are ReDoS-safe: each repetition requires a
+    // mandatory `\s+` separator, so the inner and outer alternatives are
+    // disjoint on the same input and cannot backtrack catastrophically.
     const VS_REGEX =
       /([A-Z][A-Za-z0-9.'&\-/]*(?:\s+[A-Z][A-Za-z0-9.'&\-/]*)*)\s+v(?:s)?\.\s+([A-Z][A-Za-z0-9.'&\-/]*(?:\s+[A-Z][A-Za-z0-9.'&\-/]*)*)/g
 

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -918,6 +918,15 @@ export class DocumentResolver {
     }
 
     if (candidates.length === 0) {
+      // Backward prose scan: try to recover case name from preceding prose.
+      const inferred = this.extractInferredCaseName(citation)
+      if (inferred) {
+        citation.inferredCaseName = inferred.caseName
+        citation.inferredPlaintiff = inferred.plaintiff
+        citation.inferredDefendant = inferred.defendant
+        citation.inferredCaseNameSpan = inferred.span
+      }
+
       const antecedentIndex = this.findImmediatePredecessor(citation)
       if (antecedentIndex !== undefined) {
         return {
@@ -960,6 +969,116 @@ export class DocumentResolver {
       resolvedTo: candidates[0],
       antecedentIndex: this.findImmediatePredecessor(citation),
       confidence: 0.95,
+    }
+  }
+
+  /**
+   * Backward prose scan for "Party v. Party" patterns preceding a
+   * short-form citation whose vol+reporter lookup failed. Used to recover
+   * a case name when the author introduced the authority in prose (e.g.
+   * "In Yellen v. Kassin, ...") and used a short-form that didn't carry
+   * an extractable full citation.
+   *
+   * Unlike `extractCaseName` — which performs a boundary-bounded backward
+   * walk starting *immediately before* a citation core — this scan looks
+   * anywhere in a ~200-char window before the short-form and accepts the
+   * closest "Party v. Party" mention whose plaintiff or defendant matches
+   * the short-form's `partyName`. Crossing intervening sentence boundaries
+   * (e.g., "In Yellen v. Kassin, the court held. Yellen, 416 ...") is
+   * required: the prose mention and the short-form are by definition
+   * separated by other prose.
+   *
+   * Returns the inferred case name + spans, or `undefined` if no
+   * acceptable match is found within `LOOKBACK` chars.
+   */
+  private extractInferredCaseName(citation: ShortFormCaseCitation):
+    | {
+        caseName: string
+        plaintiff: string
+        defendant: string
+        span: Span
+      }
+    | undefined {
+    const LOOKBACK = 200
+    if (!citation.partyName) return undefined
+
+    const start = Math.max(0, citation.span.cleanStart - LOOKBACK)
+    const window = this.text.substring(start, citation.span.cleanStart)
+    if (window.length === 0) return undefined
+
+    // Lightweight "Party v. Party" matcher. Allows capitalized words
+    // (with internal connectors / abbreviations / `&`, etc.) on either
+    // side of `v.` / `vs.`, ending at sentence punctuation or a comma.
+    // Looser than `V_CASE_NAME_REGEX` from `extractCase.ts`, which is
+    // anchored to a citation core — here we're scanning free prose.
+    const VS_REGEX =
+      /([A-Z][A-Za-z0-9.'&\-/]*(?:\s+[A-Z][A-Za-z0-9.'&\-/]*)*)\s+v(?:s)?\.\s+([A-Z][A-Za-z0-9.'&\-/]*(?:\s+[A-Z][A-Za-z0-9.'&\-/]*)*)/g
+
+    const shortName = this.normalizePartyName(citation.partyName)
+    let best:
+      | {
+          caseName: string
+          plaintiff: string
+          defendant: string
+          start: number
+          end: number
+        }
+      | undefined
+
+    let m: RegExpExecArray | null
+    VS_REGEX.lastIndex = 0
+    while ((m = VS_REGEX.exec(window)) !== null) {
+      // Strip leading signal words ("In", "See", "Cf", "But", "Compare")
+      // captured as part of the plaintiff. The greedy regex absorbs the
+      // preceding capitalized token, so `"In Yellen v. Kassin"` yields
+      // plaintiff `"In Yellen"`. `stripSignalWords` handles these cases
+      // and preserves `"In re ..."` procedural captions.
+      const rawPlaintiff = m[1].trim()
+      const plaintiff = this.stripSignalWords(rawPlaintiff)
+      const defendant = m[2].trim()
+      const plaintiffNorm = this.normalizePartyName(plaintiff)
+      const defendantNorm = this.normalizePartyName(defendant)
+
+      // Acceptance: exact equality, OR substring containment in either
+      // direction to tolerate abbreviation patterns (`Smith` matches
+      // `Smith, Inc.` and vice versa). Mirror the substring rule used
+      // in `resolveShortFormCase` party-name disambiguation.
+      const hit = (side: string) =>
+        side === shortName || side.includes(shortName) || shortName.includes(side)
+      if (!hit(plaintiffNorm) && !hit(defendantNorm)) continue
+
+      // Recompute the match start to reflect any signal stripping —
+      // if we stripped "In " off the plaintiff, the case-name span
+      // should start at "Yellen", not "In". stripSignalWords strips
+      // both the signal word and its trailing whitespace, so the
+      // length delta is exactly the number of leading chars to skip.
+      const stripOffset = rawPlaintiff.length - plaintiff.length
+      const matchStart = start + m.index + stripOffset
+      best = {
+        caseName: `${plaintiff} v. ${defendant}`,
+        plaintiff,
+        defendant,
+        start: matchStart,
+        end: start + m.index + m[0].length,
+      }
+      // Don't break — keep scanning so the closest (last) match wins.
+    }
+
+    if (!best) return undefined
+
+    return {
+      caseName: best.caseName,
+      plaintiff: best.plaintiff,
+      defendant: best.defendant,
+      // Clean coordinates; consumers should treat these as offsets in
+      // the resolver's input `text`. When the cleaner did not transform
+      // the source, clean == original.
+      span: {
+        cleanStart: best.start,
+        cleanEnd: best.end,
+        originalStart: best.start,
+        originalEnd: best.end,
+      },
     }
   }
 

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -482,6 +482,35 @@ export class DocumentResolver {
   }
 
   /**
+   * Find the immediate-preceding citation index for `antecedentIndex`
+   * purposes. Bluebook Rule 4.1: `Id.` anchors to "the immediately
+   * preceding cited authority" — unlike `resolveId`'s primary chase
+   * (which only accepts resolved full antecedents), this lookup accepts
+   * any prior citation that passes the existing scope / parenthetical /
+   * weak-signal / quote-zone filters, regardless of resolution state.
+   *
+   * Returns the index of the immediately-preceding eligible citation,
+   * or `undefined` if none.
+   */
+  private findImmediatePredecessor(
+    citation: IdCitation | SupraCitation | ShortFormCaseCitation,
+  ): number | undefined {
+    const currentIndex = this.context.citationIndex
+    const citationZone = isInZone(citation.span.originalStart, this.quoteZones)
+
+    for (let i = currentIndex - 1; i >= 0; i--) {
+      // Apply the same filters as resolveId's main chase.
+      if (this.isParentheticalChild(i)) continue
+      if (!this.isWithinScope(i, currentIndex)) continue
+      const candidateZone = isInZone(this.citations[i].span.originalStart, this.quoteZones)
+      if (candidateZone && candidateZone !== citationZone) continue
+      // Accept regardless of resolution state.
+      return i
+    }
+    return undefined
+  }
+
+  /**
    * Resolves `Id.` to the most recent preceding *cited authority*, respecting
    * Bluebook signal categories, block-/inline-quote zones, and the family
    * (case vs. statute) implied by `Id.`'s pincite shape (#480).
@@ -519,11 +548,25 @@ export class DocumentResolver {
       if (isFullCitation(c)) {
         primaryIdx = i
       } else {
-        // shortForm/Id./supra — follow the resolution chain. If it failed to
-        // resolve we skip it: a broken short-form shouldn't pin Id. to a
-        // citation the writer didn't successfully cite.
+        // shortForm/Id./supra — follow the resolution chain.
         const prev = this.resolutions[i]
-        if (!prev || prev.resolvedTo === undefined) continue
+        if (!prev || prev.resolvedTo === undefined) {
+          // Unresolved short-form. Per Bluebook Rule 4.1, `Id.` anchors to
+          // the immediately preceding cited authority — we must not chase
+          // past an unresolved short-form to a more-distant full cite,
+          // because the writer was citing the unresolved short-form, not
+          // the earlier authority. Stop pass-1 here. Pass-2
+          // (`findImmediatePredecessor`) will record the chain pointer in
+          // `antecedentIndex`. Exception: short-forms that are themselves
+          // syntactic asides (paren children, out of scope, wrong quote
+          // zone) are not really "in the writer's main flow" and may be
+          // skipped — those are filtered below.
+          if (this.isParentheticalChild(i)) continue
+          if (!this.isWithinScope(i, currentIndex)) continue
+          const unresolvedZone = isInZone(c.span.originalStart, this.quoteZones)
+          if (unresolvedZone && unresolvedZone !== idQuoteZone) continue
+          break
+        }
         primaryIdx = prev.resolvedTo
       }
 
@@ -548,8 +591,20 @@ export class DocumentResolver {
     }
 
     if (candidates.length === 0) {
-      // Diagnose: did we have any preceding citation at all? If not, the
-      // legacy failure message helps consumers debug "Id. before any cite".
+      // No resolved full-cite candidate. Pass 2: try the immediate
+      // predecessor regardless of resolution state — Bluebook Rule 4.1
+      // anchors `Id.` to the immediately preceding cited authority, not
+      // just to resolved ones. The chain pointer is recorded in
+      // `antecedentIndex`; `resolvedTo` stays undefined.
+      const antecedentIndex = this.findImmediatePredecessor(citation)
+      if (antecedentIndex !== undefined) {
+        return {
+          resolvedTo: undefined,
+          antecedentIndex,
+          confidence: 0.7,
+          warnings: ["Id. antecedent has unresolved authority; chained by position only"],
+        }
+      }
       const anyPrior = currentIndex > 0
       return this.createFailureResult(
         anyPrior ? "Antecedent citation outside scope boundary" : "No preceding citation found",
@@ -585,6 +640,7 @@ export class DocumentResolver {
 
     return {
       resolvedTo: best.index,
+      antecedentIndex: this.findImmediatePredecessor(citation),
       confidence,
       warnings,
     }
@@ -823,6 +879,7 @@ export class DocumentResolver {
 
     return {
       resolvedTo: bestMatch.index,
+      antecedentIndex: this.findImmediatePredecessor(citation),
       confidence: bestMatch.similarity,
       warnings: warnings.length > 0 ? warnings : undefined,
     }
@@ -861,6 +918,15 @@ export class DocumentResolver {
     }
 
     if (candidates.length === 0) {
+      const antecedentIndex = this.findImmediatePredecessor(citation)
+      if (antecedentIndex !== undefined) {
+        return {
+          resolvedTo: undefined,
+          antecedentIndex,
+          confidence: 0.5,
+          warnings: ["No matching full case citation found; chained by position only"],
+        }
+      }
       return this.createFailureResult("No matching full case citation found")
     }
 
@@ -883,6 +949,7 @@ export class DocumentResolver {
       if (namedMatch !== undefined) {
         return {
           resolvedTo: namedMatch,
+          antecedentIndex: this.findImmediatePredecessor(citation),
           confidence: 0.98, // Higher than bare vol+reporter — party-name disambiguation tightens.
         }
       }
@@ -891,6 +958,7 @@ export class DocumentResolver {
     // No party name (or no name match): pick most recent candidate.
     return {
       resolvedTo: candidates[0],
+      antecedentIndex: this.findImmediatePredecessor(citation),
       confidence: 0.95,
     }
   }

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -77,6 +77,22 @@ export interface ResolutionResult {
   resolvedTo?: number
 
   /**
+   * Index of the immediately preceding cited authority in document order,
+   * regardless of whether *that* citation itself resolved to a full cite.
+   * Bluebook Rule 4.1 / Indigo Book R6.2.2: `Id.` anchors here.
+   *
+   * - When the predecessor is a full citation or successfully-resolved
+   *   short-form, this points one step back (may equal `resolvedTo`).
+   * - When the predecessor is an unresolved short-form (e.g. because the
+   *   case name appears only in prose), this still points at it; the
+   *   `resolvedTo` field stays undefined.
+   * - Records the immediate predecessor only; follow transitively via
+   *   `resolutions[antecedentIndex].antecedentIndex` for the originator.
+   *   Same idiom as `ShortFormCaseCitation.pinciteInheritedFrom`.
+   */
+  antecedentIndex?: number
+
+  /**
    * Reason for resolution failure (if any)
    */
   failureReason?: string

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -799,6 +799,19 @@ export interface SupraCitation extends CitationBase {
    */
   pinciteInheritedFrom?: number
   /**
+   * Case name inferred from prose preceding this short-form when no full
+   * citation in `citations[]` matched its vol+reporter. Populated by the
+   * resolver fallback for the "In Smith v. Jones... Smith, 100 F.2d at 200"
+   * pattern. Consumers: prefer `caseName ?? inferredCaseName ?? partyName`.
+   */
+  inferredCaseName?: string
+  /** Plaintiff side of the inferred case name. */
+  inferredPlaintiff?: string
+  /** Defendant side of the inferred case name. */
+  inferredDefendant?: string
+  /** Span in original text where the inferred case name was found. */
+  inferredCaseNameSpan?: Span
+  /**
    * Trailing parenthetical content (text between the parens, excluding the
    * parens themselves). See `IdCitation.parenthetical` for common shapes
    * and rationale. #303
@@ -837,6 +850,19 @@ export interface ShortFormCaseCitation extends CitationBase {
    * predecessor; follow transitively for the chain's originator.
    */
   pinciteInheritedFrom?: number
+  /**
+   * Case name inferred from prose preceding this short-form when no full
+   * citation in `citations[]` matched its vol+reporter. Populated by the
+   * resolver fallback for the "In Smith v. Jones... Smith, 100 F.2d at 200"
+   * pattern. Consumers: prefer `caseName ?? inferredCaseName ?? partyName`.
+   */
+  inferredCaseName?: string
+  /** Plaintiff side of the inferred case name. */
+  inferredPlaintiff?: string
+  /** Defendant side of the inferred case name. */
+  inferredDefendant?: string
+  /** Span in original text where the inferred case name was found. */
+  inferredCaseNameSpan?: Span
   /** Component-level spans (currently just `pincite`; extend when needed). */
   spans?: import("./componentSpans").ShortFormCaseComponentSpans
   /** Back-reference party name when the short-form includes one (Bluebook

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -799,19 +799,6 @@ export interface SupraCitation extends CitationBase {
    */
   pinciteInheritedFrom?: number
   /**
-   * Case name inferred from prose preceding this short-form when no full
-   * citation in `citations[]` matched its vol+reporter. Populated by the
-   * resolver fallback for the "In Smith v. Jones... Smith, 100 F.2d at 200"
-   * pattern. Consumers: prefer `caseName ?? inferredCaseName ?? partyName`.
-   */
-  inferredCaseName?: string
-  /** Plaintiff side of the inferred case name. */
-  inferredPlaintiff?: string
-  /** Defendant side of the inferred case name. */
-  inferredDefendant?: string
-  /** Span in original text where the inferred case name was found. */
-  inferredCaseNameSpan?: Span
-  /**
    * Trailing parenthetical content (text between the parens, excluding the
    * parens themselves). See `IdCitation.parenthetical` for common shapes
    * and rationale. #303

--- a/tests/integration/resolution.test.ts
+++ b/tests/integration/resolution.test.ts
@@ -212,7 +212,12 @@ describe("Resolution Integration Tests", () => {
       expect(id!.resolution?.resolvedTo).toBe(smithIndex)
     })
 
-    it("fails Id. when preceding short-form fails to resolve", () => {
+    it("Id. anchors to preceding unresolved short-form via antecedentIndex (Bluebook Rule 4.1)", () => {
+      // Bluebook Rule 4.1: `Id.` refers to the immediately preceding cited
+      // authority, regardless of whether that authority resolved to a full
+      // citation. The short-form `400 F.3d at 200` doesn't match any full
+      // citation (none in this text), but Id. still anchors to it positionally
+      // via `antecedentIndex`. `resolvedTo` stays undefined; a warning is set.
       const text = "400 F.3d at 200. Id. at 201."
 
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
@@ -225,7 +230,10 @@ describe("Resolution Integration Tests", () => {
 
       expect(shortForm!.resolution?.resolvedTo).toBeUndefined()
       expect(id!.resolution?.resolvedTo).toBeUndefined()
-      expect(id!.resolution?.failureReason).toBeDefined()
+      // New: Id. anchors via antecedentIndex even though the short-form
+      // didn't resolve.
+      expect(id!.resolution?.antecedentIndex).toBe(citations.indexOf(shortForm!))
+      expect(id!.resolution?.warnings).toBeDefined()
     })
 
     it("Id. with no pincite after case → statute skips the statute (#480)", () => {
@@ -415,17 +423,23 @@ Second paragraph: Id. at 125.`
       expect(citations[1].resolution?.resolvedTo).toBe(0)
     })
 
-    it("fails to resolve short-form case with no matching volume/reporter", () => {
+    it("short-form case with no matching vol/reporter has resolvedTo undefined; antecedentIndex points at predecessor", () => {
+      // Vol+reporter lookup fails (500 F.2d ≠ 400 F.3d), so `resolvedTo` is
+      // undefined. Bluebook Rule 4.1: the short-form still records its
+      // immediate predecessor in `antecedentIndex` so a subsequent `Id.` (or
+      // consumer walking the chain) can cluster with it.
       const text = "Smith v. Jones, 500 F.2d 123. See 400 F.3d at 200."
 
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
 
       expect(citations).toHaveLength(2)
 
-      // Short-form fails - different volume/reporter
+      // Short-form: vol+reporter mismatch → resolvedTo undefined, but
+      // antecedentIndex still records Smith as the immediate predecessor.
       expect(citations[1].type).toBe("shortFormCase")
       expect(citations[1].resolution?.resolvedTo).toBeUndefined()
-      expect(citations[1].resolution?.failureReason).toContain("No matching full case citation")
+      expect(citations[1].resolution?.antecedentIndex).toBe(0)
+      expect(citations[1].resolution?.warnings).toBeDefined()
     })
   })
 
@@ -454,7 +468,7 @@ Second paragraph: Id. at 125.`
   })
 
   describe("Unresolved Citation Warnings", () => {
-    it("reports unresolved citations with failure reasons (default)", () => {
+    it("reports unresolved citations with failure reasons or warnings (default)", () => {
       const text = "Id. at 100. Brown, supra. 500 F.2d at 200."
 
       const citations = extractCitations(text, {
@@ -466,10 +480,17 @@ Second paragraph: Id. at 125.`
 
       expect(citations).toHaveLength(3)
 
-      // All three should have resolution results with failure reasons
+      // citations[0] (Id. with nothing prior) and citations[1] (Brown supra
+      // with no full match) both yield true failures.
       expect(citations[0].resolution?.failureReason).toBeDefined()
       expect(citations[1].resolution?.failureReason).toBeDefined()
-      expect(citations[2].resolution?.failureReason).toBeDefined()
+      // citations[2] (500 F.2d short-form) has no vol+reporter match either,
+      // but per Bluebook Rule 4.1 it records its immediate predecessor in
+      // `antecedentIndex` and surfaces the problem via `warnings`. resolvedTo
+      // is still undefined.
+      expect(citations[2].resolution?.resolvedTo).toBeUndefined()
+      expect(citations[2].resolution?.antecedentIndex).toBeDefined()
+      expect(citations[2].resolution?.warnings).toBeDefined()
     })
 
     it("omits resolution field when reportUnresolved: false", () => {

--- a/tests/resolve/idInheritsCaseName.test.ts
+++ b/tests/resolve/idInheritsCaseName.test.ts
@@ -5,7 +5,7 @@ import type { IdCitation } from "@/types/citation"
 describe("Id. inherits caseName from antecedent", () => {
   it("`Id. at 1133` after `In re Hanford, 292 F.3d 1124, 1133` inherits caseName", () => {
     const text =
-      'In re Hanford Nuclear Reservation Litig., 292 F.3d 1124, 1133 (9th Cir. 2002). The court explained the rule. Id. at 1133.'
+      "In re Hanford Nuclear Reservation Litig., 292 F.3d 1124, 1133 (9th Cir. 2002). The court explained the rule. Id. at 1133."
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c) => c.type === "id") as IdCitation | undefined
     expect(id).toBeDefined()
@@ -28,8 +28,7 @@ describe("Id. inherits caseName from antecedent", () => {
   })
 
   it("Id. inherits proceduralPrefix when antecedent has one", () => {
-    const text =
-      "In re Estate of Smith, 200 F.3d 100 (2010). The probate court said so. Id."
+    const text = "In re Estate of Smith, 200 F.3d 100 (2010). The probate court said so. Id."
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c) => c.type === "id") as IdCitation | undefined
     expect(id?.proceduralPrefix).toBe("In re")
@@ -68,8 +67,10 @@ describe("Id. inherits caseName from antecedent", () => {
   it("Id. after a short-form chain inherits root case's caseName", () => {
     // Smith v. Jones (full) → Smith, supra (short) → Id.
     // The Id. should inherit from Smith v. Jones (the chain root).
-    const text =
-      "Smith v. Jones, 100 F.2d 50 (1990). Later, Smith, supra. Id. at 60."
+    // Note: the supra must actually resolve for Id. to chain back to the
+    // root — otherwise per Bluebook Rule 4.1 Id. anchors to the unresolved
+    // supra via antecedentIndex and inherits nothing.
+    const text = "Smith v. Jones, 100 F.2d 50 (1990). Smith, supra. Id. at 60."
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c) => c.type === "id") as IdCitation | undefined
     expect(id?.caseName).toBe("Smith v. Jones")

--- a/tests/resolve/idSkipsParenChildOfShortform.test.ts
+++ b/tests/resolve/idSkipsParenChildOfShortform.test.ts
@@ -9,8 +9,11 @@ describe("Id. does not resolve to a citation inside a shortform's parenthetical"
     // then `Id.`. The `Id.` should point at the shortform's antecedent
     // (the original Dormitory Authority full citation), NOT at the case
     // quoted inside the parenthetical.
+    // Note: vol+reporter must match between the full cite and the short-form
+    // so the short-form actually resolves — otherwise Bluebook Rule 4.1
+    // would anchor `Id.` to the unresolved short-form via antecedentIndex.
     const text =
-      'Dormitory Auth. v. State, 25 N.Y.3d 600 (2015). Dormitory Auth., 30 N.Y.3d at 710 (quoting Port Chester Elec. Constr. Corp. v. Atlas, 40 N.Y.2d 652, 656 (1976)). "In the absence of express language, such third parties are generally considered mere incidental beneficiaries." Id.'
+      'Dormitory Auth. v. State, 25 N.Y.3d 600 (2015). Dormitory Auth., 25 N.Y.3d at 710 (quoting Port Chester Elec. Constr. Corp. v. Atlas, 40 N.Y.2d 652, 656 (1976)). "In the absence of express language, such third parties are generally considered mere incidental beneficiaries." Id.'
 
     const cites = extractCitations(text, { resolve: true })
 
@@ -32,8 +35,7 @@ describe("Id. does not resolve to a citation inside a shortform's parenthetical"
   it("Id. inside `<full case> (citing <inner case>)` resolves to outer, not inner (already worked for `case`)", () => {
     // Regression: this case already worked because the outer cite is a full
     // `case` type with `fullSpan` extending through the paren.
-    const text =
-      'Smith v. Jones, 100 F.2d 50 (1990) (citing Doe v. Roe, 200 F.3d 100 (1985)). Id.'
+    const text = "Smith v. Jones, 100 F.2d 50 (1990) (citing Doe v. Roe, 200 F.3d 100 (1985)). Id."
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c) => c.type === "id") as IdCitation | undefined
     const target = id?.resolution?.resolvedTo
@@ -79,8 +81,7 @@ describe("Id. does not resolve to a citation inside a shortform's parenthetical"
   it("statute inside a citation's parenthetical does not become Id.'s antecedent", () => {
     // Edge case: a case cite carries an explanatory paren that references a
     // statute. The statute is depth-1 — it should not be Id.'s antecedent.
-    const text =
-      "Smith v. State, 100 F.2d 50 (1990) (interpreting 28 U.S.C. § 1331). Id."
+    const text = "Smith v. State, 100 F.2d 50 (1990) (interpreting 28 U.S.C. § 1331). Id."
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c) => c.type === "id") as IdCitation | undefined
     const target = id?.resolution?.resolvedTo
@@ -95,8 +96,7 @@ describe("Id. does not resolve to a citation inside a shortform's parenthetical"
     // current behavior is whatever lastResolvedIndex held at the parent's
     // entry. We assert that this case does not throw and resolves to SOME
     // antecedent (the exact target is implementation-specific).
-    const text =
-      "Smith v. Jones, 100 F.2d 50 (1990) (citing Doe v. Roe, 200 F.3d 100; Id.)."
+    const text = "Smith v. Jones, 100 F.2d 50 (1990) (citing Doe v. Roe, 200 F.3d 100; Id.)."
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c) => c.type === "id") as IdCitation | undefined
     expect(id).toBeDefined()
@@ -106,8 +106,11 @@ describe("Id. does not resolve to a citation inside a shortform's parenthetical"
 
   it("the user's actual example (Dormitory Auth. v. Port Chester quote)", () => {
     // Exact reproduction of the bug reported by the user.
+    // Note: vol+reporter must match between the full cite and short-form for
+    // the short-form to resolve — see the first test in this file for the
+    // Bluebook Rule 4.1 nuance.
     const text =
-      'Dormitory Auth. v. Council, 28 N.Y.3d 500 (2014). Dormitory Auth., 30 N.Y.3d at 710 (quoting Port Chester Elec. Constr. Corp. v. Atlas, 40 N.Y.2d 652, 656 (1976)). "In the absence of express language, such third parties are generally considered mere incidental beneficiaries." Id.'
+      'Dormitory Auth. v. Council, 28 N.Y.3d 500 (2014). Dormitory Auth., 28 N.Y.3d at 710 (quoting Port Chester Elec. Constr. Corp. v. Atlas, 40 N.Y.2d 652, 656 (1976)). "In the absence of express language, such third parties are generally considered mere incidental beneficiaries." Id.'
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c) => c.type === "id") as IdCitation | undefined
     const target = id?.resolution?.resolvedTo

--- a/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
+++ b/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
@@ -69,3 +69,22 @@ describe("antecedentIndex — Id. clusters with unresolved short-form (Bluebook 
     expect(id?.resolution?.resolvedTo).toBeUndefined()
   })
 })
+
+describe("supra success path also populates antecedentIndex", () => {
+  it("Smith → Brown → Smith, supra — supra resolves AND records antecedentIndex one step back", () => {
+    const text =
+      "Smith v. Jones, 100 F.2d 50 (1990). Brown v. Doe, 200 F.3d 100 (2000). Smith, supra."
+    const cites = extractCitations(text, { resolve: true })
+    expect(cites).toHaveLength(3)
+    const supra = cites[2]
+    expect(supra.type).toBe("supra")
+    expect(
+      (supra as { resolution?: { resolvedTo?: number; antecedentIndex?: number } }).resolution
+        ?.resolvedTo,
+    ).toBe(0) // resolves to Smith
+    expect(
+      (supra as { resolution?: { resolvedTo?: number; antecedentIndex?: number } }).resolution
+        ?.antecedentIndex,
+    ).toBe(1) // immediate predecessor is Brown (one step back)
+  })
+})

--- a/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
+++ b/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, IdCitation } from "@/types/citation"
+
+describe("antecedentIndex — Id. clusters with unresolved short-form (Bluebook 4.1)", () => {
+  it("Id. after unresolved Yellen short-form: antecedentIndex points at it, resolvedTo undefined", () => {
+    // Yellen, 416 N.J. Super. at 590 is a shortFormCase. Vol+reporter
+    // (416 N.J. Super.) has no match anywhere in this text → unresolved.
+    // Id. that follows should anchor to the Yellen short-form
+    // (antecedentIndex), NOT chase past it to Smith.
+    const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Yellen, 416 N.J. Super. at 590. Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id).toBeDefined()
+    expect(id?.resolution?.resolvedTo).toBeUndefined()
+    // Antecedent is the Yellen short-form (idx 1).
+    expect(id?.resolution?.antecedentIndex).toBe(1)
+  })
+
+  it("antecedentIndex set even when resolvedTo is also set (one step back)", () => {
+    // Smith full at idx 0, Id. at idx 1, second Id. at idx 2.
+    // The second Id. resolves to Smith (resolvedTo=0) AND has
+    // antecedentIndex=1 (one step back, the first Id.).
+    const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. Id."
+    const cites = extractCitations(text, { resolve: true })
+    const ids = cites.filter((c): c is IdCitation => c.type === "id")
+    expect(ids).toHaveLength(2)
+    expect(ids[1].resolution?.resolvedTo).toBe(0)
+    expect(ids[1].resolution?.antecedentIndex).toBe(1)
+  })
+
+  it("Id. immediately after a full cite: antecedentIndex equals resolvedTo", () => {
+    const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBe(0)
+    expect(id?.resolution?.antecedentIndex).toBe(0)
+  })
+
+  it("chain via antecedentIndex: parallel unresolved short-forms cluster", () => {
+    // Yellen short-form (idx 1) and 3 A.3d parallel (idx 2) both fail
+    // vol+reporter lookup. The parallel's antecedentIndex points at the
+    // Yellen short-form. Id. (idx 3) clusters with the parallel.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). Yellen, 416 N.J. Super. at 590, 3 A.3d at 590. Id."
+    const cites = extractCitations(text, { resolve: true })
+    expect(cites).toHaveLength(4)
+    const shortFormCaseCount = cites.filter((c: Citation) => c.type === "shortFormCase").length
+    expect(shortFormCaseCount).toBe(2)
+
+    // Walk: Id (3).antecedentIndex → 2 → antecedentIndex → 1.
+    const id = cites[3] as IdCitation
+    expect(id.type).toBe("id")
+    expect(id.resolution?.antecedentIndex).toBe(2)
+    expect(id.resolution?.resolvedTo).toBeUndefined()
+
+    const parallel = cites[2]
+    expect(parallel.type).toBe("shortFormCase")
+    expect(
+      (parallel as { resolution?: { antecedentIndex?: number } }).resolution?.antecedentIndex,
+    ).toBe(1)
+  })
+
+  it("no prior citation: antecedentIndex undefined", () => {
+    const text = "Id. at 100."
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.antecedentIndex).toBeUndefined()
+    expect(id?.resolution?.resolvedTo).toBeUndefined()
+  })
+})

--- a/tests/resolve/quoteZoneRobustness.test.ts
+++ b/tests/resolve/quoteZoneRobustness.test.ts
@@ -12,7 +12,10 @@ describe("quote-zone robustness — orphan ASCII quotes", () => {
     const id = cites.find((c): c is IdCitation => c.type === "id")
     expect(id?.resolution?.resolvedTo).toBeDefined()
     // Resolved to Smith (idx 0).
-    expect(cites[id!.resolution!.resolvedTo!].type).toBe("case")
+    const resolvedTo = id?.resolution?.resolvedTo
+    if (resolvedTo !== undefined) {
+      expect(cites[resolvedTo].type).toBe("case")
+    }
   })
 
   it("orphan trailing open-quote does not create phantom zone", () => {
@@ -36,7 +39,22 @@ describe("quote-zone robustness — orphan ASCII quotes", () => {
     const cites = extractCitations(text, { resolve: true })
     const id = cites.find((c): c is IdCitation => c.type === "id")
     expect(id?.resolution?.resolvedTo).toBeDefined()
-    expect(cites[id!.resolution!.resolvedTo!].type).toBe("case")
+    const resolvedTo = id?.resolution?.resolvedTo
+    if (resolvedTo !== undefined) {
+      expect(cites[resolvedTo].type).toBe("case")
+    }
+  })
+})
+
+describe("quote-zone robustness — ASCII and typographic don't cross-pair", () => {
+  it("ASCII open with typographic close does not engulf intermediate citation", () => {
+    // Mixed-style quotes (one ASCII open, one typographic close) should
+    // NOT pair across styles — otherwise the phantom zone engulfs Smith
+    // and breaks Id. resolution.
+    const text = `He said "the rule applies. Smith v. Jones, 100 F.2d 50, 55 (1990). Was clear.” Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
   })
 })
 

--- a/tests/resolve/quoteZoneRobustness.test.ts
+++ b/tests/resolve/quoteZoneRobustness.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { IdCitation } from "@/types/citation"
+
+describe("quote-zone robustness — orphan ASCII quotes", () => {
+  it("orphan leading close-quote (mid-doc paste) does not create phantom zone", () => {
+    // The leading `use."` is a mid-document orphan close. Without the fix,
+    // the existing greedy pairing turns it into a phantom open and engulfs
+    // Smith into a quote zone, which then rejects Smith as Id.'s antecedent.
+    const text = `use." Smith v. Jones, 100 F.2d 50, 55 (1990). Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+    // Resolved to Smith (idx 0).
+    expect(cites[id!.resolution!.resolvedTo!].type).toBe("case")
+  })
+
+  it("orphan trailing open-quote does not create phantom zone", () => {
+    // Trailing orphan open at end-of-text.
+    const text = `Smith v. Jones, 100 F.2d 50, 55 (1990). Id. "and so on`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+
+  it("two mispaired orphans (close then open) do not engulf intermediate citation", () => {
+    // Reproduces the actual greedy-pairing bug: an orphan close-quote (after
+    // `use`) followed by an orphan open-quote (before `and`) gets greedily
+    // paired into a phantom zone {4..47}. Smith (originalStart=22) lands in
+    // that zone; Id. lands after it. With the old code Id. is rejected from
+    // resolving to Smith because their zones differ. With the classifier the
+    // first `"` is classified as a close (prev=`use`/letter, next=space),
+    // the second as an open (prev=space, next=letter) — both have empty
+    // stacks, so no phantom zone is created.
+    const text = `use." Smith v. Jones, 100 F.2d 50, 55 (1990). "and so on. Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+    expect(cites[id!.resolution!.resolvedTo!].type).toBe("case")
+  })
+})
+
+describe("quote-zone robustness — typographic quotes unambiguous", () => {
+  it("curly quotes pair unambiguously even with adjacent orphan ASCII quote", () => {
+    // Mix: curly quotes around the actual quoted text, plus an orphan ASCII
+    // quote elsewhere. The curly pair should always be a zone; the ASCII
+    // orphan should be ignored.
+    const text = `He said "the rule is clear." use." Smith v. Jones, 100 F.2d 50, 55 (1990). Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+})
+
+describe("quote-zone robustness — well-formed ASCII still works", () => {
+  it("standard balanced ASCII quotes around a quoted passage do not break resolution", () => {
+    const text = `Smith v. Jones, 100 F.2d 50, 55 (1990). The court held "the rule applies." Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+
+  it("apostrophes (single quotes) do not affect double-quote pairing", () => {
+    const text = `Smith's case, 100 F.2d 50, 55 (1990). The court said "it's the rule." Id.`
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBeDefined()
+  })
+})

--- a/tests/resolve/shortFormProseNameFallback.test.ts
+++ b/tests/resolve/shortFormProseNameFallback.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { ShortFormCaseCitation } from "@/types/citation"
+
+describe("backward prose case-name extraction", () => {
+  it("extracts case name from prose preceding a short-form when vol+reporter has no full match", () => {
+    // "In Yellen v. Kassin" is the prose mention; the short-form has
+    // partyName="Yellen". Vol+reporter (416 N.J. Super.) has no full match.
+    // After this PR, the short-form should be enriched with inferredCaseName.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). In Yellen v. Kassin, the court held. Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find(
+      (c): c is ShortFormCaseCitation => c.type === "shortFormCase" && c.partyName === "Yellen",
+    )
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBe("Yellen v. Kassin")
+    expect(yellenShort?.inferredPlaintiff?.toLowerCase()).toContain("yellen")
+    expect(yellenShort?.inferredDefendant?.toLowerCase()).toContain("kassin")
+  })
+
+  it("does not infer when short-form has no partyName", () => {
+    // Bare short-form `416 N.J. Super. at 590` — no party prefix.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). In Yellen v. Kassin, the court held. 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const bareShort = cites.find(
+      (c): c is ShortFormCaseCitation => c.type === "shortFormCase" && !c.partyName,
+    )
+    expect(bareShort).toBeDefined()
+    expect(bareShort?.inferredCaseName).toBeUndefined()
+  })
+
+  it("does not infer when prose case name does not match partyName", () => {
+    // Prose mentions Smith v. Jones, but the short-form's partyName is
+    // Yellen. No match → no inference.
+    const text = "In Smith v. Jones, the court held. Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find((c): c is ShortFormCaseCitation => c.type === "shortFormCase")
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBeUndefined()
+  })
+
+  it("vol+reporter match still wins over prose inference (no fallback when resolved)", () => {
+    // Provide a full Yellen citation, then a short-form. Resolution
+    // succeeds via vol+reporter; the prose-extraction fallback never runs.
+    const text =
+      "Yellen v. Kassin, 416 N.J. Super. 580 (App. Div. 2009). Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find(
+      (c): c is ShortFormCaseCitation => c.type === "shortFormCase" && c.partyName === "Yellen",
+    )
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.resolution?.resolvedTo).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBeUndefined()
+  })
+})

--- a/tests/resolve/yellenFixture.test.ts
+++ b/tests/resolve/yellenFixture.test.ts
@@ -19,8 +19,7 @@ describe("Yellen / Leach end-to-end (bug report 2026-05-19)", () => {
   it("Yellen short-form has inferredCaseName from prose", () => {
     const cites = extractCitations(text, { resolve: true })
     const yellenShort = cites.find(
-      (c): c is ShortFormCaseCitation =>
-        c.type === "shortFormCase" && c.partyName === "Yellen",
+      (c): c is ShortFormCaseCitation => c.type === "shortFormCase" && c.partyName === "Yellen",
     )
     expect(yellenShort).toBeDefined()
     expect(yellenShort?.inferredCaseName).toBe("Yellen v. Kassin")

--- a/tests/resolve/yellenFixture.test.ts
+++ b/tests/resolve/yellenFixture.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, IdCitation, ShortFormCaseCitation } from "@/types/citation"
+
+describe("Yellen / Leach end-to-end (bug report 2026-05-19)", () => {
+  // The actual passage from the user's brief (HOA-adverse-possession context).
+  const text = `Leach v. Anderl, 218 N.J. Super. 18, 30–31 (App. Div. 1987). In Yellen v. Kassin, the Appellate Division squarely held that where neighbors shared a driveway traversing both properties without objection, the use was "not recognized by the law as hostile to the property rights of the other, but [was] at all times permissive in character and subject to alteration as the needs of both neighbors changed over time." Yellen, 416 N.J. Super. at 590–91, 3 A.3d at 590–91. The court reversed the trial court's finding of mutual prescriptive easements, holding that the evidence "does not establish that the use of the driveways was hostile in the sense that either party considered use of the other's driveway under a claim of right with the intent to claim an interest in the other's property." Id. at 590.`
+
+  it("Id. at 590 does NOT resolve to Leach (the user-reported bug)", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id).toBeDefined()
+    // The bug: id.resolution.resolvedTo used to point at Leach (idx 0).
+    // After this PR, resolvedTo is undefined (no full Yellen citation
+    // in the array — Yellen's name lives in prose).
+    expect(id?.resolution?.resolvedTo).toBeUndefined()
+  })
+
+  it("Yellen short-form has inferredCaseName from prose", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const yellenShort = cites.find(
+      (c): c is ShortFormCaseCitation =>
+        c.type === "shortFormCase" && c.partyName === "Yellen",
+    )
+    expect(yellenShort).toBeDefined()
+    expect(yellenShort?.inferredCaseName).toBe("Yellen v. Kassin")
+  })
+
+  it("Id. clusters with the parallel short-form via antecedentIndex", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const id = cites.find((c): c is IdCitation => c.type === "id")
+    expect(id?.resolution?.antecedentIndex).toBeDefined()
+
+    // Walk: Id → parallel (3 A.3d) → Yellen short → ... → eventually
+    // reaches the enriched short-form with inferredCaseName.
+    let cur: number | undefined = id?.resolution?.antecedentIndex
+    let foundInferred: string | undefined
+    const visited = new Set<number>()
+    while (cur !== undefined && !visited.has(cur)) {
+      visited.add(cur)
+      const c = cites[cur] as Citation & {
+        resolution?: { antecedentIndex?: number }
+        inferredCaseName?: string
+      }
+      if (c.inferredCaseName) {
+        foundInferred = c.inferredCaseName
+        break
+      }
+      cur = c.resolution?.antecedentIndex
+    }
+    expect(foundInferred).toBe("Yellen v. Kassin")
+  })
+})


### PR DESCRIPTION
## Summary

- **`Id.` now clusters with the immediately preceding cited authority regardless of resolution state** (Bluebook Rule 4.1 / Indigo Book R6.2.2). Fixes a bug where `Id.` chased past an unresolved short-form (case name introduced in prose) to the previous full citation — wrong authority. The reported scenario: `Leach v. Anderl, 218 N.J. Super. 18 (1987). In Yellen v. Kassin, ... Yellen, 416 N.J. Super. at 590-91, 3 A.3d at 590-91. ... Id. at 590.` — `Id.` used to resolve to **Leach**; now correctly clusters with the Yellen short-form chain.
- **Short-form citations now carry `inferredCaseName`** when their case name was found in preceding prose (within ~400 chars) and their vol+reporter has no full-citation match in the array. Consumers render via `caseName ?? inferredCaseName ?? partyName`.
- **Quote-zone detection is more robust** for mid-document inputs. Replaces greedy ASCII-quote pairing with a context-based open/close classifier; typographic quotes (`"` `"`) pair unambiguously via a separate stack so cross-style cannot mispair.

**New optional fields:**
- `ResolutionResult.antecedentIndex?: number` — chain pointer to the immediately preceding cited authority, regardless of resolution state. Same shape as the existing `ShortFormCaseCitation.pinciteInheritedFrom` from 0.19.0.
- `ShortFormCaseCitation.inferredCaseName?` / `inferredPlaintiff?` / `inferredDefendant?` / `inferredCaseNameSpan?`.

**Design + research** (in-repo): `docs/superpowers/specs/2026-05-19-id-resolves-past-unresolved-shortform-design.md`, `docs/research/2026-05-19-id-unresolved-antecedent.md`. Research cites **Indigo Book R6.2.2** as the load-bearing primary source for the positional-vs-bibliographic separation, and validates the design against Python eyecite (which has the same bug but can't fix it due to its bibliographic data model) and CSL/citeproc (which separates position from resolution the same way).

**Changeset:** `.changeset/id-clusters-with-unresolved-antecedent.md` (minor bump).

## Behavior change worth flagging for consumers

`Id.` following an unresolved short-form previously resolved to the prior full citation (Bluebook-wrong but consumer-stable). It now produces `resolvedTo: undefined` with `antecedentIndex` set and a warning. Consumers doing `if (id.resolution?.resolvedTo === undefined) skip()` will silently start skipping a class of citations they used to "handle" (incorrectly). Consumers wanting the chain walk:

```ts
let cur = id.resolution?.antecedentIndex
while (cur !== undefined) {
  // inspect cites[cur]; check inferredCaseName / caseName for rendering
  cur = cites[cur].resolution?.antecedentIndex
}
```

## Test Plan

- [x] `pnpm exec vitest run` — 2995 tests pass (~20 new + 5 existing test files modified to align with Rule-4.1-correct behavior)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (236 pre-existing warnings unrelated to this PR)
- [x] `pnpm build` — succeeds
- [x] `pnpm size` — within budget (35.09 / 50 kB main; 1.8 / 3 kB utils)
- [ ] Reviewer: verify the 5 pre-existing test modifications (`tests/resolve/idSkipsParenChildOfShortform.test.ts`, `tests/resolve/idInheritsCaseName.test.ts`, `tests/integration/resolution.test.ts`) are intent-preserving — each was either a vol+reporter mismatch masking the chase-past bug or an assertion that codified the pre-fix wrong behavior.
- [ ] Reviewer: end-to-end fixture at `tests/resolve/yellenFixture.test.ts` is the user's real bug report — confirm it reads as a faithful reproduction.

## Follow-ups (NOT in this PR — flagged for tracking)

1. **Parallel citations in subsequent-history clauses** — e.g. `..., 374 N.J. Super. 448, ..., aff'd in part, 186 N.J. 78, 891 A.2d 1202 (2006)` — eyecite-ts currently splits the affirmance's parallel cite (`186 N.J. 78` and `891 A.2d 1202`) into two separate citations instead of grouping them as parallel. Separate bug from this PR's Yellen scenario.
2. **`SupraCitation` prose inference** — supra carries `partyName` directly, so prose inference adds less value than for shortFormCase; the type fields were removed from this PR for clean surface area. Revisit if a real supra-prose scenario appears.
3. **`MAX_OPINION_PAGE_COUNT`-style validation** for inherited pincites (deferred from 0.19.0 — see `docs/research/2026-05-19-pincite-inheritance.md` §5.3).
4. **Prose-block offsets between citations** — user-suggested future feature: ship spans of "non-citation prose" with offsets, for consumer use cases like quote-attribution windows.
5. **`findImmediatePredecessor` cross-zone parameter** — when `scopeStrategy: "footnote"` allows a supra/shortFormCase to resolve cross-zone, `antecedentIndex` may end up undefined because the helper defaults `allowCrossZone=false`. Latent; no test exercises it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)