### PR TITLE
fix(extract): case-name suite — 5 issues (#506, #509, #511, #512, #517)

### DIFF
--- a/.changeset/old-style-date-prefix.md
+++ b/.changeset/old-style-date-prefix.md
@@ -1,0 +1,20 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): strip old-style date prefix from caseName + harvest year (#511)
+
+The pre-Bluebook citation form `Name, YEAR, vol Reporter page` and the
+more elaborate `Name, COURT, MONTH DAY, YEAR, vol Reporter page` left the
+date/court tokens inside the captured `caseName` (e.g., `MacPherson v.
+Buick Motor Co., 1916`).
+
+Add two post-extract caseName trims (alongside the existing trailing
+parenthetical / parallel-cite / neutral-cite trims):
+
+- `,\s+(?:Cir|App|Ct|Dist).,\s+<Month> DD, YYYY` for the federal "circuit
+  + filing date" prefix.
+- `,\s+(?:17|18|19|20)\d{2}` for the bare-year prefix.
+
+When a year is trimmed, surface it on the citation's `year` field so the
+historical date isn't lost.

--- a/.changeset/open-paren-before-core.md
+++ b/.changeset/open-paren-before-core.md
@@ -1,0 +1,20 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): recover caseName when citation core sits inside `(...)` (#509)
+
+Two issues blocked caseName extraction for sentence-internal parenthetical
+citations like `(Smith v. Jones, 100 F.2d 1)`:
+
+1. The case-pattern tokenizers (`federal-reporter`, `supreme-court`,
+   `state-reporter`) omitted `)` from their trailing terminator alternation,
+   so `100 F.2d 1)` failed to tokenize as a case at all. Adds `\)` alongside
+   the existing `\s|$|\(|,|;|\.|\[|\]` terminators.
+2. When the caption sits OUTSIDE the parenthetical (`Name, (vol Reporter
+   page)`), `extractCaseName`'s precedingText ends with `, (`, which
+   `V_CASE_NAME_REGEX` can't match because the regex anchors on a trailing
+   comma or year-paren. Strip a trailing `(\s*$` so the comma is reachable.
+
+The fix is the complement of #512 (which requires the opposite — STOP at
+the open paren when the caption is INSIDE the wrapper).

--- a/.changeset/open-paren-stop-boundary.md
+++ b/.changeset/open-paren-stop-boundary.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): stop case-name scan at wrapping `(` (#512)
+
+When a citation appears as a sentence-internal parenthetical
+`(Name v. Name, vol Reporter page)`, the backward case-name scan
+absorbed any preceding capitalized prose into the captured caseName
+(yielding caseNames 100–366 chars long). The V_CASE_NAME_REGEX
+character class allows `(` inside party names, so adjacent all-cap
+prose was treated as plaintiff context.
+
+Add a right-to-left scan for the wrapping paren that has a `v.`-style
+caption (or procedural prefix) immediately inside. Truncate
+precedingText to start just after that `(` so the regex sees only the
+caption. The complement of #509 (paren-before-core, which strips a
+TRAILING `(\s*$`).
+
+Guarded against #241 admin-parens (`Spence v. Hintze (In re Hintze)`):
+when a complete `Name v. Name` caption exists BEFORE the candidate
+`(`, the `(` is an inline explanatory clause, not a wrapping boundary.

