### PR TITLE
ci(release): expose NPM_TOKEN to disable OIDC fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Also expose as NPM_TOKEN so changesets/action skips its OIDC
+          # trusted-publishing fallback and uses the token path. OIDC
+          # broke npm-side around 2026-05-19T20:00Z (404 on PUT for new
+          # versions). Token-based publish still produces provenance via
+          # NPM_CONFIG_PROVENANCE above.
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Hotfix for the 0.21.0 publish failure. \`changesets/action\` falls back to OIDC trusted-publishing when it doesn't see \`process.env.NPM_TOKEN\`, and npm-side OIDC for this package broke between 19:51 (0.20.1 published cleanly) and 21:39 UTC today (0.21.0 failed with E404 on PUT). Re-runs produce fresh sigstore signatures each time — all rejected — so it's not transient.

Exposing \`NPM_TOKEN\` in the workflow env block alongside the existing \`NODE_AUTH_TOKEN\` makes \`changesets/action\` use the token-based publish path. Provenance is still generated via \`NPM_CONFIG_PROVENANCE\`.

Once this merges, the \`Release\` workflow re-runs on the new main commit and publishes 0.21.0.

**Follow-up (not blocking):** investigate the npm trusted-publisher binding for this package — settings → trusted publishers — and re-add / verify the binding to medelman17/eyecite-ts workflow release.yml if it was modified.

## Test Plan

- [ ] Merge this PR
- [ ] Wait for Release workflow to run on the merge commit
- [ ] Verify it now publishes 0.21.0 successfully (token path instead of OIDC)
- [ ] \`npm view eyecite-ts version\` returns \`0.21.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)