### PR TITLE
fix(resolve): Id. honors strict Bluebook 4.1 regardless of signal (#498)

### DIFF
--- a/.changeset/strict-bluebook-id-signals.md
+++ b/.changeset/strict-bluebook-id-signals.md
@@ -1,0 +1,13 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `Id.` resolves-to skipping weakly-signaled antecedent (#498).
+
+`resolveId` previously down-ranked candidates carrying `See`, `Cf.`, `See also`, `Compare`, `But cf.`, or `See generally` signals (`+100 if !weak` in the scorer), which let a more-distant strong-signal full cite beat a more-recent weak-signal one. The bug surfaced when the same input was extracted with vs. without a `See` prefix on the most-recent full cite — the single-character delta flipped `Id.`'s resolved cluster from the immediately-preceding case to the prior unsignaled one.
+
+Per Bluebook Rule 4.1 (and matching the Python eyecite reference implementation, which is signal-blind), `Id.` anchors to the immediately preceding cited authority regardless of signal phrase. The signal qualifies *how* the source supports the proposition, not whether the citation can be the referent of a following `Id.`
+
+The fix removes the weak-signal scoring component from `resolveId`. Family preference (case vs. statute based on `Id.`'s pincite shape), quote-zone filtering, parenthetical-child filtering, and case-name window checks are unchanged. `resolution.resolvedTo` and `resolution.antecedentIndex` now agree in every signal case.
+
+**Behavior change for #480 weak-signal scenarios:** in `STRONG. See WEAK. Id.` patterns, `Id.` now resolves to the `See`-signaled cite (the immediately preceding citation), not the strong cite. This aligns with Python eyecite and the strict Rule 4.1 reading. Six tests in `tests/resolve/issue480_idAntecedent.test.ts` were updated to encode the new (correct) expectation.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -12,7 +12,6 @@
 
 import type {
   Citation,
-  CitationSignal,
   FullCaseCitation,
   FullCitation,
   IdCitation,
@@ -45,28 +44,6 @@ function getFullSpan(citation: Citation): Span | undefined {
   }
   return undefined
 }
-
-/**
- * Bluebook signal categories that mark a citation as an *aside* — supporting,
- * comparative, or background — rather than a primary cited authority.
- * Citations carrying a weak signal are skipped when picking an `Id.`
- * antecedent unless no stronger candidate is in scope. Suggested-contradiction
- * (`but cf.`) is weak; direct-contradiction (`contra`, `but see`) is strong
- * because the writer is squarely engaging the cited authority.
- */
-const WEAK_SIGNALS: ReadonlySet<CitationSignal> = new Set<CitationSignal>([
-  "see",
-  "see also",
-  "see generally",
-  "cf",
-  "but cf",
-  "compare",
-  "e.g.",
-  "see, e.g.",
-  "see also, e.g.",
-  "cf., e.g.",
-  "but cf., e.g.",
-])
 
 /**
  * Family classification used when matching `Id.` to an antecedent. Page-style
@@ -365,8 +342,10 @@ export class DocumentResolver {
 
   /**
    * Resolves `Id.` to the most recent preceding *cited authority*, respecting
-   * Bluebook signal categories, block-/inline-quote zones, and the family
-   * (case vs. statute) implied by `Id.`'s pincite shape (#480).
+   * block-/inline-quote zones and the family (case vs. statute) implied by
+   * `Id.`'s pincite shape (#480). Per Bluebook Rule 4.1, signal phrase is
+   * NOT a filter — `Id.` anchors to the immediately preceding cited
+   * authority regardless of whether it carries `See`, `Cf.`, etc. (#498).
    *
    * Algorithm:
    *   1. Walk backward from `currentIndex`, normalizing short-form citations
@@ -375,9 +354,8 @@ export class DocumentResolver {
    *      doesn't get double-counted with its full-cite further back.
    *   2. Filter candidates that are parenthetical children (existing #214
    *      behavior) or in a quote zone outside `Id.`'s own zone.
-   *   3. Score remaining candidates: family-match dominates, then signal
-   *      strength, then (implicitly) recency (first-added = most recent
-   *      effective mention).
+   *   3. Score remaining candidates: family-match dominates, then (implicitly)
+   *      recency (first-added = most recent effective mention).
    *   4. Apply the case-name window check to surface ambiguity when the prose
    *      immediately before `Id.` mentions a different case name.
    */
@@ -389,7 +367,6 @@ export class DocumentResolver {
     interface Candidate {
       index: number
       family: CitationFamily
-      weak: boolean
     }
     const candidates: Candidate[] = []
     const seen = new Set<number>()
@@ -439,7 +416,6 @@ export class DocumentResolver {
       candidates.push({
         index: primaryIdx,
         family: citationFamily(cit),
-        weak: this.isCandidateWeakSignal(cit),
       })
     }
 
@@ -465,15 +441,16 @@ export class DocumentResolver {
     }
 
     // Score each candidate. Family-match dominates (Id.'s pincite shape
-    // tells us which family of authority the writer intended). Strong
-    // (unsignaled or direct-engagement) candidates beat weak (aside)
-    // candidates. Recency breaks ties — candidates are pushed in reverse
-    // document order, so the first match at a given score is the most
-    // recent effective mention.
+    // tells us which family of authority the writer intended). Recency
+    // breaks ties — candidates are pushed in reverse document order, so
+    // the first match at a given score is the most recent effective
+    // mention. Per Bluebook Rule 4.1, signal phrase does NOT affect
+    // antecedent selection: `Id.` anchors to the immediately preceding
+    // cited authority regardless of whether that authority is introduced
+    // by `See`, `Cf.`, or any other signal (#498).
     const score = (c: Candidate) => {
       let s = 0
       if (c.family === preferredFamily) s += 1000
-      if (!c.weak) s += 100
       return s
     }
     let best = candidates[0]
@@ -513,30 +490,6 @@ export class DocumentResolver {
     const tail = this.text.substring(start, end)
     if (/^\s*[,]?\s*§§?\s*\d/.test(tail)) return "statute"
     return "case"
-  }
-
-  /**
-   * Computes the "effective" signal for a citation. Citations inside a
-   * string-cite group inherit the leading signal of the group's first
-   * member when they have no signal of their own — the Bluebook rule that
-   * a leading signal governs the entire string cite.
-   */
-  private getEffectiveSignal(citation: Citation): CitationSignal | undefined {
-    if (citation.signal) return citation.signal
-    const groupId = citation.stringCitationGroupId
-    if (!groupId) return undefined
-    // First member of the group carries the leading signal.
-    for (const c of this.citations) {
-      if (c.stringCitationGroupId === groupId && c.stringCitationIndex === 0) {
-        return c.signal
-      }
-    }
-    return undefined
-  }
-
-  private isCandidateWeakSignal(citation: Citation): boolean {
-    const sig = this.getEffectiveSignal(citation)
-    return sig !== undefined && WEAK_SIGNALS.has(sig)
   }
 
   /**

--- a/tests/resolve/issue480_idAntecedent.test.ts
+++ b/tests/resolve/issue480_idAntecedent.test.ts
@@ -42,72 +42,76 @@ describe("Issue #480: Id./short-form antecedent resolution", () => {
     })
   })
 
-  // Criterion 3: signal-phrase awareness — see / see also / cf. / but cf. /
-  // compare / see generally are "asides" and should not become Id. antecedents
-  // when a more-recent non-signaled case is in scope.
-  describe("signal-phrase awareness", () => {
-    it("Id. skips over a 'see also' intervening case", () => {
+  // Criterion 3: signal-phrase blindness — per Bluebook Rule 4.1, `Id.`
+  // anchors to the immediately preceding cited authority regardless of
+  // signal phrase. A `See`/`Cf.`/`Compare`-signaled full citation is still
+  // an authority; the signal qualifies *how* the source supports the
+  // proposition, not whether the citation can be the referent of a
+  // following `Id.` (originally tested as "skips over" in #480; corrected
+  // to strict Rule 4.1 in #498 to match the Python eyecite reference).
+  describe("signal-phrase blindness (Bluebook Rule 4.1, #498)", () => {
+    it("Id. anchors to a 'see also' intervening case", () => {
       const text =
         "People v. Henderson, 28 N.Y.3d 63, 70 (2016). " +
         "See also People v. Molineux, 168 N.Y. 264 (1901). Id. at 70."
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const molineux = citations.find((c) => c.type === "case" && c.volume === 168)!
       const id = citations.find((c) => c.type === "id")!
-      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(molineux))
     })
 
-    it("Id. skips over a 'cf.' intervening case", () => {
+    it("Id. anchors to a 'cf.' intervening case", () => {
       const text =
         "People v. Henderson, 28 N.Y.3d 63, 70 (2016). " +
         "Cf. People v. Molineux, 168 N.Y. 264 (1901). Id. at 70."
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const molineux = citations.find((c) => c.type === "case" && c.volume === 168)!
       const id = citations.find((c) => c.type === "id")!
-      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(molineux))
     })
 
-    it("Id. skips over a 'see' intervening case", () => {
+    it("Id. anchors to a 'see' intervening case", () => {
       const text =
         "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
         "See Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const adams = citations.find((c) => c.type === "case" && c.volume === 168)!
       const id = citations.find((c) => c.type === "id")!
-      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(adams))
     })
 
-    it("Id. skips over a 'but cf.' intervening case", () => {
+    it("Id. anchors to a 'but cf.' intervening case", () => {
       const text =
         "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
         "But cf. Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const adams = citations.find((c) => c.type === "case" && c.volume === 168)!
       const id = citations.find((c) => c.type === "id")!
-      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(adams))
     })
 
-    it("Id. skips over a 'compare' intervening case", () => {
+    it("Id. anchors to a 'compare' intervening case", () => {
       const text =
         "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
         "Compare Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const adams = citations.find((c) => c.type === "case" && c.volume === 168)!
       const id = citations.find((c) => c.type === "id")!
-      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(adams))
     })
 
-    it("Id. skips over a 'see generally' intervening case", () => {
+    it("Id. anchors to a 'see generally' intervening case", () => {
       const text =
         "Henderson v. State, 28 N.Y.3d 63, 70 (2016). " +
         "See generally Adams v. Brown, 168 N.Y. 264 (1901). Id. at 70."
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const henderson = citations.find((c) => c.type === "case" && c.volume === 28)!
+      const adams = citations.find((c) => c.type === "case" && c.volume === 168)!
       const id = citations.find((c) => c.type === "id")!
-      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(henderson))
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(adams))
     })
 
-    it("Id. resolves to a weakly-signaled case when no strong case is in scope", () => {
-      // Only weakly-signaled candidates exist; fall back to most recent.
+    it("Id. resolves to most-recent of two weakly-signaled cases (recency wins)", () => {
+      // Both candidates weakly signaled; recency picks the latter.
       const text =
         "See People v. Resek, 3 N.Y.3d 385 (2004). " +
         "See also People v. Molineux, 168 N.Y. 264 (1901). Id. at 270."

--- a/tests/resolve/issue498_idSignalAntecedent.test.ts
+++ b/tests/resolve/issue498_idSignalAntecedent.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Issue #498: `Id.` resolves-to skips weakly-signaled antecedent.
+ *
+ * Bluebook Rule 4.1: `Id.` refers to the immediately preceding cited
+ * authority — regardless of signal phrase. A `See`-signaled full citation is
+ * still an authority; the signal qualifies *how* the source supports the
+ * proposition, not whether the citation itself can be the referent of a
+ * following `Id.`
+ *
+ * Python eyecite's reference implementation (`_resolve_id_citation` in
+ * `eyecite/resolve.py`) is signal-blind: it returns `last_resolution` —
+ * the most-recent successfully-resolved citation — with no scoring or
+ * filtering by signal phrase.
+ *
+ * The pre-fix TypeScript port down-ranked weak-signaled candidates in
+ * `resolveId`'s scorer (`+100 if !weak`), causing a more-distant strong-
+ * signal full cite to beat a more-recent weak-signal one. That matched
+ * the `WEAK_SIGNALS` membership exactly: `see` / `cf` failed; `but see` /
+ * `accord` / unsignaled passed. This file pins the strict Rule 4.1 reading
+ * for every signal class.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #498: Id. resolves-to honors strict Bluebook 4.1 (signal-blind)", () => {
+  // Holding the rest of the input constant and varying only the signal
+  // before the second full cite. Per Rule 4.1, `Id.` must anchor to the
+  // immediately preceding cited authority in every row.
+  const matrix: Array<[label: string, signal: string]> = [
+    ["(none)", ""],
+    ["See", "See "],
+    ["But see", "But see "],
+    ["Cf.", "Cf. "],
+    ["Accord", "Accord "],
+    ["See also", "See also "],
+    ["But cf.", "But cf. "],
+    ["Compare", "Compare "],
+    ["See generally", "See generally "],
+  ]
+
+  for (const [label, signal] of matrix) {
+    it(`Id. resolves to immediately preceding cite when antecedent has '${label}' signal`, () => {
+      const text = `Iqbal, 556 U.S. 662 (2009). ${signal}Printing Mart, 116 N.J. 739 (1989). Id.`
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const iqbal = citations.find((c) => c.type === "case" && c.volume === 556)!
+      const printingMart = citations.find((c) => c.type === "case" && c.volume === 116)!
+      const id = citations.find((c) => c.type === "id")!
+
+      expect(iqbal, `Iqbal should be extracted for ${label}`).toBeDefined()
+      expect(printingMart, `Printing Mart should be extracted for ${label}`).toBeDefined()
+      expect(id, `Id. should be extracted for ${label}`).toBeDefined()
+
+      // Strict Bluebook 4.1: Id.'s resolved cluster matches its positional
+      // antecedent. Both must point at Printing Mart (immediately preceding).
+      expect(id.resolution?.resolvedTo, `resolvedTo for '${label}'`).toBe(
+        citations.indexOf(printingMart),
+      )
+    })
+  }
+
+  it("antecedent edge and resolves-to edge agree in every signal case", () => {
+    // The two-source-of-truth divergence from #498: `antecedent` was already
+    // correct (computed via findImmediatePredecessor); only `resolvedTo` was
+    // wrong. After the fix, the two must agree.
+    for (const [, signal] of matrix) {
+      const text = `Iqbal, 556 U.S. 662 (2009). ${signal}Printing Mart, 116 N.J. 739 (1989). Id.`
+      const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+      const id = citations.find((c) => c.type === "id")!
+      expect(id.resolution?.resolvedTo).toBe(id.resolution?.antecedentIndex)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fix [#498](https://github.com/medelman17/eyecite-ts/issues/498) — `Id.`'s `resolves-to` edge wrongly skipped over `See`/`Cf.`-signaled antecedents to a more-distant unsignaled cite, while the `antecedent` edge correctly stayed on the immediately preceding citation. The single-character delta of adding `See ` flipped the resolved cluster.

Root cause: `resolveId`'s scorer added `+100 if !weak` to candidates, letting strong-signal distance beat weak-signal recency. This contradicted Bluebook Rule 4.1 ("Id. refers to the immediately preceding cited authority") and diverged from Python eyecite, which is signal-blind (`_resolve_id_citation` returns `last_resolution` with no scoring).

## Changes

- **`src/resolve/DocumentResolver.ts`** — removed `if (!c.weak) s += 100` from `resolveId`'s scorer. Deleted the now-dead `WEAK_SIGNALS` constant, `isCandidateWeakSignal()` helper, and `getEffectiveSignal()` helper (the latter was only called by the former). Updated comments + JSDoc.
- **`tests/resolve/issue498_idSignalAntecedent.test.ts`** *(new)* — 9-signal matrix pinning strict Rule 4.1 for `(none)`, `See`, `But see`, `Cf.`, `Accord`, `See also`, `But cf.`, `Compare`, `See generally`. Plus an invariant check that `resolvedTo === antecedentIndex` in every signal case (collapses the two-source-of-truth divergence noted in the issue).
- **`tests/resolve/issue480_idAntecedent.test.ts`** — flipped 6 "skips over" tests to "anchors to" (the strict Rule 4.1 reading). The original #480 plan encoded a "smart" heuristic that contradicted Bluebook 4.1; this aligns the tests with the reference behavior.
- **`.changeset/strict-bluebook-id-signals.md`** — patch changeset with behavior-change callout.

Family preference, quote-zone filtering, parenthetical-child filtering, and case-name window checks are unchanged.

## Behavior change

In `STRONG. See WEAK. Id.` patterns, `Id.` now resolves to the `See`-signaled cite (the immediately preceding citation), not the strong cite. This is what the issue reporter requested and what Python eyecite does.

## Test plan

- [x] `pnpm exec vitest run tests/resolve/issue498_idSignalAntecedent.test.ts` — 10/10 pass
- [x] `pnpm exec vitest run` — 3062/3062 pass (no other regressions)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — no errors (only pre-existing style warnings)
- [x] Manual repro via `scripts/repro_issue_498.ts` confirms all 5 signal cases now resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)