### PR TITLE
fix(extract): pincite suite — 6 issues (#505, #507, #510, #513, #515, #516)

### DIFF
--- a/.changeset/fix-505-pincite-terminators.md
+++ b/.changeset/fix-505-pincite-terminators.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): pincite terminator class now accepts `:`, `[`, `»`, and curly/straight quotes (#505)
+
+`LOOKAHEAD_PINCITE_REGEX` and `ADDITIONAL_PINCITE_REGEX` previously required
+the page-number capture to end at sentence punctuation, closing bracket, or
+whitespace+non-capital. Real-world citations also delimit the pincite with
+`:` (block-quote intro), `[` (bracketed parallel cite), `»` (OCR artifact),
+and the four common curly/straight quote characters. Adding these
+characters to the terminator class recovers pincites that were silently
+dropped at ~6–10 per 1,000 citations.
+
+Now extracts pincite from:
+
+- `376 N.E.2d 578, 579: "Judgments..."` → 579
+- `135 Md.App. 563, 570[, 763 A.2d 252] (2000)` → 570
+- `9 Humph. 187, 193: Love v. Smith` → 193
+- `38 F. C. C. 683, 713» Id., 713-730` → 713
+- `376 N.E.2d 578, 579"…"` and curly-quote variants → 579

--- a/.changeset/fix-507-ohio-neutral-parallel.md
+++ b/.changeset/fix-507-ohio-neutral-parallel.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): neutral cites no longer consume next parallel's volume as pincite (#507)
+
+In Ohio Bluebook chains like `100 Ohio St.3d 152, 2003-Ohio-5372, 797 N.E.2d
+71, at ¶ 33`, the neutral cite (`2003-Ohio-5372`) was greedily extracting
+`pincite=797` — the volume of the next parallel — because
+`NEUTRAL_PINCITE_LOOKAHEAD` had no terminator boundary. It now applies the
+same parallel-cite disambiguation guard used by `LOOKAHEAD_PINCITE_REGEX`:
+the pincite digit sequence must end at end-of-string, sentence punctuation,
+closing bracket, or whitespace NOT followed by a capital letter (a parallel
+reporter token).
+
+Remaining work (tracked separately, out of scope here): paragraph-pincite
+inheritance from the trailing parallel onto earlier parallel members. The
+third parallel correctly captures `¶ 33`; propagating that pincite to the
+first `100 Ohio St.3d 152` parallel requires extending `detectParallel` to
+include neutral cites in the group, plus a post-pass that fills in a
+shared pincite onto earlier members.

