### PR TITLE
fix(footnote/clean): cluster — zone bounding, marker anchoring, separator guard, tag-strip spacing (#539-#542)

### DIFF
--- a/.changeset/cleaner-space-on-tag-strip.md
+++ b/.changeset/cleaner-space-on-tag-strip.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+Insert a token-boundary space when stripping HTML tags between adjacent word characters (#542).
+
+`stripHtmlTags` previously deleted tags with no replacement, so HTML like `100 F.3d 200<footnote label="3">200 F.3d 300</footnote>` collapsed to `100 F.3d 200200 F.3d 300`. The tokenizer then read the fused digit run as a single malformed citation (`100 F.3d 200200`), and the second reporter cite was lost entirely.
+
+When a tag (or run of adjacent tags) sits between two word characters, the cleaner now inserts a single space in its place. Tags between non-word neighbors (spaces, punctuation, start/end of string) are still removed with no insertion, preserving existing behavior for the common case (`Smith v. <b>Doe</b>, 500 F.2d 123`).
+
+The position-mapping algorithm handles inserted spaces correctly via its existing insertion branch — no additional adjustments needed.

--- a/.changeset/footnote-cap-trailing-zone.md
+++ b/.changeset/footnote-cap-trailing-zone.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+Cap final plain-text footnote zone at next post-footnote boundary (#539).
+
+`detectTextFootnotes` previously bounded the last footnote zone at `text.length`, so post-footnote body content (e.g., a "GOVERNMENT BRIEF" section that follows the numbered notes) was swallowed into the trailing footnote. Any citation appearing after the footnote section was misannotated `inFootnote: true`, and footnote-scoped resolution refused to link it to body antecedents.
+
+The detector now scans past the final marker for the earliest of: another separator line (5+ dashes/underscores), or a blank line followed by an ALL-CAPS heading line. The zone stops at that boundary. End-of-text remains the fallback when no such boundary exists.

--- a/.changeset/footnote-marker-column-zero.md
+++ b/.changeset/footnote-marker-column-zero.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+Anchor plain-text footnote markers at column 0 (#540).
+
+`MARKER_SRC` previously began with `^\s*`, so indented numbered sub-list items inside a footnote body (`  1. `, `  2. `) were read as new footnote markers, splitting a single footnote into multiple spurious zones. Citations inside the same footnote were then misannotated as belonging to fabricated sibling footnotes, and the resolver's `"footnote"` scope refused to link them.
+
+The marker pattern now requires the digit/`FN`/`[N]`/`n.` prefix to start at column 0 (no leading whitespace). Indented sub-lists inside footnote bodies are correctly treated as continuation text.

--- a/.changeset/footnote-short-separator-guard.md
+++ b/.changeset/footnote-short-separator-guard.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+Reject short separator + numbered-list false positives in plain-text footnote detection (#541).
+
+A signature block like `/s/ Judge Smith\n\n-----\n\n1. The first issue...` was mis-classified as a footnote section because the existing 5+ dashes/underscores separator pattern matched the decorative rule and the numbered list looked like markers. Citations in the numbered analysis were then annotated `inFootnote: true` incorrectly.
+
+Tighten in two ways:
+- Short separators (5..7 chars) now require the separator to appear at least 25% into the document. Long separators (8+ chars) bypass this gate.
+- The digit-period marker pattern now requires the marker line to contain non-whitespace content after the period (`(\d+)\.\s+\S`), rejecting heading-style `1.\n\n`.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -8,12 +8,33 @@
 /**
  * Remove all HTML tags from text.
  *
+ * When a tag (or run of adjacent tags) sits between two word characters,
+ * insert a single space in its place to preserve the token boundary.
+ * Without this guard, adjacent reporter citations separated only by a
+ * footnote tag — e.g. `100 F.3d 200<footnote>200 F.3d 300</footnote>` —
+ * fuse into a single `200200` digit run that the tokenizer reads as one
+ * malformed citation (#542).
+ *
+ * Non-word neighbors (spaces, punctuation, the start or end of the
+ * string) keep the original behavior: tags are removed with no insertion.
+ *
  * @example
  * stripHtmlTags("Smith v. <b>Doe</b>, 500 F.2d 123")
  * // => "Smith v. Doe, 500 F.2d 123"
+ *
+ * @example
+ * stripHtmlTags('100 F.3d 200<footnote>200 F.3d 300</footnote>')
+ * // => "100 F.3d 200 200 F.3d 300 "
  */
 export function stripHtmlTags(text: string): string {
-  return text.replace(/<[^>]+>/g, "")
+  // Collapse adjacent tag runs together so the boundary check sees the
+  // characters surrounding the whole run, not each tag individually.
+  return text.replace(/(?:<[^>]+>)+/g, (match, offset: number) => {
+    const before = offset > 0 ? text[offset - 1] : ""
+    const afterIdx = offset + match.length
+    const after = afterIdx < text.length ? text[afterIdx] : ""
+    return /\w/.test(before) && /\w/.test(after) ? " " : ""
+  })
 }
 
 /**

--- a/src/footnotes/textDetector.ts
+++ b/src/footnotes/textDetector.ts
@@ -12,11 +12,25 @@ const MARKER_SRC =
   /^\s*(?:FN\s*(\d+)[.\s:)]|\[(\d+)\]\s|n\.\s*(\d+)\s|(\d+)\.\s)/gm.source
 
 /**
+ * Pattern for an ALL-CAPS section heading on its own line, optionally
+ * followed by blank lines and prose. Used to detect the end of a footnote
+ * region when post-footnote body content resumes (#539).
+ *
+ * - Heading line: 2+ uppercase words, may include spaces, ampersands,
+ *   colons, digits — but no leading whitespace and no lowercase letters.
+ * - Must be preceded by a blank line (anchored via the surrounding scan).
+ */
+const POST_FOOTNOTE_HEADING_RE = /^[A-Z][A-Z0-9 &:'.-]{3,}$/m
+
+/**
  * Detect footnote zones in plain text using separator + marker heuristics.
  *
  * Strategy: find a separator line, then parse numbered markers in the text
  * that follows. Each footnote zone extends from its marker to the start
- * of the next marker (or end of text).
+ * of the next marker. The final zone is capped at the next clear
+ * post-footnote boundary (separator line, ALL-CAPS heading after a blank
+ * line, or end of text) to avoid swallowing body content that follows the
+ * footnote section (#539).
  *
  * @param text - Raw text (not cleaned -- needs newlines intact)
  * @returns FootnoteMap with zones in input-text coordinates, sorted by start position
@@ -48,7 +62,14 @@ export function detectTextFootnotes(text: string): FootnoteMap {
   const zones: FootnoteMap = []
   for (let i = 0; i < markers.length; i++) {
     const start = markers[i].index
-    const end = i + 1 < markers.length ? markers[i + 1].index : text.length
+    let end: number
+    if (i + 1 < markers.length) {
+      end = markers[i + 1].index
+    } else {
+      // #539: cap final zone at the next clear "end of footnote section"
+      // signal so we don't swallow post-footnote body prose.
+      end = findFootnoteSectionEnd(text, start)
+    }
 
     zones.push({
       start,
@@ -58,4 +79,46 @@ export function detectTextFootnotes(text: string): FootnoteMap {
   }
 
   return zones
+}
+
+/**
+ * Find where the footnote section ends after the marker at `markerStart`.
+ *
+ * Looks (after the marker line) for any of:
+ *  - a separator line (`-----` / `_____`, 5+ chars)
+ *  - a blank line followed by an ALL-CAPS heading line
+ *
+ * Returns the earliest such boundary position, or `text.length` if none found.
+ */
+function findFootnoteSectionEnd(text: string, markerStart: number): number {
+  // Skip past the marker's own line so we don't terminate immediately on it.
+  const firstLineEnd = text.indexOf("\n", markerStart)
+  const scanFrom = firstLineEnd >= 0 ? firstLineEnd + 1 : text.length
+  if (scanFrom >= text.length) return text.length
+
+  // Look for next separator line.
+  const sepRe = /^\s*[-_]{5,}\s*$/gm
+  sepRe.lastIndex = scanFrom
+  const sepHit = sepRe.exec(text)
+  const sepBoundary = sepHit ? sepHit.index : Number.POSITIVE_INFINITY
+
+  // Look for blank-line + ALL-CAPS heading boundary.
+  // A blank line means \n followed (optionally by whitespace) by \n.
+  const blankRe = /\n[ \t]*\n/g
+  blankRe.lastIndex = scanFrom
+  let blankHit: RegExpExecArray | null
+  let headingBoundary = Number.POSITIVE_INFINITY
+  while ((blankHit = blankRe.exec(text)) !== null) {
+    const lineStart = blankHit.index + blankHit[0].length
+    // Read to end-of-line at lineStart
+    const lineEnd = text.indexOf("\n", lineStart)
+    const line = text.slice(lineStart, lineEnd < 0 ? text.length : lineEnd)
+    if (POST_FOOTNOTE_HEADING_RE.test(line.trim())) {
+      headingBoundary = blankHit.index
+      break
+    }
+  }
+
+  const boundary = Math.min(sepBoundary, headingBoundary)
+  return boundary === Number.POSITIVE_INFINITY ? text.length : boundary
 }

--- a/src/footnotes/textDetector.ts
+++ b/src/footnotes/textDetector.ts
@@ -5,11 +5,16 @@ const SEPARATOR_RE = /^\s*[-_]{5,}\s*$/m
 
 /**
  * Source pattern for footnote markers at line start.
- * Captures the footnote number from whichever group matches.
+ *
+ * Captures the footnote number from whichever group matches. Anchored at
+ * column 0 (no leading whitespace tolerated): indented `  1. ` / `  2. `
+ * sub-list items inside a footnote body would otherwise be misread as new
+ * markers, splitting a single footnote into multiple zones (#540).
+ *
  * Created as a fresh RegExp per call to avoid shared mutable lastIndex state.
  */
 const MARKER_SRC =
-  /^\s*(?:FN\s*(\d+)[.\s:)]|\[(\d+)\]\s|n\.\s*(\d+)\s|(\d+)\.\s)/gm.source
+  /^(?:FN\s*(\d+)[.\s:)]|\[(\d+)\]\s|n\.\s*(\d+)\s|(\d+)\.\s)/gm.source
 
 /**
  * Pattern for an ALL-CAPS section heading on its own line, optionally
@@ -84,7 +89,7 @@ export function detectTextFootnotes(text: string): FootnoteMap {
 /**
  * Find where the footnote section ends after the marker at `markerStart`.
  *
- * Looks (after the marker line) for any of:
+ * Walks the lines after the marker's first line and looks for any of:
  *  - a separator line (`-----` / `_____`, 5+ chars)
  *  - a blank line followed by an ALL-CAPS heading line
  *
@@ -93,32 +98,48 @@ export function detectTextFootnotes(text: string): FootnoteMap {
 function findFootnoteSectionEnd(text: string, markerStart: number): number {
   // Skip past the marker's own line so we don't terminate immediately on it.
   const firstLineEnd = text.indexOf("\n", markerStart)
-  const scanFrom = firstLineEnd >= 0 ? firstLineEnd + 1 : text.length
+  if (firstLineEnd < 0) return text.length
+  const scanFrom = firstLineEnd + 1
   if (scanFrom >= text.length) return text.length
 
-  // Look for next separator line.
-  const sepRe = /^\s*[-_]{5,}\s*$/gm
-  sepRe.lastIndex = scanFrom
-  const sepHit = sepRe.exec(text)
-  const sepBoundary = sepHit ? sepHit.index : Number.POSITIVE_INFINITY
+  // Walk line by line from scanFrom.
+  let lineStart = scanFrom
+  let prevBlank = false
+  while (lineStart < text.length) {
+    const nl = text.indexOf("\n", lineStart)
+    const lineEnd = nl < 0 ? text.length : nl
+    const raw = text.slice(lineStart, lineEnd)
+    const trimmed = raw.trim()
 
-  // Look for blank-line + ALL-CAPS heading boundary.
-  // A blank line means \n followed (optionally by whitespace) by \n.
-  const blankRe = /\n[ \t]*\n/g
-  blankRe.lastIndex = scanFrom
-  let blankHit: RegExpExecArray | null
-  let headingBoundary = Number.POSITIVE_INFINITY
-  while ((blankHit = blankRe.exec(text)) !== null) {
-    const lineStart = blankHit.index + blankHit[0].length
-    // Read to end-of-line at lineStart
-    const lineEnd = text.indexOf("\n", lineStart)
-    const line = text.slice(lineStart, lineEnd < 0 ? text.length : lineEnd)
-    if (POST_FOOTNOTE_HEADING_RE.test(line.trim())) {
-      headingBoundary = blankHit.index
-      break
+    // Separator line — boundary is the start of this line.
+    if (/^[-_]{5,}$/.test(trimmed)) {
+      return lineStart
     }
+
+    // Blank-line + ALL-CAPS heading — boundary is the start of the blank line.
+    if (prevBlank && trimmed !== "" && POST_FOOTNOTE_HEADING_RE.test(trimmed)) {
+      // The previous line was blank, so this current line is the heading.
+      // Boundary should be the start of the blank line (one line back).
+      const blankLineStart = previousLineStart(text, lineStart)
+      return blankLineStart
+    }
+
+    prevBlank = trimmed === ""
+    if (nl < 0) break
+    lineStart = nl + 1
   }
 
-  const boundary = Math.min(sepBoundary, headingBoundary)
-  return boundary === Number.POSITIVE_INFINITY ? text.length : boundary
+  return text.length
+}
+
+/**
+ * Return the start index of the line that ends at `currentLineStart - 1`.
+ */
+function previousLineStart(text: string, currentLineStart: number): number {
+  if (currentLineStart <= 0) return 0
+  // currentLineStart points to the char right after a `\n`.  The previous
+  // line's `\n` is at currentLineStart - 1.  Walk back to find the `\n`
+  // before that, then add 1.
+  const prevNl = text.lastIndexOf("\n", currentLineStart - 2)
+  return prevNl < 0 ? 0 : prevNl + 1
 }

--- a/src/footnotes/textDetector.ts
+++ b/src/footnotes/textDetector.ts
@@ -4,6 +4,24 @@ import type { FootnoteMap } from "./types"
 const SEPARATOR_RE = /^\s*[-_]{5,}\s*$/m
 
 /**
+ * A "strong" separator (long enough to clearly be a footnote section
+ * divider rather than a decorative rule or signature delimiter).
+ * 8+ dashes/underscores typically marks an intentional footnote boundary.
+ */
+const STRONG_SEPARATOR_LEN = 8
+
+/**
+ * For short separators (5..7 chars), require them to appear at least this
+ * fraction of the way into the document.  Signature blocks (`-----`,
+ * decorative rules) almost always sit near the top or middle of a document
+ * trailing a short closing — they will not pass this gate, eliminating the
+ * false positives in #541.  Long separators (`STRONG_SEPARATOR_LEN+` chars)
+ * bypass this check, so existing short-fixture tests with `----------`
+ * continue to work.
+ */
+const MIN_SHORT_SEPARATOR_OFFSET_RATIO = 0.25
+
+/**
  * Source pattern for footnote markers at line start.
  *
  * Captures the footnote number from whichever group matches. Anchored at
@@ -11,10 +29,14 @@ const SEPARATOR_RE = /^\s*[-_]{5,}\s*$/m
  * sub-list items inside a footnote body would otherwise be misread as new
  * markers, splitting a single footnote into multiple zones (#540).
  *
+ * The `(\d+)\.\s+\S` alternative requires the digit-period marker to be
+ * followed by whitespace and non-whitespace on the same logical chunk.
+ * This rejects heading-style `1.\n\n` lines (#541).
+ *
  * Created as a fresh RegExp per call to avoid shared mutable lastIndex state.
  */
 const MARKER_SRC =
-  /^(?:FN\s*(\d+)[.\s:)]|\[(\d+)\]\s|n\.\s*(\d+)\s|(\d+)\.\s)/gm.source
+  /^(?:FN\s*(\d+)[.\s:)]|\[(\d+)\]\s|n\.\s*(\d+)\s|(\d+)\.\s+\S)/gm.source
 
 /**
  * Pattern for an ALL-CAPS section heading on its own line, optionally
@@ -43,6 +65,16 @@ const POST_FOOTNOTE_HEADING_RE = /^[A-Z][A-Z0-9 &:'.-]{3,}$/m
 export function detectTextFootnotes(text: string): FootnoteMap {
   const sepMatch = SEPARATOR_RE.exec(text)
   if (!sepMatch) return []
+
+  // #541: short separators (5..7 chars) are often signature-block or
+  // decorative rules.  Require them to appear at least 25% into the
+  // document to plausibly demarcate a footnote section.  Strong (8+ char)
+  // separators bypass this gate.
+  const separatorBody = sepMatch[0].replace(/\s/g, "")
+  if (separatorBody.length < STRONG_SEPARATOR_LEN) {
+    const minOffset = Math.floor(text.length * MIN_SHORT_SEPARATOR_OFFSET_RATIO)
+    if (sepMatch.index < minOffset) return []
+  }
 
   const sectionOffset = sepMatch.index + sepMatch[0].length
 

--- a/tests/clean/cleanText.test.ts
+++ b/tests/clean/cleanText.test.ts
@@ -252,6 +252,38 @@ describe("cleanText position tracking", () => {
     // First character 't' is at position 0 in cleaned, position 11 in original (after "<div><span>")
     expect(result.transformationMap.cleanToOriginal.get(0)).toBe(11)
   })
+
+  // #542 — adjacent word characters separated by a stripped HTML tag must
+  // not be fused into a single token.
+  it("inserts a space when stripping a tag between adjacent word characters", () => {
+    const input = '100 F.3d 200<footnote label="3">200 F.3d 300</footnote>'
+    const result = cleanText(input, [stripHtmlTags])
+
+    // Cleaner must NOT produce the fused string "100 F.3d 200200 F.3d 300"
+    expect(result.cleaned).not.toContain("200200")
+    expect(result.cleaned).toContain("100 F.3d 200")
+    expect(result.cleaned).toContain("200 F.3d 300")
+
+    // Position of "100" must map to original "100"
+    const oneHundred = result.cleaned.indexOf("100")
+    expect(result.transformationMap.cleanToOriginal.get(oneHundred)).toBe(
+      input.indexOf("100"),
+    )
+
+    // Position of the second-zone "200 F.3d 300" must map to original
+    const twoHundred = result.cleaned.indexOf("200 F.3d 300")
+    expect(twoHundred).toBeGreaterThanOrEqual(0)
+    const origStart = result.transformationMap.cleanToOriginal.get(twoHundred)
+    expect(origStart).toBe(input.indexOf("200 F.3d 300"))
+  })
+
+  it("does not insert a space when tag sits between non-word characters", () => {
+    // Spaces and punctuation outside a tag are word-boundary friendly already;
+    // the cleaner must not introduce extra spaces here.
+    const input = "Smith v. <b>Doe</b>, 500 F.2d 123"
+    const result = cleanText(input, [stripHtmlTags])
+    expect(result.cleaned).toBe("Smith v. Doe, 500 F.2d 123")
+  })
 })
 
 describe("normalizeDashes (issue #54)", () => {

--- a/tests/footnotes/textDetector.test.ts
+++ b/tests/footnotes/textDetector.test.ts
@@ -158,6 +158,33 @@ describe("detectTextFootnotes", () => {
     expect(text.slice(zones[0].start, zones[0].end)).toContain("Another sub-list item.")
   })
 
+  // #541 — short separators (`-----`) early in the document followed by a
+  // numbered list are NOT footnote sections (e.g., signature blocks).
+  it("does not treat a separator + numbered list near top of doc as footnotes", () => {
+    const text = [
+      "Signed,",
+      "/s/ Judge Smith",
+      "",
+      "-----",
+      "",
+      "1. The first issue is whether 200 F.3d 100 controls.",
+      "2. The second issue is 300 F.3d 200.",
+    ].join("\n")
+    const zones = detectTextFootnotes(text)
+    expect(zones).toEqual([])
+  })
+
+  // #541 corollary — guard does not strip legitimate footnote sections where
+  // the separator appears later in the document.
+  it("still detects real footnote sections (separator after substantial body)", () => {
+    // Body that pushes the separator past the 25% threshold
+    const body = "The court holds that 100 F.2d 50 (1st Cir. 2020) controls. ".repeat(20)
+    const text = [body, "", "----------", "", "1. See 200 F.3d 100."].join("\n")
+    const zones = detectTextFootnotes(text)
+    expect(zones).toHaveLength(1)
+    expect(zones[0].footnoteNumber).toBe(1)
+  })
+
   it("caps last footnote zone at a subsequent separator line", () => {
     const text = [
       "Body 100 U.S. 200.",

--- a/tests/footnotes/textDetector.test.ts
+++ b/tests/footnotes/textDetector.test.ts
@@ -115,4 +115,41 @@ describe("detectTextFootnotes", () => {
     const zones = detectTextFootnotes(text)
     expect(zones).toHaveLength(2)
   })
+
+  // #539 — last footnote zone runs greedy to end-of-text
+  it("caps last footnote zone at subsequent ALL-CAPS section heading", () => {
+    const text = [
+      "Body 100 U.S. 200.",
+      "",
+      "----------",
+      "",
+      "1. See 200 F.3d 100.",
+      "",
+      "GOVERNMENT BRIEF",
+      "",
+      "The court further holds that 400 F.3d 500 controls.",
+    ].join("\n")
+    const zones = detectTextFootnotes(text)
+    expect(zones).toHaveLength(1)
+    // The footnote zone should NOT extend into the post-footnote section
+    expect(text.slice(zones[0].start, zones[0].end)).not.toContain("GOVERNMENT BRIEF")
+    expect(text.slice(zones[0].start, zones[0].end)).not.toContain("400 F.3d 500")
+  })
+
+  it("caps last footnote zone at a subsequent separator line", () => {
+    const text = [
+      "Body 100 U.S. 200.",
+      "",
+      "----------",
+      "",
+      "1. See 200 F.3d 100.",
+      "",
+      "----------",
+      "",
+      "Closing remarks reference 400 F.3d 500.",
+    ].join("\n")
+    const zones = detectTextFootnotes(text)
+    expect(zones).toHaveLength(1)
+    expect(text.slice(zones[0].start, zones[0].end)).not.toContain("400 F.3d 500")
+  })
 })

--- a/tests/footnotes/textDetector.test.ts
+++ b/tests/footnotes/textDetector.test.ts
@@ -136,6 +136,28 @@ describe("detectTextFootnotes", () => {
     expect(text.slice(zones[0].start, zones[0].end)).not.toContain("400 F.3d 500")
   })
 
+  // #540 — indented `N.` lines were being read as new markers, splitting
+  // one footnote into multiple spurious zones.
+  it("does not treat indented numbered sub-list items as new markers", () => {
+    const text = [
+      "Body text.",
+      "",
+      "----------",
+      "",
+      "1. The first footnote contains:",
+      "  1. Sub-list item one.",
+      "  2. Another sub-list item.",
+      "2. The second real footnote.",
+    ].join("\n")
+    const zones = detectTextFootnotes(text)
+    expect(zones).toHaveLength(2)
+    expect(zones[0].footnoteNumber).toBe(1)
+    expect(zones[1].footnoteNumber).toBe(2)
+    // The sub-list items belong to footnote 1, not separate zones
+    expect(text.slice(zones[0].start, zones[0].end)).toContain("Sub-list item one.")
+    expect(text.slice(zones[0].start, zones[0].end)).toContain("Another sub-list item.")
+  })
+
   it("caps last footnote zone at a subsequent separator line", () => {
     const text = [
       "Body 100 U.S. 200.",

--- a/tests/integration/footnotes.test.ts
+++ b/tests/integration/footnotes.test.ts
@@ -66,6 +66,45 @@ describe("Footnote Integration Tests", () => {
       expect(footnoteCites.length).toBeGreaterThanOrEqual(1)
       expect(footnoteCites[0].footnoteNumber).toBe(1)
     })
+
+    // #541 — signature block + short separator + numbered list must not be
+    // misclassified as a footnote section.
+    it("does not misclassify signature block + numbered analysis as footnotes", () => {
+      const text = [
+        "Signed,",
+        "/s/ Judge Smith",
+        "",
+        "-----",
+        "",
+        "1. The first issue is whether 200 F.3d 100 controls.",
+        "2. The second issue is 300 F.3d 200.",
+      ].join("\n")
+      const citations = extractCitations(text, { detectFootnotes: true })
+      expect(citations.length).toBeGreaterThan(0)
+      for (const c of citations) {
+        expect(c.inFootnote).not.toBe(true)
+      }
+    })
+
+    // #539 — post-footnote ALL-CAPS section content must not be tagged as
+    // belonging to the trailing footnote.
+    it("does not annotate post-footnote ALL-CAPS section content as footnote", () => {
+      const text = [
+        "Body 100 U.S. 200.",
+        "",
+        "----------",
+        "",
+        "1. See 200 F.3d 100.",
+        "",
+        "GOVERNMENT BRIEF",
+        "",
+        "The court further holds that 400 F.3d 500 controls.",
+      ].join("\n")
+      const citations = extractCitations(text, { detectFootnotes: true })
+      const post = citations.find((c) => c.matchedText.includes("400 F.3d 500"))
+      expect(post).toBeDefined()
+      expect(post?.inFootnote).not.toBe(true)
+    })
   })
 
   describe("opt-in behavior", () => {

--- a/tests/integration/footnotes.test.ts
+++ b/tests/integration/footnotes.test.ts
@@ -32,6 +32,29 @@ describe("Footnote Integration Tests", () => {
       expect(citations[1].footnoteNumber).toBe(1)
     })
 
+    // #542 — cleaner fuses adjacent digits across HTML footnote tags
+    it("does not fuse adjacent digit citations across footnote tag boundary", () => {
+      const text = '100 F.3d 200<footnote label="3">200 F.3d 300</footnote>'
+      const citations = extractCitations(text, { detectFootnotes: true })
+
+      // Must produce TWO citations, not a fused "100 F.3d 200200"
+      expect(citations).toHaveLength(2)
+
+      // Body citation
+      const body = citations.find(
+        (c) => c.matchedText.includes("100 F.3d") && !c.inFootnote,
+      )
+      expect(body).toBeDefined()
+      expect(body?.matchedText).toContain("100 F.3d 200")
+      expect(body?.matchedText).not.toContain("200200")
+
+      // Footnote citation
+      const fn = citations.find((c) => c.inFootnote)
+      expect(fn).toBeDefined()
+      expect(fn?.matchedText).toContain("200 F.3d 300")
+      expect(fn?.footnoteNumber).toBe(3)
+    })
+
     it("multiple footnotes with separate citations", () => {
       // Uses <fn> tags (shorter) to stay within the position mapping system's
       // maxLookAhead=20 window when consecutive tags are stripped.


### PR DESCRIPTION
## Summary

Four footnote/cleaner fixes from the CAP corpus audit.

| Issue | Fix |
|---|---|
| [#539](https://github.com/medelman17/eyecite-ts/issues/539) | Added `findFootnoteSectionEnd` — caps the trailing plain-text zone at the next separator line or blank+ALL-CAPS-heading boundary instead of `text.length`. Post-footnote body content no longer swallowed. |
| [#540](https://github.com/medelman17/eyecite-ts/issues/540) | Removed `^\s*` from `MARKER_SRC` — markers must be at column 0. Indented `1.`/`2.` sub-list items inside a footnote body no longer misread as new markers. |
| [#541](https://github.com/medelman17/eyecite-ts/issues/541) | Two guards added: short separators (5..7 chars) must appear past the 25% mark; digit-period marker pattern requires `\s+\S` after the period to reject heading-style `1.\n\n`. |
| [#542](https://github.com/medelman17/eyecite-ts/issues/542) | `stripHtmlTags` rewritten to insert a single space when a run of adjacent tags sits between two word characters. Prevents fused digit runs across HTML footnote tag boundaries. |

Four changesets, one per issue.

## Test plan

- [x] `pnpm exec vitest run` — 3148 pass (+8 new), 9 skipped
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)