### PR TITLE
fix(resolve): suite — supra/P-v-D, Id. antecedent agreement, family fallback (#504, #508, #514)

### DIFF
--- a/.changeset/fix-504-supra-full-caption.md
+++ b/.changeset/fix-504-supra-full-caption.md
@@ -1,0 +1,17 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): supra resolution handles `Plaintiff v. Defendant` captions (#504)
+
+`extractSupra` captures the full caption (`"Fitzgerald v. Cleveland"` for
+`Fitzgerald v. Cleveland, supra`), but the BK-tree is indexed under the
+*individual* normalized plaintiff/defendant names. Querying the combined
+caption against per-name keys produced Levenshtein distances above the
+threshold-derived `maxDistance`, so resolution silently failed for every
+`"X v. Y, supra"` form — ~59% of supra citations in the CAP corpus.
+
+`resolveSupra` now splits on ` v. ` / ` vs. ` and queries each half
+independently in addition to the combined caption, picking the highest-
+similarity in-scope match. Single-name supras (`Smith, supra`) and
+non-caption forms (`Walker & Horwich, supra`) are unaffected.

--- a/.changeset/fix-508-id-antecedent-agreement.md
+++ b/.changeset/fix-508-id-antecedent-agreement.md
@@ -1,0 +1,23 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): Id. `antecedentIndex` agrees with `resolvedTo` on success path (#508)
+
+After #498 made `resolveId` a single-source-of-truth resolver, the two
+pointers were still computed separately: `resolvedTo` from the family/
+scope-aware primary chase, `antecedentIndex` from a position-only
+`findImmediatePredecessor` walk. The two diverged in ~8% of `Id.`
+citations — typically when an intervening statute sat between a
+case-style `Id.` and its full case antecedent.
+
+`resolveId` now sets `antecedentIndex` to the primary-chase result on
+the success path so consumers see one source of truth.
+`findImmediatePredecessor` still drives the pass-2 fallback for chained
+unresolved short-forms. Supra and short-form-case resolution paths are
+unchanged.
+
+Note: chained `Id. Id.` sequences (`Smith. Id. Id.`) now report
+`antecedentIndex = 0` (Smith) on the second `Id.` rather than `1`
+(first `Id.`), reflecting the post-#498 invariant that `Id.` anchors
+to a specific resolved authority.

--- a/.changeset/fix-514-id-family-fallback.md
+++ b/.changeset/fix-514-id-family-fallback.md
@@ -1,0 +1,19 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): Id. family preference falls back to any in-scope authority (#514)
+
+`getIdPreferredFamily` defaults to `"case"` for any `Id.` not followed by
+`§` — including `Id.`, `Id. at N`, and `Id. ¶ N`. In documents whose only
+prior authority is a statute (~8% of `Id.` citations per the audit), the
+scorer's `+1000` family-match boost left the candidate set's first entry
+as the winner only by accident (no preferred-family member to override
+it). A future scorer refactor could easily regress this.
+
+`resolveId` now selects the antecedent via an explicit two-step rule:
+prefer the most recent candidate of the preferred family, otherwise the
+most recent candidate of any family. The behavior matches the previous
+implementation but the intent is now obvious in the code, and regression
+tests pin the statute-only context for both `Id.`, `Id. at N`, and the
+`Id. ¶ N` "complaint paragraph N" idiom the audit flagged.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -468,9 +468,18 @@ export class DocumentResolver {
     // flag ambiguity (without refusing to commit).
     const { confidence, warnings } = this.applyCaseNameWindowCheck(best.index, citation)
 
+    // #508: `antecedentIndex` mirrors `resolvedTo` on the success path so
+    // consumers see one source of truth. The pre-fix code called
+    // `findImmediatePredecessor` here, which walks the array by position and
+    // ignores the family / scope filters the primary chase applied — that
+    // produced disagreement when an intervening citation of a different
+    // family sat between the picked antecedent and the `Id.` (e.g.,
+    // case → statute → Id. at 5: resolvedTo=case, antecedentIndex=statute).
+    // `findImmediatePredecessor` remains the fallback for the unresolved-
+    // short-form chain (above) where no `resolvedTo` is available.
     return {
       resolvedTo: best.index,
-      antecedentIndex: this.findImmediatePredecessor(citation),
+      antecedentIndex: best.index,
       confidence,
       warnings,
     }

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -631,42 +631,42 @@ export class DocumentResolver {
 
   /**
    * Resolves supra citation by matching party name.
+   *
+   * When the supra `partyName` is a full caption (`"Fitzgerald v. Cleveland"`),
+   * splitting on ` v. ` / ` vs. ` and querying each half independently rescues
+   * resolution (#504). The BK-tree is indexed under the individual normalized
+   * plaintiff and defendant names from `trackFullCitation`, so the combined
+   * caption sits too far from either single name for the Levenshtein
+   * threshold-derived `maxDistance` to recover it.
    */
   private resolveSupra(citation: SupraCitation): ResolutionResult | undefined {
     if (!citation.partyName) return undefined // Standalone supra — cannot resolve by party name
     const currentIndex = this.context.citationIndex
-    const targetPartyName = this.normalizePartyName(citation.partyName)
+    const fullPartyName = this.normalizePartyName(citation.partyName)
 
-    // Query BK-Tree for candidates within distance threshold, then filter by scope
-    const queryLen = targetPartyName.length
-    const threshold = this.options.partyMatchThreshold
-    // Safe upper bound: guarantees no match with similarity >= threshold is missed
-    const maxDistance = queryLen === 0 ? 0 : Math.ceil((queryLen * (1 - threshold)) / threshold)
-    const candidates = this.partyNameTree.query(targetPartyName, maxDistance)
-
-    // Sort by insertion order to match Map iteration behavior (first-inserted wins on ties)
-    candidates.sort((a, b) => a.insertionOrder - b.insertionOrder)
-
-    let bestMatch: { index: number; similarity: number } | undefined
-
-    for (const candidate of candidates) {
-      const citationIndex = this.context.fullCitationHistory.get(candidate.key)
-      if (citationIndex === undefined) continue
-
-      // Check scope boundary (supra allows cross-zone: footnote -> body)
-      if (!this.isWithinScope(citationIndex, currentIndex, true)) continue
-
-      // Convert distance to normalized similarity
-      const maxLen = Math.max(queryLen, candidate.key.length)
-      const similarity = maxLen === 0 ? 1.0 : 1 - candidate.distance / maxLen
-
-      // Update best match if this is better (strict > preserves first-wins tie-breaking)
-      if (!bestMatch || similarity > bestMatch.similarity) {
-        bestMatch = { index: citationIndex, similarity }
+    // #504: split `Plaintiff v. Defendant` into individual party-name queries
+    // so each half can match the BK-tree's per-name index. Querying the
+    // combined caption alone fails because the index holds individual names.
+    // The combined query is kept first as a tiebreaker for non-caption forms
+    // (e.g., `Walker & Horwich, supra` should still query the joined string).
+    const queries: string[] = [fullPartyName]
+    const vSplit = fullPartyName.split(/\s+vs?\.\s+/)
+    if (vSplit.length === 2) {
+      for (const half of vSplit) {
+        const trimmed = half.trim()
+        if (trimmed.length > 0) queries.push(trimmed)
       }
     }
 
-    // Check if we found a match above threshold
+    let bestMatch: { index: number; similarity: number } | undefined
+    for (const query of queries) {
+      const match = this.queryPartyNameTree(query, currentIndex)
+      if (!match) continue
+      if (!bestMatch || match.similarity > bestMatch.similarity) {
+        bestMatch = match
+      }
+    }
+
     if (!bestMatch) {
       return this.createFailureResult("No full citation found in scope")
     }
@@ -689,6 +689,45 @@ export class DocumentResolver {
       confidence: bestMatch.similarity,
       warnings: warnings.length > 0 ? warnings : undefined,
     }
+  }
+
+  /**
+   * BK-tree query for a single normalized party name, returning the best
+   * in-scope citation index and similarity score (or undefined if no
+   * candidate clears the configured threshold-derived `maxDistance`).
+   * Shared between full-caption and split-half supra queries (#504).
+   */
+  private queryPartyNameTree(
+    query: string,
+    currentIndex: number,
+  ): { index: number; similarity: number } | undefined {
+    const queryLen = query.length
+    const threshold = this.options.partyMatchThreshold
+    // Safe upper bound: guarantees no match with similarity >= threshold is missed
+    const maxDistance = queryLen === 0 ? 0 : Math.ceil((queryLen * (1 - threshold)) / threshold)
+    const candidates = this.partyNameTree.query(query, maxDistance)
+
+    // Sort by insertion order to match Map iteration behavior (first-inserted wins on ties)
+    candidates.sort((a, b) => a.insertionOrder - b.insertionOrder)
+
+    let best: { index: number; similarity: number } | undefined
+    for (const candidate of candidates) {
+      const citationIndex = this.context.fullCitationHistory.get(candidate.key)
+      if (citationIndex === undefined) continue
+
+      // Check scope boundary (supra allows cross-zone: footnote -> body)
+      if (!this.isWithinScope(citationIndex, currentIndex, true)) continue
+
+      // Convert distance to normalized similarity
+      const maxLen = Math.max(queryLen, candidate.key.length)
+      const similarity = maxLen === 0 ? 1.0 : 1 - candidate.distance / maxLen
+
+      // Update best match if this is better (strict > preserves first-wins tie-breaking)
+      if (!best || similarity > best.similarity) {
+        best = { index: citationIndex, similarity }
+      }
+    }
+    return best
   }
 
   /**

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -440,28 +440,17 @@ export class DocumentResolver {
       )
     }
 
-    // Score each candidate. Family-match dominates (Id.'s pincite shape
-    // tells us which family of authority the writer intended). Recency
-    // breaks ties — candidates are pushed in reverse document order, so
-    // the first match at a given score is the most recent effective
+    // Pick the antecedent: family preference is a soft signal — when at
+    // least one candidate matches the preferred family (inferred from
+    // `Id.`'s pincite shape), pick the most recent of them; otherwise
+    // fall back to the most recent candidate regardless of family (#514).
+    // Recency wins automatically because candidates are pushed in reverse
+    // document order, so `candidates[0]` is the most recent effective
     // mention. Per Bluebook Rule 4.1, signal phrase does NOT affect
     // antecedent selection: `Id.` anchors to the immediately preceding
-    // cited authority regardless of whether that authority is introduced
-    // by `See`, `Cf.`, or any other signal (#498).
-    const score = (c: Candidate) => {
-      let s = 0
-      if (c.family === preferredFamily) s += 1000
-      return s
-    }
-    let best = candidates[0]
-    let bestScore = score(best)
-    for (let i = 1; i < candidates.length; i++) {
-      const s = score(candidates[i])
-      if (s > bestScore) {
-        best = candidates[i]
-        bestScore = s
-      }
-    }
+    // cited authority regardless of `See`, `Cf.`, etc. (#498).
+    const preferred = candidates.find((c) => c.family === preferredFamily)
+    const best = preferred ?? candidates[0]
 
     // Case-name window check: if the prose immediately before Id. names a
     // case that doesn't match the picked antecedent, downgrade confidence and

--- a/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
+++ b/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
@@ -17,16 +17,19 @@ describe("antecedentIndex — Id. clusters with unresolved short-form (Bluebook 
     expect(id?.resolution?.antecedentIndex).toBe(1)
   })
 
-  it("antecedentIndex set even when resolvedTo is also set (one step back)", () => {
+  it("antecedentIndex agrees with resolvedTo on the success path (#508)", () => {
     // Smith full at idx 0, Id. at idx 1, second Id. at idx 2.
-    // The second Id. resolves to Smith (resolvedTo=0) AND has
-    // antecedentIndex=1 (one step back, the first Id.).
+    // Per #508, when the primary chase picks an antecedent, both pointers
+    // reference it (single source of truth). The pre-#508 behavior used
+    // `findImmediatePredecessor` for `antecedentIndex`, which produced
+    // disagreement with `resolvedTo` whenever an intervening citation of a
+    // different family sat between them.
     const text = "Smith v. Jones, 100 F.2d 50, 55 (1990). Id. Id."
     const cites = extractCitations(text, { resolve: true })
     const ids = cites.filter((c): c is IdCitation => c.type === "id")
     expect(ids).toHaveLength(2)
     expect(ids[1].resolution?.resolvedTo).toBe(0)
-    expect(ids[1].resolution?.antecedentIndex).toBe(1)
+    expect(ids[1].resolution?.antecedentIndex).toBe(0)
   })
 
   it("Id. immediately after a full cite: antecedentIndex equals resolvedTo", () => {

--- a/tests/resolve/issue504_supraFullCaption.test.ts
+++ b/tests/resolve/issue504_supraFullCaption.test.ts
@@ -53,9 +53,7 @@ describe("Issue #504: supra resolution with `Party v. Party` caption", () => {
   it("`Smith v. Jones, supra` still resolves when only plaintiff matches indexed name", () => {
     // Ensure the split-and-query fallback works even if only one half matches.
     const text =
-      "Smith v. Doe, 100 F.3d 1 (1990). " +
-      "Other prose here. " +
-      "Smith v. Jones, supra."
+      "Smith v. Doe, 100 F.3d 1 (1990). " + "Other prose here. " + "Smith v. Jones, supra."
     const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
     const full = citations.find((c) => c.type === "case")!
     const supra = citations.find((c) => c.type === "supra")!

--- a/tests/resolve/issue504_supraFullCaption.test.ts
+++ b/tests/resolve/issue504_supraFullCaption.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Issue #504: supra resolution fails when partyName is "Plaintiff v. Defendant".
+ *
+ * `extractSupra` captures the full caption (`"Fitzgerald v. Cleveland"` for
+ * `Fitzgerald v. Cleveland, supra`), but `trackFullCitation` indexes the
+ * BK-tree under the *individual* normalized plaintiff/defendant strings
+ * (`"fitzgerald"`, `"cleveland"`). Levenshtein distance between
+ * `"fitzgerald v. cleveland"` (queryLen ≈ 23) and either single name
+ * (length 7 / 9) exceeds the threshold-implied `maxDistance`, so the
+ * BK-tree query returns no candidates and resolution fails.
+ *
+ * Fix: when the supra `partyName` contains ` v. ` (or ` vs. `), split it
+ * and query each half independently. Either half hitting an indexed full
+ * cite is acceptable — return the first match.
+ *
+ * Affects ~59% of supra citations in the CAP corpus per the resolution
+ * audit.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #504: supra resolution with `Party v. Party` caption", () => {
+  it("`Fitzgerald v. Cleveland, supra` resolves to prior `Fitzgerald v. Cleveland`", () => {
+    const text =
+      "Fitzgerald v. Cleveland, 88 Ohio St. 338 (1913). " +
+      "The court explained the rule. " +
+      "Fitzgerald v. Cleveland, supra, at 342."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const full = citations.find((c) => c.type === "case")!
+    const supra = citations.find((c) => c.type === "supra")!
+    expect(full, "full Fitzgerald cite should extract").toBeDefined()
+    expect(supra, "supra should extract").toBeDefined()
+    expect(supra.partyName).toBe("Fitzgerald v. Cleveland")
+    expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(full))
+  })
+
+  it("`Auld v. Travis, supra` resolves to prior `Auld v. Travis`", () => {
+    const text =
+      "Auld v. Travis, 5 Colo. App. 535 (1895). " +
+      "The court reasoned thus. " +
+      "Auld v. Travis, supra, at 540."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const full = citations.find((c) => c.type === "case")!
+    const supra = citations.find((c) => c.type === "supra")!
+    expect(full).toBeDefined()
+    expect(supra).toBeDefined()
+    expect(supra.partyName).toBe("Auld v. Travis")
+    expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(full))
+  })
+
+  it("`Smith v. Jones, supra` still resolves when only plaintiff matches indexed name", () => {
+    // Ensure the split-and-query fallback works even if only one half matches.
+    const text =
+      "Smith v. Doe, 100 F.3d 1 (1990). " +
+      "Other prose here. " +
+      "Smith v. Jones, supra."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const full = citations.find((c) => c.type === "case")!
+    const supra = citations.find((c) => c.type === "supra")!
+    expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(full))
+  })
+
+  it("regression: single-word `Smith, supra` still resolves to `Smith v. Jones`", () => {
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). Smith, supra."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const full = citations.find((c) => c.type === "case")!
+    const supra = citations.find((c) => c.type === "supra")!
+    expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(full))
+  })
+})

--- a/tests/resolve/issue508_idAntecedentAgreement.test.ts
+++ b/tests/resolve/issue508_idAntecedentAgreement.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #508: `Id.` `antecedentIndex` diverges from `resolvedTo` when an
+ * intervening citation of a different family sits between them.
+ *
+ * After #498 fixed the strict-Bluebook reading of `Id.`, the resolver
+ * computes two pointers:
+ *   - `resolvedTo` — the family-preferred, scope-filtered antecedent
+ *   - `antecedentIndex` — the positional immediate predecessor
+ *
+ * For case-family `Id.` (the default), an intervening statute is
+ * deprioritized as the resolution target but still surfaces as the
+ * positional predecessor. Result: `resolvedTo` and `antecedentIndex`
+ * disagree on the same citation in ~8% of the corpus.
+ *
+ * Fix shape (option a in the task spec): when the primary chase succeeds,
+ * set `antecedentIndex` to `resolvedTo`. The two are then one source of
+ * truth, matching the post-#498 invariant that `Id.` anchors to a
+ * specific resolved authority. `findImmediatePredecessor` is still
+ * useful for the pass-2 unresolved-short-form path.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #508: Id. antecedentIndex agrees with resolvedTo on the success path", () => {
+  it("case → statute → Id. at 5 — both pointers should be the case", () => {
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). 42 U.S.C. § 1983. Id. at 5."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = citations.find((c) => c.type === "case")!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    expect(id.resolution?.antecedentIndex).toBe(id.resolution?.resolvedTo)
+  })
+
+  it("two cases → statute → Id. — both pointers should be the recent case", () => {
+    const text =
+      "Smith v. Jones, 100 F.3d 1. " +
+      "Doe v. Roe, 200 F.3d 50. " +
+      "42 U.S.C. § 1983. " +
+      "Id. at 55."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const doe = citations.find((c) => c.type === "case" && c.volume === 200)!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(doe))
+    expect(id.resolution?.antecedentIndex).toBe(id.resolution?.resolvedTo)
+  })
+
+  it("case → see also case → Id. — both pointers should be the see-also case", () => {
+    // Already covered by #498's strict reading; pin the antecedentIndex agreement.
+    const text =
+      "People v. Henderson, 28 N.Y.3d 63, 70 (2016). " +
+      "See also People v. Molineux, 168 N.Y. 264 (1901). Id. at 70."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const molineux = citations.find((c) => c.type === "case" && c.volume === 168)!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(molineux))
+    expect(id.resolution?.antecedentIndex).toBe(id.resolution?.resolvedTo)
+  })
+
+  it("case → Id. (immediate) — both pointers should be the case", () => {
+    // Regression: the trivial path was already correct; lock it in.
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). Id."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = citations.find((c) => c.type === "case")!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    expect(id.resolution?.antecedentIndex).toBe(citations.indexOf(smith))
+  })
+})

--- a/tests/resolve/issue514_idFamilyFallback.test.ts
+++ b/tests/resolve/issue514_idFamilyFallback.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Issue #514: `Id.` with no `§`-trailer defaults to family=case, but should
+ * still anchor to a prior statute when no case-family candidate exists.
+ *
+ * `getIdPreferredFamily` defaults to `"case"` for any `Id.` not followed by
+ * `§` — including `Id.`, `Id. at N`, and `Id. ¶ N`. In documents whose only
+ * prior authority is a statute (~8% of `Id.` citations in the audit, per the
+ * issue), the resolver should treat family preference as a soft signal and
+ * fall back to the available authority.
+ *
+ * The pre-fix scorer awarded +1000 for a family match but happened to work
+ * because `best` was initialized to `candidates[0]` unconditionally. These
+ * tests pin the explicit fallback so future scorer refactors don't silently
+ * regress it. They also cover the `Id. ¶ N` "complaint paragraph N" idiom
+ * the audit reported failing, which is structurally the same problem.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #514: Id. family-preference fallback to statute when no case in scope", () => {
+  it("statute-only context: `Id.` resolves to the statute", () => {
+    const text = "29 U.S.C. § 201. Id."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = citations.find((c) => c.type === "statute")!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
+    expect(id.resolution?.confidence).toBeGreaterThan(0)
+    expect(id.resolution?.failureReason).toBeUndefined()
+  })
+
+  it("statute-only context: `Id. at 5` (case-style pincite) resolves to statute", () => {
+    const text = "29 U.S.C. § 201. Id. at 5."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = citations.find((c) => c.type === "statute")!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
+    expect(id.resolution?.confidence).toBeGreaterThan(0)
+  })
+
+  it("statute-only context: `Id. ¶ 5` (paragraph-style pincite) resolves to statute", () => {
+    // The audit's repro: "complaint paragraph N" idiom after a statute citation.
+    const text = "29 U.S.C. § 201. Id. ¶ 5."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = citations.find((c) => c.type === "statute")!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
+    expect(id.resolution?.confidence).toBeGreaterThan(0)
+  })
+
+  it("statute-only context: chained `Id. ¶ N` references all resolve to the statute", () => {
+    const text =
+      "Plaintiff alleges violations of the FLSA. 29 U.S.C. § 201. " +
+      "The complaint alleges failure to pay overtime. Id. ¶ 5. " +
+      "The complaint further alleges minimum-wage violations. Id. ¶ 6. " +
+      "And retaliation. Id. ¶ 7."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = citations.find((c) => c.type === "statute")!
+    const ids = citations.filter((c) => c.type === "id")
+    expect(ids).toHaveLength(3)
+    for (const id of ids) {
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
+      expect(id.resolution?.confidence).toBeGreaterThan(0)
+    }
+  })
+
+  it("case present in scope: family preference still wins over statute (no regression)", () => {
+    // Case-preferred Id. should still pick the case when one is in scope,
+    // even if a statute is more recent. The fallback only activates when
+    // the preferred family is absent.
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). 42 U.S.C. § 1983. Id. at 5."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = citations.find((c) => c.type === "case")!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+  })
+
+  it("section-style pincite: `Id. § 1983(c)` still prefers statute", () => {
+    // Regression — the inverse fallback case.
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). 42 U.S.C. § 1983. Id. § 1983(c)."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = citations.find((c) => c.type === "statute")!
+    const id = citations.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
+  })
+})


### PR DESCRIPTION
## Summary

Three resolution fixes from the CAP-corpus audit.

| Issue | Fix |
|---|---|
| [#504](https://github.com/medelman17/eyecite-ts/issues/504) | `supra` with `"Plaintiff v. Defendant"` partyName now resolves — `resolveSupra` queries both the combined caption and each `v.`-split half independently |
| [#508](https://github.com/medelman17/eyecite-ts/issues/508) | `Id.` `antecedentIndex` now equals `resolvedTo` on the success path — completes the #498 alignment |
| [#514](https://github.com/medelman17/eyecite-ts/issues/514) | `Id.` family preference (case-vs-statute) is now a soft tiebreaker — falls back when no preferred-family candidate exists. Repro already happened to work; the rewrite makes the intent explicit and lock-tested |

Touches `src/resolve/DocumentResolver.ts` only. Three changesets, one per issue.

## Test plan

- [x] `pnpm exec vitest run` — 3087 passing (+14 new across 3 issue-specific suites), 9 pre-existing skips
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)