### PR TITLE
fix(annotate): cluster — fullSpan overlap, bare-`<` snap, overlap-confidence (#543, #544, #545)

### DIFF
--- a/.changeset/annotate-bare-lt-not-tag.md
+++ b/.changeset/annotate-bare-lt-not-tag.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `annotate` engulfing prose around bare `<` characters (#544).
+
+`snapOutOfHtmlTags` treated ANY unpaired `<` as the open of an HTML tag, so when the source contained bare `<` characters from OCR or math notation (`A < B`, `rate is < 30%`, `<®=»`), citation start positions snapped backwards to the bare `<` and the `<cite>` wrap engulfed everything between the bare `<` and the citation. Catastrophic with the canonical `<cite>` template.
+
+`findContainingTag` now only treats a `<` as a tag open when it is IMMEDIATELY followed by `[a-zA-Z!/]` — the only characters that begin a well-formed HTML tag, comment, doctype, or close-tag. Bare `<` followed by whitespace, digits, punctuation, or end-of-text is left alone, so prose with mathematical / inequality syntax annotates cleanly.

--- a/.changeset/annotate-fullspan-overlap.md
+++ b/.changeset/annotate-fullspan-overlap.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `annotate` corrupting wraps for parallel-reporter sequences when `useFullSpan: true` (#543).
+
+When `useFullSpan: true`, `annotate` sorted citations by `span.originalStart` (the core citation) but wrapped using `fullSpan.originalStart`/`fullSpan.originalEnd`. For parallel-reporter sequences whose `fullSpan`s all extend back to the same case name (e.g., `Roe v. Wade, 410 U.S. 113, 93 S.Ct. 705, 35 L.Ed.2d 147 (1973)`), the sort order disagreed with the wrap ranges. The reverse-iterate splice then dropped `<cite>` tags inside text that subsequent (outer) wraps were about to encompass, producing nested `<cite>` tags, mid-token truncations like `L. Ed. 2</cite>d`, and HTML-escaped sentinels like `&lt;cite&gt;`. The pathology hit roughly 21% of opinions in a CAP-corpus audit.
+
+`annotate` now resolves each citation's wrap range up-front (core span or `fullSpan`, depending on `useFullSpan`) and sorts/iterates against that range. It also performs explicit overlap detection: when two wraps intersect, the earlier-starting (outer/wider) wrap wins and the inner citation is surfaced via the `skipped` array — matching the promise in `AnnotationResult.skipped`'s docstring. Parallel-reporter clusters now produce a single outer `<cite>…</cite>` around the case name + reporters + parenthetical, with the inner two citations reported as skipped.

--- a/.changeset/annotate-overlap-confidence.md
+++ b/.changeset/annotate-overlap-confidence.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `annotate` producing malformed sentinels for overlapping core spans (#545).
+
+When two citations' core `span.originalStart`/`originalEnd` ranges overlapped (e.g., a statute false-positive nested inside a case name's core span), `annotate` spliced both wraps and chopped one sentinel into the middle of the other's text, producing malformed output. Roughly 7% of opinions were affected.
+
+The overlap detection added in #543 now applies to core-span wraps too, and is confidence-aware: when two wraps intersect, the citation with the higher `confidence` score wins and the other is surfaced via the `skipped` array. Nested wraps (one fully inside another) always keep the outer wrap. The `AnnotationResult.skipped` docstring is updated to reflect the new behaviour.

--- a/src/annotate/annotate.ts
+++ b/src/annotate/annotate.ts
@@ -154,7 +154,13 @@ export function annotate<C extends Citation = Citation>(
 
 /**
  * Check if a position falls inside an HTML tag (between `<` and `>`).
- * Returns the index of the opening `<` if inside a tag, otherwise -1.
+ * Returns the tag's start/end indices if inside a tag, otherwise null.
+ *
+ * Real-world opinions (especially OCR output) contain bare `<` characters in
+ * prose (`A < B`, `rate is < 30%`). Treating every unpaired `<` as a tag-open
+ * caused `annotate` to engulf prose between the bare `<` and the next citation
+ * (issue #544). A `<` only opens a tag when followed (possibly after whitespace)
+ * by an ASCII letter, `!` (comments/doctype), or `/` (closing tag).
  */
 function findContainingTag(text: string, pos: number): { tagStart: number; tagEnd: number } | null {
   // Search backwards from pos for '<' without encountering '>' first
@@ -162,6 +168,11 @@ function findContainingTag(text: string, pos: number): { tagStart: number; tagEn
   while (i >= 0) {
     if (text[i] === ">") return null // Hit a tag close — we're outside
     if (text[i] === "<") {
+      if (!looksLikeTagOpen(text, i)) {
+        // Bare `<` (prose / math), not an HTML tag — keep walking backwards
+        i--
+        continue
+      }
       // Found opening '<' — now find the closing '>'
       let j = pos
       while (j < text.length) {
@@ -174,6 +185,20 @@ function findContainingTag(text: string, pos: number): { tagStart: number; tagEn
     i--
   }
   return null
+}
+
+/**
+ * True when the `<` at `ltIndex` plausibly opens an HTML tag, comment, or
+ * close-tag. Well-formed HTML tags have no whitespace between `<` and the
+ * tag-name character, so `<` must be IMMEDIATELY followed by an ASCII letter,
+ * `!` (comment/doctype), or `/` (closing tag). Everything else (digits,
+ * punctuation, whitespace, end-of-text) is treated as prose — e.g. `< 30%`,
+ * `< B`, `<3`, OCR noise like `<®=»`.
+ */
+function looksLikeTagOpen(text: string, ltIndex: number): boolean {
+  const next = text[ltIndex + 1]
+  if (next === undefined) return false
+  return /[a-zA-Z!/]/.test(next)
 }
 
 /**

--- a/src/annotate/annotate.ts
+++ b/src/annotate/annotate.ts
@@ -86,20 +86,44 @@ export function annotate<C extends Citation = Citation>(
     return b.end - a.end
   })
 
-  // Overlap detection: walk ascending and skip any wrap whose range overlaps
-  // (intersects) the currently-selected outer wrap. Two wraps overlap when
-  // one starts before the other ends — the inner one is discarded.
+  // Overlap detection: walk ascending and resolve any wrap whose range
+  // intersects the currently-accepted wrap (issues #543, #545). Two wraps
+  // overlap when one starts before the other ends.
+  //
+  // Resolution rule:
+  // - If one wrap fully contains the other, keep the outer (already accepted)
+  //   wrap so the entire cluster ends up under a single sentinel.
+  // - Otherwise (true intersection) prefer the higher-confidence citation —
+  //   this lets a real citation displace an earlier low-confidence false
+  //   positive that happens to start first.
+  // The discarded citation surfaces via `skipped`.
   const skipped: Citation[] = []
   const accepted: Resolved[] = []
-  let activeEnd = -1
   for (const item of ascending) {
-    if (item.start < activeEnd) {
-      // Overlaps the previously-accepted wrap — skip this citation
-      skipped.push(item.citation)
+    const last = accepted[accepted.length - 1]
+    if (last !== undefined && item.start < last.end) {
+      // Overlaps the most recently accepted wrap. Decide which wins.
+      const lastContainsItem = item.end <= last.end
+      if (lastContainsItem) {
+        // Inner wrap nested inside outer — drop the inner one
+        skipped.push(item.citation)
+        continue
+      }
+      // True intersection — prefer the higher-confidence citation
+      const lastConf = last.citation.confidence ?? 0
+      const itemConf = item.citation.confidence ?? 0
+      if (itemConf > lastConf) {
+        // Incoming wins — eject the previously-accepted wrap
+        accepted.pop()
+        skipped.push(last.citation)
+        accepted.push(item)
+      } else {
+        // Existing wrap wins (ties keep the earlier-starting one)
+        skipped.push(item.citation)
+      }
       continue
     }
     accepted.push(item)
-    activeEnd = item.end
   }
 
   // Process accepted wraps in reverse so splicing earlier ranges doesn't

--- a/src/annotate/annotate.ts
+++ b/src/annotate/annotate.ts
@@ -58,31 +58,61 @@ export function annotate<C extends Citation = Citation>(
     callback,
   } = options
 
-  // Sort reverse to avoid position shifts invalidating subsequent annotations
-  const sorted = [...citations].sort((a, b) => {
-    const aPos = useCleanText ? a.span.cleanStart : a.span.originalStart
-    const bPos = useCleanText ? b.span.cleanStart : b.span.originalStart
-    return bPos - aPos // Reverse for backward iteration
+  // Resolve each citation to its actual wrap range up-front. When useFullSpan
+  // is true, the wrap region is the citation's fullSpan (if present), so the
+  // sort and overlap checks must agree on that range — sorting by the core
+  // span.originalStart while wrapping the fullSpan corrupts parallel-reporter
+  // sequences whose fullSpans all share an endpoint (issue #543).
+  type Resolved = {
+    citation: C
+    start: number
+    end: number
+  }
+  const resolved: Resolved[] = citations.map((citation) => {
+    const span =
+      useFullSpan && "fullSpan" in citation && citation.fullSpan ? citation.fullSpan : citation.span
+    return {
+      citation,
+      start: useCleanText ? span.cleanStart : span.originalStart,
+      end: useCleanText ? span.cleanEnd : span.originalEnd,
+    }
   })
+
+  // Sort ascending by start position. Tie-break on wider range first (smaller
+  // end last) so that when two wraps share a start, the outer (longer) one is
+  // processed first and the inner one is skipped via overlap detection.
+  const ascending = [...resolved].sort((a, b) => {
+    if (a.start !== b.start) return a.start - b.start
+    return b.end - a.end
+  })
+
+  // Overlap detection: walk ascending and skip any wrap whose range overlaps
+  // (intersects) the currently-selected outer wrap. Two wraps overlap when
+  // one starts before the other ends — the inner one is discarded.
+  const skipped: Citation[] = []
+  const accepted: Resolved[] = []
+  let activeEnd = -1
+  for (const item of ascending) {
+    if (item.start < activeEnd) {
+      // Overlaps the previously-accepted wrap — skip this citation
+      skipped.push(item.citation)
+      continue
+    }
+    accepted.push(item)
+    activeEnd = item.end
+  }
+
+  // Process accepted wraps in reverse so splicing earlier ranges doesn't
+  // shift later (rightmost) positions.
+  const ordered = [...accepted].sort((a, b) => b.start - a.start)
 
   let result = text
   const positionMap = new Map<number, number>()
-  const skipped: Citation[] = []
 
-  for (const citation of sorted) {
-    // Determine which span to use
-    let start: number
-    let end: number
-
-    if (useFullSpan && "fullSpan" in citation && citation.fullSpan) {
-      // Full span mode: case name through parenthetical
-      start = useCleanText ? citation.fullSpan.cleanStart : citation.fullSpan.originalStart
-      end = useCleanText ? citation.fullSpan.cleanEnd : citation.fullSpan.originalEnd
-    } else {
-      // Default mode: core citation only
-      start = useCleanText ? citation.span.cleanStart : citation.span.originalStart
-      end = useCleanText ? citation.span.cleanEnd : citation.span.originalEnd
-    }
+  for (const item of ordered) {
+    const { citation } = item
+    let start = item.start
+    let end = item.end
 
     // Snap positions out of HTML tags when annotating original text
     if (!useCleanText) {

--- a/src/annotate/types.ts
+++ b/src/annotate/types.ts
@@ -127,8 +127,11 @@ export interface AnnotationResult {
   /**
    * Citations that couldn't be annotated.
    *
-   * Currently empty (all citations are annotated if callback/template provided).
-   * Future versions may skip overlapping citations or invalid positions.
+   * Populated when:
+   * - Two citation wraps overlap (intersect or nest). The outer/higher-
+   *   confidence wrap wins; the other surfaces here (#543, #545).
+   * - A citation's positions snap to invalid coordinates inside an HTML tag
+   *   (#17), e.g. start >= end after snapping.
    */
   skipped: Citation[]
 }

--- a/tests/annotate/annotate.test.ts
+++ b/tests/annotate/annotate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { annotate } from "@/annotate/annotate"
+import { extractCitations } from "@/extract/extractCitations"
 import type { Citation } from "@/types/citation"
 import type { Span } from "@/types/span"
 
@@ -663,6 +664,89 @@ describe("annotate", () => {
       // but the REPLACEMENT happens at fullSpan positions
       expect(result.text).toBe('See <a href="/cases/500-123">500 F.2d 123</a>')
       expect(result.skipped).toHaveLength(0)
+    })
+
+    it("does not produce nested cite tags or mid-token truncation for parallel reporters (#543)", () => {
+      // Parallel reporters: all three citations have fullSpan that extends back to
+      // "Roe v. Wade" and forward to "(1973)". Sorting by span.originalStart instead
+      // of fullSpan.originalStart, plus failing to skip overlapping wraps, produced
+      // nested <cite> tags and mid-word truncation like "L. Ed. 2</cite>d".
+      const text =
+        "In Roe v. Wade, 410 U.S. 113, 93 S.Ct. 705, 35 L.Ed.2d 147 (1973), the Court held..."
+      const citations = extractCitations(text)
+
+      const result = annotate(text, citations, {
+        template: { before: "<cite>", after: "</cite>" },
+        useFullSpan: true,
+      })
+
+      // No nested <cite> tags (literal or HTML-escaped) — the wrap output must be flat.
+      expect(result.text).not.toMatch(/<cite>[^<]*<cite>/)
+      expect(result.text).not.toContain("&lt;cite&gt;")
+      expect(result.text).not.toContain("&amp;lt;cite&amp;gt;")
+
+      // No mid-token truncation: every recognisable reporter token must still be
+      // contiguous (no </cite> appearing inside a reporter abbreviation).
+      expect(result.text).not.toMatch(/L\.\s*Ed\.\s*2<\/cite>d/)
+      expect(result.text).not.toMatch(/U\.\s*S<\/cite>\.\s*1/)
+      expect(result.text).not.toMatch(/S\.\s*Ct<\/cite>\./)
+
+      // The wrap should encompass at least the outermost fullSpan exactly once.
+      const openCount = (result.text.match(/<cite>/g) ?? []).length
+      const closeCount = (result.text.match(/<\/cite>/g) ?? []).length
+      expect(openCount).toBe(closeCount)
+      expect(openCount).toBeGreaterThanOrEqual(1)
+
+      // When wraps overlap, only the outermost should remain — the others must
+      // surface in `skipped` so callers know they were not annotated.
+      expect(result.skipped.length).toBeGreaterThanOrEqual(citations.length - 1)
+    })
+
+    it("sorts by fullSpan.originalStart when useFullSpan is true so reverse splice is safe", () => {
+      // Two citations whose CORE spans appear in order [A, B] but whose fullSpans
+      // disagree on ordering. Sorting by span.originalStart (A.span=10, B.span=20)
+      // would splice B first (correct), but if their fullSpans overlap
+      // (A.fullSpan=[0, 30], B.fullSpan=[15, 25]), the inner B wrap corrupts A.
+      // With fullSpan-aware sorting AND overlap skip, A wins and B is skipped.
+      const text = "Smith v. Jones, 100 U.S. 1, 200 U.S. 2 (1900) more text"
+      const citationA: Citation = {
+        type: "case",
+        text: "100 U.S. 1",
+        span: { cleanStart: 16, cleanEnd: 26, originalStart: 16, originalEnd: 26 },
+        matchedText: "100 U.S. 1",
+        confidence: 0.9,
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 100,
+        reporter: "U.S.",
+        page: 1,
+        fullSpan: { cleanStart: 0, cleanEnd: 45, originalStart: 0, originalEnd: 45 },
+      }
+      const citationB: Citation = {
+        type: "case",
+        text: "200 U.S. 2",
+        span: { cleanStart: 28, cleanEnd: 38, originalStart: 28, originalEnd: 38 },
+        matchedText: "200 U.S. 2",
+        confidence: 0.9,
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 200,
+        reporter: "U.S.",
+        page: 2,
+        fullSpan: { cleanStart: 28, cleanEnd: 45, originalStart: 28, originalEnd: 45 },
+      }
+
+      const result = annotate(text, [citationA, citationB], {
+        template: { before: "<cite>", after: "</cite>" },
+        useFullSpan: true,
+      })
+
+      // Outer wrap survives intact; inner is skipped.
+      expect(result.text).toBe(
+        "<cite>Smith v. Jones, 100 U.S. 1, 200 U.S. 2 (1900)</cite> more text",
+      )
+      expect(result.skipped).toHaveLength(1)
+      expect(result.skipped[0]).toBe(citationB)
     })
   })
 })

--- a/tests/annotate/annotate.test.ts
+++ b/tests/annotate/annotate.test.ts
@@ -496,6 +496,82 @@ describe("annotate", () => {
     })
   })
 
+  describe("bare `<` characters (#544)", () => {
+    it("does not engulf prose around a bare `<` used as math/inequality", () => {
+      // Real OCR'd opinions contain bare `<` (e.g., `< 30%`). The previous
+      // `snapOutOfHtmlTags` implementation treated ANY position after an
+      // unpaired `<` as 'inside an HTML tag' and snapped citation start back
+      // to the bare `<`, swallowing prose between the bare `<` and the
+      // citation. The fix only treats `<` followed by `[a-zA-Z!/]` as a tag.
+      const text =
+        "When the rate is < 30% of revenue, see Smith v. Jones, 500 U.S. 100 (1991), the court reverses."
+      const citations = extractCitations(text)
+      expect(citations).toHaveLength(1)
+
+      const result = annotate(text, citations, {
+        template: { before: "<cite>", after: "</cite>" },
+      })
+
+      // Wrap covers ONLY the citation; the prose `< 30%` is untouched.
+      expect(result.text).toContain("< 30% of revenue")
+      expect(result.text).not.toContain("&lt; 30%")
+      expect(result.text).toBe(
+        "When the rate is < 30% of revenue, see Smith v. Jones, <cite>500 U.S. 100</cite> (1991), the court reverses.",
+      )
+      expect(result.skipped).toHaveLength(0)
+    })
+
+    it("does not engulf prose between bare `<` and a parallel-reporter cluster", () => {
+      // Confirms that a bare `<` early in the text doesn't bleed into
+      // subsequent citations. Without the fix, the first citation's start
+      // snapped backwards to the bare `<` and the wrap engulfed everything
+      // up to (and through) the citation.
+      const text =
+        "A < B (an aside) ... Roe v. Wade, 410 U.S. 113 (1973), and Casey, 505 U.S. 833 (1992)."
+      const citations = extractCitations(text)
+      expect(citations.length).toBeGreaterThanOrEqual(2)
+
+      const result = annotate(text, citations, {
+        template: { before: "<cite>", after: "</cite>" },
+      })
+
+      // No nested wraps — wraps cover only the citations themselves.
+      expect(result.text).not.toMatch(/<cite>[^<]*<cite>/)
+      // The bare `<` must remain literally (not escaped, not engulfed).
+      expect(result.text.startsWith("A < B (an aside)")).toBe(true)
+      // Each citation gets exactly one wrap pair.
+      const openCount = (result.text.match(/<cite>/g) ?? []).length
+      const closeCount = (result.text.match(/<\/cite>/g) ?? []).length
+      expect(openCount).toBe(closeCount)
+      expect(openCount).toBe(citations.length)
+    })
+
+    it("still snaps out of real HTML tags (regression guard)", () => {
+      // Make sure the narrower tag-detection rule does not regress the
+      // legitimate snap behaviour for actual HTML.
+      const text = '<a href="/x">See</a> 500 F.2d 123'
+      const citation = createCaseCitation(21, 33, "500 F.2d 123")
+      const result = annotate(text, [citation], {
+        template: { before: "<cite>", after: "</cite>" },
+        autoEscape: false,
+      })
+      expect(result.text).toBe('<a href="/x">See</a> <cite>500 F.2d 123</cite>')
+      expect(result.skipped).toHaveLength(0)
+    })
+
+    it("does not treat `<` followed by a digit or space as a tag", () => {
+      // Both `<3` (heart / age comparison) and `< text` (whitespace after `<`)
+      // appear in legal prose. Neither is a tag.
+      const text = "See if x <3 or y < text matches 500 F.2d 123 here"
+      const citation = createCaseCitation(32, 44, "500 F.2d 123")
+      const result = annotate(text, [citation], {
+        template: { before: "<cite>", after: "</cite>" },
+      })
+      expect(result.text).toBe("See if x <3 or y < text matches <cite>500 F.2d 123</cite> here")
+      expect(result.skipped).toHaveLength(0)
+    })
+  })
+
   describe("edge cases", () => {
     it("should handle empty citations array", () => {
       const text = "See 500 F.2d 123"

--- a/tests/annotate/annotate.test.ts
+++ b/tests/annotate/annotate.test.ts
@@ -572,6 +572,153 @@ describe("annotate", () => {
     })
   })
 
+  describe("overlapping core spans (#545)", () => {
+    it("skips an inner citation nested inside another citation's core span", () => {
+      // Real-world: a statute false-positive's core span lands inside a case
+      // citation's core span. Before overlap detection, both wraps got spliced,
+      // chopping the outer wrap's closing sentinel into the middle of the
+      // inner wrap's text and producing malformed output.
+      const text = "Smith v. Jones, 500 F.2d 123 (1980), see also more text"
+      const outer: Citation = {
+        type: "case",
+        text: "500 F.2d 123",
+        span: { cleanStart: 0, cleanEnd: 28, originalStart: 0, originalEnd: 28 },
+        matchedText: "Smith v. Jones, 500 F.2d 123",
+        confidence: 0.9,
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 500,
+        reporter: "F.2d",
+        page: 123,
+      }
+      const inner: Citation = {
+        type: "case",
+        text: "500 F.2d 1",
+        span: { cleanStart: 16, cleanEnd: 26, originalStart: 16, originalEnd: 26 },
+        matchedText: "500 F.2d 1",
+        confidence: 0.4, // Lower confidence — the false positive
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 500,
+        reporter: "F.2d",
+        page: 1,
+      }
+
+      const result = annotate(text, [outer, inner], {
+        template: { before: "<cite>", after: "</cite>" },
+      })
+
+      // Outer wins, inner is skipped, output is clean (no malformed sentinels).
+      expect(result.text).toBe(
+        "<cite>Smith v. Jones, 500 F.2d 123</cite> (1980), see also more text",
+      )
+      expect(result.skipped).toHaveLength(1)
+      expect(result.skipped[0]).toBe(inner)
+
+      // Sanity: open/close cite counts match (no truncated sentinels).
+      const openCount = (result.text.match(/<cite>/g) ?? []).length
+      const closeCount = (result.text.match(/<\/cite>/g) ?? []).length
+      expect(openCount).toBe(closeCount)
+    })
+
+    it("skips the lower-confidence citation when two overlap but neither nests", () => {
+      // Two citations whose core spans truly intersect (A=[10,20], B=[15,25]).
+      // Without confidence-aware tie-breaking, ordering by start position would
+      // keep A; if A is the false positive, the real citation gets dropped.
+      // The fix prefers the higher-confidence citation in this case.
+      const text = "x y z aaa BBB CCC DDD eee fff text after"
+      const falsePositive: Citation = {
+        type: "case",
+        text: "aaa BBB CCC",
+        span: { cleanStart: 6, cleanEnd: 17, originalStart: 6, originalEnd: 17 },
+        matchedText: "aaa BBB CCC",
+        confidence: 0.3, // Low confidence
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 1,
+        reporter: "X",
+        page: 1,
+      }
+      const realCitation: Citation = {
+        type: "case",
+        text: "CCC DDD eee",
+        span: { cleanStart: 14, cleanEnd: 25, originalStart: 14, originalEnd: 25 },
+        matchedText: "CCC DDD eee",
+        confidence: 0.95, // High confidence
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 2,
+        reporter: "Y",
+        page: 2,
+      }
+
+      const result = annotate(text, [falsePositive, realCitation], {
+        template: { before: "<cite>", after: "</cite>" },
+      })
+
+      // The higher-confidence citation survives; the lower-confidence one is skipped.
+      expect(result.skipped).toHaveLength(1)
+      expect(result.skipped[0]).toBe(falsePositive)
+      // No malformed sentinels.
+      const openCount = (result.text.match(/<cite>/g) ?? []).length
+      const closeCount = (result.text.match(/<\/cite>/g) ?? []).length
+      expect(openCount).toBe(closeCount)
+      expect(openCount).toBe(1)
+      // The kept wrap spans the real citation's range exactly.
+      expect(result.text).toContain("<cite>CCC DDD eee</cite>")
+    })
+
+    it("never produces malformed sentinels even with multiple overlaps", () => {
+      // Three citations all overlapping in a cluster — only the first
+      // accepted wrap should survive; the others must be skipped.
+      const text = "ALPHA BETA GAMMA DELTA EPSILON tail"
+      const a: Citation = {
+        type: "case",
+        text: "ALPHA BETA GAMMA",
+        span: { cleanStart: 0, cleanEnd: 16, originalStart: 0, originalEnd: 16 },
+        matchedText: "ALPHA BETA GAMMA",
+        confidence: 0.9,
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 1,
+        reporter: "A",
+        page: 1,
+      }
+      const b: Citation = {
+        type: "case",
+        text: "BETA GAMMA DELTA",
+        span: { cleanStart: 6, cleanEnd: 22, originalStart: 6, originalEnd: 22 },
+        matchedText: "BETA GAMMA DELTA",
+        confidence: 0.5,
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 2,
+        reporter: "B",
+        page: 2,
+      }
+      const c: Citation = {
+        type: "case",
+        text: "GAMMA DELTA EPSILON",
+        span: { cleanStart: 11, cleanEnd: 30, originalStart: 11, originalEnd: 30 },
+        matchedText: "GAMMA DELTA EPSILON",
+        confidence: 0.5,
+        processTimeMs: 0,
+        patternsChecked: 1,
+        volume: 3,
+        reporter: "C",
+        page: 3,
+      }
+      const result = annotate(text, [a, b, c], {
+        template: { before: "<cite>", after: "</cite>" },
+      })
+      const openCount = (result.text.match(/<cite>/g) ?? []).length
+      const closeCount = (result.text.match(/<\/cite>/g) ?? []).length
+      expect(openCount).toBe(closeCount)
+      // Total skipped = total citations - accepted wraps
+      expect(result.skipped.length + openCount).toBe(3)
+    })
+  })
+
   describe("edge cases", () => {
     it("should handle empty citations array", () => {
       const text = "See 500 F.2d 123"


### PR DESCRIPTION
## Summary

Three annotate fixes from the CAP corpus audit, all bundled.

| Issue | Fix |
|---|---|
| [#543](https://github.com/medelman17/eyecite-ts/issues/543) | `annotate` now resolves each citation's wrap range (core span or `fullSpan`, depending on `useFullSpan`) up-front and sorts/iterates against that range. Previously sorted by `span.originalStart` even when wrapping the wider `fullSpan`, corrupting parallel-reporter sequences (~21% of opinions). |
| [#544](https://github.com/medelman17/eyecite-ts/issues/544) | `findContainingTag` only treats `<` as a tag open when immediately followed by `[a-zA-Z!/]`. Bare `<` followed by whitespace/digits/punctuation is left alone. Stricter than the issue spec's `\s*[a-zA-Z!/]` — well-formed HTML never has whitespace between `<` and the tag name. |
| [#545](https://github.com/medelman17/eyecite-ts/issues/545) | Overlap detection now applies to core-span wraps too and is confidence-aware. Nested wraps keep the outer; true intersections keep the higher-`confidence` citation. Discarded citations surface via the existing `skipped` array. |

Three changesets, one per issue.

## Test plan

- [x] `pnpm exec vitest run` — 3147 passed, 9 skipped
- [x] `pnpm typecheck` clean
- [x] Biome clean for changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)