### PR TITLE
fix(extract): detect parallel cites across pincite-between gaps (Bluebook canonical)

### DIFF
--- a/.changeset/parallel-cites-pincite-between.md
+++ b/.changeset/parallel-cites-pincite-between.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): detect parallel citations across pincite-between gaps (Bluebook canonical)
+
+`detectParallel` now accepts the **Bluebook-canonical pincite-between form** per Indigo Book R12.3, where the primary's pincite sits between the two parallel cites:
+
+```
+374 N.J. Super. 448, 453–55, 864 A.2d 1191 (App. Div. 2005)
+```
+
+Previously, `MAX_PROXIMITY = 5` chars after the comma rejected this form, so eyecite-ts only detected the less-common no-pincite variant (`186 N.J. 78, 891 A.2d 1202`). The fix delegates to the existing `parsePincite` helper as single source of truth for "what counts as a pincite," automatically covering all forms (page, range, star, paragraph, footnote, etc.).
+
+**Behavior changes:**
+
+- Parallel citations across pincite-between gaps are now grouped via `groupId` and `parallelCitations[]`. Consumers calling `groupByCase()` will see fewer logical case groups for inputs containing this form (parallel pairs now collapse from two groups into one — correct behavior).
+- `detectStringCites` now skips parallel-secondary cites when building string-citation groups. This fixes a related defect where a parallel secondary could be mis-grouped via `stringCitationGroupId` with an unrelated primary across a `;` separator (e.g., the secondary of an affirmance's parallel cite ending up in the same group as a `see also` cite for a different case).
+
+**No API changes.** Existing `groupId`, `parallelCitations[]`, `stringCitationGroupId`, and `groupByCase()` work as before; they just get populated correctly for more inputs.
+
+See `docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md` for the full design and `docs/research/2026-05-19-parallel-citation-detection.md` for the Bluebook + Python eyecite + industry reference validation.

--- a/docs/research/2026-05-19-parallel-citation-detection.md
+++ b/docs/research/2026-05-19-parallel-citation-detection.md
@@ -1,0 +1,235 @@
+# Parallel Citation Detection — Research & Scope Recommendation
+
+**Date:** 2026-05-19
+**Status:** Research only — no code changes
+**Audience:** Decision-maker (`eyecite-ts` maintainer) and downstream frontend consumer
+**Read time:** ~5 minutes
+
+---
+
+## TL;DR — Scope Recommendation
+
+**Do scope #1 only, but do it with option C (reuse `parsePincite`).** Fix the proximity gate so pincite-between cases like `374 N.J. Super. 448, 453–55, 864 A.2d 1191` are detected. Defer the data-model change.
+
+- The current N-citations + `groupId` + `parallelCitations[]` model is **already richer than Python eyecite's output** and aligns with how Westlaw, Lexis, CourtListener, LawCite, and CSL-M conceptually treat parallels (one logical authority, multiple reporters). The frontend pain ("two highlighted spans per case") is a renderer concern, not a parser bug — and `groupByCase()` already gives the consumer the one-per-case view they want.
+- The string-cite anomaly almost certainly **resolves itself** once parallel detection succeeds: `891 A.2d 1202` is currently treated as a standalone case and becomes a string-cite peer of `416 N.J. Super. 113` via the `;` between them. Once it's tagged as a secondary of `186 N.J. 78`, the string-cite walker should skip past it correctly (verify this empirically — see Action C-3 below).
+- Folding secondaries into the primary (scope #3) is a breaking API change that the Free Law Project team explicitly debated for **four years** (issue [freelawproject/eyecite#76](https://github.com/freelawproject/eyecite/issues/76), open since 2021) and still has not landed. Don't take it on as part of a bug fix.
+
+---
+
+## Findings
+
+### 1. Bluebook / Indigo Book canonical form
+
+**Verdict: "pincite-between" is the canonical Bluebook pattern, not an edge case.**
+
+The Indigo Book covers parallel citations in **Rule R12.3** (state-court parallel cites), and explicitly says: *"Use one pincite per reporter citation."* The canonical example given is `Harden v. Playboy Enters., Inc., 261 Ill. App. 3d 443, 633 N.E.2d 764 (1993)` — one reporter pincite each side of the parallel comma. (Source: [Indigo Book § R12.3 mirror at law.resource.org](https://law.resource.org/pub/us/code/blue/IndigoBook.html); [Indigo Book 2.0 PDF](https://indigobook.github.io/versions/indigobook-2.0.pdf); pincite rules at [§ R11.7](https://library.ju.edu/bluebook-citation/parallel-citations).)
+
+Concrete real-world example cited by Tarlton Law Library: `Williams v. Smalls, 390 S.C. 375, 378, 701 S.E.2d 772, 774 (Ct. App. 2010)` — pincites `378` and `774` sit between the two reporters. Source: [Bluebook Pages, Paragraphs, and Pincites guide](https://tarlton.law.utexas.edu/bluebook-legal-citation/pages-paragraphs-pincites).
+
+So the structure is: `Vol1 Rptr1 Page1[, Pincite1], Vol2 Rptr2 Page2[, Pincite2] (Court Year)`. Pincite-at-end is **not** Bluebook-compliant; if you see it, treat it as a malformed input we can be permissive about, not as the standard.
+
+**Pincite variant zoo to keep in mind:**
+- Page (`453`)
+- Page range (`453–55`, `453-55`, `453, 460`)
+- Multiple discrete pages (`115, 153`) — already handled by `parsePincite` via `additionalPincites`
+- Footnote (`570 n.3`, `nn.3-5`, `fn. 3`)
+- Star pagination (`*42` — slip ops, NY Slip Op)
+- Paragraph (`¶ 5`, `¶¶ 12-14`, `para. 12`) — used in neutral cites
+- Combinations (`570, 575 n.3`)
+
+All of the above are already understood by `src/extract/pincite.ts:parsePincite`. The relevance for parallel detection: **the gap text between two parallel cites can legitimately be anywhere from `, ` (2 chars) to `, ¶¶ 12-14, 32 n.5, ` (~25 chars).** `MAX_PROXIMITY = 5` cannot cover this.
+
+---
+
+### 2. Python eyecite's parallel handling
+
+**Verdict: Python eyecite already detects pincite-between parallels — and its mechanism is independent of any "MAX_PROXIMITY" gate.**
+
+Python eyecite uses `FullCaseCitation.is_parallel_citation(preceding)` ([eyecite/models.py, found in the repo](https://github.com/freelawproject/eyecite/blob/main/eyecite/models.py)):
+
+```python
+def is_parallel_citation(self, preceding: CaseCitation):
+    if self.full_span_start == preceding.full_span_start:
+        # if parallel get plaintiff/defendant data from
+        # the earlier citation, since it won't be on the
+        # parallel one.
+        self.metadata.defendant = preceding.metadata.defendant
+        self.metadata.plaintiff = preceding.metadata.plaintiff
+        self.metadata.year = preceding.metadata.year
+        self.year = preceding.year
+```
+
+Called immediately after each `_extract_full_citation` in [`eyecite/find.py`](https://github.com/freelawproject/eyecite/blob/main/eyecite/find.py).
+
+**The key insight:** `full_span_start` is set by the **case-name backward search** (`_process_case_name` in `eyecite/helpers.py`). For a pattern like `Foo v. Bar, 12 Mass. 34, 35, 56 N.E.2d 78, 79 (1999)`, **both** `12 Mass. 34` and `56 N.E.2d 78` walk backwards through the same comma-joined tokens to the *same* `v.`-anchored case-name start. Their `full_span_start` ends up identical → they're parallel. The pincite between them does not break this because the backward scanner skips commas (`if word == ",": continue`).
+
+The forward pincite regex `PIN_CITE_REGEX = ,?\ ?(?:at\ )?<token>(?:,\ ?<token>)* (?=...)` ([eyecite/regexes.py](https://github.com/freelawproject/eyecite/blob/main/eyecite/regexes.py)) is also greedy across comma-separated tokens. So Python eyecite assigns the first citation a pincite like `35, 56 N.E.2d 78, 79`. This is documented as messy by jcushman in issue #76 — but it does at least *link* the parallels.
+
+**Important caveats from the Free Law Project team:**
+
+- Issue [#76 "Link parallel cites"](https://github.com/freelawproject/eyecite/issues/76) — **still open since May 2021**. The team has debated three proposed data models (see § 3 below). None has shipped.
+- Issue [#111 "Parallel citations are detected as separate citations"](https://github.com/freelawproject/eyecite/issues/111) — closed Jan 2025 as a dup of #76. No new code, just deduplication.
+- Open PR [#288 "fix(citation): Ensure full_span is aligned for parallel citations"](https://github.com/freelawproject/eyecite/pull/288) (Jul 2025) — fixes a `full_span_end` greedy-regex bug that bleeds into the next citation. Confirms Python eyecite's parallel handling is **still buggy in production today**.
+- jcushman, May 2021: *"the first cite has a pin_cite that contains the second cite, and the second cite has a title that contains the first cite."* — i.e., the metadata copy via `is_parallel_citation` is a Band-Aid, not a real fix.
+
+**Bottom line:** eyecite-ts's current model (separate citations linked via `groupId` + `parallelCitations[]`) is **strictly better** than Python eyecite's (separate citations with copied plaintiff/defendant metadata and no group ID). We should keep our model and just fix the proximity gate.
+
+---
+
+### 3. The four-year design debate at Free Law Project (issue #76)
+
+From `gh issue view 76 --repo freelawproject/eyecite --comments`:
+
+**Three approaches were proposed:**
+
+| # | Author | Shape | Verdict |
+|---|--------|-------|---------|
+| A | mlissner (2021) | Nested groups: `[{ citations: [c1, c2], parenthetical }]` | Rejected as too much overhead for naive callers |
+| B | mlissner (2021) | Flat list w/ back-pointer: `{..., parallel_to: 0}` | Considered; not pursued |
+| C | jcushman (2021) | Fold secondaries into primary: `{..., parallel_cites: [{vol, rptr, page}]}` | **Endorsed by mlissner and flooie (2025)** — *"Jack's approach wins. Let's do it."* |
+
+A fourth idea (mattdahl) was to defer linking to `resolve_citations()`, then prune by resource-id. mattdahl himself withdrew this in 2022: *"my previous proposal is intractable because resolution is too inaccurate."*
+
+**Despite consensus in 2022 that approach C is correct, nothing has shipped in four years.** The reason is the messy-metadata problem jcushman flagged — folding secondaries into the primary requires re-running case-name extraction, pincite extraction, and `full_span` computation against the *unified* citation, not the per-reporter slice. That's a non-trivial refactor.
+
+**eyecite-ts is already closer to "approach C" than Python eyecite ever got.** Our `groupId` + `parallelCitations[]` is roughly approach B with a stable group key. `groupByCase()` materializes approach A on demand for consumers who want it. Switching the default `citations[]` output to approach C is a breaking change with the same refactor cost FLP has been avoiding.
+
+---
+
+### 4. How other systems represent parallels
+
+| System | Data model | Source |
+|---|---|---|
+| **Westlaw** | One case record; parallel reporters under a "Citations" tab on the case detail page. KeyCite shows parallels under "Citing References." | [LawShun guide](https://lawshun.com/article/how-to-find-paralell-citations-on-west-law), [Pace Law Library blog](https://lawlibrary.blogs.pace.edu/2011/11/16/westlawnext-and-the-bluebook/) |
+| **Lexis+** | One case record; "Parallel Citation Lookup" feature returns the canonical case from any parallel cite. | [LexisNexis InfoPro](https://www.lexisnexis.com/community/infopro/b/weblog/posts/parallel-citation-lookup-now-available-on-lexis) |
+| **CourtListener** | One opinion cluster per case; `citations` is an **array field on the cluster**, holding all known parallel cites. (Each cite is not a separate record.) | [CourtListener v4 Citation API](https://wiki.free.law/c/courtlistener/help/api/rest/v4/citations) |
+| **LawCite (AustLII)** | One case record with "alternative (parallel) citations" displayed alongside the title. Citation extraction is also used to **harvest new parallel cites** for existing cases. | [AustLII LawCite help](https://www.austlii.edu.au/austlii/help/lawcite_announce.html) |
+| **CSL-M (Juris-M)** | Per-cite records; the **renderer** uses `parallel-first` attribute on a `cs:group` to suppress repeated variables in adjacent parallel cites. Data model is flat; presentation is grouped. | [CSL-M docs](https://citeproc-js.readthedocs.io/en/latest/csl-m/) |
+
+**The convergent pattern:** "one logical case, multiple reporter strings" is universal at the *display/storage* layer. None of these tools rely on the **extractor** to fold parallels for them — they fold at the case/cluster boundary or at the renderer. Westlaw and Lexis don't even expose a "this is the primary" choice; the user picks via UI tabs.
+
+For an eyecite-ts consumer building a brief viewer, the analogous architecture is: extractor returns per-reporter citations with group IDs → consumer's renderer decides whether to show one badge per reporter (Bluebook-faithful) or one badge per case (Westlaw-style). **The eyecite-ts model already supports both** via `extractCitations()` + `groupByCase()`. The frontend's "two badges per case" complaint is a *renderer choice*, not a parser limitation.
+
+---
+
+### 5. Why the current detection misses pincite-between cases
+
+`src/extract/detectParallel.ts:19,27`:
+
+```ts
+const MAX_PROXIMITY = 5            // chars after the comma
+const MAX_GAP_FOR_PARALLEL = 20    // total gap before early-exit
+```
+
+For `374 N.J. Super. 448, 453–55, 864 A.2d 1191`:
+- Total gap = `", 453–55, "` = 10 chars → passes `MAX_GAP_FOR_PARALLEL` ✓
+- `distanceAfterComma = gapText.length - commaIndex - 1` measures distance after the **first** comma → `", 453–55, "` has first comma at idx 0, length 10, so `distanceAfterComma = 9` → fails `MAX_PROXIMITY` (5) ✗
+
+The `MAX_PROXIMITY = 5` rule effectively says *"only allow direct adjacency: a single comma plus a few spaces, nothing in between."* This is the **non-pincited** Bluebook variant. The pincited variant is, per § 1 above, the **canonical** Bluebook variant.
+
+For `416 N.J. Super. 113, 120, 3 A.3d 584` the gap is `", 120, "` = 7 chars; `distanceAfterComma = 6 > 5` → fails.
+
+For `186 N.J. 78, 891 A.2d 1202` the gap is `", "` = 2 chars; `distanceAfterComma = 1` → passes (this is why ~1 of 3 still works).
+
+**So the bug is precisely the MAX_PROXIMITY heuristic mis-modeling Bluebook structure.** It allows non-pincited parallels and rejects pincited parallels.
+
+---
+
+### 6. Detection-fix options compared
+
+| Option | Description | Pros | Cons |
+|---|---|---|---|
+| **A: Widen MAX_PROXIMITY** to ~25–30 | Quickest patch | One-line change. Covers most pincited cases. | Higher false-positive risk: `See A, but B, and C` could trigger. Doesn't validate the intermediate text is actually a pincite. |
+| **B: Pincite-shape regex** in gap | Require gap to match `,\s*\d+([-–—]\d+)?(\s*n\.\s*\d+)?\s*,\s*` etc. | Tight false-positive control. No new code dependencies. | Need to maintain the regex against pincite variants (paragraphs, stars, footnotes, multi-pincite chains). Duplicates `pincite.ts` knowledge. |
+| **C: Reuse `parsePincite`** on gap | Strip leading/trailing `,\s*`, hand the middle to `parsePincite`; accept if it returns non-null. | Single source of truth for "what is a pincite shape." Picks up paragraph/star/footnote forms for free. Future pincite changes propagate automatically. | One extra function call per candidate (negligible). `parsePincite` was designed for trailing pincites, not gap middle — needs a small adapter that handles multi-pincite chains (`115, 153`). |
+
+**Recommendation: Option C.** The cost is one helper (`isPinciteGap(text: string): boolean`) and a slightly higher `MAX_GAP_FOR_PARALLEL` (e.g., 40 to cover `, 570-75, fn. 3, ¶¶ 4-6, `). The reuse means edge cases (`¶`, `*`, `n.`, ranges, multi-pincite `, 115, 153,`) are handled correctly without re-implementing.
+
+**False-positive risk for Option C is low** because the gate is `pincite-shape + comma + same shared parenthetical + both tokens are case citations of correct adjacency`. A `See A, but B, and C` pattern fails on "but" not matching any pincite shape; `See cases such as A, B, and C` fails on `B` not being preceded by a pincite-shape token.
+
+**One real-world risk to test:** strings like `1 U.S. 1, 2, 3, 4 S. Ct. 2` where someone writes a multi-page pincite as commas instead of `n` notation. `parsePincite("2, 3")` is ambiguous — could be page 2 + extra. The `additionalPincites` field already understands this. Suggest the adapter accepts either `parsePincite(whole)` or a regex chain of pincite-shapes joined by `,\s*`.
+
+---
+
+### 7. The string-cite anomaly is downstream of the parallel bug
+
+The user reports `891 A.2d 1202` and `416 N.J. Super. 113` ended up sharing a `stringCitationGroupId`. Looking at `src/extract/detectStringCites.ts:145-228`:
+
+- `detectStringCitations` walks **all** citations in document order and groups them whenever the gap text is `;` + optional signal word.
+- The text between `891 A.2d 1202 (2006)` and `416 N.J. Super. 113` is `; see also Yellen v. Kassin, ` — but `getCitationStart(next)` uses `fullSpan?.originalStart`, which on `416 N.J. Super. 113` includes the case name `Yellen v. Kassin`. So the gap text the analyzer sees is roughly `; see also ` — matches the string-cite pattern.
+- This **only happens because `891 A.2d 1202` was treated as a standalone case citation** rather than a secondary. If parallel detection had folded it into `186 N.J. 78`, then the string-cite walker would pair `186 N.J. 78` with `416 N.J. Super.` directly — which is the correct grouping (semicolon-separated authorities for separate propositions).
+
+**Implication:** Fixing the parallel detection should fix the string-cite anomaly as a side effect. Action item: after the parallel fix lands, write a regression test that pipes the user's full brief through `extractCitations({ resolve: true })` and asserts:
+1. Two parallel pairs detected (`374-N.J.-Super.-448` and `186-N.J.-78`).
+2. String-cite group contains the two primaries only (`374 N.J. Super.`, `186 N.J.`, `416 N.J. Super.`), not the A.2d/A.3d secondaries.
+
+---
+
+## Scope decision
+
+### Recommended: Scope #1 (Narrow detection fix) with option C, plus a regression test for the string-cite side effect.
+
+**Concrete plan:**
+
+1. **C-1.** Add `isPinciteGap(text: string): boolean` helper (probably in `src/extract/detectParallel.ts` or a new `src/extract/pinciteGap.ts`). Implementation sketch:
+   - Trim leading `,\s*` and trailing `,\s*`.
+   - If empty → true (covers `, ` direct adjacency, the current `MAX_PROXIMITY` case).
+   - Else split the middle on `,\s*` and require every part to match a `parsePincite`-compatible shape, OR call `parsePincite` on the joined string and accept if non-null.
+2. **C-2.** Replace `MAX_PROXIMITY` check in `detectParallel.ts:128-134` with `isPinciteGap(gapText)`. Bump `MAX_GAP_FOR_PARALLEL` to ~40 (room for multi-pincite + footnote refs).
+3. **C-3.** Regression tests:
+   - `tests/extract/detectParallel.test.ts`: add positive cases for `, 453–55, ` / `, 120, ` / `, 115, 153, ` / `, ¶ 5, ` / `, *42, ` / `, 570 n.3, `; add negative cases for `, but ` / `, and others, ` / `, see ` / `, e.g., `.
+   - `tests/integration/`: add a fixture from the user's brief, assert 2 parallel groups + correct string-cite group membership.
+4. **C-4.** Changeset (`pnpm changeset` → patch — *no* breaking API change).
+5. **C-5.** Document in `docs/handoffs/` that the data-model debate (#3 here) was researched and explicitly deferred; reference issue freelawproject/eyecite#76.
+
+**Estimated effort:** ~half a day (helper + tests + changeset). Touches one file's heuristic, one new helper, ~10 unit tests, one integration test.
+
+### Explicitly NOT in scope
+
+- **Folding secondaries into primaries (scope #3).** This is a breaking change that the Free Law Project team debated for 4 years and still has not shipped. The current `groupId` + `parallelCitations[]` model + `groupByCase()` helper is already richer than Python eyecite's output and gives consumers both views (per-reporter for granular highlighting, per-case via `groupByCase()`).
+- **Separate string-cite investigation (scope #2).** Should resolve as a side effect of the detection fix. Add the regression test (C-3) to verify; only investigate further if the test fails.
+
+### Frontend guidance (not a parser change)
+
+The consumer's frontend is showing two badges per parallel pair because it iterates `extractCitations()` output directly. The fix is on the **frontend**, not the parser: either (a) call `groupByCase()` and render one badge per `CaseGroup`, with the secondary reporters as text inside the badge, or (b) keep iterating `citations` but group the rendered DOM by `groupId` (render one outer wrapper per group, with one inner span per cite).
+
+This is the same pattern Westlaw uses: one clickable case row, parallels surfaced on hover/click. The eyecite-ts API supports this today; no parser change is required to enable it.
+
+---
+
+## Sources
+
+- **Bluebook / Indigo Book**
+  - [Indigo Book § R12.3 (parallel citation in state court documents) — law.resource.org mirror](https://law.resource.org/pub/us/code/blue/IndigoBook.html)
+  - [Indigo Book 2.0 PDF — full citation reference](https://indigobook.github.io/versions/indigobook-2.0.pdf)
+  - [Tarlton Law Library — Pages, Paragraphs, and Pincites (Bluebook 21st ed.)](https://tarlton.law.utexas.edu/bluebook-legal-citation/pages-paragraphs-pincites)
+  - [Jacksonville University Bluebook guide — parallel citations](https://library.ju.edu/bluebook-citation/parallel-citations)
+
+- **Python eyecite source**
+  - [eyecite/find.py — main extraction loop, calls `is_parallel_citation`](https://github.com/freelawproject/eyecite/blob/main/eyecite/find.py)
+  - [eyecite/models.py — `FullCaseCitation.is_parallel_citation`](https://github.com/freelawproject/eyecite/blob/main/eyecite/models.py)
+  - [eyecite/helpers.py — `_process_case_name` sets `full_span_start`](https://github.com/freelawproject/eyecite/blob/main/eyecite/helpers.py)
+  - [eyecite/regexes.py — `PIN_CITE_REGEX`](https://github.com/freelawproject/eyecite/blob/main/eyecite/regexes.py)
+
+- **Python eyecite issues/PRs**
+  - [Issue #76 — "Link parallel cites" (OPEN since May 2021; full design debate)](https://github.com/freelawproject/eyecite/issues/76)
+  - [Issue #111 — "Parallel citations are detected as separate citations" (closed as dup of #76)](https://github.com/freelawproject/eyecite/issues/111)
+  - [PR #288 — "fix(citation): Ensure full_span is aligned for parallel citations" (OPEN, Jul 2025)](https://github.com/freelawproject/eyecite/pull/288)
+  - [Issue #25 — "Citator doesn't pick up old SCOTUS parallel citations"](https://github.com/freelawproject/eyecite/issues/25)
+
+- **Other systems**
+  - [CourtListener v4 Citation API — opinion cluster `citations` array](https://wiki.free.law/c/courtlistener/help/api/rest/v4/citations)
+  - [LawCite (AustLII) — alternative-citation harvesting and display](https://www.austlii.edu.au/austlii/help/lawcite_announce.html)
+  - [LexisNexis — Parallel Citation Lookup feature](https://www.lexisnexis.com/community/infopro/b/weblog/posts/parallel-citation-lookup-now-available-on-lexis)
+  - [Westlaw — accessing parallel citations from the case view](https://lawshun.com/article/how-to-find-paralell-citations-on-west-law)
+  - [Pace Law Library — WestlawNext and the Bluebook on parallel citation suggestions](https://lawlibrary.blogs.pace.edu/2011/11/16/westlawnext-and-the-bluebook/)
+  - [CSL-M extensions docs — `parallel-first` attribute on `cs:group`](https://citeproc-js.readthedocs.io/en/latest/csl-m/)
+
+- **Relevant local source files**
+  - `/Users/medelman/Projects/OSS/eyecite-ts/src/extract/detectParallel.ts` — current detection (`MAX_PROXIMITY = 5`)
+  - `/Users/medelman/Projects/OSS/eyecite-ts/src/extract/pincite.ts` — `parsePincite` to reuse for option C
+  - `/Users/medelman/Projects/OSS/eyecite-ts/src/extract/detectStringCites.ts` — downstream consumer; verify regression
+  - `/Users/medelman/Projects/OSS/eyecite-ts/src/extract/extractCitations.ts:395-428` — where `groupId` / `parallelCitations` are populated
+  - `/Users/medelman/Projects/OSS/eyecite-ts/src/utils/groupByCase.ts` — existing per-case view for consumers
+  - `/Users/medelman/Projects/OSS/eyecite-ts/src/types/citation.ts:274-288` — current `groupId` / `parallelCitations` type shape

--- a/docs/superpowers/plans/2026-05-19-parallel-cites-pincite-between.md
+++ b/docs/superpowers/plans/2026-05-19-parallel-cites-pincite-between.md
@@ -1,0 +1,544 @@
+# Parallel Citation Detection (Pincite-Between) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `detectParallel.ts` to accept the Bluebook-canonical pincite-between form (`vol rep page, pincite, vol rep page`), so parallel citations like `374 N.J. Super. 448, 453–55, 864 A.2d 1191` are correctly grouped via `groupId` and `parallelCitations[]`.
+
+**Architecture:** Replace the `MAX_PROXIMITY = 5` numeric check with a structural classifier that accepts two gap shapes: tight comma (existing) and pincite-between (new). The pincite-between path delegates to the existing `parsePincite` helper from `src/extract/pincite.ts` as the single source of truth for "what counts as a pincite." No new types; no consumer-facing API change.
+
+**Tech Stack:** TypeScript, Vitest 4, pnpm 10, Biome 2. Zero new runtime dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md`
+**Research:** `docs/research/2026-05-19-parallel-citation-detection.md`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `src/extract/detectParallel.ts` | Modify | Replace `MAX_PROXIMITY` check with tight-or-pincite-between classifier. Import `parsePincite`. Widen `MAX_GAP_FOR_PARALLEL` to 80. Remove `MAX_PROXIMITY` constant. |
+| `tests/extract/detectParallelPinciteBetween.test.ts` | Create | Focused unit tests for new gap shapes (page, range, multi-pincite, star, paragraph, footnote; negative cases) |
+| `tests/extract/randolphFixture.test.ts` | Create | End-to-end fixture from the bug report; asserts all three parallel pairs detected + string-cite anomaly auto-resolves |
+| `.changeset/parallel-cites-pincite-between.md` | Create | Patch bump for the detection fix |
+
+---
+
+## Pre-flight
+
+Verify branch + spec are in place:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+# Expected: fix/parallel-cites-in-subsequent-history
+
+ls docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md
+ls docs/research/2026-05-19-parallel-citation-detection.md
+# Both should exist.
+```
+
+If you're elsewhere, switch back and pop any lock-file stash (per `project_persistent_drift` memory: `package.json` + `pnpm-lock.yaml` are expected to show as modified — leave alone or stash during branch switches).
+
+---
+
+## Task 1: Write the Randolph End-to-End Failing Test (TDD red)
+
+This is the canonical bug-report scenario. Write the failing test first so we're driving the implementation against a real-world input.
+
+**Files:**
+- Create: `tests/extract/randolphFixture.test.ts`
+
+- [ ] **Step 1.1: Create the test file**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, FullCaseCitation } from "@/types/citation"
+
+describe("Randolph fixture — all parallel pairs across pincite-between gaps detect", () => {
+  // The actual passage from the user's brief (HOA / adverse-possession context).
+  // Three logical authorities, each with parallel citations:
+  //   - Randolph App. Div. 2005: 374 N.J. Super. 448 + 864 A.2d 1191
+  //   - Randolph N.J. 2006 (affirmance): 186 N.J. 78 + 891 A.2d 1202
+  //   - Yellen App. Div. 2010: 416 N.J. Super. 113 + 3 A.3d 584
+  const text = `The prescriptive period in New Jersey is not twenty years, as was formerly assumed, but thirty years for developed land (or sixty years for woodlands or uncultivated tracts), by analogy to the adverse-possession periods set forth in N.J.S.A. 2A:14-30. Randolph Town Ctr., L.P. v. County of Morris, 374 N.J. Super. 448, 453–55, 864 A.2d 1191 (App. Div. 2005), aff'd in part, 186 N.J. 78, 891 A.2d 1202 (2006); see also Yellen v. Kassin, 416 N.J. Super. 113, 120, 3 A.3d 584 (App. Div. 2010).`
+
+  it("all three parallel pairs detected with correct groupIds", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const caseCites = cites.filter(
+      (c): c is FullCaseCitation => c.type === "case",
+    )
+    expect(caseCites).toHaveLength(6)
+
+    // Pair 1: Randolph App. Div. 2005
+    expect(caseCites[0].text).toContain("374 N.J. Super. 448")
+    expect(caseCites[1].text).toContain("864 A.2d 1191")
+    expect(caseCites[0].groupId).toBeDefined()
+    expect(caseCites[0].groupId).toBe(caseCites[1].groupId)
+    expect(caseCites[0].parallelCitations).toEqual([
+      { volume: 864, reporter: "A.2d", page: 1191 },
+    ])
+
+    // Pair 2: Randolph N.J. 2006 (affirmance)
+    expect(caseCites[2].text).toContain("186 N.J. 78")
+    expect(caseCites[3].text).toContain("891 A.2d 1202")
+    expect(caseCites[2].groupId).toBeDefined()
+    expect(caseCites[2].groupId).toBe(caseCites[3].groupId)
+    expect(caseCites[2].parallelCitations).toEqual([
+      { volume: 891, reporter: "A.2d", page: 1202 },
+    ])
+
+    // Pair 3: Yellen App. Div. 2010
+    expect(caseCites[4].text).toContain("416 N.J. Super. 113")
+    expect(caseCites[5].text).toContain("3 A.3d 584")
+    expect(caseCites[4].groupId).toBeDefined()
+    expect(caseCites[4].groupId).toBe(caseCites[5].groupId)
+    expect(caseCites[4].parallelCitations).toEqual([
+      { volume: 3, reporter: "A.3d", page: 584 },
+    ])
+
+    // Three logical authorities → three distinct groupIds
+    const distinctGroupIds = new Set([
+      caseCites[0].groupId,
+      caseCites[2].groupId,
+      caseCites[4].groupId,
+    ])
+    expect(distinctGroupIds.size).toBe(3)
+  })
+
+  it("string-cite anomaly auto-resolves — Randolph affirmance secondary does not share sc group with Yellen primary", () => {
+    // Pre-fix: 891 A.2d 1202 (Randolph affirmance secondary, currently extracted
+    // as a standalone primary because parallel detection fails) shared a
+    // stringCitationGroupId with 416 N.J. Super. 113 (Yellen primary across `;`).
+    // Post-fix: 891 A.2d 1202 is now a parallel secondary, no longer a
+    // string-cite primary candidate; the walker pairs the correct primaries
+    // across the `;` separator (or leaves them ungrouped — exact behavior
+    // depends on detectStringCites's logic, but the cross-authority pairing
+    // must NOT persist).
+    const cites = extractCitations(text, { resolve: true })
+    const caseCites = cites.filter(
+      (c): c is FullCaseCitation => c.type === "case",
+    )
+
+    const randolphAffirmanceSecondary = caseCites[3] // 891 A.2d 1202
+    const yellenPrimary = caseCites[4] // 416 N.J. Super. 113
+
+    // The affirmance secondary and the Yellen primary should NOT share a
+    // stringCitationGroupId after the fix.
+    expect(
+      randolphAffirmanceSecondary.stringCitationGroupId !== undefined &&
+        randolphAffirmanceSecondary.stringCitationGroupId ===
+          yellenPrimary.stringCitationGroupId,
+    ).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 1.2: Run the test to verify it fails**
+
+```bash
+pnpm exec vitest run tests/extract/randolphFixture.test.ts 2>&1 | tail -20
+```
+
+Expected: **FAIL.** The first test fails because `caseCites[0]` (the 374 N.J. Super.) and `caseCites[2]` (the 186 N.J. — wait, indices depend on extraction order) don't have `groupId` set. The second test may pass or fail depending on existing behavior — note the result and proceed.
+
+Don't try to make these pass yet. Move to Task 2.
+
+- [ ] **Step 1.3: Do NOT commit yet**
+
+Stay red. Implementation in Tasks 2-3 will make them green.
+
+---
+
+## Task 2: Implement the Pincite-Between Classifier (TDD green for Randolph)
+
+**Files:**
+- Modify: `src/extract/detectParallel.ts`
+
+- [ ] **Step 2.1: Add the `parsePincite` import**
+
+Open `src/extract/detectParallel.ts`. Find the existing imports at the top (around line 13: `import type { Token } from "@/tokenize/tokenizer"`). Add this import below it:
+
+```ts
+import { parsePincite } from "./pincite"
+```
+
+- [ ] **Step 2.2: Widen `MAX_GAP_FOR_PARALLEL` and remove `MAX_PROXIMITY`**
+
+In the same file, find the existing constants block (around lines 17-27):
+
+```ts
+/**
+ * Maximum characters allowed between end of comma and start of next citation.
+ * Bluebook standard uses tight spacing: "500 F.2d 123, 200 F. Supp. 456"
+ */
+const MAX_PROXIMITY = 5
+
+/**
+ * Maximum total gap (chars) between end of one citation and start of next
+ * to even consider them as parallel candidates. Beyond this distance, we can
+ * skip all other checks (comma, parenthetical, etc.) for performance.
+ * Includes comma, spaces, and potential pincite: ", 125, " = ~10 chars
+ */
+const MAX_GAP_FOR_PARALLEL = 20
+```
+
+Replace with:
+
+```ts
+/**
+ * Maximum total gap (chars) between end of one citation and start of next
+ * to even consider them as parallel candidates. Beyond this distance, we can
+ * skip all other checks (comma, parenthetical, etc.) for performance.
+ *
+ * Sized to comfortably hold a comma-separated pincite list like
+ * `, 410-13 nn. 5-10, ` (~17 chars) or `, 453-55, 460, ` (14 chars). The
+ * pincite-validation gate inside the loop is the real false-positive
+ * defense; this cap is just an early-exit performance optimization.
+ */
+const MAX_GAP_FOR_PARALLEL = 80
+```
+
+(`MAX_PROXIMITY` is removed entirely — replaced by the structural classifier below.)
+
+- [ ] **Step 2.3: Replace the MAX_PROXIMITY check with the structural classifier**
+
+In the same file, find this block inside the for-loop (around lines 122-134):
+
+```ts
+      // Bluebook requires comma separator for parallel citations
+      if (!gapText.includes(",")) {
+        break // No comma = not parallel, stop looking
+      }
+
+      // Check proximity: distance from comma to next citation start
+      // MAX_PROXIMITY enforces tight spacing: "A, B" not "A,      B"
+      const commaIndex = gapText.indexOf(",")
+      const distanceAfterComma = gapText.length - commaIndex - 1
+
+      if (distanceAfterComma > MAX_PROXIMITY) {
+        break // Too far apart, stop looking
+      }
+```
+
+Replace with:
+
+```ts
+      // Gap text between primary and secondary cite must be one of two shapes:
+      //
+      //   Tight comma: ", " (no pincite between cites)
+      //     "374 N.J. Super. 448, 864 A.2d 1191"
+      //
+      //   Pincite-between: ", PINCITE_LIST, " — the Bluebook-canonical form
+      //   per Indigo Book R12.3, where the primary's pincite sits between
+      //   the two parallel cites.
+      //     "374 N.J. Super. 448, 453-55, 864 A.2d 1191"
+      //     "410 U.S. 113, 115, 153, 93 S. Ct. 705"  (multi-pincite list)
+      //
+      // A PINCITE is anything `parsePincite()` accepts — page, range, star,
+      // paragraph, footnote, etc. Reusing parsePincite keeps it as the single
+      // source of truth for "what counts as a pincite" and means future
+      // pincite improvements propagate here automatically.
+      const tight = /^,\s*$/.test(gapText)
+      let pinciteBetween = false
+      if (!tight) {
+        const inner = gapText.match(/^,\s*(.+?)\s*,\s*$/)
+        if (inner) {
+          const segments = inner[1].split(/\s*,\s*/)
+          pinciteBetween =
+            segments.length > 0 && segments.every((s) => parsePincite(s) !== null)
+        }
+      }
+      if (!tight && !pinciteBetween) break
+```
+
+- [ ] **Step 2.4: Run the Randolph fixture tests**
+
+```bash
+pnpm exec vitest run tests/extract/randolphFixture.test.ts 2>&1 | tail -15
+```
+
+Expected: the first test "all three parallel pairs detected with correct groupIds" PASSES. The second "string-cite anomaly auto-resolves" should also pass (the affirmance secondary is no longer a primary-shape candidate for string-cite walker).
+
+If the first test fails:
+- Print the extracted citations to debug: temporarily add `console.log(JSON.stringify(caseCites.map(c => ({ text: c.text, groupId: c.groupId, parallels: c.parallelCitations })), null, 2))` before the assertions.
+- Most likely cause if it fails: the inner-content regex `^,\s*(.+?)\s*,\s*$/` not matching for the specific input. Test the regex on `", 453-55, "` and `", 120, "` in isolation.
+
+If the second test fails: read the resolved `stringCitationGroupId` values for `caseCites[3]` and `caseCites[4]` and report. The behavior may differ from the predicted post-fix state; document the actual behavior in the assertion comment and adjust if the spec's prediction was wrong.
+
+- [ ] **Step 2.5: Run the full test suite**
+
+```bash
+pnpm exec vitest run 2>&1 | tail -5
+```
+
+Expected: full suite passes (~2995 + 2 new tests = ~2997). If any existing test fails, investigate:
+- Tests that previously asserted "this pair is NOT a parallel because the gap is too wide" — flip the assertion AND update the test description to reflect the new (correct) behavior. Mention in commit message.
+- Tests that count distinct citations in a fixture — counts may drop because previously-unpaired cites now collapse into parallel groups when `groupByCase()` is invoked.
+- If something fails that doesn't fit either pattern, surface it — don't silently adjust.
+
+- [ ] **Step 2.6: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint 2>&1 | tail -5
+```
+
+Expected: both pass (Biome may report pre-existing warnings; those are fine).
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/extract/detectParallel.ts tests/extract/randolphFixture.test.ts
+git commit -m "$(cat <<'EOF'
+fix(extract): parallel detection across pincite-between gaps (Bluebook canonical)
+
+Replaces MAX_PROXIMITY=5 with a structural classifier that accepts two
+gap shapes between candidate parallel cites:
+- Tight comma: ", " (existing behavior, unchanged)
+- Pincite-between: ", PINCITE_LIST, " — the Bluebook-canonical form per
+  Indigo Book R12.3, validated by delegating to the existing parsePincite
+  helper as single source of truth for pincite shapes.
+
+Widens MAX_GAP_FOR_PARALLEL from 20 to 80 to accommodate realistic
+multi-pincite gaps (e.g., ", 410-13 nn. 5-10, "). The structural
+classifier inside the loop is the real false-positive defense; the
+gap cap is now just an early-exit performance optimization.
+
+Fixes the Randolph fixture from the bug report: three parallel pairs
+across pincite-between gaps now correctly grouped via groupId and
+parallelCitations[]. Indirect win: the string-cite walker no longer
+mis-groups parallel secondaries with unrelated authorities across `;`
+separators, because they're now properly classified as secondaries.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Focused Unit Tests for Each Gap Shape
+
+The Randolph fixture proves the algorithm works end-to-end on a representative real-world input. This task adds finer-grained unit tests so future regressions on specific gap shapes get caught immediately.
+
+**Files:**
+- Create: `tests/extract/detectParallelPinciteBetween.test.ts`
+
+- [ ] **Step 3.1: Create the unit test file**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, FullCaseCitation } from "@/types/citation"
+
+function caseCites(text: string): FullCaseCitation[] {
+  return extractCitations(text).filter(
+    (c): c is FullCaseCitation => c.type === "case",
+  )
+}
+
+describe("detectParallel — pincite-between gap shapes", () => {
+  it("accepts single page pincite (', NNN, ')", () => {
+    const text = "Smith v. Jones, 374 N.J. Super. 448, 453, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBeDefined()
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+    expect(cites[0].parallelCitations).toEqual([
+      { volume: 864, reporter: "A.2d", page: 1191 },
+    ])
+  })
+
+  it("accepts page range (', NNN-NN, ')", () => {
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, 453-55, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+
+  it("accepts en-dash page range (', NNN–NN, ')", () => {
+    // En-dash (U+2013) is common in published opinions.
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, 453–55, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+
+  it("accepts multi-pincite list (', NNN, NNN, ')", () => {
+    const text =
+      "Roe v. Wade, 410 U.S. 113, 115, 153, 93 S. Ct. 705 (1973)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+    expect(cites[0].parallelCitations).toEqual([
+      { volume: 93, reporter: "S. Ct.", page: 705 },
+    ])
+  })
+
+  it("accepts footnote pincite (', NNN n.N, ')", () => {
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 n.3, 200 A.2d 100 (1990)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+
+  it("REJECTS gap with prose text (', see also, ')", () => {
+    // ", see also, " between cites is two separate cases joined by a signal,
+    // not a parallel pair. Must NOT be detected as parallel.
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, see also, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    // Whatever the extractor produces, the two case-shape tokens must NOT
+    // share a groupId (no parallel detection across prose).
+    if (cites.length >= 2) {
+      expect(
+        cites[0].groupId !== undefined && cites[0].groupId === cites[1].groupId,
+      ).toBe(false)
+    }
+  })
+
+  it("REJECTS gap with mixed prose and digits (', page 453 of, ')", () => {
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, page 453 of, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    if (cites.length >= 2) {
+      expect(
+        cites[0].groupId !== undefined && cites[0].groupId === cites[1].groupId,
+      ).toBe(false)
+    }
+  })
+
+  it("tight comma (', ') still works (regression for existing behavior)", () => {
+    // Pre-existing canonical case — `186 N.J. 78, 891 A.2d 1202` with no
+    // pincite between — must continue to detect.
+    const text = "Smith v. Jones, 186 N.J. 78, 891 A.2d 1202 (2006)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+})
+```
+
+- [ ] **Step 3.2: Run the new tests**
+
+```bash
+pnpm exec vitest run tests/extract/detectParallelPinciteBetween.test.ts 2>&1 | tail -15
+```
+
+Expected: all 8 tests PASS.
+
+If any test fails:
+- For "accepts" failures: print the extracted citations and inspect the `groupId` / `parallelCitations` fields. Likely cause is that the test text doesn't tokenize as expected — verify by minimizing the input.
+- For "REJECTS" failures: this would mean the structural classifier is too permissive. Print the gap text and the segments array — confirm `parsePincite` correctly returns null for the prose.
+
+- [ ] **Step 3.3: Run the full suite**
+
+```bash
+pnpm exec vitest run 2>&1 | tail -5
+```
+
+Expected: full suite still passes.
+
+- [ ] **Step 3.4: Typecheck + lint**
+
+```bash
+pnpm typecheck && pnpm lint 2>&1 | tail -5
+```
+
+Expected: both pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add tests/extract/detectParallelPinciteBetween.test.ts
+git commit -m "$(cat <<'EOF'
+test(extract): cover pincite-between gap shapes in detectParallel
+
+Focused unit tests for each pincite shape the classifier accepts
+(single page, page range, en-dash range, multi-pincite list, footnote)
+and the prose shapes it must reject (signal words, mixed digits/text).
+Plus a regression test for the existing tight-comma case.
+
+Locks in the gap-classifier behavior so future changes to parsePincite
+or the detectParallel logic don't silently regress any individual form.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Changeset
+
+**Files:**
+- Create: `.changeset/parallel-cites-pincite-between.md`
+
+- [ ] **Step 4.1: Write the changeset**
+
+```markdown
+---
+"eyecite-ts": patch
+---
+
+fix(extract): detect parallel citations across pincite-between gaps (Bluebook canonical)
+
+`detectParallel` now accepts the **Bluebook-canonical pincite-between form** per Indigo Book R12.3, where the primary's pincite sits between the two parallel cites:
+
+```
+374 N.J. Super. 448, 453–55, 864 A.2d 1191 (App. Div. 2005)
+```
+
+Previously, `MAX_PROXIMITY = 5` chars after the comma rejected this form, so eyecite-ts only detected the less-common no-pincite variant (`186 N.J. 78, 891 A.2d 1202`). The fix delegates to the existing `parsePincite` helper as single source of truth for "what counts as a pincite," automatically covering all forms (page, range, star, paragraph, footnote, etc.).
+
+**Behavior changes:**
+
+- Parallel citations across pincite-between gaps are now grouped via `groupId` and `parallelCitations[]`. Consumers calling `groupByCase()` will see fewer logical case groups for inputs containing this form (parallel pairs now collapse from two groups into one — correct behavior).
+- Indirect win: the string-cite walker (`detectStringCites.ts`) no longer mis-groups parallel secondaries with unrelated authorities across `;` separators, because they're now properly classified as secondaries.
+
+**No API changes.** Existing `groupId`, `parallelCitations[]`, and `groupByCase()` work as before; they just get populated correctly for more inputs.
+
+See `docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md` for the full design and `docs/research/2026-05-19-parallel-citation-detection.md` for the Bluebook + Python eyecite + industry reference validation.
+```
+
+- [ ] **Step 4.2: Commit**
+
+```bash
+git add .changeset/parallel-cites-pincite-between.md
+git commit -m "$(cat <<'EOF'
+chore: changeset for parallel-cite pincite-between detection fix
+
+Patch bump — bug fix only, no API change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Final Verification
+
+- [ ] **Step 5.1: Full suite + typecheck + lint + build + size**
+
+```bash
+pnpm exec vitest run && pnpm typecheck && pnpm lint && pnpm build && pnpm size 2>&1 | tail -15
+```
+
+Expected: all five pass. Tests should show ~2995 baseline + 10 new (2 Randolph fixture + 8 unit tests) = ~3005 passing.
+
+- [ ] **Step 5.2: Review the diff**
+
+```bash
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+Expected: 4 commits (Tasks 2, 3, 4 each create one; Task 1 was rolled into Task 2's commit because the test was written but not committed). Stat shows changes concentrated in `src/extract/detectParallel.ts`, `tests/extract/`, and `.changeset/`.
+
+- [ ] **Step 5.3: Hand off**
+
+Implementation complete. Open a PR (don't push automatically — confirm with the user first per project conventions). Suggested PR title: **"fix(extract): detect parallel cites across pincite-between gaps (Bluebook canonical)"**.

--- a/docs/superpowers/plans/2026-05-19-parallel-cites-pincite-between.md
+++ b/docs/superpowers/plans/2026-05-19-parallel-cites-pincite-between.md
@@ -39,16 +39,19 @@ ls docs/research/2026-05-19-parallel-citation-detection.md
 
 If you're elsewhere, switch back and pop any lock-file stash (per `project_persistent_drift` memory: `package.json` + `pnpm-lock.yaml` are expected to show as modified — leave alone or stash during branch switches).
 
+**Known LSP noise:** Every new test file under `tests/` in this codebase triggers spurious LSP `Cannot find module '@/extract'` and "Parameter 'c' implicitly has 'any' type" warnings. `pnpm typecheck` and `pnpm exec vitest run` are the authoritative checks; ignore the LSP diagnostics on the new test files.
+
 ---
 
-## Task 1: Write the Randolph End-to-End Failing Test (TDD red)
+## Task 1: Write Failing Randolph Test + Implement Classifier (TDD red→green)
 
-This is the canonical bug-report scenario. Write the failing test first so we're driving the implementation against a real-world input.
+The canonical bug-report scenario drives the implementation. Single task because the test file and the source change are committed together in a TDD red→green cycle (avoids leaving uncommitted state for a subsequent subagent to pick up).
 
 **Files:**
 - Create: `tests/extract/randolphFixture.test.ts`
+- Modify: `src/extract/detectParallel.ts`
 
-- [ ] **Step 1.1: Create the test file**
+- [ ] **Step 1.1: Create the failing test file**
 
 ```ts
 import { describe, expect, it } from "vitest"
@@ -140,22 +143,9 @@ describe("Randolph fixture — all parallel pairs across pincite-between gaps de
 pnpm exec vitest run tests/extract/randolphFixture.test.ts 2>&1 | tail -20
 ```
 
-Expected: **FAIL.** The first test fails because `caseCites[0]` (the 374 N.J. Super.) and `caseCites[2]` (the 186 N.J. — wait, indices depend on extraction order) don't have `groupId` set. The second test may pass or fail depending on existing behavior — note the result and proceed.
+Expected: **FAIL.** The first test "all three parallel pairs detected" fails because the `374 N.J. Super.` and `416 N.J. Super.` pairs (with pincite between) aren't being grouped. The second test may pass or fail depending on current string-cite behavior — note the result.
 
-Don't try to make these pass yet. Move to Task 2.
-
-- [ ] **Step 1.3: Do NOT commit yet**
-
-Stay red. Implementation in Tasks 2-3 will make them green.
-
----
-
-## Task 2: Implement the Pincite-Between Classifier (TDD green for Randolph)
-
-**Files:**
-- Modify: `src/extract/detectParallel.ts`
-
-- [ ] **Step 2.1: Add the `parsePincite` import**
+- [ ] **Step 1.3: Add the `parsePincite` import**
 
 Open `src/extract/detectParallel.ts`. Find the existing imports at the top (around line 13: `import type { Token } from "@/tokenize/tokenizer"`). Add this import below it:
 
@@ -163,7 +153,7 @@ Open `src/extract/detectParallel.ts`. Find the existing imports at the top (arou
 import { parsePincite } from "./pincite"
 ```
 
-- [ ] **Step 2.2: Widen `MAX_GAP_FOR_PARALLEL` and remove `MAX_PROXIMITY`**
+- [ ] **Step 1.4: Widen `MAX_GAP_FOR_PARALLEL` and remove `MAX_PROXIMITY`**
 
 In the same file, find the existing constants block (around lines 17-27):
 
@@ -201,7 +191,7 @@ const MAX_GAP_FOR_PARALLEL = 80
 
 (`MAX_PROXIMITY` is removed entirely — replaced by the structural classifier below.)
 
-- [ ] **Step 2.3: Replace the MAX_PROXIMITY check with the structural classifier**
+- [ ] **Step 1.5: Replace the MAX_PROXIMITY check with the structural classifier**
 
 In the same file, find this block inside the for-loop (around lines 122-134):
 
@@ -239,6 +229,12 @@ Replace with:
       // paragraph, footnote, etc. Reusing parsePincite keeps it as the single
       // source of truth for "what counts as a pincite" and means future
       // pincite improvements propagate here automatically.
+      //
+      // Punctuation other than commas inside the segment list (e.g.
+      // `, 453; 460, `) deliberately fails — `parsePincite("453; 460")`
+      // returns null, the segment-by-segment validation fails, and the gap
+      // is rejected. That's correct: semicolons don't appear in legitimate
+      // pincite lists.
       const tight = /^,\s*$/.test(gapText)
       let pinciteBetween = false
       if (!tight) {
@@ -252,7 +248,7 @@ Replace with:
       if (!tight && !pinciteBetween) break
 ```
 
-- [ ] **Step 2.4: Run the Randolph fixture tests**
+- [ ] **Step 1.6: Run the Randolph fixture tests**
 
 ```bash
 pnpm exec vitest run tests/extract/randolphFixture.test.ts 2>&1 | tail -15
@@ -260,13 +256,9 @@ pnpm exec vitest run tests/extract/randolphFixture.test.ts 2>&1 | tail -15
 
 Expected: the first test "all three parallel pairs detected with correct groupIds" PASSES. The second "string-cite anomaly auto-resolves" should also pass (the affirmance secondary is no longer a primary-shape candidate for string-cite walker).
 
-If the first test fails:
-- Print the extracted citations to debug: temporarily add `console.log(JSON.stringify(caseCites.map(c => ({ text: c.text, groupId: c.groupId, parallels: c.parallelCitations })), null, 2))` before the assertions.
-- Most likely cause if it fails: the inner-content regex `^,\s*(.+?)\s*,\s*$/` not matching for the specific input. Test the regex on `", 453-55, "` and `", 120, "` in isolation.
+If a test fails, print the extracted citations to understand actual vs expected, then debug from there.
 
-If the second test fails: read the resolved `stringCitationGroupId` values for `caseCites[3]` and `caseCites[4]` and report. The behavior may differ from the predicted post-fix state; document the actual behavior in the assertion comment and adjust if the spec's prediction was wrong.
-
-- [ ] **Step 2.5: Run the full test suite**
+- [ ] **Step 1.7: Run the full test suite**
 
 ```bash
 pnpm exec vitest run 2>&1 | tail -5
@@ -277,7 +269,7 @@ Expected: full suite passes (~2995 + 2 new tests = ~2997). If any existing test 
 - Tests that count distinct citations in a fixture — counts may drop because previously-unpaired cites now collapse into parallel groups when `groupByCase()` is invoked.
 - If something fails that doesn't fit either pattern, surface it — don't silently adjust.
 
-- [ ] **Step 2.6: Typecheck + lint**
+- [ ] **Step 1.8: Typecheck + lint**
 
 ```bash
 pnpm typecheck && pnpm lint 2>&1 | tail -5
@@ -285,7 +277,7 @@ pnpm typecheck && pnpm lint 2>&1 | tail -5
 
 Expected: both pass (Biome may report pre-existing warnings; those are fine).
 
-- [ ] **Step 2.7: Commit**
+- [ ] **Step 1.9: Commit (test + implementation together)**
 
 ```bash
 git add src/extract/detectParallel.ts tests/extract/randolphFixture.test.ts
@@ -317,14 +309,14 @@ EOF
 
 ---
 
-## Task 3: Focused Unit Tests for Each Gap Shape
+## Task 2: Focused Unit Tests for Each Gap Shape
 
 The Randolph fixture proves the algorithm works end-to-end on a representative real-world input. This task adds finer-grained unit tests so future regressions on specific gap shapes get caught immediately.
 
 **Files:**
 - Create: `tests/extract/detectParallelPinciteBetween.test.ts`
 
-- [ ] **Step 3.1: Create the unit test file**
+- [ ] **Step 2.1: Create the unit test file**
 
 ```ts
 import { describe, expect, it } from "vitest"
@@ -378,8 +370,13 @@ describe("detectParallel — pincite-between gap shapes", () => {
   })
 
   it("accepts footnote pincite (', NNN n.N, ')", () => {
-    const text =
-      "Smith v. Jones, 100 F.2d 50, 55 n.3, 200 A.2d 100 (1990)."
+    // Note: this synthetic uses F.2d (federal) + A.2d (regional reporter) as
+    // a parallel pair, which isn't a real-world combination but exercises the
+    // classifier in isolation. If the test fails, print the extracted tokens
+    // first — the tokenizer may treat one of these as non-case-shape in this
+    // exact context, in which case substitute a more realistic reporter combo
+    // (e.g. two state-court reporters that legitimately appear as parallels).
+    const text = "Smith v. Jones, 100 F.2d 50, 55 n.3, 200 A.2d 100 (1990)."
     const cites = caseCites(text)
     expect(cites).toHaveLength(2)
     expect(cites[0].groupId).toBe(cites[1].groupId)
@@ -391,12 +388,11 @@ describe("detectParallel — pincite-between gap shapes", () => {
     const text =
       "Smith v. Jones, 374 N.J. Super. 448, see also, 864 A.2d 1191 (2005)."
     const cites = caseCites(text)
-    // Whatever the extractor produces, the two case-shape tokens must NOT
-    // share a groupId (no parallel detection across prose).
-    if (cites.length >= 2) {
-      expect(
-        cites[0].groupId !== undefined && cites[0].groupId === cites[1].groupId,
-      ).toBe(false)
+    // Two valid outcomes both count as "rejected":
+    //   (a) tokenizer doesn't extract both as case-shape (length < 2)
+    //   (b) both extracted but without a shared groupId
+    if (cites.length >= 2 && cites[0].groupId !== undefined && cites[1].groupId !== undefined) {
+      expect(cites[0].groupId).not.toBe(cites[1].groupId)
     }
   })
 
@@ -404,10 +400,8 @@ describe("detectParallel — pincite-between gap shapes", () => {
     const text =
       "Smith v. Jones, 374 N.J. Super. 448, page 453 of, 864 A.2d 1191 (2005)."
     const cites = caseCites(text)
-    if (cites.length >= 2) {
-      expect(
-        cites[0].groupId !== undefined && cites[0].groupId === cites[1].groupId,
-      ).toBe(false)
+    if (cites.length >= 2 && cites[0].groupId !== undefined && cites[1].groupId !== undefined) {
+      expect(cites[0].groupId).not.toBe(cites[1].groupId)
     }
   })
 
@@ -422,7 +416,7 @@ describe("detectParallel — pincite-between gap shapes", () => {
 })
 ```
 
-- [ ] **Step 3.2: Run the new tests**
+- [ ] **Step 2.2: Run the new tests**
 
 ```bash
 pnpm exec vitest run tests/extract/detectParallelPinciteBetween.test.ts 2>&1 | tail -15
@@ -434,7 +428,7 @@ If any test fails:
 - For "accepts" failures: print the extracted citations and inspect the `groupId` / `parallelCitations` fields. Likely cause is that the test text doesn't tokenize as expected — verify by minimizing the input.
 - For "REJECTS" failures: this would mean the structural classifier is too permissive. Print the gap text and the segments array — confirm `parsePincite` correctly returns null for the prose.
 
-- [ ] **Step 3.3: Run the full suite**
+- [ ] **Step 2.3: Run the full suite**
 
 ```bash
 pnpm exec vitest run 2>&1 | tail -5
@@ -442,7 +436,7 @@ pnpm exec vitest run 2>&1 | tail -5
 
 Expected: full suite still passes.
 
-- [ ] **Step 3.4: Typecheck + lint**
+- [ ] **Step 2.4: Typecheck + lint**
 
 ```bash
 pnpm typecheck && pnpm lint 2>&1 | tail -5
@@ -450,7 +444,7 @@ pnpm typecheck && pnpm lint 2>&1 | tail -5
 
 Expected: both pass.
 
-- [ ] **Step 3.5: Commit**
+- [ ] **Step 2.5: Commit**
 
 ```bash
 git add tests/extract/detectParallelPinciteBetween.test.ts
@@ -472,12 +466,12 @@ EOF
 
 ---
 
-## Task 4: Changeset
+## Task 3: Changeset
 
 **Files:**
 - Create: `.changeset/parallel-cites-pincite-between.md`
 
-- [ ] **Step 4.1: Write the changeset**
+- [ ] **Step 3.1: Write the changeset**
 
 ```markdown
 ---
@@ -504,7 +498,7 @@ Previously, `MAX_PROXIMITY = 5` chars after the comma rejected this form, so eye
 See `docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md` for the full design and `docs/research/2026-05-19-parallel-citation-detection.md` for the Bluebook + Python eyecite + industry reference validation.
 ```
 
-- [ ] **Step 4.2: Commit**
+- [ ] **Step 3.2: Commit**
 
 ```bash
 git add .changeset/parallel-cites-pincite-between.md
@@ -520,9 +514,9 @@ EOF
 
 ---
 
-## Task 5: Final Verification
+## Task 4: Final Verification
 
-- [ ] **Step 5.1: Full suite + typecheck + lint + build + size**
+- [ ] **Step 4.1: Full suite + typecheck + lint + build + size**
 
 ```bash
 pnpm exec vitest run && pnpm typecheck && pnpm lint && pnpm build && pnpm size 2>&1 | tail -15
@@ -530,15 +524,15 @@ pnpm exec vitest run && pnpm typecheck && pnpm lint && pnpm build && pnpm size 2
 
 Expected: all five pass. Tests should show ~2995 baseline + 10 new (2 Randolph fixture + 8 unit tests) = ~3005 passing.
 
-- [ ] **Step 5.2: Review the diff**
+- [ ] **Step 4.2: Review the diff**
 
 ```bash
 git log --oneline main..HEAD
 git diff main..HEAD --stat
 ```
 
-Expected: 4 commits (Tasks 2, 3, 4 each create one; Task 1 was rolled into Task 2's commit because the test was written but not committed). Stat shows changes concentrated in `src/extract/detectParallel.ts`, `tests/extract/`, and `.changeset/`.
+Expected: **3 commits** (Tasks 1, 2, 3 each create one). Stat shows changes concentrated in `src/extract/detectParallel.ts`, `tests/extract/`, and `.changeset/`.
 
-- [ ] **Step 5.3: Hand off**
+- [ ] **Step 4.3: Hand off**
 
 Implementation complete. Open a PR (don't push automatically — confirm with the user first per project conventions). Suggested PR title: **"fix(extract): detect parallel cites across pincite-between gaps (Bluebook canonical)"**.

--- a/docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md
+++ b/docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md
@@ -1,0 +1,189 @@
+# Design: Parallel Citation Detection Across Pincite-Between Gaps
+
+**Date:** 2026-05-19
+**Status:** Approved by user, ready for implementation plan
+**Related research:** [`docs/research/2026-05-19-parallel-citation-detection.md`](../../research/2026-05-19-parallel-citation-detection.md)
+
+## Background
+
+A real legal brief passage:
+
+> Randolph Town Ctr., L.P. v. County of Morris, **374 N.J. Super. 448**, 453–55, **864 A.2d 1191** (App. Div. 2005), aff'd in part, **186 N.J. 78**, **891 A.2d 1202** (2006); see also Yellen v. Kassin, **416 N.J. Super. 113**, 120, **3 A.3d 584** (App. Div. 2010).
+
+Contains three logical authorities, each with parallel cites:
+- Randolph App. Div. 2005: `374 N.J. Super. 448` + `864 A.2d 1191`
+- Randolph N.J. 2006 (affirmance): `186 N.J. 78` + `891 A.2d 1202`
+- Yellen App. Div. 2010: `416 N.J. Super. 113` + `3 A.3d 584`
+
+### The bug
+
+`eyecite-ts@0.20.0` detects only **one** of the three pairs — the Randolph affirmance (`186 N.J. 78` + `891 A.2d 1202`), where no pincite sits between primary and secondary. The other two pairs go undetected.
+
+The cause is in `src/extract/detectParallel.ts`. The gap text between two case-shape tokens must satisfy:
+
+```ts
+const MAX_PROXIMITY = 5  // chars after the comma to the next citation
+// ...
+const distanceAfterComma = gapText.length - commaIndex - 1
+if (distanceAfterComma > MAX_PROXIMITY) break
+```
+
+For `374 N.J. Super. 448, 453–55, 864 A.2d 1191`, the gap text `, 453–55, ` is 10 chars — fails the 5-char check. The presence of a pincite between primary and secondary breaks detection.
+
+### Why this matters
+
+Per the **Indigo Book R12.3** (verified in [research §1](../../research/2026-05-19-parallel-citation-detection.md)), pincite-between is the **canonical Bluebook form**, not an edge case:
+
+> 261 Ill. App. 3d 443, 633 N.E.2d 764 (1993)
+
+is the standard pattern. The current detection only catches the *less common* no-pincite variant. Most real-world parallel citations are missed.
+
+### Why we're choosing reuse over rewrite
+
+The research surveyed Python eyecite, CourtListener, Westlaw, Lexis+, LawCite, and CSL-M. Findings:
+
+- **Python eyecite has the same bug class** ([open PR #288](https://github.com/freelawproject/eyecite/pull/288), debate going back to [issue #76](https://github.com/freelawproject/eyecite/issues/76) since May 2021).
+- **eyecite-ts's data model is already richer** than upstream's — we have `groupId` + `parallelCitations[]` + `groupByCase()` utility. Both per-reporter and per-case views are supported today.
+- **Industry convention is "fold at the cluster boundary, not the parser."** Westlaw, Lexis+, CourtListener, etc. all expose per-reporter spans from extraction and consolidate downstream. No reason to change the data model.
+
+So the fix is narrow: extend the gap classifier in `detectParallel.ts` to also accept pincite-between text, reusing the existing `parsePincite` helper.
+
+## Algorithm
+
+In `src/extract/detectParallel.ts`, replace the `MAX_PROXIMITY` check with a structural classifier that accepts two gap shapes:
+
+```ts
+const gapText = cleanedText.substring(gapStart, gapEnd)
+
+// Case A: tight comma — canonical Bluebook with no pincite between cites.
+const tight = /^,\s*$/.test(gapText)
+
+// Case B: pincite-between — comma-separated pincite list bracketed by commas.
+// Strip leading `,\s*` and trailing `\s*,\s*`, split inner on commas, require
+// every segment to parse as a pincite via the existing parsePincite helper.
+let pinciteBetween = false
+if (!tight) {
+  const inner = gapText.match(/^,\s*(.+?)\s*,\s*$/)
+  if (inner) {
+    const segments = inner[1].split(/\s*,\s*/)
+    pinciteBetween = segments.length > 0 && segments.every((s) => parsePincite(s) !== null)
+  }
+}
+
+if (!tight && !pinciteBetween) break  // gap isn't a recognized shape
+```
+
+### Replaced check
+
+The existing block (after the bracket-form check):
+
+```ts
+// Bluebook requires comma separator for parallel citations
+if (!gapText.includes(",")) {
+  break // No comma = not parallel, stop looking
+}
+
+// Check proximity: distance from comma to next citation start
+// MAX_PROXIMITY enforces tight spacing: "A, B" not "A,      B"
+const commaIndex = gapText.indexOf(",")
+const distanceAfterComma = gapText.length - commaIndex - 1
+if (distanceAfterComma > MAX_PROXIMITY) {
+  break // Too far apart, stop looking
+}
+```
+
+is replaced by the tight/pinciteBetween block above.
+
+### Key invariants
+
+- **Tight case unchanged**: `, ` between cites still works exactly as before. No regression.
+- **Pincite-between case accepted**: `, NNN, `, `, NNN-NN, `, `, NNN, NNN, `, `, *NNN, `, `, ¶ N, `, `, NNN n.N, ` — anything `parsePincite()` accepts as a single pincite, in a comma-separated list.
+- **`parsePincite` is single source of truth** for "is this a pincite." All current and future pincite shapes (page/range/star/¶/footnote/etc.) are accepted automatically.
+- **Defense in depth via shared parenthetical**: the existing `hasSharedParenthetical` check on the secondary still gates final acceptance — both cites must close into the same `(year)`. So a comma-separated digit sequence that doesn't have a shared paren is still rejected.
+
+### `MAX_GAP_FOR_PARALLEL` adjustment
+
+Current `MAX_GAP_FOR_PARALLEL = 20` is too narrow for realistic pincite gaps like `, 410-13 nn. 5-10, ` (~17 chars; `, 453-55, 460, ` is 14). Widen to **80** to comfortably cover real-world cases without enabling pathological scans. The pincite-validation gate inside the loop is the real false-positive defense; the outer cap is just an early-exit performance optimization.
+
+### `MAX_PROXIMITY` constant
+
+Remove. The check it enabled is now replaced by the structural classifier. No callers outside `detectParallel.ts`.
+
+### Why the alternatives were rejected (per research §6)
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **A. Widen `MAX_PROXIMITY` to ~30** | One-line change | Tolerates random text like `, see also, ` | Rejected — too permissive |
+| **B. Hand-rolled regex for pincite shapes** | No dependency on `parsePincite` | Re-implements page/range/star/¶/footnote variants; drift risk; future pincite improvements don't propagate | Rejected — duplicate work |
+| **C. Reuse `parsePincite` (chosen)** | Single source of truth; auto-covers all pincite forms; small change | Slightly more code than A | Chosen |
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `src/extract/detectParallel.ts` | Replace `MAX_PROXIMITY` check with structural tight-or-pincite-between classifier. Import `parsePincite`. Widen `MAX_GAP_FOR_PARALLEL` to 80. Remove `MAX_PROXIMITY` constant. |
+| `tests/extract/detectParallelPinciteBetween.test.ts` | NEW — focused unit tests for the new gap shapes (page, range, multi-pincite, star, paragraph, footnote, negative cases) |
+| `tests/extract/randolphFixture.test.ts` | NEW — end-to-end fixture from the bug report; asserts all three parallel pairs detected + string-cite anomaly auto-resolves |
+| `.changeset/parallel-cites-pincite-between.md` | NEW — patch bump describing the detection fix |
+
+No type changes; no consumer-facing API changes. Output shape unchanged: `groupId` and `parallelCitations[]` get populated correctly for more inputs.
+
+## Testing
+
+### Unit tests for the new gap shapes
+
+`tests/extract/detectParallelPinciteBetween.test.ts` covers:
+
+- `", NNN, "` (single page pincite between)
+- `", NNN-NN, "` (page range)
+- `", NNN, NNN, "` (multi-pincite list, per `parsePincite.additionalPincites`)
+- `", *N, "` (star pagination)
+- `", ¶ N, "` (paragraph pincite, per #204)
+- `", NNN n.N, "` (footnote pincite)
+- **Negative**: `", see also, "` — gap with prose text → no parallel detected.
+- **Negative**: `", page 453 of, "` — mixed prose and digits → no parallel detected.
+
+### End-to-end fixture
+
+`tests/extract/randolphFixture.test.ts` — the full Randolph passage:
+
+```
+Randolph Town Ctr., L.P. v. County of Morris, 374 N.J. Super. 448,
+453–55, 864 A.2d 1191 (App. Div. 2005), aff'd in part,
+186 N.J. 78, 891 A.2d 1202 (2006); see also Yellen v. Kassin,
+416 N.J. Super. 113, 120, 3 A.3d 584 (App. Div. 2010).
+```
+
+Asserts:
+
+1. **All three parallel pairs detected** — six case citations form three distinct `groupId`s, with the right `parallelCitations[]` on each primary.
+2. **String-cite anomaly auto-resolves** — `891 A.2d 1202` (Randolph affirmance secondary) no longer shares a `stringCitationGroupId` with `416 N.J. Super. 113` (Yellen primary). The string-cite walker now correctly pairs the Yellen primary with the Randolph N.J. 78 primary (or doesn't pair them — whichever the corrected behavior is; verify empirically).
+
+### Regression coverage
+
+Run the full ~2995-test suite. Tests likely affected:
+
+- `tests/extract/extractCase.test.ts` — has parallel-cite coverage; existing tests that exercised pre-fix detection should still pass.
+- `tests/extract/parallel*.test.ts` if any exist — verify alignment.
+- `tests/integration/realWorldCorpusFixtures.test.ts` — fixture counts may shift (some previously-unpaired cites now pair into groups).
+- `tests/integration/resolution.test.ts` — indirect impact if parallel cites affect resolver behavior.
+
+If anything regresses, **surface as a concern; don't silently flip assertions**. Most likely regression: a fixture that counted `unique authorities` may now report fewer (because parallels collapse via `groupByCase`), which is the correct new behavior. Adjust the count and document.
+
+## Non-Goals
+
+- **Data-model change** (one entity per case vs. N entities linked by `groupId`). Research confirms current model is industry-correct and consumer-side dedupe via `groupByCase()` is the right pattern.
+- **String-cite algorithm rewrite** (`detectStringCites.ts`). The existing logic becomes correct once parallel detection improves. No code change to that file. Regression test in the Randolph fixture verifies.
+- **Python-eyecite-style `full_span_start` detection** — restructuring case-name backward search to derive parallel groups. Bigger refactor; not required when reusing `parsePincite` works.
+- **Subsequent-history clause handling** (`aff'd in part, ...`). Existing subsequent-history detection in `extractCase.ts` separately tags these via `subsequentHistoryOf`. Out of scope; verified working in the Randolph fixture pre-fix (idx 3 has `subHistOf: 1`).
+
+## Open Questions
+
+None outstanding. Research validated against Indigo Book R12.3, Python eyecite, and industry tools.
+
+## Migration Notes (for the changeset)
+
+- **Patch bump** — bug fix, no API or output-shape change. Existing consumers see strictly more `groupId`/`parallelCitations[]` populations on already-extracted citations.
+- **Behavior change** — `detectParallel` now accepts parallel citations separated by a pincite (`vol rep page, pincite, vol rep page`). This is the canonical Bluebook form per Indigo Book R12.3; the previous behavior was incomplete. Consumers calling `groupByCase()` will see fewer logical groups when input contains this form (each pair collapses from two groups into one — correct behavior).
+- **Indirect string-cite improvement** — when parallel detection succeeds on a pair, `stringCitationGroupId` no longer cross-groups the parallel's secondary with an unrelated cite after a `;` separator.
+- **No new fields, no new types.** Existing `groupId`, `parallelCitations[]`, `groupByCase()` work unchanged.

--- a/src/extract/detectParallel.ts
+++ b/src/extract/detectParallel.ts
@@ -34,7 +34,10 @@ const MAX_GAP_FOR_PARALLEL = 80
  * Detection algorithm:
  * 1. Iterate tokens with lookahead (i, i+1, i+2...)
  * 2. Check if token[i] and token[i+1] are both case citations
- * 3. Check if comma separates them (within MAX_PROXIMITY chars)
+ * 3. Classify the gap text as either tight comma (`, `) or pincite-between
+ *    (`, PINCITE_LIST, `) — Bluebook canonical per Indigo Book R12.3. Reuses
+ *    the existing parsePincite helper as single source of truth for pincite
+ *    shapes (page/range/star/¶/footnote/etc.).
  * 4. Check if both citations share a closing parenthetical (via cleaned text)
  * 5. If all conditions met, add to parallel group
  * 6. Continue for chain (i+1, i+2, i+3...) until no more matches

--- a/src/extract/detectParallel.ts
+++ b/src/extract/detectParallel.ts
@@ -11,20 +11,19 @@
  */
 
 import type { Token } from "@/tokenize/tokenizer"
-
-/**
- * Maximum characters allowed between end of comma and start of next citation.
- * Bluebook standard uses tight spacing: "500 F.2d 123, 200 F. Supp. 456"
- */
-const MAX_PROXIMITY = 5
+import { parsePincite } from "./pincite"
 
 /**
  * Maximum total gap (chars) between end of one citation and start of next
  * to even consider them as parallel candidates. Beyond this distance, we can
  * skip all other checks (comma, parenthetical, etc.) for performance.
- * Includes comma, spaces, and potential pincite: ", 125, " = ~10 chars
+ *
+ * Sized to comfortably hold a comma-separated pincite list like
+ * `, 410-13 nn. 5-10, ` (~17 chars) or `, 453-55, 460, ` (14 chars). The
+ * pincite-validation gate inside the loop is the real false-positive
+ * defense; this cap is just an early-exit performance optimization.
  */
-const MAX_GAP_FOR_PARALLEL = 20
+const MAX_GAP_FOR_PARALLEL = 80
 
 /**
  * Detect parallel citation groups from tokenized citations.
@@ -119,19 +118,38 @@ export function detectParallelCitations(tokens: Token[], cleanedText = ""): Map<
         break
       }
 
-      // Bluebook requires comma separator for parallel citations
-      if (!gapText.includes(",")) {
-        break // No comma = not parallel, stop looking
+      // Gap text between primary and secondary cite must be one of two shapes:
+      //
+      //   Tight comma: ", " (no pincite between cites)
+      //     "374 N.J. Super. 448, 864 A.2d 1191"
+      //
+      //   Pincite-between: ", PINCITE_LIST, " — the Bluebook-canonical form
+      //   per Indigo Book R12.3, where the primary's pincite sits between
+      //   the two parallel cites.
+      //     "374 N.J. Super. 448, 453-55, 864 A.2d 1191"
+      //     "410 U.S. 113, 115, 153, 93 S. Ct. 705"  (multi-pincite list)
+      //
+      // A PINCITE is anything `parsePincite()` accepts — page, range, star,
+      // paragraph, footnote, etc. Reusing parsePincite keeps it as the single
+      // source of truth for "what counts as a pincite" and means future
+      // pincite improvements propagate here automatically.
+      //
+      // Punctuation other than commas inside the segment list (e.g.
+      // `, 453; 460, `) deliberately fails — `parsePincite("453; 460")`
+      // returns null, the segment-by-segment validation fails, and the gap
+      // is rejected. That's correct: semicolons don't appear in legitimate
+      // pincite lists.
+      const tight = /^,\s*$/.test(gapText)
+      let pinciteBetween = false
+      if (!tight) {
+        const inner = gapText.match(/^,\s*(.+?)\s*,\s*$/)
+        if (inner) {
+          const segments = inner[1].split(/\s*,\s*/)
+          pinciteBetween =
+            segments.length > 0 && segments.every((s) => parsePincite(s) !== null)
+        }
       }
-
-      // Check proximity: distance from comma to next citation start
-      // MAX_PROXIMITY enforces tight spacing: "A, B" not "A,      B"
-      const commaIndex = gapText.indexOf(",")
-      const distanceAfterComma = gapText.length - commaIndex - 1
-
-      if (distanceAfterComma > MAX_PROXIMITY) {
-        break // Too far apart, stop looking
-      }
+      if (!tight && !pinciteBetween) break
 
       // Check for shared parenthetical
       // Both citations must share the SAME closing parenthetical

--- a/src/extract/detectStringCites.ts
+++ b/src/extract/detectStringCites.ts
@@ -80,6 +80,24 @@ function setSignal(c: Citation, sig: CitationSignal): void {
 }
 
 /**
+ * Parallel-group secondaries (e.g., `864 A.2d 1191` in
+ * `374 N.J. Super. 448, 864 A.2d 1191 (App. Div. 2005)`) are not
+ * independent authorities — they're the same case reported in another
+ * reporter. The string-cite walker must skip them so it doesn't pair the
+ * secondary with an adjacent unrelated authority across a `;` separator
+ * (e.g., grouping `891 A.2d 1202` with a following `Yellen v. Kassin`).
+ *
+ * A case citation is a parallel secondary iff it has a `groupId` (set by
+ * detectParallelCitations) but no `parallelCitations` (which the primary
+ * alone carries).
+ */
+function isParallelSecondary(c: Citation): boolean {
+  if (c.type !== "case") return false
+  const fc = c as FullCaseCitation
+  return fc.groupId !== undefined && fc.parallelCitations === undefined
+}
+
+/**
  * Parse a recognized signal word from text.
  * Returns the normalized signal and the length of the match, or undefined.
  */
@@ -145,13 +163,58 @@ function analyzeGap(gapText: string): { valid: boolean; signal?: CitationSignal 
 export function detectStringCitations(citations: Citation[], cleanedText: string): void {
   if (citations.length < 2) return
 
-  // Build groups as arrays of citation indices
+  // Build the anchor list: indices of citations that can act as string-cite
+  // members. Parallel-group secondaries are excluded — they're the same
+  // authority as their group's primary, not an independent string-cite
+  // member. (Subsequent-history entries are handled inside the walk below
+  // because they cause the current group to finalize, not just be skipped.)
+  //
+  // When the primary of a parallel group is the "previous" anchor, the gap
+  // to the next anchor must start AFTER the group's last secondary so the
+  // gap text only contains the inter-authority separator (e.g., "; see also ")
+  // and not the secondary's `(year)` parenthetical.
+  const anchorIndices: number[] = []
+  // anchorEnd[k] = cleanedText position to use as the END of anchor k for
+  // gap analysis. For a primary with secondaries, this is the LAST secondary's
+  // fullSpan.cleanEnd; otherwise just the anchor's own end.
+  const anchorEnd: number[] = []
+  for (let i = 0; i < citations.length; i++) {
+    if (isParallelSecondary(citations[i])) continue
+    anchorIndices.push(i)
+    // Look ahead for parallel-group secondaries belonging to this anchor.
+    // They appear contiguously after the primary in document order (the
+    // parallel detector only groups adjacent same-paren cites).
+    let endPos = getCitationEnd(citations[i])
+    const groupId =
+      citations[i].type === "case"
+        ? (citations[i] as FullCaseCitation).groupId
+        : undefined
+    if (groupId !== undefined) {
+      for (let j = i + 1; j < citations.length; j++) {
+        const sib = citations[j]
+        if (sib.type !== "case") break
+        const fc = sib as FullCaseCitation
+        if (fc.groupId !== groupId) break
+        if (!isParallelSecondary(sib)) break
+        endPos = getCitationEnd(sib)
+      }
+    }
+    anchorEnd.push(endPos)
+  }
+
+  if (anchorIndices.length < 2) return
+
+  // Build groups as arrays of citation indices (the original primary indices,
+  // not anchor-list positions — downstream metadata is keyed off the
+  // citation array).
   const groups: number[][] = []
   let currentGroup: number[] = []
 
-  for (let i = 0; i < citations.length - 1; i++) {
+  for (let k = 0; k < anchorIndices.length - 1; k++) {
+    const i = anchorIndices[k]
+    const nextI = anchorIndices[k + 1]
     const current = citations[i]
-    const next = citations[i + 1]
+    const next = citations[nextI]
 
     // Skip if next citation is a subsequent history entry
     if (next.type === "case" && (next as FullCaseCitation).subsequentHistoryOf) {
@@ -168,8 +231,9 @@ export function detectStringCitations(citations: Citation[], cleanedText: string
       continue
     }
 
-    // Extract gap text between end of current's full extent and start of next's full extent
-    const gapStart = getCitationEnd(current)
+    // Extract gap text between end of current's parallel group (anchorEnd[k])
+    // and start of next's full extent.
+    const gapStart = anchorEnd[k]
     const gapEnd = getCitationStart(next)
 
     // Guard against overlapping or adjacent spans with no gap
@@ -190,7 +254,7 @@ export function detectStringCitations(citations: Citation[], cleanedText: string
         currentGroup.push(i)
       }
       // Always add the next citation to the group
-      currentGroup.push(i + 1)
+      currentGroup.push(nextI)
       // Set mid-group signal on next citation if found and not already set
       if (analysis.signal && !next.signal) {
         setSignal(next, analysis.signal)

--- a/tests/extract/detectParallel.test.ts
+++ b/tests/extract/detectParallel.test.ts
@@ -200,7 +200,12 @@ describe("detectParallelCitations", () => {
       expect(result.size).toBe(0)
     })
 
-    it("does not link citations with wide separation after comma", () => {
+    it("links citations with wide whitespace after comma when shared parenthetical present", () => {
+      // The structural classifier accepts `, \s* ` as a tight comma gap, since
+      // whitespace alone (no other text) is just formatting noise. The shared
+      // parenthetical check (`hasSharedParenthetical`) remains the defense in
+      // depth — `,      ` between two reporter cites that close into a shared
+      // `(year)` is a legitimate (if poorly formatted) parallel citation.
       const cleaned = "500 F.2d 123,      200 F. Supp. 456 (1974)" // 6 spaces after comma
       const tokens: Token[] = [
         {
@@ -219,7 +224,8 @@ describe("detectParallelCitations", () => {
 
       const result = detectParallelCitations(tokens, cleaned)
 
-      expect(result.size).toBe(0)
+      expect(result.size).toBe(1)
+      expect(result.get(0)).toEqual([1])
     })
   })
 

--- a/tests/extract/detectParallelPinciteBetween.test.ts
+++ b/tests/extract/detectParallelPinciteBetween.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+function caseCites(text: string): FullCaseCitation[] {
+  return extractCitations(text).filter(
+    (c): c is FullCaseCitation => c.type === "case",
+  )
+}
+
+describe("detectParallel — pincite-between gap shapes", () => {
+  it("accepts single page pincite (', NNN, ')", () => {
+    const text = "Smith v. Jones, 374 N.J. Super. 448, 453, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBeDefined()
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+    expect(cites[0].parallelCitations).toEqual([
+      { volume: 864, reporter: "A.2d", page: 1191 },
+    ])
+  })
+
+  it("accepts page range (', NNN-NN, ')", () => {
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, 453-55, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+
+  it("accepts en-dash page range (', NNN–NN, ')", () => {
+    // En-dash (U+2013) is common in published opinions.
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, 453–55, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+
+  it("accepts multi-pincite list (', NNN, NNN, ')", () => {
+    const text = "Roe v. Wade, 410 U.S. 113, 115, 153, 93 S. Ct. 705 (1973)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+    // Note: parallelCitations stores the normalized reporter form ("S.Ct.",
+    // no space), not the source form ("S. Ct."). See reporter normalization
+    // in extractCitations.ts.
+    expect(cites[0].parallelCitations).toEqual([
+      { volume: 93, reporter: "S.Ct.", page: 705 },
+    ])
+  })
+
+  it("accepts footnote pincite (', NNN n.N, ')", () => {
+    // Note: this synthetic uses F.2d (federal) + A.2d (regional reporter) as
+    // a parallel pair, which isn't a real-world combination but exercises the
+    // classifier in isolation.
+    const text = "Smith v. Jones, 100 F.2d 50, 55 n.3, 200 A.2d 100 (1990)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+
+  it("REJECTS gap with prose text (', see also, ')", () => {
+    // ", see also, " between cites is two separate cases joined by a signal,
+    // not a parallel pair. Must NOT be detected as parallel.
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, see also, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    // Two valid outcomes both count as "rejected":
+    //   (a) tokenizer doesn't extract both as case-shape (length < 2)
+    //   (b) both extracted but without a shared groupId
+    if (
+      cites.length >= 2 &&
+      cites[0].groupId !== undefined &&
+      cites[1].groupId !== undefined
+    ) {
+      expect(cites[0].groupId).not.toBe(cites[1].groupId)
+    } else {
+      // Either fewer than 2 cites, or at least one has no groupId — both pass.
+      expect(true).toBe(true)
+    }
+  })
+
+  it("REJECTS gap with mixed prose and digits (', page 453 of, ')", () => {
+    const text =
+      "Smith v. Jones, 374 N.J. Super. 448, page 453 of, 864 A.2d 1191 (2005)."
+    const cites = caseCites(text)
+    if (
+      cites.length >= 2 &&
+      cites[0].groupId !== undefined &&
+      cites[1].groupId !== undefined
+    ) {
+      expect(cites[0].groupId).not.toBe(cites[1].groupId)
+    } else {
+      expect(true).toBe(true)
+    }
+  })
+
+  it("tight comma (', ') still works (regression for existing behavior)", () => {
+    // Pre-existing canonical case — `186 N.J. 78, 891 A.2d 1202` with no
+    // pincite between — must continue to detect.
+    const text = "Smith v. Jones, 186 N.J. 78, 891 A.2d 1202 (2006)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+})

--- a/tests/extract/detectParallelPinciteBetween.test.ts
+++ b/tests/extract/detectParallelPinciteBetween.test.ts
@@ -44,7 +44,7 @@ describe("detectParallel — pincite-between gap shapes", () => {
     expect(cites[0].groupId).toBe(cites[1].groupId)
     // Note: parallelCitations stores the normalized reporter form ("S.Ct.",
     // no space), not the source form ("S. Ct."). See reporter normalization
-    // in extractCitations.ts.
+    // in src/clean/cleaners.ts (normalizeReporterSpacing).
     expect(cites[0].parallelCitations).toEqual([
       { volume: 93, reporter: "S.Ct.", page: 705 },
     ])
@@ -55,6 +55,16 @@ describe("detectParallel — pincite-between gap shapes", () => {
     // a parallel pair, which isn't a real-world combination but exercises the
     // classifier in isolation.
     const text = "Smith v. Jones, 100 F.2d 50, 55 n.3, 200 A.2d 100 (1990)."
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(2)
+    expect(cites[0].groupId).toBe(cites[1].groupId)
+  })
+
+  it("accepts star-pagination pincite (', *N, ')", () => {
+    // Star-pagination (`*2`) is common in slip-opinion / unreported decisions
+    // and explicitly handled by parsePincite. The classifier accepts it as
+    // a pincite-between segment.
+    const text = "Smith v. Jones, 374 N.J. Super. 448, *2, 864 A.2d 1191 (2005)."
     const cites = caseCites(text)
     expect(cites).toHaveLength(2)
     expect(cites[0].groupId).toBe(cites[1].groupId)

--- a/tests/extract/randolphFixture.test.ts
+++ b/tests/extract/randolphFixture.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, FullCaseCitation } from "@/types/citation"
+
+describe("Randolph fixture — all parallel pairs across pincite-between gaps detect", () => {
+  // The actual passage from the user's brief (HOA / adverse-possession context).
+  // Three logical authorities, each with parallel citations:
+  //   - Randolph App. Div. 2005: 374 N.J. Super. 448 + 864 A.2d 1191
+  //   - Randolph N.J. 2006 (affirmance): 186 N.J. 78 + 891 A.2d 1202
+  //   - Yellen App. Div. 2010: 416 N.J. Super. 113 + 3 A.3d 584
+  const text = `The prescriptive period in New Jersey is not twenty years, as was formerly assumed, but thirty years for developed land (or sixty years for woodlands or uncultivated tracts), by analogy to the adverse-possession periods set forth in N.J.S.A. 2A:14-30. Randolph Town Ctr., L.P. v. County of Morris, 374 N.J. Super. 448, 453–55, 864 A.2d 1191 (App. Div. 2005), aff'd in part, 186 N.J. 78, 891 A.2d 1202 (2006); see also Yellen v. Kassin, 416 N.J. Super. 113, 120, 3 A.3d 584 (App. Div. 2010).`
+
+  it("all three parallel pairs detected with correct groupIds", () => {
+    const cites = extractCitations(text, { resolve: true })
+    const caseCites = cites.filter(
+      (c): c is FullCaseCitation => c.type === "case",
+    )
+    expect(caseCites).toHaveLength(6)
+
+    // Pair 1: Randolph App. Div. 2005
+    expect(caseCites[0].text).toContain("374 N.J. Super. 448")
+    expect(caseCites[1].text).toContain("864 A.2d 1191")
+    expect(caseCites[0].groupId).toBeDefined()
+    expect(caseCites[0].groupId).toBe(caseCites[1].groupId)
+    expect(caseCites[0].parallelCitations).toEqual([
+      { volume: 864, reporter: "A.2d", page: 1191 },
+    ])
+
+    // Pair 2: Randolph N.J. 2006 (affirmance)
+    expect(caseCites[2].text).toContain("186 N.J. 78")
+    expect(caseCites[3].text).toContain("891 A.2d 1202")
+    expect(caseCites[2].groupId).toBeDefined()
+    expect(caseCites[2].groupId).toBe(caseCites[3].groupId)
+    expect(caseCites[2].parallelCitations).toEqual([
+      { volume: 891, reporter: "A.2d", page: 1202 },
+    ])
+
+    // Pair 3: Yellen App. Div. 2010
+    expect(caseCites[4].text).toContain("416 N.J. Super. 113")
+    expect(caseCites[5].text).toContain("3 A.3d 584")
+    expect(caseCites[4].groupId).toBeDefined()
+    expect(caseCites[4].groupId).toBe(caseCites[5].groupId)
+    expect(caseCites[4].parallelCitations).toEqual([
+      { volume: 3, reporter: "A.3d", page: 584 },
+    ])
+
+    // Three logical authorities → three distinct groupIds
+    const distinctGroupIds = new Set([
+      caseCites[0].groupId,
+      caseCites[2].groupId,
+      caseCites[4].groupId,
+    ])
+    expect(distinctGroupIds.size).toBe(3)
+  })
+
+  it("string-cite anomaly auto-resolves — Randolph affirmance secondary does not share sc group with Yellen primary", () => {
+    // Pre-fix: 891 A.2d 1202 (Randolph affirmance secondary, currently extracted
+    // as a standalone primary because parallel detection fails) shared a
+    // stringCitationGroupId with 416 N.J. Super. 113 (Yellen primary across `;`).
+    // Post-fix: 891 A.2d 1202 is now a parallel secondary, no longer a
+    // string-cite primary candidate; the walker pairs the correct primaries
+    // across the `;` separator (or leaves them ungrouped — exact behavior
+    // depends on detectStringCites's logic, but the cross-authority pairing
+    // must NOT persist).
+    const cites = extractCitations(text, { resolve: true })
+    const caseCites = cites.filter(
+      (c): c is FullCaseCitation => c.type === "case",
+    )
+
+    const randolphAffirmanceSecondary = caseCites[3] // 891 A.2d 1202
+    const yellenPrimary = caseCites[4] // 416 N.J. Super. 113
+
+    // The affirmance secondary and the Yellen primary should NOT share a
+    // stringCitationGroupId after the fix.
+    expect(
+      randolphAffirmanceSecondary.stringCitationGroupId !== undefined &&
+        randolphAffirmanceSecondary.stringCitationGroupId ===
+          yellenPrimary.stringCitationGroupId,
+    ).toBe(false)
+  })
+})

--- a/tests/extract/randolphFixture.test.ts
+++ b/tests/extract/randolphFixture.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { extractCitations } from "@/extract"
-import type { Citation, FullCaseCitation } from "@/types/citation"
+import type { FullCaseCitation } from "@/types/citation"
 
 describe("Randolph fixture — all parallel pairs across pincite-between gaps detect", () => {
   // The actual passage from the user's brief (HOA / adverse-possession context).


### PR DESCRIPTION
## Summary

- **Parallel-citation detection now accepts the Bluebook-canonical pincite-between form** per Indigo Book R12.3 (`vol rep page, pincite, vol rep page` — e.g., `374 N.J. Super. 448, 453–55, 864 A.2d 1191`). The previous `MAX_PROXIMITY = 5` heuristic only caught the less-common tight-comma variant. Reuses the existing `parsePincite` helper as single source of truth for "what counts as a pincite," automatically covering page/range/star/¶/footnote/multi-pincite forms.
- **String-citation walker (`detectStringCites.ts`) now skips parallel secondaries** when building groups. Fixes a related defect where a parallel secondary (e.g. an affirmance's parallel cite) could be mis-grouped via `stringCitationGroupId` with an unrelated primary across a `;` separator (e.g., a subsequent `see also` cite to a different case). The spec predicted this would auto-resolve from the parallel fix; in practice it required a code change to the walker, included here.
- **Flipped one pre-existing assertion** in `tests/extract/detectParallel.test.ts` that was locking in the removed `MAX_PROXIMITY` behavior. New assertion reflects the correct Bluebook-canonical semantics (whitespace alone between cites is formatting noise; `hasSharedParenthetical` is the defense-in-depth gate).

**Design + research** (in-repo): `docs/superpowers/specs/2026-05-19-parallel-cites-pincite-between-design.md`, `docs/research/2026-05-19-parallel-citation-detection.md`. Research surveyed Indigo Book R12.3, Python eyecite (which has the same bug class — open PR #288), CourtListener, Westlaw, Lexis+, LawCite, and CSL-M; converged on "fold at the cluster boundary, not in the parser." eyecite-ts already exposes both views (raw per-reporter via `citations[]`; per-case via `groupByCase()`).

**Changeset:** `.changeset/parallel-cites-pincite-between.md` (patch bump).

## Behavior change worth flagging

Consumers calling `groupByCase()` on inputs containing pincite-between parallel pairs will see fewer logical case groups (parallels now collapse correctly). Raw `citations[]` count is unchanged.

## Test Plan

- [x] `pnpm exec vitest run` — 3006 tests pass (Randolph end-to-end fixture + 9 per-shape unit tests covering page/range/en-dash/multi-pincite/footnote/star + 2 prose negatives + tight-comma regression)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (236 pre-existing warnings unrelated to this PR)
- [x] `pnpm build` — succeeds
- [x] `pnpm size` — within budget (35.3 / 50 kB main; 1.8 / 3 kB utils)
- [ ] Reviewer: verify `tests/extract/detectParallel.test.ts` flipped assertion (line ~203-229) — it now expects parallels to detect across wider whitespace, with `hasSharedParenthetical` as the still-in-place defense-in-depth gate. This matches the removed `MAX_PROXIMITY`'s intent (which the spec explicitly removed).
- [ ] Reviewer: end-to-end Randolph fixture (`tests/extract/randolphFixture.test.ts`) is the user's actual bug-report passage — verify it reads as a faithful reproduction.
- [ ] Reviewer: scope expansion to `detectStringCites.ts` was empirically required (spec reviewer reverted the file and confirmed the second Randolph test fails without it). The change uses an anchor-list walker that skips parallel-secondary indices when computing gap positions — read the inline rationale comment in the file.

## Follow-ups (NOT in this PR)

1. Consider extracting `detectStringCites.ts`'s anchor-end walk-forward loop as a named helper `findParallelGroupEnd(citations, primaryIdx, groupId)` for clarity. Minor refactor; doesn't change behavior.
2. The plan and spec stated "No code change to detectStringCites.ts" — that turned out to be wrong (the spec's "auto-resolve" prediction was over-optimistic). Worth updating the spec/plan documents in a follow-up commit for future readers.
3. Negative test pattern in `detectParallelPinciteBetween.test.ts` could be tightened — consider `expect.assertions(1)` over the current `if/else { expect(true).toBe(true) }` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)