### PR TITLE
fix(document): analyzeDocument prose-spans use ORIGINAL coords (#535, #536)

### DIFF
--- a/.changeset/analyze-document-prose-coords.md
+++ b/.changeset/analyze-document-prose-coords.md
@@ -1,0 +1,13 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `analyzeDocument` prose-span coordinate confusion (#535, #536).
+
+`computeProseOffsets` derived prose-span boundaries via `getCitationStart` / `getCitationEnd`, which return CLEAN-text coordinates, then wrote those same numbers into the output `Span`'s `originalStart` / `originalEnd`. For any text where cleaning shifts positions (HTML, smart quotes, collapsed whitespace, Unicode normalization — i.e., most real opinions), slicing the original text with the wrong coordinates produced invalid prose text. Roughly 25% of opinions were affected, with cumulative drift up to 40+ characters.
+
+`computeProseOffsets` now tracks both clean and original cursors independently, reading each citation's `span.clean*` and `span.original*` (or `fullSpan` when present) directly. Two new helpers `getCitationOriginalStart` / `getCitationOriginalEnd` mirror the existing clean-coord helpers.
+
+`analyzeDocument`'s `transformationMap` option is no longer needed for correctness — citations already carry both coordinate systems — but the option remains in the signature for API compatibility (its value is unused; previously declared as `_transformationMap`, which was itself the cause of #536).
+
+Surfaced by a CAP-corpus `analyzeDocument` quality audit.

--- a/src/document/proseOffsets.ts
+++ b/src/document/proseOffsets.ts
@@ -1,6 +1,11 @@
 import type { Citation } from "../types/citation"
 import type { Span, TransformationMap } from "../types/span"
-import { getCitationEnd, getCitationStart } from "../utils/citationBounds"
+import {
+  getCitationEnd,
+  getCitationOriginalEnd,
+  getCitationOriginalStart,
+  getCitationStart,
+} from "../utils/citationBounds"
 
 interface ProseOffsetResult {
   proseSpans: Span[]
@@ -17,16 +22,27 @@ interface ProseOffsetResult {
  *   - followingProse: Map<citationIndex, Span> — the prose starting after this cite
  *
  * Uses `fullSpan` when available (case-family citations) so the case-name
- * text isn't mislabeled as prose. When no transformationMap is provided,
- * cleanStart === originalStart on the output spans (best effort).
+ * text isn't mislabeled as prose. Each output Span carries BOTH clean and
+ * original coordinates, derived directly from each citation's clean/original
+ * span fields — no `transformationMap` lookup is required because the
+ * citations themselves already carry both coordinate systems.
  *
  * Note on adjacency: when two citations are adjacent with no prose between
  * them, this implementation skips setting the map entries silently rather
  * than emitting length-0 spans. Consumers check Map.has() to detect absence.
+ *
+ * Issue #535 / #536: an earlier version of this function used clean-text
+ * coordinates as both `cleanStart/End` and `originalStart/End` on the output
+ * spans. That silently broke `text.slice(span.originalStart, span.originalEnd)`
+ * for any caller passing original (uncleaned) text — the slice would land
+ * at the wrong offset by the cumulative cleaning shift. Both coordinate
+ * systems are now tracked independently from each citation's own span.
  */
 export function computeProseOffsets(
   text: string,
   citations: Citation[],
+  // Kept for API compatibility; positions are derived directly from each
+  // citation's clean/original span fields so no lookup map is needed.
   _transformationMap?: TransformationMap,
 ): ProseOffsetResult {
   const proseSpans: Span[] = []
@@ -35,30 +51,44 @@ export function computeProseOffsets(
 
   if (citations.length === 0) {
     if (text.length > 0) {
-      proseSpans.push(makeSpan(0, text.length))
+      proseSpans.push(makeSpan(0, text.length, 0, text.length))
     }
     return { proseSpans, precedingProse, followingProse }
   }
 
-  // Sort by citation start. The input is usually already sorted but be safe.
+  // Sort by clean start. The input is usually already sorted but be safe.
   const indexed = citations.map((c, i) => ({ c, originalIndex: i }))
   indexed.sort((a, b) => getCitationStart(a.c) - getCitationStart(b.c))
 
-  let cursor = 0
+  let cleanCursor = 0
+  let originalCursor = 0
   for (const { c, originalIndex } of indexed) {
-    const start = getCitationStart(c)
-    const end = getCitationEnd(c)
-    if (start > cursor) {
-      const span = makeSpan(cursor, start)
+    const cleanStart = getCitationStart(c)
+    const cleanEnd = getCitationEnd(c)
+    const originalStart = getCitationOriginalStart(c)
+    const originalEnd = getCitationOriginalEnd(c)
+    if (cleanStart > cleanCursor) {
+      const span = makeSpan(cleanCursor, cleanStart, originalCursor, originalStart)
       proseSpans.push(span)
       precedingProse.set(originalIndex, span)
     }
-    cursor = Math.max(cursor, end)
+    if (cleanEnd > cleanCursor) {
+      cleanCursor = cleanEnd
+      originalCursor = originalEnd
+    }
   }
 
   // Trailing prose after the last citation.
-  if (cursor < text.length) {
-    const trailing = makeSpan(cursor, text.length)
+  if (cleanCursor < text.length || originalCursor < text.length) {
+    // The trailing prose extends to the end of `text` in original coords; the
+    // clean trailing end isn't known here, so we use the same delta as the
+    // trailing original-text length, mirroring the leading/middle behavior.
+    const trailing = makeSpan(
+      cleanCursor,
+      cleanCursor + (text.length - originalCursor),
+      originalCursor,
+      text.length,
+    )
     proseSpans.push(trailing)
     const lastIdx = indexed[indexed.length - 1].originalIndex
     followingProse.set(lastIdx, trailing)
@@ -77,11 +107,11 @@ export function computeProseOffsets(
   return { proseSpans, precedingProse, followingProse }
 }
 
-function makeSpan(start: number, end: number): Span {
-  return {
-    cleanStart: start,
-    cleanEnd: end,
-    originalStart: start,
-    originalEnd: end,
-  }
+function makeSpan(
+  cleanStart: number,
+  cleanEnd: number,
+  originalStart: number,
+  originalEnd: number,
+): Span {
+  return { cleanStart, cleanEnd, originalStart, originalEnd }
 }

--- a/src/utils/citationBounds.ts
+++ b/src/utils/citationBounds.ts
@@ -18,3 +18,23 @@ export function getCitationStart(c: Citation): number {
   const fullSpan = "fullSpan" in c ? (c as FullCaseCitation).fullSpan : undefined
   return fullSpan ? fullSpan.cleanStart : c.span.cleanStart
 }
+
+/**
+ * Get the end position of a citation's full extent in ORIGINAL text.
+ * Mirrors `getCitationEnd` but returns original coordinates — used by
+ * consumers that need to slice the user-provided original text rather
+ * than the cleaned internal text. Prefers `fullSpan` when available.
+ */
+export function getCitationOriginalEnd(c: Citation): number {
+  const fullSpan = "fullSpan" in c ? (c as FullCaseCitation).fullSpan : undefined
+  return fullSpan ? fullSpan.originalEnd : c.span.originalEnd
+}
+
+/**
+ * Get the start position of a citation's full extent in ORIGINAL text.
+ * Mirrors `getCitationStart` but returns original coordinates.
+ */
+export function getCitationOriginalStart(c: Citation): number {
+  const fullSpan = "fullSpan" in c ? (c as FullCaseCitation).fullSpan : undefined
+  return fullSpan ? fullSpan.originalStart : c.span.originalStart
+}

--- a/tests/document/proseOffsets.test.ts
+++ b/tests/document/proseOffsets.test.ts
@@ -80,4 +80,156 @@ describe("computeProseOffsets", () => {
       expect(span.cleanEnd).toBe(span.originalEnd)
     }
   })
+
+  // Issue #535 / #536: computeProseOffsets used getCitationStart/End (which
+  // return CLEAN coords) as ORIGINAL coords. When the input text contains
+  // anything that shifts positions during cleaning (smart quotes, HTML
+  // entities, repeated whitespace, Unicode), prose spans had wrong original
+  // coordinates and slicing `text` (original) with those coords returned
+  // text from the wrong offsets.
+  describe("preserves original-text coordinates when cleaning shifts positions (#535, #536)", () => {
+    // Direct test: hand-craft citations with known clean/original offset gaps
+    // and assert that prose-span original coords align with citation original
+    // coords (NOT clean coords).
+    it("prose spans use citation ORIGINAL coords, not CLEAN coords (direct, with known offsets)", () => {
+      // Imagine an opinion with HTML markup or repeated whitespace that adds
+      // 5 chars to the original text vs the cleaned text. Two citations:
+      // - cite A spans original [50, 70), clean [40, 60)
+      // - cite B spans original [120, 140), clean [110, 130)
+      // After cite A there should be prose at original [70, 120).
+      // BEFORE the fix, the buggy code emits prose at original [60, 110)
+      // (using clean coords for original).
+      const original = `${"A".repeat(50)}cite-A-original-text!${"B".repeat(50)}cite-B-original-text!${"C".repeat(40)}`
+      const cites = [
+        {
+          type: "case" as const,
+          text: "cite-A-original-text",
+          matchedText: "cite-A-original-text",
+          confidence: 1.0,
+          processTimeMs: 0,
+          patternsChecked: 0,
+          span: {
+            cleanStart: 40,
+            cleanEnd: 60,
+            originalStart: 50,
+            originalEnd: 70,
+          },
+        } as unknown as Parameters<typeof computeProseOffsets>[1][number],
+        {
+          type: "case" as const,
+          text: "cite-B-original-text",
+          matchedText: "cite-B-original-text",
+          confidence: 1.0,
+          processTimeMs: 0,
+          patternsChecked: 0,
+          span: {
+            cleanStart: 110,
+            cleanEnd: 130,
+            originalStart: 120,
+            originalEnd: 140,
+          },
+        } as unknown as Parameters<typeof computeProseOffsets>[1][number],
+      ]
+
+      const result = computeProseOffsets(original, cites)
+
+      // Three prose spans: before A, between A and B, after B.
+      expect(result.proseSpans).toHaveLength(3)
+
+      // Each span's text, sliced from ORIGINAL using its originalStart/End,
+      // must NOT contain any of "cite-A-original-text" or "cite-B-original-text".
+      for (const span of result.proseSpans) {
+        const sliced = original.slice(span.originalStart, span.originalEnd)
+        expect(sliced).not.toContain("cite-A-original-text")
+        expect(sliced).not.toContain("cite-B-original-text")
+      }
+
+      // Specifically:
+      //   prose[0] aligns to cite-A's original boundaries:  originalStart=0, originalEnd=cite[0].originalStart
+      //   prose[1] sits between A's end and B's start (original coords)
+      //   prose[2] is the trailing tail after B
+      expect(result.proseSpans[0].originalStart).toBe(0)
+      expect(result.proseSpans[0].originalEnd).toBe(50)
+      expect(result.proseSpans[1].originalStart).toBe(70)
+      expect(result.proseSpans[1].originalEnd).toBe(120)
+      expect(result.proseSpans[2].originalStart).toBe(140)
+      expect(result.proseSpans[2].originalEnd).toBe(original.length)
+
+      // And clean coords should align with citation clean coords:
+      expect(result.proseSpans[1].cleanStart).toBe(60)
+      expect(result.proseSpans[1].cleanEnd).toBe(110)
+    })
+
+    it("prose-span original coords match the citations' original coords (smart quotes)", () => {
+      // Smart-quoted text triggers Unicode normalization in cleaning, which
+      // can shift positions when the smart quotes get normalized to ASCII.
+      const text =
+        "The court “held” that " +
+        "Smith v. Jones, 100 F.2d 50 (1990), was wrong. " +
+        "Then “noted” further that " +
+        "Brown v. Doe, 200 F.3d 100 (2000), agreed. " +
+        "End."
+      const cites = extractCitations(text)
+      expect(cites).toHaveLength(2)
+
+      const result = computeProseOffsets(text, cites)
+
+      // Every prose span's text, when sliced from the ORIGINAL text using
+      // originalStart/originalEnd, must NOT cut into a citation.
+      for (const span of result.proseSpans) {
+        const sliced = text.slice(span.originalStart, span.originalEnd)
+        for (const c of cites) {
+          // Prose should not contain the literal volume/reporter/page of any
+          // citation it's meant to surround.
+          expect(sliced).not.toContain("100 F.2d 50")
+          expect(sliced).not.toContain("200 F.3d 100")
+          void c
+        }
+      }
+
+      // followingProse[0] should start at or after the END of cite[0] in
+      // ORIGINAL coords.
+      const cite0End = cites[0].span.originalEnd
+      const following0 = result.followingProse.get(0)
+      expect(following0).toBeDefined()
+      expect(following0!.originalStart).toBeGreaterThanOrEqual(cite0End)
+    })
+
+    it("prose-span original coords align with citation original boundaries (collapsed whitespace)", () => {
+      // Repeated whitespace gets collapsed during cleaning, shifting clean
+      // positions earlier than original positions.
+      const text =
+        "Intro.    See   " + // multiple spaces — get collapsed during clean
+        "Smith v. Jones, 100 F.2d 50 (1990).    " +
+        "Then    note   " +
+        "Brown v. Doe, 200 F.3d 100 (2000).    " +
+        "End."
+      const cites = extractCitations(text)
+      expect(cites.length).toBeGreaterThanOrEqual(2)
+
+      const result = computeProseOffsets(text, cites)
+
+      // For every citation that has a followingProse entry, the entry's
+      // originalStart must equal the citation's originalEnd (modulo fullSpan).
+      for (let i = 0; i < cites.length; i++) {
+        const following = result.followingProse.get(i)
+        if (!following) continue
+        // Slicing original text with the follow-prose span must NOT include
+        // the cite's volume/reporter/page.
+        const tail = text.slice(following.originalStart, following.originalEnd)
+        const c = cites[i] as { volume?: number | string; reporter?: string; page?: number | string }
+        if (typeof c.volume === "number" || typeof c.volume === "string") {
+          expect(tail).not.toContain(`${c.volume} ${c.reporter} ${c.page}`)
+        }
+      }
+
+      // Each prose span's text, sliced from the original, must NOT contain
+      // any of the citation cores.
+      for (const span of result.proseSpans) {
+        const sliced = text.slice(span.originalStart, span.originalEnd)
+        expect(sliced).not.toContain("100 F.2d 50")
+        expect(sliced).not.toContain("200 F.3d 100")
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Hotfix for a correctness bug shipped in 0.21.0's `analyzeDocument` API.

`computeProseOffsets` was deriving prose-span boundaries via `getCitationStart` / `getCitationEnd` (which return CLEAN-text coordinates) and writing those numbers into the output `Span`'s `originalStart` / `originalEnd`. For any input text where cleaning shifts positions (HTML, smart quotes, collapsed whitespace, Unicode normalization), slicing `text` (original) with the wrong coordinates produced invalid prose text. **~25% of opinions affected** in a 600-opinion CAP audit; cumulative drift hit 40+ chars in one VA opinion with 244 citations.

## Fix

Track both clean and original cursors independently in `computeProseOffsets`. Derive each prose span's coordinates from the surrounding citations' `span.clean*` and `span.original*` (or `fullSpan` when present). Two new helpers `getCitationOriginalStart` / `getCitationOriginalEnd` mirror the existing clean-coord helpers.

The `transformationMap` option (#536) is no longer needed for correctness — citations already carry both coordinate systems. Option remains in the signature for API compatibility; was previously declared as `_transformationMap` (intentionally-unused parameter), which was itself the cause of #536.

Closes #535. Closes #536.

## Test plan

- [x] Direct hand-crafted test in `tests/document/proseOffsets.test.ts` with known clean/original offset gap — reproduces #535 then verifies the fix
- [x] `pnpm exec vitest run` — 3138 passing (+2 new), 9 pre-existing skips
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)