--- a/.changeset/reject-id-as-casename.md
+++ b/.changeset/reject-id-as-casename.md
@@ -1,0 +1,18 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): reject literal `Id.` / `Ibid.` as caseName (#517)
+
+The older parallel-reporter form `Id., NN <reporter> NN` (e.g.,
+`physical injury. Id., 584 N.Y.S.2d 744`) isn't matched by ID_PATTERN
+(which requires `Id. at <pincite>`), so the tokenizer falls through to
+the case extractor and the backward case-name scan picks up the bare
+`Id.` (or `Id`) as a single-party caption — yielding case citations
+with `caseName="Id."`.
+
+Refuse short-form citation markers (`Id`, `Id.`, `Ibid`, `Ibid.`,
+`supra`) as captured captions in the single-party fallback. The case
+citation still surfaces (so the resolver can attach it to the Id.
+antecedent's parallel reporter); it just doesn't carry a phantom
+`caseName`.

--- a/.changeset/signal-comma-strip.md
+++ b/.changeset/signal-comma-strip.md
@@ -1,0 +1,13 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): strip comma-separated signal variants from caseName (#506)
+
+`SIGNAL_STRIP_REGEX` now accepts older typesetting variants — `See, also,`
+(extra inter-word comma), `See, generally,`, `See e.g.,` (spaced/comma-less
+`e.g.`), and the canonical Bluebook forms with relaxed punctuation. A small
+set of post-signal prose connectors (`the case of`, `the opinion in`) is
+also stripped so captions like `See also the case of King v. Carter` no
+longer carry the connector into `caseName`. Mirrors the signal-detection
+relaxation from PR #503.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1340,6 +1340,18 @@ export function extractCaseName(
     adjustedSearchStart = searchStart + lastBoundaryIndex
   }
 
+  // Issue #509: When the citation core sits inside a sentence-internal
+  // parenthetical that does NOT also contain the caption — i.e.,
+  // `Name, (vol Reporter page)` — the precedingText ends with `, (` and the
+  // V_CASE_NAME_REGEX never matches because it anchors on a trailing comma
+  // or year-paren. Strip a trailing `(\s*$` so the caption (which lives
+  // outside the paren) is reachable.
+  //
+  // This is safe relative to #512 (`(Name v. Name, vol Reporter page)`)
+  // because the caption is INSIDE the wrapping paren in that case, so
+  // precedingText ends with `, ` not `(`.
+  precedingText = precedingText.replace(/\(\s*$/, "")
+
   // Priority 1: Standard "v." or "vs." format with comma before citation
   // Match party names with letters, numbers (for "Doe No. 2"), periods, apostrophes, ampersands, hyphens, slashes
   const vMatch = V_CASE_NAME_REGEX.exec(precedingText)

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1630,13 +1630,30 @@ export function extractCaseName(
     if (!SENTENCE_INITIAL_WORDS.has(firstWordClean)) {
       // Skip multi-citation strings (joined by semicolons)
       if (!caption.includes(";")) {
-        const nameStart = adjustedSearchStart + leadingWsLen + signalStripLen
-        return { caseName: caption, nameStart, precedingDocketMeta }
+        // Reject literal short-form citation markers as captions (#517).
+        // When the tokenizer can't match a token like `Id., 584 N.Y.S.2d 744`
+        // (older parallel-reporter Id. form not handled by ID_PATTERN), the
+        // backward scan picks up the bare `Id.` token as a single-party
+        // caption. `Id.` / `Ibid.` are never legitimate party names.
+        if (!isShortFormMarker(caption)) {
+          const nameStart = adjustedSearchStart + leadingWsLen + signalStripLen
+          return { caseName: caption, nameStart, precedingDocketMeta }
+        }
       }
     }
   }
 
   return undefined
+}
+
+/**
+ * Returns true when `caption` is a literal short-form citation marker
+ * (Id., Ibid., supra) rather than a real party name (#517). Comparison
+ * is case-insensitive and tolerates a trailing period.
+ */
+function isShortFormMarker(caption: string): boolean {
+  const normalized = caption.trim().toLowerCase().replace(/\.$/, "")
+  return normalized === "id" || normalized === "ibid" || normalized === "supra"
 }
 
 /** A raw parenthetical block extracted from text */

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -63,11 +63,37 @@ const VALID_SIGNALS = new Set([
  * Multi-word signals are listed first so "See also" matches before "See".
  * The trailing `,?` accommodates combined `, e.g.` signals (Bluebook Rule 1.3)
  * whose source-text form has a trailing comma between the signal and citation.
+ *
+ * Each whitespace gap inside a multi-word signal is permitted as `\s*,?\s+` so
+ * older typesetting variants like `See, also,` (extra inter-word comma) and
+ * `See e.g.,` (spaced `e.g.`) are stripped alongside the canonical Bluebook
+ * forms. This mirrors PR #503's relaxation for signal *detection* in
+ * detectStringCites.ts (#506).
+ *
+ * Additionally, a small set of prose connectors that commonly follow a signal
+ * are stripped here (`the case of`, `the opinion (filed at this term )?in`).
+ * Without this, captions like `See also the case of the King v. ...` carry
+ * `See also the case of` into the captured caseName.
  */
 const SIGNAL_STRIP_REGEX = (() => {
   const sorted = [...VALID_SIGNALS].sort((a, b) => b.length - a.length)
-  const alternatives = sorted.map((s) => s.replace(/\s+/g, "\\s+").replace(/\./g, "\\."))
-  return new RegExp(`^(${alternatives.join("|")}),?\\s+`, "i")
+  const alternatives = sorted.map((s) =>
+    // Whitespace between signal words tolerates an extra `, ` separator
+    // (e.g., `See, also,` for `See also`, `See, generally,` for `See generally`).
+    // Internal literal commas (from canonical forms like `see, e.g.`) are
+    // made optional so the bare typesetting variant `See e.g.,` also matches.
+    // Periods in `e.g.` / `cf.` tolerate an extra space (e.g., `See e. g.,`).
+    s
+      .replace(/\s+/g, "\\s*,?\\s+")
+      .replace(/,\s*/g, ",?\\s*")
+      .replace(/\./g, "\\.\\s*"),
+  )
+  // Optional prose connector after the signal: `the case of`, `the opinion
+  // (filed at this term )?in`. The connector is consumed lazily — only when
+  // present — and is followed by mandatory whitespace before the party name.
+  const proseConnector =
+    "(?:the\\s+(?:case\\s+of(?:\\s+the)?|opinion(?:\\s+filed\\s+at\\s+this\\s+term)?\\s+in)\\s+)?"
+  return new RegExp(`^(${alternatives.join("|")}),?\\s+${proseConnector}`, "i")
 })()
 
 /** Parse a volume string as number when purely numeric, string when hyphenated */

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -2689,6 +2689,11 @@ export function extractCase(
       // - Trailing `(YYYY)` or `(Court YYYY)` → strip whole paren.
       // - Trailing `, NNNN <reporter token>` → strip the parallel-cite
       //   start, e.g., `State v. Lane, 1998 MT 76` → `State v. Lane`.
+      // - Trailing `, COURT, MONTH DAY, YYYY` or bare `, YYYY` — the
+      //   old-style "name, date, citation" form (Picard v. United Aircraft,
+      //   2 Cir., May 28, 1942, 128 F.2d 632; Seymour v. Osborne, 1870, 11
+      //   Wall. 516) — strip and harvest the year (#511).
+      let oldStyleYear: number | undefined
       if (caseName) {
         // Trailing parenthetical (year or court+year)
         caseName = caseName.replace(/\s*\((?:[^()]*\s)?\d{4}\)\s*$/, "").trim()
@@ -2698,6 +2703,32 @@ export function extractCase(
           .trim()
         // Trailing comma + neutral-cite shape (YYYY <state> NN)
         caseName = caseName.replace(/,\s+\d{4}\s+[A-Z]+\s+\d+\s*$/, "").trim()
+        // Old-style `, COURT, MONTH DAY, YYYY` prefix (#511). Court is
+        // `[0-9]+\s+Cir.|App.|Ct.` or just `[A-Z][a-z]+.` shapes; we keep
+        // the match narrow so it doesn't strip legitimate trailing tokens.
+        const oldStyleCourtDate =
+          /,\s+\d{1,2}(?:st|nd|rd|th)?\s+(?:Cir|App|Ct|Dist|Cir\.\s+App)\.,\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},\s+(\d{4})\s*$/
+        const courtDateMatch = oldStyleCourtDate.exec(caseName)
+        if (courtDateMatch) {
+          oldStyleYear = Number.parseInt(courtDateMatch[1], 10)
+          caseName = caseName.replace(oldStyleCourtDate, "").trim()
+        } else {
+          // Bare `, YYYY` prefix (Seymour v. Osborne, 1870; MacPherson v.
+          // Buick Motor Co., 1916). Only when the year stands alone right
+          // before the citation core — restrict to 1700-2099 to keep the
+          // strip conservative.
+          const bareYear = /,\s+((?:17|18|19|20)\d{2})\s*$/
+          const bareMatch = bareYear.exec(caseName)
+          if (bareMatch) {
+            oldStyleYear = Number.parseInt(bareMatch[1], 10)
+            caseName = caseName.replace(bareYear, "").trim()
+          }
+        }
+      }
+      // Surface the harvested year on the citation when one wasn't already
+      // captured from a trailing parenthetical (#511).
+      if (oldStyleYear !== undefined && !year) {
+        year = oldStyleYear
       }
 
       // CSM year-first form puts the year *before* volume-reporter-page

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1157,6 +1157,63 @@ const LA_DOCKET_BOUNDARY_REGEX =
   /,?\s*(\d{2,4}-[A-Z\d-]+)(?:,\s*p\.\s*\d+)?\s*\((La\.[^)]*?)\s+(\d{1,2}\/\d{1,2}\/\d{2,4})\),\s*/g
 
 /**
+ * Find the rightmost `(` in `text` that wraps a caption + (eventually) the
+ * citation core — i.e., the open-paren of a `(Name v. Name, vol Reporter
+ * page)` envelope (#512). Returns the position immediately AFTER the `(`
+ * (so callers can `substring` from it), or `-1` when no such paren exists.
+ *
+ * Detection heuristic: scan right-to-left for `(`. The first one whose
+ * unbalanced suffix contains a `v.`-style anchor or a procedural prefix
+ * is the wrapping paren. We don't require the matching `)` to be present
+ * (the trailing `)` lives past the citation core).
+ *
+ * The matching is intentionally narrow:
+ * - Only `(` immediately followed (after optional whitespace) by a
+ *   capitalized word that participates in a v.-style or procedural
+ *   caption qualifies. Plain parens like `(sequestration)` or
+ *   `(entry of a money judgment)` are skipped.
+ * - The `v.` / procedural prefix must appear within the paren-suffix to
+ *   coreStart, ensuring we don't truncate when the paren wraps something
+ *   else (a date-paren, court-paren, explanatory paren, ...).
+ * - If a complete v.-style caption already exists BEFORE the candidate
+ *   `(`, that `(` is an inline admin parenthetical (`Spence v. Hintze
+ *   (In re Hintze), ...` — #241) and must NOT be used as a boundary;
+ *   stripping past it would destroy the real caption.
+ */
+function findCaptionWrapperParen(text: string): number {
+  // Quick reject: no `(` in text.
+  if (text.indexOf("(") === -1) return -1
+  // Scan right-to-left for `(`.
+  for (let i = text.length - 1; i >= 0; i--) {
+    if (text[i] !== "(") continue
+    const after = text.substring(i + 1)
+    // The content must START with optional whitespace + a capital letter
+    // — a paren around lowercase prose ("(sequestration)") is not a
+    // caption wrapper.
+    if (!/^\s*[A-Z]/.test(after)) continue
+    // Look for a v.-style anchor OR a procedural prefix within the paren
+    // body up to where the precedingText ends (which is the citation
+    // core position).
+    const looksLikeCaption =
+      /\s+vs?\.?\s+[A-Z]/.test(after) ||
+      /^\s*(?:In\s+re|Ex\s+parte|Matter\s+of|Estate\s+of|State\s+ex\s+rel\.|United\s+States\s+ex\s+rel\.|People\s+ex\s+rel\.)\b/.test(
+        after,
+      )
+    if (!looksLikeCaption) continue
+    // Admin-paren guard (#241): if a complete `Name v. Name` caption
+    // already lives BEFORE this `(`, the `(` introduces an inline
+    // explanatory clause (`Spence v. Hintze (In re Hintze)`) — it is not
+    // a wrapping caption boundary. Skip it.
+    const before = text.substring(0, i)
+    if (/[A-Z][A-Za-z0-9.'&\-/]+(?:\s+[A-Z][A-Za-z0-9.'&\-/]+)*\s+vs?\.?\s+[A-Z]/.test(before)) {
+      continue
+    }
+    return i + 1
+  }
+  return -1
+}
+
+/**
  * Extract case name via backward search from citation core.
  * Looks for "v." pattern or procedural prefixes (In re, Ex parte, Matter of).
  *
@@ -1351,6 +1408,23 @@ export function extractCaseName(
   // because the caption is INSIDE the wrapping paren in that case, so
   // precedingText ends with `, ` not `(`.
   precedingText = precedingText.replace(/\(\s*$/, "")
+
+  // Issue #512: When the caption sits INSIDE the wrapping parenthetical
+  // (`(Name v. Name, vol Reporter page)`), the backward scan must stop
+  // at the wrapping paren's open `(`. Otherwise the V_CASE_NAME_REGEX
+  // greedily absorbs the host sentence ahead of the `(` (which is allowed
+  // by the regex's `[A-Za-z0-9\s.,'&()/-]` character class for all-caps
+  // prose). This is the COMPLEMENT of the trailing-paren strip above.
+  //
+  // Detect the rightmost `(` whose contents contain a `v.`-style caption
+  // shape (or procedural prefix) — that's the wrapping paren. Truncate
+  // precedingText to start just after it so the regex sees only the
+  // caption.
+  const openParenStop = findCaptionWrapperParen(precedingText)
+  if (openParenStop !== -1) {
+    precedingText = precedingText.substring(openParenStop)
+    adjustedSearchStart += openParenStop
+  }
 
   // Priority 1: Standard "v." or "vs." format with comma before citation
   // Match party names with letters, numbers (for "Doe No. 2"), periods, apostrophes, ampersands, hyphens, slashes

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -28,8 +28,11 @@ export const casePatterns: Pattern[] = [
     // pattern survives the eventual rollout of F.5th / F.6th / F.Supp.Nth (#234).
     // F.Supp.* and F.App'x must come before the generic F.* alternative so the
     // longer prefixes win during alternation.
+    //
+    // Terminator accepts `)` for citations wrapped in a sentence-internal
+    // parenthetical — e.g., `(Smith v. Jones, 500 F.2d 123)` (#509).
     regex:
-      /\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+      /\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|\)|,|;|\.)/g,
     description: "Federal Reporter (F., F.2d, F.3d, F.Nth, F.Supp., F.App'x, etc.)",
     type: "case",
   },
@@ -37,8 +40,11 @@ export const casePatterns: Pattern[] = [
     id: "supreme-court",
     // L.Ed. edition suffix accepts any ordinal so a future L.Ed.3d edition does
     // not silently fall through to the state-reporter fallback (#234).
+    //
+    // Terminator accepts `)` for sentence-internal parenthetical citations
+    // (#509).
     regex:
-      /\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.)/g,
+      /\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|\(|\)|,|;|\.)/g,
     description:
       "U.S. Supreme Court reporters (with optional nominative reporter parenthetical)",
     type: "case",
@@ -50,11 +56,12 @@ export const casePatterns: Pattern[] = [
     // Apostrophe `'` is admitted for reporters like `F. App'x` already covered by
     // federal-reporter; including it here is harmless and future-proofs other
     // possessive forms. Trailing lookahead also accepts `[` (NY Slip Op `[U]`
-    // markers — #231) and `]` (California Style Manual bracketed parallel
-    // cites like `[266 Cal.Rptr. 569]` — #237). Negative lookahead on the
-    // reporter body rejects ` at ` so `18 Cal.4th at p. 717` (CSM short-form,
-    // #236) doesn't absorb `at p.` into the reporter; the short-form pattern
-    // handles it instead.
+    // markers — #231), `]` (California Style Manual bracketed parallel cites
+    // like `[266 Cal.Rptr. 569]` — #237), and `)` (sentence-internal
+    // parenthetical citations like `(Smith v. Jones, 100 Cal. App. 4th 1)`
+    // — #509). Negative lookahead on the reporter body rejects ` at ` so
+    // `18 Cal.4th at p. 717` (CSM short-form, #236) doesn't absorb `at p.`
+    // into the reporter; the short-form pattern handles it instead.
     //
     // ` R.\s+\d` guard (#332): Illinois Supreme Court Rules cite as
     // `177 Ill. 2d R. 234` (volume + reporter + `R. ruleNum`), which the lazy
@@ -64,7 +71,7 @@ export const casePatterns: Pattern[] = [
     // untokenized rather than misclassified. A typed rule citation is out
     // of scope; the goal here is to suppress the false positive.
     regex:
-      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?! R\.\s+\d)(?!\s+vs?\.\s)(?!\s+at\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|,|;|\.|\[|\])/g,
+      /\b(\d+(?:-\d+)?)\s+([A-Z](?:(?! L\.[JQR\s])(?! R\.\s+\d)(?!\s+vs?\.\s)(?!\s+at\s)[A-Za-z.\d\s&'])+?)\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|\)|,|;|\.|\[|\])/g,
     description:
       'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev", phantom matches across " v. "/" vs. ", CSM " at " short-form boundaries, and Illinois " R. N" rule-marker boundaries, validated against reporters-db in Phase 3)',
     type: "case",

--- a/tests/extract/issue506SignalComma.test.ts
+++ b/tests/extract/issue506SignalComma.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+/**
+ * Issue #506: signal phrases bleed into caseName when separated by commas.
+ *
+ * SIGNAL_STRIP_REGEX is derived from VALID_SIGNALS (canonical forms like
+ * "see also") and so doesn't accept the older comma-separated typesetting
+ * variants ("See, also,", "See, generally,", "See e.g.,", "See also the
+ * case of"). Result: the signal text leaks into the captured caseName.
+ *
+ * Fix: broaden SIGNAL_STRIP_REGEX to allow optional commas inside multi-word
+ * signals and recognize a few common prose connectors ("the case of").
+ */
+describe("issue #506 — signal phrases bleed into caseName (comma variants)", () => {
+  const caseName = (text: string): string | undefined => {
+    const cs = extractCitations(text)
+    const cc = cs.find((c) => c.type === "case") as FullCaseCitation | undefined
+    return cc?.caseName
+  }
+
+  it("strips `See, also,` prefix (extra comma after See)", () => {
+    const name = caseName(
+      "See, also, the opinion filed at this term in Steen vs Swadley, 5 Ind. Ter. Rep. 451",
+    )
+    expect(name).toBeDefined()
+    expect(name).not.toMatch(/^See,?\s+also/i)
+    expect(name).toContain("Steen")
+    expect(name).toContain("Swadley")
+  })
+
+  it("strips `See, generally,` prefix", () => {
+    const name = caseName(
+      "See, generally, Berkebile v. Nationwide Insurance Co., 5 Ind. Ter. Rep. 451",
+    )
+    expect(name).toBeDefined()
+    expect(name).not.toMatch(/^See/i)
+    expect(name).toBe("Berkebile v. Nationwide Insurance Co.")
+  })
+
+  it("strips `See also the case of` prose connector", () => {
+    const name = caseName(
+      "See also the case of the King v. Sir J. Carter and others, 5 Ind. Ter. Rep. 451",
+    )
+    expect(name).toBeDefined()
+    // The captured name should not start with `See`, and the "case of" connector
+    // should be dropped. The leading "the" before King is part of the source —
+    // capture from "King" onward (or include "the" — both acceptable, but never
+    // include "See also the case of").
+    expect(name).not.toMatch(/^See/i)
+    expect(name).not.toMatch(/case of/i)
+    expect(name).toMatch(/King v\.\s+Sir J\. Carter/)
+  })
+
+  it("strips `See e.g.,` (spaced variant)", () => {
+    const name = caseName(
+      "See e.g., Vandermark v. Ford Motor Co., 5 Ind. Ter. Rep. 451",
+    )
+    expect(name).toBeDefined()
+    expect(name).not.toMatch(/^See/i)
+    expect(name).toBe("Vandermark v. Ford Motor Co.")
+  })
+})

--- a/tests/extract/issue509OpenParenBeforeCore.test.ts
+++ b/tests/extract/issue509OpenParenBeforeCore.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+/**
+ * Issue #509: an open-paren `(` immediately before the citation core
+ * (`(volume Reporter page)`) is currently treated as a hard boundary
+ * by the backward case-name scan, so the caseName is lost.
+ *
+ * Fix: the scan should be able to step PAST a `(` immediately to the
+ * left of the citation core to look for the case name that lives just
+ * outside the parenthetical wrapping the citation.
+ *
+ * Distinct from #512 (the COMPLEMENT) — when the parenthetical contains
+ * BOTH the caption AND the citation core (`(Name v. Name, vol Reporter
+ * page)`), the open-paren must STOP the scan. The disambiguator is
+ * whether a case name has been recovered before the scan reaches the `(`.
+ */
+describe("issue #509 — open-paren before citation core does not suppress caseName", () => {
+  const caseName = (text: string): string | undefined => {
+    const cs = extractCitations(text)
+    const cc = cs.find((c) => c.type === "case") as FullCaseCitation | undefined
+    return cc?.caseName
+  }
+
+  it("captures caseName when caption precedes `, (vol Reporter page)`", () => {
+    const name = caseName(
+      "Thus, in the case of Murray v. Ballou, (1 Johns. Ch. Rep. 566)",
+    )
+    expect(name).toBe("Murray v. Ballou")
+  })
+
+  it("captures caseName for a bare `(Name v. Name, vol Reporter page)` wrapper", () => {
+    const name = caseName("(Murray v. Ballou, 1 Johns. Ch. Rep. 566)")
+    expect(name).toBe("Murray v. Ballou")
+  })
+})

--- a/tests/extract/issue511OldStyleDate.test.ts
+++ b/tests/extract/issue511OldStyleDate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+/**
+ * Issue #511: old-style citation form `Name, YEAR, vol Reporter page` (and
+ * `Name, COURT, MONTH DAY, YEAR, vol Reporter page`) leaves the trailing
+ * year / court / date in the captured caseName.
+ *
+ * Fix shape: trim a trailing `,\s+\d{4}` (and the more elaborate
+ * `,\s+\d{1,2}\s+Cir\.,\s+Month \d{1,2}, \d{4}` form) from the captured
+ * caseName when it sits immediately before the citation core.
+ */
+describe("issue #511 — old-style date-prefix citation form", () => {
+  const caseName = (text: string): string | undefined => {
+    const cs = extractCitations(text)
+    const cc = cs.find((c) => c.type === "case") as FullCaseCitation | undefined
+    return cc?.caseName
+  }
+
+  it("strips `, YYYY` from caseName: `Seymour v. Osborne, 1870, 11 Wall. 516`", () => {
+    expect(caseName("Seymour v. Osborne, 1870, 11 Wall. 516")).toBe(
+      "Seymour v. Osborne",
+    )
+  })
+
+  it("strips `, YYYY` from caseName: `MacPherson v. Buick Motor Co., 1916, 217 N.Y. 382`", () => {
+    expect(caseName("MacPherson v. Buick Motor Co., 1916, 217 N.Y. 382")).toBe(
+      "MacPherson v. Buick Motor Co.",
+    )
+  })
+
+  it("strips `, YYYY` from caseName: `Kendall v. Winsor, 1858, 21 How. 322`", () => {
+    expect(caseName("Kendall v. Winsor, 1858, 21 How. 322")).toBe(
+      "Kendall v. Winsor",
+    )
+  })
+
+  it("strips `, COURT, MONTH DAY, YYYY` from caseName: `Picard v. United Aircraft, 2 Cir., May 28, 1942, 128 F.2d 632`", () => {
+    expect(
+      caseName("Picard v. United Aircraft, 2 Cir., May 28, 1942, 128 F.2d 632"),
+    ).toBe("Picard v. United Aircraft")
+  })
+})

--- a/tests/extract/issue512OpenParenStopBoundary.test.ts
+++ b/tests/extract/issue512OpenParenStopBoundary.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+/**
+ * Issue #512: when `(Name v. Name, vol Reporter page)` appears as a
+ * sentence-internal parenthetical, the backward case-name scan must
+ * stop at the open paren of the wrapping parenthetical — otherwise it
+ * absorbs the entire host sentence into `caseName`.
+ *
+ * This is the COMPLEMENT of #509: that issue is about REACHING into
+ * the paren from outside; this is about STOPPING at the open paren
+ * when the caption lives INSIDE the paren.
+ */
+describe("issue #512 — backward scan stops at wrapping paren's open `(`", () => {
+  const caseName = (text: string): string | undefined => {
+    const cs = extractCitations(text)
+    const cc = cs.find((c) => c.type === "case") as FullCaseCitation | undefined
+    return cc?.caseName
+  }
+
+  it("captures `Covello v Covello` (NY-style `v` without period)", () => {
+    const name = caseName(
+      "Domestic Relations Law (sequestration), section 244 (entry of a money judgment); (Covello v Covello, 68 AD2d 818)",
+    )
+    expect(name).toBe("Covello v Covello")
+    // Negative: must not be hundreds of chars
+    expect((name ?? "").length).toBeLessThan(50)
+  })
+
+  it("captures `Moran v. Town of Mashpee` without bleeding bracketed prose", () => {
+    const name = caseName(
+      "The few cases ... involved [contracts]; (Moran v. Town of Mashpee, 17 Mass.App.Ct. 679)",
+    )
+    expect(name).toBe("Moran v. Town of Mashpee")
+    expect((name ?? "").length).toBeLessThan(50)
+  })
+
+  it("does not regress #509 paren-before-core (sanity)", () => {
+    // The OPPOSITE shape: caption is OUTSIDE the paren that wraps the
+    // citation core. Both should resolve correctly side by side.
+    expect(caseName("Thus, in the case of Murray v. Ballou, (1 Johns. Ch. Rep. 566)")).toBe(
+      "Murray v. Ballou",
+    )
+    expect(caseName("(Murray v. Ballou, 1 Johns. Ch. Rep. 566)")).toBe(
+      "Murray v. Ballou",
+    )
+  })
+
+  it("stops at the wrapping `(` even when host prose is all-capitalized", () => {
+    // Without the open-paren stop, the V_CASE_NAME_REGEX character class
+    // allows `(` inside plaintiff, so adjacent capitalized prose like
+    // `Some Title For Section And More Text (Smith v. Jones` is absorbed
+    // into plaintiff — yielding wildly long caseNames. The `(` boundary
+    // ensures only the paren contents are captured.
+    expect(
+      caseName("Some Title For Section And More Text (Smith v. Jones, 100 F.2d 1)"),
+    ).toBe("Smith v. Jones")
+    expect(
+      caseName("Some Important Sentence Here, (Smith v. Jones, 100 F.2d 1)"),
+    ).toBe("Smith v. Jones")
+  })
+})

--- a/tests/extract/issue517IdAsCaseName.test.ts
+++ b/tests/extract/issue517IdAsCaseName.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+/**
+ * Issue #517: literal `Id.` is being captured as the caseName on a `case`-
+ * typed citation when the source text uses the older `Id., vol Reporter
+ * page` form (e.g., `physical injury. Id., 584 N.Y.S.2d 744`).
+ *
+ * Root cause: the `id` token pattern requires `Id. at <pincite>` and so
+ * does not match `Id.,` followed by a comma + reporter. The tokenizer
+ * falls through, treating `584 N.Y.S.2d 744` as a bare case citation and
+ * letting the backward case-name scan absorb `Id.` as the caption.
+ *
+ * Fix: refuse `Id.` (and `Id`) as a captured caseName — these are short-
+ * form citation markers, not party names. The case citation still
+ * surfaces (so the resolver can attach it to the antecedent), it just
+ * doesn't carry `caseName="Id."`.
+ */
+describe("issue #517 — literal `Id.` not captured as caseName", () => {
+  const caseCite = (text: string): FullCaseCitation | undefined => {
+    const cs = extractCitations(text)
+    return cs.find((c) => c.type === "case") as FullCaseCitation | undefined
+  }
+
+  it("does not produce caseName='Id.' for `physical injury. Id., 584 N.Y.S.2d 744`", () => {
+    const cc = caseCite(
+      "the plaintiff suffered no physical injury. Id., 584 N.Y.S.2d 744",
+    )
+    // We don't assert that NO case citation surfaces — that's a separate
+    // tokenizer concern (the bug report says it produces a case citation
+    // for `584 N.Y.S.2d 744`). What MUST hold: caseName must NOT be
+    // literally `Id.` / `Id` (with or without trailing punctuation).
+    // `undefined` is acceptable — the caption simply doesn't surface, and
+    // the resolver can pair the citation via Id. semantics if needed.
+    if (cc) {
+      const name = cc.caseName ?? ""
+      expect(name).not.toMatch(/^Id\.?$/)
+    }
+  })
+
+  it("does not produce caseName='Id' for `... text. Id, 100 F.2d 1`", () => {
+    const cc = caseCite("Some preceding text. Id, 100 F.2d 1")
+    if (cc) {
+      const name = cc.caseName ?? ""
+      expect(name).not.toMatch(/^Id\.?$/)
+    }
+  })
+
+  it("does not produce caseName='Ibid' / 'Ibid.' either", () => {
+    const cc = caseCite("Some preceding text. Ibid, 100 F.2d 1")
+    if (cc) {
+      const name = cc.caseName ?? ""
+      expect(name).not.toMatch(/^Ibid\.?$/i)
+    }
+  })
+
+  it("does not regress legitimate single-party captions", () => {
+    // `Microsoft` is a legitimate single-party caption (Antitrust suit
+    // shorthand). Stripping short-form markers must not affect real names.
+    const cc = caseCite("As discussed in Microsoft, 100 F.2d 1")
+    // No assertion on caseName equality — the existing extractor may or
+    // may not surface "Microsoft" depending on context — but if it does,
+    // it must NOT be filtered by the new short-form-marker reject.
+    if (cc?.caseName) {
+      expect(cc.caseName).not.toMatch(/^Id\.?$/)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Five case-name-extraction fixes from the CAP-corpus audit.

| Issue | Fix |
|---|---|
| [#506](https://github.com/medelman17/eyecite-ts/issues/506) | Comma-separated signal variants (`See, also,`, `See, generally,`) stripped from `caseName` |
| [#509](https://github.com/medelman17/eyecite-ts/issues/509) | Parenthetical citations like `(Murray v. Ballou, 1 Johns. Ch. Rep. 566)` now recover the case name. Also added `\)` to case-pattern tokenizer terminators (the open-paren form wasn't even tokenizing as a case) |
| [#511](https://github.com/medelman17/eyecite-ts/issues/511) | Old-style date prefix `Name, YEAR, vol Reporter page` no longer rubble in `caseName`. The captured year is harvested into `citation.year` when no other year is present |
| [#512](https://github.com/medelman17/eyecite-ts/issues/512) | Backward scan stops at the wrapping `(` of `(Name v. Name, vol Reporter page)` — fixes 100–366 char caseNames in older state reporters |
| [#517](https://github.com/medelman17/eyecite-ts/issues/517) | Literal `Id.` / `Ibid.` no longer captured as a `caseName` (single-party caption fallback now rejects them) |

Five changesets, one per issue.

## Test plan

- [x] `pnpm exec vitest run` — 3091 passing, 9 skipped, 0 failures
- [x] `pnpm typecheck` — clean
- [x] No new lint warnings (verified by stashing & re-running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)