### PR TITLE
fix(extract): `Id,` no longer crashes on unusual pincite prefixes

### DIFF
--- a/.changeset/id-comma-crash.md
+++ b/.changeset/id-comma-crash.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `Id,` (typo comma, no period) crash on opinions with unusual pincite prefixes.
+
+`extractCitations` would throw `Error: Failed to parse Id. citation: Id,` when an opinion contained text like `Id, at pages 2-4` (or `Id, at section 3`, etc.) — kinds where the tokenizer matched `Id,` as the start of an Id. citation via its `(?=\s+at\s)` lookahead, but then the optional pincite branch refused to extend the match because `pages` / `section` / etc. is not a recognized pincite prefix. The matched `text` field was just `Id,` (3 characters). `extractId` then re-applied the same lookahead-bearing regex against only those 3 characters — where the lookahead has nothing to look at — and threw.
+
+The lookahead in `extractId` was redundant defensive code: the tokenizer (`ID_PATTERN`) has already enforced it. Removing it lets `extractId` parse `Id,` as a valid (typo-comma) Id citation with no pincite, matching the rest of the function's tolerance for partial parses.
+
+Surfaced by a CAP-corpus signal-extraction audit on `f-supp-2d/876/json/0128-01.json` (`"to understand the procedure (Id, at pages 2-4)"`). No behavior change for citations that parse fully — `Id, at 1483`, `Id., at 253`, `Id. at p. 125`, and `Id. ¶ 12` all still produce identical output.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -129,7 +129,16 @@ export function extractId(
   // `p.` / `pp.` prefix for CSM form (`Id. at p. 125`; see #236), and
   // `¶` / `¶¶` / `para.` / `paras.` paragraph markers (#204). When the
   // pincite is a paragraph form, `at` is optional (`Id. ¶ 12`).
-  const idRegex = /([Ii])(?:d|bid)\s*(?:(\.)|(,)(?=\s+at\s))(?:(,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
+  //
+  // The comma alternative deliberately omits ID_PATTERN's `(?=\s+at\s)`
+  // lookahead because the tokenizer has already enforced it; the `text` we
+  // receive is only the matched substring (often `Id,` with the `at` and
+  // any unrecognized pincite trailing OUTSIDE the match), and re-checking
+  // the lookahead here would always fail. Without this, an opinion like
+  // `Id, at pages 2-4` (where the tokenizer matches `Id,` but the
+  // unrecognized `pages` prefix prevents the pincite branch from
+  // extending the match) crashes the whole pipeline.
+  const idRegex = /([Ii])(?:d|bid)\s*([.,])(?:(,\s+|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const match = idRegex.exec(text)
 
   if (!match) {
@@ -140,21 +149,21 @@ export function extractId(
   // Non-standard punctuation signals:
   //   - `isTypoComma`: comma replacing the period (`Id, at 1483`) — lower confidence
   //   - `hasComma`: post-period comma (`Id., at 253` or `Id., 253`) — slightly
-  //     lower confidence than canonical. Connector capture (group 4) starts
+  //     lower confidence than canonical. Connector capture (group 3) starts
   //     with `,` for both the post-period-comma-at form and the Connecticut
   //     comma-pincite form.
-  const isTypoComma = match[3] === ","
-  const hasComma = isTypoComma || match[4]?.startsWith(",") === true
-  const pinciteInfo: PinciteInfo | undefined = match[5]
-    ? (parsePincite(match[5]) ?? undefined)
+  const isTypoComma = match[2] === ","
+  const hasComma = isTypoComma || match[3]?.startsWith(",") === true
+  const pinciteInfo: PinciteInfo | undefined = match[4]
+    ? (parsePincite(match[4]) ?? undefined)
     : undefined
   const pincite = pinciteInfo?.page
 
   // Component span for pincite (#210)
   let spans: IdComponentSpans | undefined
-  if (match[5] && match.indices?.[5]) {
+  if (match[4] && match.indices?.[4]) {
     spans = {
-      pincite: spanFromGroupIndex(span.cleanStart, match.indices[5], transformationMap),
+      pincite: spanFromGroupIndex(span.cleanStart, match.indices[4], transformationMap),
     }
   }
 

--- a/tests/extract/extractShortForms.test.ts
+++ b/tests/extract/extractShortForms.test.ts
@@ -1790,4 +1790,34 @@ describe("Connecticut comma-pincite for Id./Ibid./supra (#353)", () => {
       expect(id.confidence).toBeLessThanOrEqual(0.7)
     }
   })
+
+  // Crash bug surfaced by a CAP-corpus signal-extraction audit on
+  // `f-supp-2d/876/json/0128-01.json` ("Id, at pages 2-4"). The tokenizer's
+  // ID_PATTERN matches `Id,` because the lookahead `(?=\s+at\s)` is satisfied
+  // by the surrounding context, but its optional pincite branch can't parse
+  // the unusual `pages` prefix, so token.text ends up as just `Id,` (3 chars).
+  // `extractId` then re-applies the same lookahead-bearing regex against only
+  // the 3-char token text — where the lookahead has nothing to look at — and
+  // throws `Failed to parse Id. citation: Id,`. Fix: do not throw on regex
+  // re-parse failure; the tokenizer already vetted the token.
+  describe("does not crash on unusual Id, pincite forms", () => {
+    it("`Id, at pages 2-4` (unrecognized `pages` prefix) extracts Id without crashing", () => {
+      const text = "See Smith v. Jones, 100 F.3d 1 (1990). Id, at pages 2-4 explain the rule."
+      // Must not throw.
+      const cites = extractCitations(text)
+      const id = cites.find((c) => c.type === "id")
+      expect(id?.type).toBe("id")
+      // Pincite is not parseable from `pages 2-4`; that's expected.
+      if (id?.type === "id") {
+        expect(id.pincite).toBeUndefined()
+      }
+    })
+
+    it("`Id, at section 3` (unrecognized `section` prefix) extracts Id without crashing", () => {
+      const text = "See Smith v. Jones, 100 F.3d 1 (1990). Id, at section 3."
+      const cites = extractCitations(text)
+      const id = cites.find((c) => c.type === "id")
+      expect(id?.type).toBe("id")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

`extractCitations` would throw `Error: Failed to parse Id. citation: Id,` and kill the whole pipeline when an opinion contained text like:

```
"to understand the procedure (Id, at pages 2-4)"
```

The tokenizer's `ID_PATTERN` matches `Id,` via its `(?=\s+at\s)` lookahead, but its optional pincite branch refuses to extend the match because `pages` / `section` / etc. is not a recognized pincite prefix. The matched `text` ends up as just `Id,` (3 characters). `extractId` then re-runs the same lookahead-bearing regex against those 3 characters — where the lookahead has nothing to look at — and throws.

## Fix

The lookahead in `extractId` is redundant defensive code: the tokenizer already enforces it. Drop it. `extractId` now parses `Id,` as a valid (typo-comma) Id citation with no pincite, matching the function's existing tolerance for partial parses.

Regex restructure: `(?:(\.)|(,)(?=\s+at\s))` (two alternates) → `([.,])` (one capture). Downstream group indices shifted by one (`match[3]`→`[2]`, `[4]`→`[3]`, `[5]`→`[4]`). No semantic change.

## How surfaced

A CAP-corpus signal-extraction audit (`scripts/audit-signals.ts`) crashed on `f-supp-2d/876/json/0128-01.json` — Federal Supplement 2d volume 876, an unremarkable opinion containing this single problematic Id reference. The bug is silent in normal usage but blocks any consumer running over a corpus.

## Behavior change

None for any fully-parseable Id form. All of these continue to extract identically:

| Input | pincite | confidence |
|---|---|---|
| `Id. at 253` | 253 | 1.0 |
| `Id., at 253` | 253 | 0.9 |
| `Id, at 1483` | 1483 | 0.7 |
| `Id. at p. 125` | 125 | 1.0 |
| `Id. ¶ 12` | 12 | 1.0 |

New: `Id, at pages 2-4` and `Id, at section 3` now extract as `Id,` with no pincite (instead of crashing).

## Test plan

- [x] `pnpm exec vitest run tests/extract/extractShortForms.test.ts` — 135 pass (2 new)
- [x] `pnpm exec vitest run` — 3071/3071 pass (no regressions)
- [x] `pnpm typecheck` — clean
- [x] Replay the original crashing opinion via the audit script — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)