--- a/.changeset/fix-510-at-page-pincite.md
+++ b/.changeset/fix-510-at-page-pincite.md
@@ -1,0 +1,13 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): full-case extractor accepts `at page N` / `at pages N-M` (#510)
+
+`LOOKAHEAD_PINCITE_REGEX` only allowed the abbreviated `p.` / `pp.` prefix
+for spelled-out page references, while the short-form extractor already
+accepts `page` / `pages` (#344). The full-case path now matches, so
+citations like `90 A.2d 653, at page 655` and `90 A.2d 660, at page 664
+(Del. Sup. Ct. 1952)` extract the pincite correctly. `PINCITE_SKIP_REGEX`
+is updated in lockstep so later metadata parens still parse after a
+spelled-out pincite.

--- a/.changeset/fix-513-star-range-end.md
+++ b/.changeset/fix-513-star-range-end.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): full-case `at *10-*11` star-pincite range now extracted (#513)
+
+`LOOKAHEAD_PINCITE_REGEX` page body `\*?\d+(?:-\d+)?` only allowed the
+star-pagination marker on the START of a range. The short-form extractor
+already allows `\*?\d+[-–—]\*?\d+` (#201), so star ranges with stars on
+both ends now extract from full-case citations as well. Test case:
+`2012 PA Super 169 at *10-*11 (Pa.Super.Ct. 2012)`.

--- a/.changeset/fix-515-footnote-only-pincite.md
+++ b/.changeset/fix-515-footnote-only-pincite.md
@@ -1,0 +1,20 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): footnote-only pincite (`, n. 7`) no longer silently dropped (#515)
+
+`PINCITE_REGEX` / `LOOKAHEAD_PINCITE_REGEX` previously made page digits
+mandatory, so a footnote-only reference (`16 Mass. 299, n. 7.`) — used when
+the cited material is on the citation's start page and the author only
+references the footnote — dropped the pincite entirely. `parsePincite` now
+recognizes a footnote-only branch (`nn?\.\s*\d+(?:[-–—~]\d+)?` plus `note`,
+`fn`, `fns` variants), and `LOOKAHEAD_PINCITE_REGEX` adds a matching
+alternation that captures the bare footnote suffix. The structured result
+surfaces with `footnote=N` / `footnoteEnd=M` and `page=undefined`.
+
+Now extracts:
+
+- `16 Mass. 299, n. 7.` → `footnote: 7`
+- `2 Hoffman's Ch. Pr. 95, n. 3` → `footnote: 3`
+- `16 Mass. 299, note 7.` → `footnote: 7`

--- a/.changeset/fix-516-tilde-range-separator.md
+++ b/.changeset/fix-516-tilde-range-separator.md
@@ -1,0 +1,14 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): tilde (`~`) accepted as pincite range separator (#516)
+
+`LOOKAHEAD_PINCITE_REGEX`, `ADDITIONAL_PINCITE_REGEX`, `PINCITE_SKIP_REGEX`,
+and the `parsePincite` regexes (page body, footnote suffix, paragraph
+range) now accept `~` alongside hyphen / en-dash / em-dash as a range
+separator. Tilde shows up as an OCR artifact in scanned reporters and in
+some PDF dehyphenators, and dropping it silently lost the range end page.
+
+Example: `2012 PA Super 169 at *10~*11` now extracts a star-page range
+with `pincite=10`, `endPage=11`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -196,8 +196,11 @@ const LOOKAHEAD_PAREN_REGEX =
 // Page-prefix forms (#510): accept spelled-out `page` / `pages` in addition
 // to the abbreviated `p.` / `pp.` so full-case citations match the
 // short-form extractor's accepted prefixes (#344).
+//
+// Star-pagination range (#513): page body now allows `*` on BOTH ends of
+// the range (`*10-*11`), matching the short-form extractor (#201).
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:-\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -210,7 +210,7 @@ const LOOKAHEAD_PAREN_REGEX =
 // `pinciteInfo.footnote` with `page=undefined`. The leading `at` prefix is
 // allowed for symmetry with the page-bearing forms.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)([\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -234,7 +234,7 @@ const PAREN_SKIP_REGEX = /[\s,]/
 //
 // Range separators include tilde (#516).
 const ADDITIONAL_PINCITE_REGEX =
-  /^,\s*(\*?\d+(?:[-–—~]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/
+  /^,\s*(\*?\d+(?:[-–—~]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?)(?=$|[.,:;)([\]»"'“”‘’]|\s(?![A-Z]))/
 
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -187,8 +187,13 @@ const LOOKAHEAD_PAREN_REGEX =
 // either `\s+` (the original `768 n.3` form) or `,\s+` (the California
 // `768, fn. 3` form). `fn` / `fns` are added to the alternation alongside
 // `n` / `nn` / `note`.
+//
+// Terminator class (#505): in addition to sentence punctuation and closing
+// brackets, accept `:` (block-quote intro), `[` (bracketed parallel cite),
+// `»` (OCR artifact), and the four common curly/straight quote characters
+// (`"`, `"`, `'`, `'`, `"`). Frequency ~6–10 per 1,000 cites in the wild.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,;)(\]]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -206,8 +211,11 @@ const PAREN_SKIP_REGEX = /[\s,]/
 // Parallel-cite disambiguation: tighten the trailing whitespace branch to
 // reject `\s+[A-Z]` (a parallel-cite reporter token). Allow bracket close
 // `]` as a terminator so bracketed parallel pincites still capture.
+//
+// Terminator class mirrors LOOKAHEAD_PINCITE_REGEX (#505): accept `:`, `[`,
+// `»`, and curly/straight quotes as additional terminators.
 const ADDITIONAL_PINCITE_REGEX =
-  /^,\s*(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)(?=$|[.,;)(\]]|\s(?![A-Z]))/
+  /^,\s*(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/
 
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -199,8 +199,12 @@ const LOOKAHEAD_PAREN_REGEX =
 //
 // Star-pagination range (#513): page body now allows `*` on BOTH ends of
 // the range (`*10-*11`), matching the short-form extractor (#201).
+//
+// Range separators (#516): tilde (`~`) is accepted as a range separator
+// alongside hyphen / en-dash / em-dash. Tilde shows up as an OCR artifact
+// in some scanned reporters and PDF dehyphenators.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -221,18 +225,21 @@ const PAREN_SKIP_REGEX = /[\s,]/
 //
 // Terminator class mirrors LOOKAHEAD_PINCITE_REGEX (#505): accept `:`, `[`,
 // `»`, and curly/straight quotes as additional terminators.
+//
+// Range separators include tilde (#516).
 const ADDITIONAL_PINCITE_REGEX =
-  /^,\s*(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/
+  /^,\s*(\*?\d+(?:[-–—~]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/
 
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.
  *  E.g., ", 199 n.2", ", 999-1000", ", 130 n.5", ", at p. 115" (CSM, #236),
  *  ", ¶ 12" / ", paras. 12-14" (paragraph form, #204),
  *  ", at page 115" / ", at pages 100-105" (spelled-out form, #510).
+ *  Range separators include `~` (OCR artifact, #516).
  *  The outer `+` is intentionally greedy to handle multi-pincite citations
  *  (e.g., ", 199, 205, 210"). Safe because the scan window is bounded by maxLookahead. */
 const PINCITE_SKIP_REGEX =
-  /^(?:,\s*(?:(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?|(?:at\s+)?(?:¶¶?|paras?\.?)\s*\d+(?:[-–—]\d+)?))+/
+  /^(?:,\s*(?:(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?\*?\d+(?:[-–—~]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?|(?:at\s+)?(?:¶¶?|paras?\.?)\s*\d+(?:[-–—~]\d+)?))+/
 
 /**
  * Signal normalization table. Longer patterns first so "aff'd on other grounds"

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -192,8 +192,12 @@ const LOOKAHEAD_PAREN_REGEX =
 // brackets, accept `:` (block-quote intro), `[` (bracketed parallel cite),
 // `»` (OCR artifact), and the four common curly/straight quote characters
 // (`"`, `"`, `'`, `'`, `"`). Frequency ~6–10 per 1,000 cites in the wild.
+//
+// Page-prefix forms (#510): accept spelled-out `page` / `pages` in addition
+// to the abbreviated `p.` / `pp.` so full-case citations match the
+// short-form extractor's accepted prefixes (#344).
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:pp?\.\s*)?|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:-\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:-\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -220,11 +224,12 @@ const ADDITIONAL_PINCITE_REGEX =
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.
  *  E.g., ", 199 n.2", ", 999-1000", ", 130 n.5", ", at p. 115" (CSM, #236),
- *  ", ¶ 12" / ", paras. 12-14" (paragraph form, #204).
+ *  ", ¶ 12" / ", paras. 12-14" (paragraph form, #204),
+ *  ", at page 115" / ", at pages 100-105" (spelled-out form, #510).
  *  The outer `+` is intentionally greedy to handle multi-pincite citations
  *  (e.g., ", 199, 205, 210"). Safe because the scan window is bounded by maxLookahead. */
 const PINCITE_SKIP_REGEX =
-  /^(?:,\s*(?:(?:at\s+(?:pp?\.\s*)?)?\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?|(?:at\s+)?(?:¶¶?|paras?\.?)\s*\d+(?:[-–—]\d+)?))+/
+  /^(?:,\s*(?:(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:n|note)\s*\.?\s*\d+)?|(?:at\s+)?(?:¶¶?|paras?\.?)\s*\d+(?:[-–—]\d+)?))+/
 
 /**
  * Signal normalization table. Longer patterns first so "aff'd on other grounds"

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -203,8 +203,14 @@ const LOOKAHEAD_PAREN_REGEX =
 // Range separators (#516): tilde (`~`) is accepted as a range separator
 // alongside hyphen / en-dash / em-dash. Tilde shows up as an OCR artifact
 // in some scanned reporters and PDF dehyphenators.
+//
+// Footnote-only pincite (#515): a footnote reference without a preceding
+// page (`, n. 7` / `, note 7` / `, nn. 3-5` / `, fn. 4`) is accepted as
+// the trailing alternation. `parsePincite` surfaces this as
+// `pinciteInfo.footnote` with `page=undefined`. The leading `at` prefix is
+// allowed for symmetry with the page-bearing forms.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -33,7 +33,7 @@ import { parsePincite, type PinciteInfo } from "./pincite"
  *  Star-pagination, paragraph, and explicit `at`-keyword forms are exempted
  *  from this guard because they cannot be confused with a parallel cite. */
 const NEUTRAL_PINCITE_LOOKAHEAD =
-  /^(?:\s+at\s+|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)([\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Trailing `(court date)` parenthetical lookahead for database cites.
  *  Allows optional intervening pincite (`, at *3`) per #191. The body

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -23,9 +23,17 @@ import { parsePincite, type PinciteInfo } from "./pincite"
  *  accepts paragraph-marker pincites `, ¶ N` / `, ¶¶ N-M` / `, paras. N-M`
  *  for state neutral-cite forms like `2015-NMCA-072, ¶ 2` where the
  *  paragraph numbering is the canonical pinpoint format (#311). When the
- *  pincite is a paragraph form, `at` is optional. */
+ *  pincite is a paragraph form, `at` is optional.
+ *
+ *  Parallel-cite disambiguation (#507): in Ohio Bluebook chains like
+ *  `100 Ohio St.3d 152, 2003-Ohio-5372, 797 N.E.2d 71` the neutral cite
+ *  was greedily consuming `797` (the next parallel's volume) as a pincite.
+ *  The trailing lookahead now rejects matches where the digit sequence is
+ *  followed by whitespace + capital letter (a parallel reporter token).
+ *  Star-pagination, paragraph, and explicit `at`-keyword forms are exempted
+ *  from this guard because they cannot be confused with a parallel cite. */
 const NEUTRAL_PINCITE_LOOKAHEAD =
-  /^(?:\s+at\s+|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)/d
+  /^(?:\s+at\s+|,\s*(?:at\s+(?:pp?\.\s*)?)?)(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)(?=$|[.,:;)(\[\]»"'“”‘’]|\s(?![A-Z]))/d
 
 /** Trailing `(court date)` parenthetical lookahead for database cites.
  *  Allows optional intervening pincite (`, at *3`) per #191. The body

--- a/src/extract/pincite.ts
+++ b/src/extract/pincite.ts
@@ -58,6 +58,13 @@ const PARA_NUM_REGEX = /^(\d+)(?:\s*[-–—~]\s*(\d+))?\s*$/
 const PINCITE_PARSE_REGEX =
   /^(?:at\s+)?(\*?)(\d+)(?:[-–—~]\*?(\d+))?(?:\s*,)?\s*(?:(?:nn?|fns?|note)\s*\.?\s*(\d+)(?:[-–—~](\d+))?)?$/i
 
+/** Footnote-only pincite — no page digits, just `n. 7`, `note 7`, `nn. 3-5`,
+ *  `fn. 4` (#515). Surfaces when the cited material is on the citation's
+ *  start page and the author references only the footnote. Accepts an
+ *  optional leading `at `. */
+const FOOTNOTE_ONLY_PINCITE_REGEX =
+  /^(?:at\s+)?(?:nn?|fns?|note)\s*\.?\s*(\d+)(?:[-–—~](\d+))?$/i
+
 /**
  * Parse a pincite string into structured components.
  *
@@ -95,6 +102,24 @@ export function parsePincite(raw: string): PinciteInfo | null {
       return result
     }
     // Falls through to page parsing if the body isn't a clean number — defensive.
+  }
+
+  // Footnote-only pincite (`n. 7`, `note 7`, `nn. 3-5`, `fn. 4`). Checked
+  // before the page parser because the page parser requires leading digits
+  // and would reject these forms. (#515)
+  const footnoteOnly = FOOTNOTE_ONLY_PINCITE_REGEX.exec(trimmed)
+  if (footnoteOnly) {
+    const footnote = Number.parseInt(footnoteOnly[1], 10)
+    const footnoteEnd = footnoteOnly[2]
+      ? Number.parseInt(footnoteOnly[2], 10)
+      : undefined
+    const result: PinciteInfo = {
+      footnote,
+      isRange: footnoteEnd !== undefined,
+      raw: trimmed,
+    }
+    if (footnoteEnd !== undefined) result.footnoteEnd = footnoteEnd
+    return result
   }
 
   const match = PINCITE_PARSE_REGEX.exec(trimmed)

--- a/src/extract/pincite.ts
+++ b/src/extract/pincite.ts
@@ -44,16 +44,19 @@ export interface PinciteInfo {
  *  `at`. Routes the rest of the string into paragraph parsing. (#204) */
 const PARA_PREFIX_REGEX = /^(?:at\s+)?(?:¶¶?|paras?\.?)\s*/i
 
-/** Body of a paragraph pincite once the marker has been consumed: `N` or `N-M`. */
-const PARA_NUM_REGEX = /^(\d+)(?:\s*[-–—]\s*(\d+))?\s*$/
+/** Body of a paragraph pincite once the marker has been consumed: `N` or `N-M`.
+ *  Range separator includes tilde (`~`) for OCR-artifact tolerance (#516). */
+const PARA_NUM_REGEX = /^(\d+)(?:\s*[-–—~]\s*(\d+))?\s*$/
 
 /** Matches: optional "at ", optional "*" (star pagination), digits, optional
- *  "-/–/—[*]digits", optional "n./nn./note digits" with optional range end.
+ *  "-/–/—/~[*]digits", optional "n./nn./note digits" with optional range end.
  *  The footnote separator accepts a comma+space variant (`, fn. 3` — common
  *  in California opinions, #311) in addition to the canonical whitespace
- *  separator. `fn` / `fns` are recognized alongside `n` / `nn` / `note`. */
+ *  separator. `fn` / `fns` are recognized alongside `n` / `nn` / `note`.
+ *  Tilde (`~`) is accepted as a range separator alongside hyphen and dashes
+ *  for OCR-artifact tolerance (#516). */
 const PINCITE_PARSE_REGEX =
-  /^(?:at\s+)?(\*?)(\d+)(?:[-–—]\*?(\d+))?(?:\s*,)?\s*(?:(?:nn?|fns?|note)\s*\.?\s*(\d+)(?:[-–—](\d+))?)?$/i
+  /^(?:at\s+)?(\*?)(\d+)(?:[-–—~]\*?(\d+))?(?:\s*,)?\s*(?:(?:nn?|fns?|note)\s*\.?\s*(\d+)(?:[-–—~](\d+))?)?$/i
 
 /**
  * Parse a pincite string into structured components.

--- a/tests/extract/issue505PinciteTerminators.test.ts
+++ b/tests/extract/issue505PinciteTerminators.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+/**
+ * Issue #505: Pincite terminator character set incomplete.
+ *
+ * `LOOKAHEAD_PINCITE_REGEX` previously required the page-number capture to end at
+ * `[.,;)(\]]` or whitespace+non-capital. It didn't accept `:`, `[`, `»`, or curly
+ * quotes — common in real-world citations (block-quote intros, parallel-citation
+ * brackets, OCR artifacts, smart-quote opinions). Frequency ~6–10 per 1,000 cites.
+ */
+describe("issue #505: pincite terminator characters", () => {
+  it("accepts colon (`579:`) as pincite terminator before a quoted block intro", () => {
+    const cites = extractCitations(
+      `376 N.E.2d 578, 579: "Judgments..."`,
+    )
+    const fullCase = cites.find((c) => c.type === "case")
+    expect(fullCase).toBeDefined()
+    if (fullCase?.type === "case") {
+      expect(fullCase.pincite).toBe(579)
+    }
+  })
+
+  it("accepts open bracket (`570[`) as pincite terminator before bracketed parallel", () => {
+    const cites = extractCitations(
+      "135 Md.App. 563, 570[, 763 A.2d 252] (2000)",
+    )
+    const md = cites.find(
+      (c) => c.type === "case" && c.reporter === "Md.App.",
+    )
+    expect(md).toBeDefined()
+    if (md?.type === "case") {
+      expect(md.pincite).toBe(570)
+    }
+  })
+
+  it("accepts colon (`193:`) as pincite terminator before next case body", () => {
+    const cites = extractCitations("9 Humph. 187, 193: Love v. Smith")
+    const cite = cites.find((c) => c.type === "case" && c.page === 187)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(193)
+    }
+  })
+
+  it("accepts guillemet (`713»`) as pincite terminator (OCR artifact)", () => {
+    const cites = extractCitations("38 F. C. C. 683, 713» Id., 713-730")
+    const cite = cites.find((c) => c.type === "case" && c.page === 683)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(713)
+    }
+  })
+
+  it("accepts straight double-quote (`579\"`) as pincite terminator", () => {
+    const cites = extractCitations(`376 N.E.2d 578, 579"Judgments..."`)
+    const cite = cites.find((c) => c.type === "case" && c.page === 578)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(579)
+    }
+  })
+
+  it("accepts curly double-quote as pincite terminator (smart quotes)", () => {
+    const cites = extractCitations(`376 N.E.2d 578, 579“Judgments...”`)
+    const cite = cites.find((c) => c.type === "case" && c.page === 578)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(579)
+    }
+  })
+
+  it("accepts curly single-quote as pincite terminator", () => {
+    const cites = extractCitations(`376 N.E.2d 578, 579‘foo’`)
+    const cite = cites.find((c) => c.type === "case" && c.page === 578)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(579)
+    }
+  })
+})

--- a/tests/extract/issue507OhioNeutralParallel.test.ts
+++ b/tests/extract/issue507OhioNeutralParallel.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+/**
+ * Issue #507: Ohio neutral parallel chain consumes next parallel's volume.
+ *
+ * In Ohio Bluebook chains like
+ *   `100 Ohio St.3d 152, 2003-Ohio-5372, 797 N.E.2d 71, at ¶ 33`
+ * the neutral cite (`2003-Ohio-5372`) was extracting `pincite=797` (the
+ * volume of the next parallel) because the pincite lookahead greedily
+ * consumed the `, 797` digits. The first parallel (`100 Ohio St.3d 152`)
+ * carried `pincite=undefined`.
+ *
+ * Fix shape:
+ *   1. The neutral-cite extractor must NOT consume a parallel-cite reporter's
+ *      volume as a pincite. Stop the pincite scan when what follows the digit
+ *      sequence is a reporter abbreviation (capital letter + period).
+ *   2. (Stretch) Parallel-group pincite inheritance — when one member of a
+ *      parallel group carries a trailing pincite, propagate it to earlier
+ *      group members.
+ *
+ * Minimum behavior asserted here: three citations produced; the neutral cite
+ * must NOT carry `pincite=797`. Paragraph-pincite inheritance across the full
+ * parallel chain is tracked separately if not delivered.
+ */
+describe("issue #507: Ohio neutral parallel chain pincite", () => {
+  it("extracts three citations from the Ohio parallel chain", () => {
+    const cites = extractCitations(
+      "100 Ohio St.3d 152, 2003-Ohio-5372, 797 N.E.2d 71, at ¶ 33",
+    )
+    expect(cites.length).toBe(3)
+  })
+
+  it("neutral cite (2003-Ohio-5372) does NOT consume the next parallel's volume", () => {
+    const cites = extractCitations(
+      "100 Ohio St.3d 152, 2003-Ohio-5372, 797 N.E.2d 71, at ¶ 33",
+    )
+    const neutral = cites.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    if (neutral?.type === "neutral") {
+      // The 797 belongs to the next parallel cite's volume, not this cite's pincite.
+      expect(neutral.pincite).not.toBe(797)
+    }
+  })
+
+  it("third parallel (797 N.E.2d 71) carries the ¶ 33 paragraph pincite", () => {
+    const cites = extractCitations(
+      "100 Ohio St.3d 152, 2003-Ohio-5372, 797 N.E.2d 71, at ¶ 33",
+    )
+    const ne2d = cites.find(
+      (c) => c.type === "case" && c.reporter === "N.E.2d",
+    )
+    expect(ne2d).toBeDefined()
+    if (ne2d?.type === "case") {
+      expect(ne2d.pinciteInfo?.paragraph).toBe(33)
+    }
+  })
+
+  it("neutral cite extracted with correct components", () => {
+    const cites = extractCitations(
+      "100 Ohio St.3d 152, 2003-Ohio-5372, 797 N.E.2d 71, at ¶ 33",
+    )
+    const neutral = cites.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    if (neutral?.type === "neutral") {
+      expect(neutral.year).toBe(2003)
+      expect(neutral.court).toBe("Ohio")
+      expect(neutral.documentNumber).toBe("5372")
+    }
+  })
+})

--- a/tests/extract/issue510AtPagePincite.test.ts
+++ b/tests/extract/issue510AtPagePincite.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+/**
+ * Issue #510: Full-case extractor doesn't accept `at page N` / `at pages N-M`.
+ *
+ * `LOOKAHEAD_PINCITE_REGEX` only allowed `pp?\.` as a spelled-out prefix, not
+ * `pages?`. The short-form extractor already accepts `pages?` (#344), so this
+ * brings the full-case path in line.
+ */
+describe("issue #510: full-case `at page N` pincite", () => {
+  it("captures pincite with `, at page 655`", () => {
+    const cites = extractCitations("90 A.2d 653, at page 655")
+    const cite = cites.find((c) => c.type === "case" && c.page === 653)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(655)
+    }
+  })
+
+  it("captures pincite with `, at page 664` and trailing court parenthetical", () => {
+    const cites = extractCitations("90 A.2d 660, at page 664 (Del. Sup. Ct. 1952)")
+    const cite = cites.find((c) => c.type === "case" && c.page === 660)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(664)
+      expect(cite.year).toBe(1952)
+    }
+  })
+
+  it("captures pincite with `, at pages 100-105` (plural + range)", () => {
+    const cites = extractCitations("90 A.2d 100, at pages 100-105")
+    const cite = cites.find((c) => c.type === "case" && c.page === 100)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(100)
+      expect(cite.pinciteInfo?.endPage).toBe(105)
+      expect(cite.pinciteInfo?.isRange).toBe(true)
+    }
+  })
+
+  it("still accepts the existing `at p. 115` short form (no regression)", () => {
+    const cites = extractCitations("90 A.2d 100, at p. 115")
+    const cite = cites.find((c) => c.type === "case" && c.page === 100)
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(115)
+    }
+  })
+})

--- a/tests/extract/issue513StarRangeEnd.test.ts
+++ b/tests/extract/issue513StarRangeEnd.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+
+/**
+ * Issue #513: Star-pincite range with star on END dropped in full-case extraction.
+ *
+ * `LOOKAHEAD_PINCITE_REGEX` page body `\*?\d+(?:-\d+)?` only allowed `*` on the
+ * START of the range. Short-form already accepts `\*?\d+[-–—]\*?\d+` (per #201).
+ * Aligning the full-case pattern lets `*10-*11` star ranges parse.
+ */
+describe("issue #513: star-pincite range with star on END", () => {
+  it("captures `at *10-*11` star range pincite (full-case)", () => {
+    const cites = extractCitations(
+      "2012 PA Super 169 at *10-*11 (Pa.Super.Ct. 2012)",
+    )
+    expect(cites.length).toBeGreaterThan(0)
+    const cite = cites[0]
+    expect(cite.pincite).toBeDefined()
+    expect(cite.pincite).toBe(10)
+    expect(cite.pinciteInfo?.endPage).toBe(11)
+    expect(cite.pinciteInfo?.starPage).toBe(true)
+    expect(cite.pinciteInfo?.isRange).toBe(true)
+  })
+
+  it("still accepts star on start only (`*10-11`)", () => {
+    const cites = extractCitations("2012 PA Super 169 at *10-11")
+    expect(cites.length).toBeGreaterThan(0)
+    const cite = cites[0]
+    expect(cite.pincite).toBe(10)
+    expect(cite.pinciteInfo?.endPage).toBe(11)
+    expect(cite.pinciteInfo?.starPage).toBe(true)
+  })
+
+  it("still accepts plain numeric range (`100-105`)", () => {
+    const cites = extractCitations("500 F.2d 100, 100-105")
+    const cite = cites.find((c) => c.type === "case")
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(100)
+      expect(cite.pinciteInfo?.endPage).toBe(105)
+    }
+  })
+})

--- a/tests/extract/issue515FootnoteOnlyPincite.test.ts
+++ b/tests/extract/issue515FootnoteOnlyPincite.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+import { parsePincite } from "../../src/extract/pincite"
+
+/**
+ * Issue #515: Footnote-only pincite (`, n. 7`) silently dropped.
+ *
+ * The existing pincite regexes (`PINCITE_REGEX`, `LOOKAHEAD_PINCITE_REGEX`)
+ * required page digits before the footnote suffix. There is no branch for a
+ * footnote-only pincite — i.e., when the cited material is on the citation's
+ * start page and the author only references the footnote (`16 Mass. 299, n. 7`).
+ *
+ * Fix: add a branch that captures `nn?\.\s*\d+(?:[-–—~]\d+)?` (and `note`/
+ * `fn`/`fns` variants) without a preceding page; surface as
+ * `pinciteInfo.footnote` with `page=undefined`.
+ */
+describe("issue #515: footnote-only pincite", () => {
+  describe("parsePincite", () => {
+    it("parses `n. 7` as footnote-only (no page)", () => {
+      const info = parsePincite("n. 7")
+      expect(info).toBeDefined()
+      expect(info?.footnote).toBe(7)
+      expect(info?.page).toBeUndefined()
+    })
+
+    it("parses `note 7` as footnote-only", () => {
+      const info = parsePincite("note 7")
+      expect(info).toBeDefined()
+      expect(info?.footnote).toBe(7)
+      expect(info?.page).toBeUndefined()
+    })
+
+    it("parses `n. 3` as footnote-only", () => {
+      const info = parsePincite("n. 3")
+      expect(info).toBeDefined()
+      expect(info?.footnote).toBe(3)
+      expect(info?.page).toBeUndefined()
+    })
+
+    it("parses `nn. 3-5` as footnote-only range", () => {
+      const info = parsePincite("nn. 3-5")
+      expect(info).toBeDefined()
+      expect(info?.footnote).toBe(3)
+      expect(info?.footnoteEnd).toBe(5)
+      expect(info?.page).toBeUndefined()
+    })
+
+    it("parses `fn. 4` (California form)", () => {
+      const info = parsePincite("fn. 4")
+      expect(info).toBeDefined()
+      expect(info?.footnote).toBe(4)
+      expect(info?.page).toBeUndefined()
+    })
+  })
+
+  describe("extractCitations integration", () => {
+    it("captures `, n. 7` after a full case citation", () => {
+      const cites = extractCitations("16 Mass. 299, n. 7.")
+      const cite = cites.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.page).toBe(299)
+        expect(cite.pincite).toBeUndefined()
+        expect(cite.pinciteInfo?.footnote).toBe(7)
+      }
+    })
+
+    it("captures `, n. 3` after a Chancery Practice citation", () => {
+      const cites = extractCitations("2 Hoffman's Ch. Pr. 95, n. 3")
+      const cite = cites.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.page).toBe(95)
+        expect(cite.pincite).toBeUndefined()
+        expect(cite.pinciteInfo?.footnote).toBe(3)
+      }
+    })
+
+    it("captures `, note 7` (spelled-out)", () => {
+      const cites = extractCitations("16 Mass. 299, note 7.")
+      const cite = cites.find((c) => c.type === "case")
+      expect(cite).toBeDefined()
+      if (cite?.type === "case") {
+        expect(cite.page).toBe(299)
+        expect(cite.pincite).toBeUndefined()
+        expect(cite.pinciteInfo?.footnote).toBe(7)
+      }
+    })
+  })
+})

--- a/tests/extract/issue516TildeRangeSeparator.test.ts
+++ b/tests/extract/issue516TildeRangeSeparator.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "../../src"
+import { parsePincite } from "../../src/extract/pincite"
+
+/**
+ * Issue #516: Tilde (`~`) not recognized as pincite range separator.
+ *
+ * Likely OCR-driven (some PDF dehyphenators emit `~` for hyphens). Low
+ * priority but trivial — add `~` alongside `-`, `–`, `—` in the range
+ * separator class for pincite regexes. Depends on #513 having shipped first
+ * so star-on-end is already valid in the page body.
+ */
+describe("issue #516: tilde as pincite range separator", () => {
+  it("captures `at *10~*11` star range pincite with tilde", () => {
+    const cites = extractCitations("2012 PA Super 169 at *10~*11")
+    expect(cites.length).toBeGreaterThan(0)
+    const cite = cites[0]
+    expect(cite.pincite).toBe(10)
+    expect(cite.pinciteInfo?.endPage).toBe(11)
+    expect(cite.pinciteInfo?.starPage).toBe(true)
+    expect(cite.pinciteInfo?.isRange).toBe(true)
+  })
+
+  it("captures `, 999~1000` numeric range with tilde", () => {
+    const cites = extractCitations("500 F.2d 999, 999~1000")
+    const cite = cites.find((c) => c.type === "case")
+    expect(cite).toBeDefined()
+    if (cite?.type === "case") {
+      expect(cite.pincite).toBe(999)
+      expect(cite.pinciteInfo?.endPage).toBe(1000)
+      expect(cite.pinciteInfo?.isRange).toBe(true)
+    }
+  })
+
+  it("parsePincite handles tilde in raw pincite text", () => {
+    const info = parsePincite("100~105")
+    expect(info?.page).toBe(100)
+    expect(info?.endPage).toBe(105)
+    expect(info?.isRange).toBe(true)
+  })
+
+  it("parsePincite handles tilde in paragraph range", () => {
+    const info = parsePincite("¶¶ 10~12")
+    expect(info?.paragraph).toBe(10)
+    expect(info?.endParagraph).toBe(12)
+    expect(info?.isRange).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Six pincite-extraction fixes from the CAP-corpus audit.

| Issue | Fix |
|---|---|
| [#505](https://github.com/medelman17/eyecite-ts/issues/505) | Pincite terminator class accepts `:`, `[`, `»`, and quotes |
| [#507](https://github.com/medelman17/eyecite-ts/issues/507) | Neutral cites no longer consume the next parallel cite's volume as their pincite (Ohio Bluebook chains) |
| [#510](https://github.com/medelman17/eyecite-ts/issues/510) | Full-case extractor accepts `at page N` / `at pages N-M` (matching short-form, per #344) |
| [#513](https://github.com/medelman17/eyecite-ts/issues/513) | Full-case `at *10-*11` star-pincite range now extracted (matching short-form, per #201) |
| [#515](https://github.com/medelman17/eyecite-ts/issues/515) | Footnote-only pincite (`, n. 7`) no longer silently dropped — surfaced via `pinciteInfo.footnote` with `page=undefined` |
| [#516](https://github.com/medelman17/eyecite-ts/issues/516) | Tilde `~` accepted as a pincite range separator (OCR-driven) |

Six changesets, one per issue. **Out of scope (noted in #507's changeset):** parallel-pincite *inheritance* across mixed case/neutral parallel groups — the third parallel correctly captures `¶ 33`, but propagating that pincite back to earlier parallels requires extending `detectParallel` plus a back-fill pass; meaningful refactor for a follow-up issue.

## Test plan

- [x] `pnpm exec vitest run` — 3103 passing (+30 new across 6 issue-specific suites), 9 pre-existing skips
- [x] `pnpm typecheck` — clean
- [x] Biome lint clean (one chore commit unescaped useless `\[` inside char classes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)