### PR TITLE
fix(signal): recognize `e. g.` (spaced) as the `e.g.` signal

### DIFF
--- a/.changeset/signal-eg-spacing.md
+++ b/.changeset/signal-eg-spacing.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+Recognize `e. g.` (with internal whitespace) as the `e.g.` signal.
+
+The Bluebook abbreviation `e.g.` appears in two typesetting variants: the closed form `e.g.` and the older spaced form `e. g.` (with whitespace between the letters), common in older opinions and some publishers' styles. The closed form already worked; the spaced form was silently missed, dropping the signal entirely.
+
+Both the prefix matchers (`SIGNAL_PATTERNS` in `detectStringCites.ts`) and the leading-signal scanner (`detectLeadingSignals`) now accept optional whitespace between `e.` and `g.`. Affects all six combined forms: `e.g.`, `see, e.g.`, `see also, e.g.`, `but see, e.g.`, `cf., e.g.`, `but cf., e.g.`.
+
+Surfaced by a CAP-corpus signal-extraction audit: e.g. `See, e. g., New State Ice Co. v. Liebmann, 285 U.S. 262 (1932)` was extracting the case but losing the signal.

--- a/src/extract/detectStringCites.ts
+++ b/src/extract/detectStringCites.ts
@@ -30,12 +30,16 @@ function buildSignalPatterns() {
   // counterparts so the alternation prefers the more specific match. The
   // trailing `,?` after `e\.g\.` allows the optional comma that typically
   // separates the signal from the citation (e.g., "See, e.g., Smith v. Jones").
+  //
+  // The `e\.\s*g\.` form accepts both the closed `e.g.` and the older spaced
+  // typesetting variant `e. g.` (with whitespace between the letters), which
+  // shows up in older opinions and some publishers' styles.
   const raw: ReadonlyArray<{ regex: RegExp; signal: CitationSignal }> = [
-    { regex: /^but\s+cf\.,\s+e\.g\.,?(?=\s|$)/i, signal: "but cf., e.g." },
-    { regex: /^see\s+also,\s+e\.g\.,?(?=\s|$)/i, signal: "see also, e.g." },
-    { regex: /^but\s+see,\s+e\.g\.,?(?=\s|$)/i, signal: "but see, e.g." },
-    { regex: /^cf\.,\s+e\.g\.,?(?=\s|$)/i, signal: "cf., e.g." },
-    { regex: /^see,\s+e\.g\.,?(?=\s|$)/i, signal: "see, e.g." },
+    { regex: /^but\s+cf\.,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "but cf., e.g." },
+    { regex: /^see\s+also,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "see also, e.g." },
+    { regex: /^but\s+see,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "but see, e.g." },
+    { regex: /^cf\.,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "cf., e.g." },
+    { regex: /^see,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "see, e.g." },
     { regex: /^see\s+generally\b/i, signal: "see generally" },
     { regex: /^see\s+also\b/i, signal: "see also" },
     { regex: /^but\s+see\b/i, signal: "but see" },
@@ -45,7 +49,7 @@ function buildSignalPatterns() {
     { regex: /^contra\b/i, signal: "contra" },
     { regex: /^see\b/i, signal: "see" },
     { regex: /^cf\.?(?=\s|$)/i, signal: "cf" },
-    { regex: /^e\.g\.,?(?=\s|$)/i, signal: "e.g." },
+    { regex: /^e\.\s*g\.,?(?=\s|$)/i, signal: "e.g." },
   ]
   return raw.map(({ regex, signal }) => ({
     regex,
@@ -341,7 +345,13 @@ export function detectLeadingSignals(citations: Citation[], cleanedText: string)
     const matches: Array<{ signal: CitationSignal; start: number; end: number }> = []
 
     for (const { signal } of SIGNAL_PATTERNS) {
-      const escaped = signal.replace(/\./g, "\\.").replace(/\s+/g, "\\s+")
+      // The `e\.\s*g\.` form accepts both the closed `e.g.` and the spaced
+      // typesetting variant `e. g.` (with whitespace between the letters),
+      // which appears in older opinions and some publishers' styles.
+      const escaped = signal
+        .replace(/\./g, "\\.")
+        .replace(/\s+/g, "\\s+")
+        .replace(/e\\\.g\\\./g, "e\\.\\s*g\\.")
       const pattern = new RegExp(`(?<![a-zA-Z])(${escaped})(?![a-zA-Z])`, "gi")
       let match: RegExpExecArray | null
       while ((match = pattern.exec(gapText)) !== null) {

--- a/tests/extract/signalDetection.test.ts
+++ b/tests/extract/signalDetection.test.ts
@@ -129,4 +129,62 @@ describe("isolated citation signal detection", () => {
     expect(caseCites[0].signal).toBe("see")
     expect(caseCites[1].signal).toBe("see also") // Set by string cite mid-group detection
   })
+
+  // Bluebook abbreviation `e.g.` appears in two typesetting variants: the
+  // closed form `e.g.` and the older/spaced form `e. g.` (with whitespace
+  // between the letters). Both are recognized as the same signal. Surfaced
+  // by a CAP-corpus audit that found `See, e. g., New State Ice Co. v.
+  // Liebmann, 285 U.S. 262 (1932)` missed.
+  describe('"e.g." with internal whitespace ("e. g.")', () => {
+    it('detects bare "E. g.," (spaced)', () => {
+      const text = "Other circuits agree. E. g., Ecology Center v. Castaneda, 574 F.3d 652 (9th Cir. 2009)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite).toBeDefined()
+      expect(caseCite!.signal).toBe("e.g.")
+    })
+
+    it('detects "See, e. g.," (spaced)', () => {
+      const text = "Police regulation. See, e. g., New State Ice Co. v. Liebmann, 285 U.S. 262 (1932)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite).toBeDefined()
+      expect(caseCite!.signal).toBe("see, e.g.")
+    })
+
+    it('detects "But see, e. g.," (spaced)', () => {
+      const text = "But see, e. g., American Postal Workers v. USPS, 789 F.2d 1 (D.C. Cir. 1986)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite!.signal).toBe("but see, e.g.")
+    })
+
+    it('detects "See also, e. g.," (spaced)', () => {
+      const text = "See also, e. g., Davis v. Lee, 200 F.3d 100 (5th Cir. 2018)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite!.signal).toBe("see also, e.g.")
+    })
+
+    it('detects "Cf., e. g.," (spaced)', () => {
+      const text = "Cf., e. g., Yellow Cab Co. v. Chicago, 186 F.2d 946 (7th Cir. 1951)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite!.signal).toBe("cf., e.g.")
+    })
+
+    it('detects "But cf., e. g.," (spaced)', () => {
+      const text = "But cf., e. g., Griswold v. Connecticut, 381 U.S. 479 (1965)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite!.signal).toBe("but cf., e.g.")
+    })
+
+    it("closed form still works (regression check)", () => {
+      const text = "See, e.g., Smith v. Jones, 500 F.2d 123 (9th Cir. 2020)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite!.signal).toBe("see, e.g.")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Older legal opinions and some publishers' styles typeset the Bluebook abbreviation `e.g.` with internal whitespace as `e. g.`. The closed form worked; the spaced form was silently missed, dropping the signal entirely.

Both the prefix matcher (`SIGNAL_PATTERNS` in `detectStringCites.ts`) and the leading-signal scanner (`detectLeadingSignals`) now accept optional whitespace between `e.` and `g.`. Affects all six combined forms: `e.g.`, `see, e.g.`, `see also, e.g.`, `but see, e.g.`, `cf., e.g.`, `but cf., e.g.`.

## How surfaced

A CAP-corpus signal-extraction audit (`scripts/audit-signals.ts` — new) sampled 80 random opinions and found cases like:

```
"See, e. g., New State Ice Co. v. Liebmann, 285 U.S. 262 (1932)."  → signal=undefined
"E. g., Ecology Center v. Castaneda, 574 F.3d 652 (9th Cir. 2009)." → signal=undefined
```

while the closed form `e.g.` / `E.g.` worked. Same opinions, just typesetting variants.

## Changes

- **`src/extract/detectStringCites.ts`** — two regex patches:
  - `buildSignalPatterns()`: all six `e\.g\.` patterns become `e\.\s*g\.`
  - `detectLeadingSignals()`: the dynamically-built escaped-signal regex adds a post-escape replace to turn `e\.g\.` → `e\.\s*g\.`
- **`tests/extract/signalDetection.test.ts`** — new `"e.g." with internal whitespace` describe block with 7 tests covering all six combined-form variants + a closed-form regression check.
- **`.changeset/signal-eg-spacing.md`** — patch changeset.

No other code or behavior changes.

## Test plan

- [x] `pnpm exec vitest run tests/extract/signalDetection.test.ts` — 23/23 pass (7 new)
- [x] `pnpm exec vitest run` — 3069/3069 pass (no regressions)
- [x] `pnpm typecheck` — clean
- [x] Manual probe via `extractCitations` confirms both spaced and closed forms now extract signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)