### PR TITLE
fix(signal): recognize `See, also,` (extra inter-word comma) as `see also`

### DIFF
--- a/.changeset/signal-see-comma-also.md
+++ b/.changeset/signal-see-comma-also.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+Recognize `See, also,` (extra inter-word comma) as the `see also` signal.
+
+Older typesetting variants in legal opinions sometimes insert an extra comma between `See` and `also`, producing forms like `See, also, The Plymouth, 70 U.S. (3 Wall.) 20`. The canonical `See also` worked; the comma-bearing variant was missed entirely (signal=undefined).
+
+Both the prefix matcher (`SIGNAL_PATTERNS` in `detectStringCites.ts`) and the leading-signal scanner (`detectLeadingSignals`) now accept optional `\s*,?\s+` between `see` and `also`. Affects both `see also` and the combined `see also, e.g.` form.
+
+Surfaced by a CAP-corpus signal-extraction audit on a 19th-century admiralty case. The canonical `See also` continues to extract identically.

--- a/src/extract/detectStringCites.ts
+++ b/src/extract/detectStringCites.ts
@@ -36,12 +36,15 @@ function buildSignalPatterns() {
   // shows up in older opinions and some publishers' styles.
   const raw: ReadonlyArray<{ regex: RegExp; signal: CitationSignal }> = [
     { regex: /^but\s+cf\.,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "but cf., e.g." },
-    { regex: /^see\s+also,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "see also, e.g." },
+    // `see\s*,?\s+also` accepts the older typesetting variant `See, also,`
+    // (extra comma after `See`) seen in CAP-corpus opinions, while the
+    // canonical `See also` continues to match.
+    { regex: /^see\s*,?\s+also,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "see also, e.g." },
     { regex: /^but\s+see,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "but see, e.g." },
     { regex: /^cf\.,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "cf., e.g." },
     { regex: /^see,\s+e\.\s*g\.,?(?=\s|$)/i, signal: "see, e.g." },
     { regex: /^see\s+generally\b/i, signal: "see generally" },
-    { regex: /^see\s+also\b/i, signal: "see also" },
+    { regex: /^see\s*,?\s+also\b/i, signal: "see also" },
     { regex: /^but\s+see\b/i, signal: "but see" },
     { regex: /^but\s+cf\.?(?=\s|$)/i, signal: "but cf" },
     { regex: /^compare\b/i, signal: "compare" },
@@ -348,10 +351,15 @@ export function detectLeadingSignals(citations: Citation[], cleanedText: string)
       // The `e\.\s*g\.` form accepts both the closed `e.g.` and the spaced
       // typesetting variant `e. g.` (with whitespace between the letters),
       // which appears in older opinions and some publishers' styles.
+      //
+      // The `see\\s*,?\\s+also` substitution accepts the older typesetting
+      // variant `See, also,` (extra comma after `See`); the canonical
+      // `See also` (no extra comma) continues to match.
       const escaped = signal
         .replace(/\./g, "\\.")
         .replace(/\s+/g, "\\s+")
         .replace(/e\\\.g\\\./g, "e\\.\\s*g\\.")
+        .replace(/see\\s\+also/g, "see\\s*,?\\s+also")
       const pattern = new RegExp(`(?<![a-zA-Z])(${escaped})(?![a-zA-Z])`, "gi")
       let match: RegExpExecArray | null
       while ((match = pattern.exec(gapText)) !== null) {

--- a/tests/extract/signalDetection.test.ts
+++ b/tests/extract/signalDetection.test.ts
@@ -187,4 +187,26 @@ describe("isolated citation signal detection", () => {
       expect(caseCite!.signal).toBe("see, e.g.")
     })
   })
+
+  // `See, also,` with an extra comma after `See` is an older typesetting
+  // variant of `See also`. Surfaced by a CAP-corpus signal-extraction audit
+  // (1 occurrence in 80 modern federal opinions): "in admiralty jurisdiction.
+  // See, also, The Plymouth, 70 U.S. (3 Wall.) 20." The canonical form
+  // (no extra comma) continues to work unchanged.
+  describe('"See, also," (extra inter-word comma)', () => {
+    it('detects "See, also," as "see also"', () => {
+      const text = "In admiralty jurisdiction. See, also, The Plymouth, 70 U.S. (3 Wall.) 20 (1865)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite).toBeDefined()
+      expect(caseCite!.signal).toBe("see also")
+    })
+
+    it("canonical 'See also' (no extra comma) still works", () => {
+      const text = "Other circuits agree. See also Davis v. Lee, 200 F.3d 100 (5th Cir. 2018)."
+      const citations = extractCitations(text)
+      const caseCite = citations.find((c) => c.type === "case")
+      expect(caseCite!.signal).toBe("see also")
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Older typesetting variants in legal opinions sometimes insert an extra comma between `See` and `also`, producing forms like:

```
"in admiralty jurisdiction. See, also, The Plymouth, 70 U.S. (3 Wall.) 20 (1865)."
```

The canonical `See also` worked; the comma-bearing variant was missed entirely (signal=undefined).

## Fix

Both the prefix matcher (`SIGNAL_PATTERNS` in `detectStringCites.ts`) and the leading-signal scanner (`detectLeadingSignals`) now accept optional `\s*,?\s+` between `see` and `also`. Affects both `see also` and the combined `see also, e.g.` form.

## Scope

Narrow: only `see also` is patched. The CAP-corpus signal-extraction audit observed one such occurrence. If `But, see,` / `But, cf,` / etc. show up in future audits, broaden then — I'd rather not loosen patterns speculatively.

## Test plan

- [x] `pnpm exec vitest run tests/extract/signalDetection.test.ts` — 25/25 pass (2 new)
- [x] `pnpm exec vitest run` — 3071/3071 pass (no regressions)
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)