### PR TITLE
fix(statute): cluster — Va/Ala code prefix, NM guard, neutral docket, Public Law, Constitutional ordinals (#530-#534)

### DIFF
--- a/.changeset/constitutional-short-forms.md
+++ b/.changeset/constitutional-short-forms.md
@@ -1,0 +1,15 @@
+---
+"eyecite-ts": patch
+---
+
+fix(constitutional): accept ordinal abbreviation and word-form amendments (#534)
+
+The constitutional patterns only matched Roman numerals or Arabic numbers after `art./amend.` (e.g., `U.S. Const. amend. XIV`). Real-world citations frequently use ordinal abbreviations (`U.S. Const., 5th Amend.`) and spelled-out word forms (`U.S. Const., Fifth Amendment`), neither of which tokenized.
+
+Three additions:
+
+- The numeral group now accepts `1st`..`27th` and `First`..`Twenty-Seventh` (in either hyphenated or space-separated form).
+- The amendment word accepts unabbreviated `Amendment` alongside `amend.` / `amdt.`.
+- A new `bare-amendment-word` pattern catches prefix forms without `Const.` (e.g., "the Fifth Amendment", "the Fourteenth Amendment") with confidence 0.5.
+
+The extractor parses all four numeral forms (Roman, Arabic, ordinal abbreviation, word ordinal) into the existing `amendment` / `article` integer fields.

--- a/.changeset/neutral-docket-year-guards.md
+++ b/.changeset/neutral-docket-year-guards.md
@@ -1,0 +1,12 @@
+---
+"eyecite-ts": patch
+---
+
+fix(neutral): reject docket-shaped strings and implausible years (#532)
+
+Strings like `03A01-9103-CH-96` (a TN/IN docket number) were matching the hyphenated neutral pattern, producing a `type: "neutral"` citation with `year: 9103`. Two guards now prevent this:
+
+- The year segment must fall in 1700-2199 (was: any 4 digits).
+- A negative lookbehind rejects matches whose preceding text contains a `Case No.` / `Cause No.` / `Docket No.` prefix.
+
+Both apply to the 3-segment (NM/Ohio/NC) and 4-segment (MS) hyphenated patterns.

--- a/.changeset/nm-bare-section-context-guard.md
+++ b/.changeset/nm-bare-section-context-guard.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+fix(statute): require NM signal in context for bare `§ N-N-N` cites (#531)
+
+The bare three-hyphen section shape (`§ 12-17-189`, `Section 32A-2-7(A)`) was defaulting to New Mexico (`code: "NMSA 1978", jurisdiction: "NM"`) because the pattern is common there — but the shape is too generic and the same form appears in Virginia, Alabama, and other states. We now require an explicit NM signal (`NMSA`, `N.M.`, `New Mexico`) within ~200 chars before the cite. Without it, the bare section is still emitted but with `jurisdiction` and `code` left undefined.
+
+Minor type change: `StatuteCitation.code` is now `string | undefined` to support these untagged bare cites.

--- a/.changeset/public-law-spelled-out.md
+++ b/.changeset/public-law-spelled-out.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+fix(publicLaw): accept spelled-out `Public Law` and `Public Law No.` (#533)
+
+The public-law pattern only matched the abbreviated `Pub. L.` / `Pub. L. No.` forms, so spelled-out variants like `Public Law 116-127` and `Public Law No. 116-127` (common in House/Senate reports and in opinions that introduce the citation without prior abbreviation) were never tokenized. Both forms now extract correctly with `congress` and `lawNumber` populated.

--- a/.changeset/va-ala-code-prefix.md
+++ b/.changeset/va-ala-code-prefix.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+fix(statute): surface `Va. Code` / `Ala. Code` instead of bare `"Code"` in the `code` field (#530)
+
+Named-code extraction for Virginia and Alabama produced `code: "Code"` because the registry only stores the bare suffix (`"Code"`, `"Code Ann."`) and `cleanCodeName()` strips the trailing word. The extractor now re-attaches the jurisdictional prefix so consumers see `"Va. Code"`, `"Va. Code Ann."`, `"Ala. Code"`, or `"Ala. Code Ann."`. The Virginia bare-Code extractor (`Code §`, `Virginia Code §`) is normalized to `"Va. Code"` for the same reason.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -781,6 +781,26 @@ const BARE_SECTION_CONTEXT_OVERRIDES: Record<string, BareSectionContext> = {
   MT: { jurisdiction: "MT", code: "MCA" },
 }
 
+/**
+ * Look for an explicit New Mexico signal (`NMSA`, `N.M.`, `N. M.`,
+ * `New Mexico`) in the cleaned text within ~200 chars before the citation
+ * start. Used to gate the default `NM` jurisdiction tag attached to bare
+ * `§ N-N-N` citations — without a nearby signal the shape is too generic
+ * to claim NM (#531).
+ */
+const NM_CONTEXT_WINDOW = 200
+// Match `NMSA`, `N.M.` (with optional space between letters and trailing
+// period), or `New Mexico` as a phrase. The `N.M.` form ends in `.` (a
+// non-word char), so we must NOT require a trailing `\b` — instead we
+// require the explicit `.` to anchor the right edge.
+const NM_CONTEXT_RE = /\bNMSA\b|\bN\.\s*M\.|\bNew\s+Mexico\b/
+
+function hasNmContextNearby(cleaned: string, cleanStart: number): boolean {
+  const start = Math.max(0, cleanStart - NM_CONTEXT_WINDOW)
+  const window = cleaned.slice(start, cleanStart)
+  return NM_CONTEXT_RE.test(window)
+}
+
 function inheritBareSectionJurisdiction(
   citations: Citation[],
   cleaned: string,
@@ -821,6 +841,16 @@ function inheritBareSectionJurisdiction(
     if (context) {
       cite.jurisdiction = context.jurisdiction
       cite.code = context.code
+      continue
+    }
+
+    // #531: NM is the historical default for bare `§ N-N-N` shapes, but the
+    // shape itself is too generic (Virginia, Alabama, and others use it
+    // too). Require an explicit NM signal nearby; otherwise drop the
+    // jurisdiction so downstream consumers don't trust a guess.
+    if (!hasNmContextNearby(cleaned, cite.span.cleanStart)) {
+      cite.jurisdiction = undefined
+      cite.code = undefined
     }
   }
 }

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -52,11 +52,64 @@ const ROMAN_TO_INT: Record<string, number> = {
   XXVII: 27,
 }
 
-/** Parse a Roman numeral or Arabic number string to an integer. */
+/**
+ * Lookup table for word-form amendment ordinals (#534).
+ * Both unit forms (`First`..`Twentieth`) and compound forms
+ * (`Twenty-First`..`Twenty-Seventh`) are supported in either
+ * hyphenated or space-separated style.
+ */
+const WORD_ORDINAL_TO_INT: Record<string, number> = {
+  first: 1,
+  second: 2,
+  third: 3,
+  fourth: 4,
+  fifth: 5,
+  sixth: 6,
+  seventh: 7,
+  eighth: 8,
+  ninth: 9,
+  tenth: 10,
+  eleventh: 11,
+  twelfth: 12,
+  thirteenth: 13,
+  fourteenth: 14,
+  fifteenth: 15,
+  sixteenth: 16,
+  seventeenth: 17,
+  eighteenth: 18,
+  nineteenth: 19,
+  twentieth: 20,
+  "twenty-first": 21,
+  "twenty-second": 22,
+  "twenty-third": 23,
+  "twenty-fourth": 24,
+  "twenty-fifth": 25,
+  "twenty-sixth": 26,
+  "twenty-seventh": 27,
+}
+
+/**
+ * Parse any supported numeral form (Roman, Arabic, ordinal abbreviation
+ * `5th` / `14th`, word form `Fifth` / `Twenty-Seventh`) to an integer.
+ * Returns undefined when the input is unrecognized.
+ */
 function parseNumeral(raw: string): number | undefined {
-  const upper = raw.toUpperCase()
+  if (!raw) return undefined
+  const trimmed = raw.trim()
+  // Word-form ordinals (case-insensitive; hyphen or space between parts)
+  const wordKey = trimmed.toLowerCase().replace(/\s+/g, "-")
+  if (wordKey in WORD_ORDINAL_TO_INT) return WORD_ORDINAL_TO_INT[wordKey]
+
+  // Ordinal abbreviation: strip the trailing letters (`5th` → `5`)
+  const ordinalMatch = /^(\d+)(?:st|nd|rd|th)$/i.exec(trimmed)
+  if (ordinalMatch) return Number.parseInt(ordinalMatch[1], 10)
+
+  // Roman numerals
+  const upper = trimmed.toUpperCase()
   if (upper in ROMAN_TO_INT) return ROMAN_TO_INT[upper]
-  const n = Number.parseInt(raw, 10)
+
+  // Plain Arabic numerals
+  const n = Number.parseInt(trimmed, 10)
   return Number.isNaN(n) ? undefined : n
 }
 
@@ -167,17 +220,26 @@ export function extractConstitutional(
   let section: string | undefined
   let clause: number | undefined
 
+  // BODY_TAIL groups (#534 — added inverse-shape `5th Amend.` branch):
+  //   1: numeral (canonical `art./amend. <numeral>` branch)
+  //   2: ordinal (inverse `<ordinal> amend.` branch)
+  //   3: section
+  //   4: clause
+  // Exactly one of group 1 or group 2 is populated per match.
   if (bodyMatch) {
-    const numeral = parseNumeral(bodyMatch[1])
+    const numeralText = bodyMatch[1] ?? bodyMatch[2]
+    const numeral = parseNumeral(numeralText)
+    const isInverseShape = bodyMatch[2] !== undefined
+    const isAmendment = isInverseShape || IS_AMENDMENT_RE.test(bodyMatch[0])
 
-    if (IS_AMENDMENT_RE.test(bodyMatch[0])) {
+    if (isAmendment) {
       amendment = numeral
     } else {
       article = numeral
     }
 
-    section = bodyMatch[2] || undefined
-    clause = bodyMatch[3] ? Number.parseInt(bodyMatch[3], 10) : undefined
+    section = bodyMatch[3] || undefined
+    clause = bodyMatch[4] ? Number.parseInt(bodyMatch[4], 10) : undefined
   }
 
   let jurisdiction: string | undefined
@@ -196,7 +258,10 @@ export function extractConstitutional(
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
   let confidence: number
-  if (token.patternId === "bare-article") {
+  if (token.patternId === "bare-article" || token.patternId === "bare-amendment-word") {
+    // #534: bare ordinal-prefix amendment forms lack the `Const.` anchor
+    // so confidence matches `bare-article`. Downstream consumers can
+    // filter low-confidence matches when stricter precision is needed.
     confidence = 0.5
   } else if (token.patternId === "bare-constitution") {
     confidence = 0.7
@@ -228,23 +293,30 @@ export function extractConstitutional(
     }
   }
 
-  // Body match groups for article/amendment, section, clause
-  // bodyMatch.indices[n] gives positions relative to the full token text
+  // Body match groups for article/amendment, section, clause.
+  // bodyMatch.indices[n] gives positions relative to the full token text.
+  // Group layout (see comment in body parser above):
+  //   1: numeral (canonical) — present for article OR canonical amendment
+  //   2: ordinal (inverse) — present only for ordinal-prefix amendments
+  //   3: section
+  //   4: clause
   if (bodyMatch?.indices) {
-    if (IS_AMENDMENT_RE.test(bodyMatch[0])) {
-      if (bodyMatch.indices[1]) {
-        spans.amendment = spanFromGroupIndex(span.cleanStart, bodyMatch.indices[1], transformationMap)
+    const numeralIdx = bodyMatch.indices[1] ?? bodyMatch.indices[2]
+    const isInverseShape = bodyMatch[2] !== undefined
+    const isAmendment = isInverseShape || IS_AMENDMENT_RE.test(bodyMatch[0])
+    if (numeralIdx) {
+      const targetSpan = spanFromGroupIndex(span.cleanStart, numeralIdx, transformationMap)
+      if (isAmendment) {
+        spans.amendment = targetSpan
+      } else {
+        spans.article = targetSpan
       }
-    } else {
-      if (bodyMatch.indices[1]) {
-        spans.article = spanFromGroupIndex(span.cleanStart, bodyMatch.indices[1], transformationMap)
-      }
-    }
-    if (bodyMatch.indices[2]) {
-      spans.section = spanFromGroupIndex(span.cleanStart, bodyMatch.indices[2], transformationMap)
     }
     if (bodyMatch.indices[3]) {
-      spans.clause = spanFromGroupIndex(span.cleanStart, bodyMatch.indices[3], transformationMap)
+      spans.section = spanFromGroupIndex(span.cleanStart, bodyMatch.indices[3], transformationMap)
+    }
+    if (bodyMatch.indices[4]) {
+      spans.clause = spanFromGroupIndex(span.cleanStart, bodyMatch.indices[4], transformationMap)
     }
   }
 

--- a/src/extract/extractPublicLaw.ts
+++ b/src/extract/extractPublicLaw.ts
@@ -53,9 +53,10 @@ export function extractPublicLaw(
 ): PublicLawCitation {
   const { text, span } = token
 
-  // Parse congress-lawNumber using regex
-  // Pattern: "Pub. L." (with optional "No.") + congress number + "-" + law number
-  const publicLawRegex = /Pub\.\s?L\.(?:\s?No\.)?\s?(\d+)-(\d+)/d
+  // Parse congress-lawNumber using regex.
+  // Pattern: `Pub. L.` / `Public Law` (with optional `No.`) + congress number
+  // + `-` + law number. The spelled-out `Public Law` form is per #533.
+  const publicLawRegex = /(?:Pub\.\s?L\.|Public\s+Law)(?:\s?No\.)?\s?(\d+)-(\d+)/d
   const match = publicLawRegex.exec(text)
 
   if (!match) {

--- a/src/extract/statutes/extractNamedCode.ts
+++ b/src/extract/statutes/extractNamedCode.ts
@@ -59,6 +59,18 @@ function resolveJurisdiction(prefix: string): string | undefined {
 }
 
 /**
+ * Canonical short-name for the jurisdiction prefix, used to build the
+ * `code` field for VA / AL named-code citations (#530). The named-code
+ * registry only stores the bare suffix (`"Code"`, `"Code Ann."`); without
+ * re-attaching the prefix here the consumer sees `code: "Code"` which is
+ * useless for downstream linkers.
+ */
+const JURISDICTION_PREFIX: Record<string, string> = {
+  VA: "Va.",
+  AL: "Ala.",
+}
+
+/**
  * Strip common trailing/leading suffixes from code name text to produce a
  * lookup key for the namedCodes registry.
  *
@@ -134,6 +146,18 @@ export function extractNamedCode(
         const entry = findNamedCode(jurisdiction, cleaned)
         // Store the cleaned name (e.g., "Penal" not "Penal Code"); fall back to raw if no registry hit
         code = entry ? cleaned : rawCodeName.trim()
+        // #530: VA and AL have a single registry entry whose patterns are
+        // bare `"Code"` / `"Code Ann."`. After cleanCodeName trims the
+        // trailing " Ann.", the surviving token is just `"Code"`, which
+        // collapses every Va./Ala. citation to the same useless string.
+        // Re-attach the jurisdiction prefix from the original token so
+        // consumers see `"Va. Code"` / `"Va. Code Ann."` / `"Ala. Code"`.
+        const prefix = JURISDICTION_PREFIX[jurisdiction]
+        if (prefix && entry) {
+          // Preserve the raw suffix shape (Code vs. Code Ann.) by reusing
+          // the normalized rawCodeName rather than the registry lookup key.
+          code = `${prefix} ${rawCodeName.trim().replace(/\s+/g, " ")}`
+        }
       } else {
         code = rawCodeName.trim()
       }

--- a/src/extract/statutes/extractVaBareCode.ts
+++ b/src/extract/statutes/extractVaBareCode.ts
@@ -25,7 +25,11 @@ export function extractVaBareCode(
 ): StatuteCitation {
   const { text, span } = token
   const match = VA_BARE_CODE_RE.exec(text)!
-  const codeName = match[1].replace(/\s+/g, " ")
+  // #530: regardless of the surface form (`Code §` or `Virginia Code §`),
+  // surface the canonical jurisdictional prefix `"Va. Code"` in the
+  // `code` field. The raw match still drives the component span so the
+  // user-facing range covers the original text exactly.
+  const codeName = "Va. Code"
   const rawBody = match[2]
   const { section, subsection, hasEtSeq } = parseBody(rawBody)
 

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -14,12 +14,45 @@
 import type { Pattern } from "./casePatterns"
 
 // Shared tail: art./amend. + numeral + optional § section + optional cl. clause
-// Roman numerals: I, II, III, IV, V, VI, VII, VIII, IX, X, XI, XII, XIII, XIV, XV, XVI, XVII, XVIII, XIX, XX, XXI, XXII, XXIII, XXIV, XXV, XXVI, XXVII
-// Also accepts Arabic numerals as fallback
-const ARTICLE_OR_AMENDMENT = String.raw`(?:art(?:icle)?\.?|amend(?:ment)?\.?|amdt\.?)\s+([IVX]+|\d+)`
+//
+// Numeral forms accepted (#534):
+//   - Roman numerals: I, II, III, IV, V, VI, VII, ..., XXVII
+//   - Arabic numerals: 1, 2, 3, ..., 27
+//   - Ordinal abbreviations: 1st, 2nd, 3rd, 4th, ..., 27th
+//   - Word forms: First, Second, Third, ..., Twenty-Seventh
+//
+// Article-or-amendment token forms:
+//   - art. / article / Art. / Article
+//   - amend. / amendment / Amend. / Amendment
+//   - amdt. / Amdt.
+//
+// The ordinal-prefix forms (`5th Amend.`) put the numeral BEFORE the
+// article/amendment token, so an alternative shape is needed.
+
+// Word-form amendment ordinals (`First`..`Twenty-Seventh`). The first
+// twenty unit-ordinals are followed by ten compound forms (Twentieth..
+// Twenty-Seventh).
+const AMEND_WORD_ORDINALS = String.raw`Twenty[-\s]Seventh|Twenty[-\s]Sixth|Twenty[-\s]Fifth|Twenty[-\s]Fourth|Twenty[-\s]Third|Twenty[-\s]Second|Twenty[-\s]First|Twentieth|Nineteenth|Eighteenth|Seventeenth|Sixteenth|Fifteenth|Fourteenth|Thirteenth|Twelfth|Eleventh|Tenth|Ninth|Eighth|Seventh|Sixth|Fifth|Fourth|Third|Second|First`
+
+// Ordinal abbreviation forms (`1st`..`27th`).
+const AMEND_ORDINAL_ABBREV = String.raw`(?:1st|2nd|3rd|4th|5th|6th|7th|8th|9th|10th|11th|12th|13th|14th|15th|16th|17th|18th|19th|20th|21st|22nd|23rd|24th|25th|26th|27th)`
+
+// Numeral form accepted in the canonical `art./amend. <numeral>` shape.
+// Includes Roman, Arabic, ordinal abbreviations, and word forms.
+const NUMERAL_FORM = `(?:[IVX]+|\\d+|${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})`
+
+// Article-or-amendment word, including the unabbreviated `Amendment`
+// alternative (#534).
+const ARTICLE_OR_AMENDMENT = String.raw`(?:art(?:icle)?\.?|amend(?:ment)?\.?|amdt\.?|Amendment)\s+(${NUMERAL_FORM})`
+
+// Inverse shape: numeral BEFORE the amendment word (e.g., `5th Amend.`,
+// `Fifth Amendment`). Only matches the amendment family — articles are
+// never written with an ordinal-prefix form (`5th Art.` is not legal).
+const ORDINAL_PREFIX_AMENDMENT = `(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+(?:amend(?:ment)?\\.?|amdt\\.?|Amendment)`
+
 const OPTIONAL_SECTION = String.raw`(?:[,;]\s*§\s*([\w-]+))?`
 const OPTIONAL_CLAUSE = String.raw`(?:[,;]\s*cl\.?\s*(\d+))?`
-const BODY_TAIL = `${ARTICLE_OR_AMENDMENT}${OPTIONAL_SECTION}${OPTIONAL_CLAUSE}`
+const BODY_TAIL = `(?:${ARTICLE_OR_AMENDMENT}|${ORDINAL_PREFIX_AMENDMENT})${OPTIONAL_SECTION}${OPTIONAL_CLAUSE}`
 
 /** Compiled body regex shared with the extractor to avoid duplicate definitions. */
 export const CONSTITUTIONAL_BODY_RE: RegExp = new RegExp(BODY_TAIL, "id")
@@ -74,6 +107,27 @@ export const constitutionalPatterns: Pattern[] = [
     ),
     description:
       'Bare article references without "Const." prefix (e.g., "Art. I, §8, cl. 3")',
+    type: "constitutional",
+  },
+  {
+    // #534 — Bare word-form amendment references without `Const.` prefix:
+    // `the Fifth Amendment`, `the Fourteenth Amendment`. Use a leading
+    // word-boundary plus negative-lookbehind for `Const.?,?\s` so this
+    // pattern doesn't double-match what the higher-priority `bare-article`
+    // / `bare-constitution` patterns already cover (their `BODY_TAIL`
+    // includes the ordinal-prefix branch).
+    //
+    // Confidence set to 0.5 in the extractor for the same reason as
+    // `bare-article` — without the `Const.` anchor the FP risk is
+    // higher (e.g., movie titles, generic prose), so consumers can
+    // filter low-confidence matches if they need stricter precision.
+    id: "bare-amendment-word",
+    regex: new RegExp(
+      `(?<!Const\\.?,?\\s)\\b(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+(?:[Aa]mend(?:ment)?\\.?|[Aa]mdt\\.?)`,
+      "g",
+    ),
+    description:
+      'Bare word-form amendment references without "Const." prefix (e.g., "the Fifth Amendment", "the Fourteenth Amendment") — #534',
     type: "constitutional",
   },
 ]

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -93,9 +93,13 @@ export const neutralPatterns: Pattern[] = [
     type: "neutral",
   },
   {
+    // Accepts both the canonical abbreviated form (`Pub. L. No. 116-283`,
+    // `Pub. L. 116-283`) and the spelled-out form (`Public Law 116-127`,
+    // `Public Law No. 116-127`). #533
     id: "public-law",
-    regex: /\bPub\.\s?L\.(?:\s?No\.)?\s?(\d+-\d+)\b/g,
-    description: 'Public Law citations (e.g., "Pub. L. No. 117-58" or "Pub. L. 116-283")',
+    regex: /\b(?:Pub\.\s?L\.|Public\s+Law)(?:\s?No\.)?\s?(\d+-\d+)\b/g,
+    description:
+      'Public Law citations: "Pub. L. No. 117-58", "Pub. L. 116-283", "Public Law 116-127", "Public Law No. 116-127"',
     type: "publicLaw",
   },
   {

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -13,13 +13,31 @@
 
 import type { Pattern } from "./casePatterns"
 
+// #532 — Year must be plausible (1700-2199) to weed out docket-shape
+// strings like `03A01-9103-CH-96` whose middle segment (9103) is a
+// docket index that happens to fit 4 digits. Using a tight prefix
+// alternation rather than `\d{4}` keeps the regex anchored.
+const PLAUSIBLE_YEAR = String.raw`(?:1[789]\d{2}|2[01]\d{2})`
+
+// #532 — Docket prefixes (`Case No.`, `Cause No.`, `Docket No.`, `No.`)
+// are followed by a sequence of `<word>-<word>-<word>` tokens that
+// looks identical to a hyphenated neutral cite. We negative-lookbehind
+// for the docket prefix so the neutral pattern declines to match in
+// that context. The Case/Cause/Docket variants are explicit; bare `No.`
+// is left alone because legitimate neutral cites are sometimes
+// introduced as `held in No. 2010-NMSC-007`.
+const NOT_AFTER_DOCKET_PREFIX = String.raw`(?<!(?:Case|Cause|Docket)\s+No\.\s+[A-Za-z0-9-]{0,40})`
+
 export const neutralPatterns: Pattern[] = [
   {
     // Mississippi 4-segment form: year-caseType-number-appellateTrack. Listed
     // before the 3-segment hyphenated pattern so it wins on the longer match
     // (e.g., "2010-CT-01234-SCT"). (#233)
     id: "state-vendor-neutral-hyphenated-ms",
-    regex: /\b(\d{4})-([A-Z]+)-(\d+)-([A-Z]+)\b/g,
+    regex: new RegExp(
+      `${NOT_AFTER_DOCKET_PREFIX}\\b(${PLAUSIBLE_YEAR})-([A-Z]+)-(\\d+)-([A-Z]+)\\b`,
+      "g",
+    ),
     description:
       'Mississippi 4-segment vendor-neutral (e.g., "2010-CT-01234-SCT", "2015-CA-00567-COA")',
     type: "neutral",
@@ -30,7 +48,10 @@ export const neutralPatterns: Pattern[] = [
     // with an uppercase letter and may contain lowercase (so the Ohio token
     // matches). (#233)
     id: "state-vendor-neutral-hyphenated",
-    regex: /\b(\d{4})-([A-Z][A-Za-z]+)-(\d+)\b/g,
+    regex: new RegExp(
+      `${NOT_AFTER_DOCKET_PREFIX}\\b(${PLAUSIBLE_YEAR})-([A-Z][A-Za-z]+)-(\\d+)\\b`,
+      "g",
+    ),
     description:
       'Hyphenated vendor-neutral (e.g., "2010-NMSC-007", "2024-Ohio-764", "2020-NCSC-118")',
     type: "neutral",

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -457,7 +457,13 @@ export interface FullCaseCitation extends CitationBase {
 export interface StatuteCitation extends CitationBase {
   type: "statute"
   title?: number
-  code: string
+  /**
+   * Code identifier (e.g. "U.S.C.", "Va. Code", "Fla. Stat."). Optional
+   * because the bare-section forms (`§ N-N-N`) may surface with no
+   * jurisdiction signal at all — in that case `code` is omitted and the
+   * cite is reported as a generic statutory reference.
+   */
+  code?: string
   section: string
   /** Subsection/pincite chain, e.g. "(a)(1)(A)" */
   subsection?: string

--- a/src/utils/bluebook.ts
+++ b/src/utils/bluebook.ts
@@ -59,7 +59,10 @@ export function toBluebook(citation: Citation): string {
       const section = `\u00A7 ${citation.section}`
       const subsection = citation.subsection ?? ""
       const etSeq = citation.hasEtSeq ? " et seq." : ""
-      return `${title}${citation.code} ${section}${subsection}${etSeq}`
+      // `code` may be absent when an untagged bare-section cite was emitted
+      // (#531) — fall back to just the section in that case.
+      const code = citation.code ? `${citation.code} ` : ""
+      return `${title}${code}${section}${subsection}${etSeq}`
     }
 
     case "constitutional": {

--- a/tests/extract/extractNeutralHyphenated.test.ts
+++ b/tests/extract/extractNeutralHyphenated.test.ts
@@ -219,4 +219,53 @@ describe("hyphenated neutral citations (#233)", () => {
       expect(neutrals[0].pincite).toBe(3)
     })
   })
+
+  // #532 — TN/IN docket numbers (e.g., `03A01-9103-CH-96`) match the
+  // 3-segment hyphenated neutral pattern when scanned in isolation. The
+  // resulting `year` is implausible (9103) and the document never
+  // contained a true neutral citation, so the cite must be suppressed.
+  describe("docket-shaped strings do NOT match neutral (#532)", () => {
+    it("`Case No. 03A01-9103-CH-96` produces zero neutral cites", () => {
+      const cits = extractCitations("Case No. 03A01-9103-CH-96")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(0)
+    })
+
+    it("`Cause No. 03A01-9103-CH-96` produces zero neutral cites", () => {
+      const cits = extractCitations("Cause No. 03A01-9103-CH-96")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(0)
+    })
+
+    it("`Docket No. 03A01-9103-CH-96` produces zero neutral cites", () => {
+      const cits = extractCitations("Docket No. 03A01-9103-CH-96")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(0)
+    })
+
+    it("implausible year (9103) is rejected as neutral", () => {
+      const cits = extractCitations("Random 9103-CH-96 token in prose.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(0)
+    })
+
+    it("implausible year (1599) is rejected as neutral", () => {
+      const cits = extractCitations("Random 1599-CH-96 token in prose.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(0)
+    })
+
+    it("regression: a valid year inside a docket number still suppressed by Case No. prefix", () => {
+      const cits = extractCitations("Case No. 03A01-2010-CH-96")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(0)
+    })
+
+    it("regression: legitimate neutral cite still matches", () => {
+      const cits = extractCitations("State v. Smith, 2010-NMSC-007.")
+      const neutrals = cits.filter((c): c is NeutralCitation => c.type === "neutral")
+      expect(neutrals).toHaveLength(1)
+      expect(neutrals[0].year).toBe(2010)
+    })
+  })
 })

--- a/tests/extract/extractOthers.test.ts
+++ b/tests/extract/extractOthers.test.ts
@@ -168,6 +168,54 @@ describe("Other extraction functions", () => {
 
       expect(citation.confidence).toBe(0.9)
     })
+
+    // #533 — Statutes that spell out `Public Law` (rather than abbreviating
+    // to `Pub. L.`) should also tokenize and extract correctly. This shows
+    // up in House/Senate reports and in opinions that introduce a Pub. L.
+    // citation without prior abbreviation.
+    it("extracts spelled-out `Public Law 116-127` (#533)", () => {
+      const cites = extractCitations("Public Law 116-127 was enacted in 2020.").filter(
+        (c) => c.type === "publicLaw",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "publicLaw") {
+        expect(cites[0].congress).toBe(116)
+        expect(cites[0].lawNumber).toBe(127)
+      }
+    })
+
+    it("extracts spelled-out `Public Law No. 116-127` (#533)", () => {
+      const cites = extractCitations("Public Law No. 116-127").filter(
+        (c) => c.type === "publicLaw",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "publicLaw") {
+        expect(cites[0].congress).toBe(116)
+        expect(cites[0].lawNumber).toBe(127)
+      }
+    })
+
+    it("regression: abbreviated `Pub. L. 116-283` continues to work (#533)", () => {
+      const cites = extractCitations("See Pub. L. 116-283.").filter(
+        (c) => c.type === "publicLaw",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "publicLaw") {
+        expect(cites[0].congress).toBe(116)
+        expect(cites[0].lawNumber).toBe(283)
+      }
+    })
+
+    it("regression: abbreviated `Pub. L. No. 116-283` continues to work (#533)", () => {
+      const cites = extractCitations("See Pub. L. No. 116-283.").filter(
+        (c) => c.type === "publicLaw",
+      )
+      expect(cites).toHaveLength(1)
+      if (cites[0]?.type === "publicLaw") {
+        expect(cites[0].congress).toBe(116)
+        expect(cites[0].lawNumber).toBe(283)
+      }
+    })
   })
 
   describe("extractFederalRegister", () => {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2132,15 +2132,20 @@ describe("extractStatute", () => {
 
   describe("New Mexico bare-section form (#382)", () => {
     it("extracts `Section 32A-2-7(A)` (bare, letter-prefix first part)", () => {
-      const cites = extractCitations("Section 32A-2-7(A) requires.").filter(
-        (c) => c.type === "statute",
+      // Pre-#531 this defaulted to NM. Now the bare 3-hyphen shape
+      // requires an explicit NM signal in context — provide one.
+      const cites = extractCitations(
+        "NMSA 1978 governs. Section 32A-2-7(A) requires.",
+      ).filter((c) => c.type === "statute")
+      expect(cites.length).toBeGreaterThanOrEqual(2)
+      const bare = cites.find(
+        (c) => c.type === "statute" && /Section\s+32A-2-7/.test(c.matchedText),
       )
-      expect(cites).toHaveLength(1)
-      if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("NMSA 1978")
-        expect(cites[0].jurisdiction).toBe("NM")
-        expect(cites[0].section).toBe("32A-2-7")
-        expect(cites[0].subsection).toBe("(A)")
+      if (bare?.type === "statute") {
+        expect(bare.code).toBe("NMSA 1978")
+        expect(bare.jurisdiction).toBe("NM")
+        expect(bare.section).toBe("32A-2-7")
+        expect(bare.subsection).toBe("(A)")
       }
     })
 
@@ -2156,9 +2161,11 @@ describe("extractStatute", () => {
     })
 
     it("extracts `§ 41-2-2` (symbol form, no subsection)", () => {
-      const cites = extractCitations("See § 41-2-2.").filter(
-        (c) => c.type === "statute",
-      )
+      // Pre-#531 this defaulted to NM. Now the bare 3-hyphen shape
+      // requires an explicit NM signal in context — provide one.
+      const cites = extractCitations(
+        "Under New Mexico law, See § 41-2-2.",
+      ).filter((c) => c.type === "statute")
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
         expect(cites[0].code).toBe("NMSA 1978")
@@ -2469,13 +2476,16 @@ describe("extractStatute", () => {
       }
     })
 
-    it("regression: NM bare-section `Section 32A-2-7(A)` still routes to NM", () => {
-      const cites = extractCitations("Section 32A-2-7(A) requires.").filter(
-        (c) => c.type === "statute",
+    it("regression: NM bare-section `Section 32A-2-7(A)` routes to NM when NMSA signal nearby (#531)", () => {
+      const cites = extractCitations(
+        "NMSA 1978 cited. Section 32A-2-7(A) requires.",
+      ).filter((c) => c.type === "statute")
+      expect(cites.length).toBeGreaterThanOrEqual(2)
+      const bare = cites.find(
+        (c) => c.type === "statute" && /Section\s+32A-2-7/.test(c.matchedText),
       )
-      expect(cites).toHaveLength(1)
-      if (cites[0]?.type === "statute") {
-        expect(cites[0].jurisdiction).toBe("NM")
+      if (bare?.type === "statute") {
+        expect(bare.jurisdiction).toBe("NM")
       }
     })
   })
@@ -3306,14 +3316,18 @@ describe("extractStatute", () => {
       }
     })
 
-    it("bare-section with NO preceding context stays NM (default)", () => {
+    // #531 — Before the fix, a bare `§ N-N-N` with no surrounding NM
+    // signal still claimed NM jurisdiction. The pattern shape is too generic
+    // (every state uses 3-hyphen sections somewhere) so we now require a
+    // nearby `NMSA` / `N.M.` / `New Mexico` hint before tagging.
+    it("bare-section with NO preceding context drops NM tag (#531)", () => {
       const cites = extractCitations("Section 32A-2-7(A).").filter(
         (c) => c.type === "statute",
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].jurisdiction).toBe("NM")
-        expect(cites[0].code).toBe("NMSA 1978")
+        expect(cites[0].jurisdiction).toBeUndefined()
+        expect(cites[0].code).toBeUndefined()
       }
     })
 
@@ -3333,6 +3347,58 @@ describe("extractStatute", () => {
       const cites = extractCitations(text).filter((c) => c.type === "statute")
       expect(cites).toHaveLength(3)
       if (cites[2]?.type === "statute") expect(cites[2].jurisdiction).toBe("NM")
+    })
+  })
+
+  // #531 — Regression suite for the NM context guard. The bare three-hyphen
+  // section shape is common across jurisdictions; without a NM signal in the
+  // surrounding ~200 chars the cite must NOT be tagged as NM.
+  describe("NM bare-section context guard (#531)", () => {
+    it("`See Code § 12-17-189 (1975).` does not get tagged as NM", () => {
+      const cites = extractCitations("See Code § 12-17-189 (1975).").filter(
+        (c) => c.type === "statute",
+      )
+      // The cite is still extracted (the §-form is unambiguous as a
+      // statutory reference) but jurisdiction is left blank — downstream
+      // consumers can resolve from contextual signals we don't yet model.
+      for (const cite of cites) {
+        if (cite.type === "statute") {
+          expect(cite.jurisdiction).not.toBe("NM")
+          expect(cite.code).not.toBe("NMSA 1978")
+        }
+      }
+    })
+
+    it("`§ 12-17-189` standalone does not get tagged as NM", () => {
+      const cites = extractCitations("Some prose. § 12-17-189 applies.").filter(
+        (c) => c.type === "statute",
+      )
+      for (const cite of cites) {
+        if (cite.type === "statute") {
+          expect(cite.jurisdiction).not.toBe("NM")
+        }
+      }
+    })
+
+    it("nearby `New Mexico` keeps the NM tag", () => {
+      const cites = extractCitations(
+        "Under New Mexico law, Section 12-17-189 governs.",
+      ).filter((c) => c.type === "statute")
+      expect(cites.length).toBeGreaterThanOrEqual(1)
+      if (cites[0]?.type === "statute") {
+        expect(cites[0].jurisdiction).toBe("NM")
+      }
+    })
+
+    it("nearby `N.M.` keeps the NM tag", () => {
+      const cites = extractCitations(
+        "Under N.M. statute, Section 41-2-2 governs.",
+      ).filter((c) => c.type === "statute")
+      expect(cites.length).toBeGreaterThanOrEqual(1)
+      // The bare Section 41-2-2 is preceded by `N.M.` within 200 chars, so
+      // the NM tag survives.
+      const bare = cites.find((c) => c.type === "statute" && /Section\s+41-2-2/.test(c.matchedText))
+      expect(bare?.type === "statute" && bare.jurisdiction).toBe("NM")
     })
   })
 })

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2666,7 +2666,8 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("Code")
+        // #530: bare `Code §` in a VA context produces `Va. Code`, not literal "Code"
+        expect(cites[0].code).toBe("Va. Code")
         expect(cites[0].jurisdiction).toBe("VA")
         expect(cites[0].section).toBe("18.2-308.2")
       }
@@ -2701,7 +2702,9 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("Virginia Code")
+        // #530: `Virginia Code §` normalizes to canonical `Va. Code` so the
+        // `code` field is consistent across prefix variants.
+        expect(cites[0].code).toBe("Va. Code")
         expect(cites[0].jurisdiction).toBe("VA")
         expect(cites[0].section).toBe("8.01-581.17")
       }

--- a/tests/extract/issue464MtCoBareSection.test.ts
+++ b/tests/extract/issue464MtCoBareSection.test.ts
@@ -55,12 +55,15 @@ describe("issue #464 — MT/CO bare-section context routing", () => {
       expect(sts[1].jurisdiction).toBe("CO")
     })
 
-    it("bare `§ 13-25-130` with NO Colorado context still routes NM (default preserved)", () => {
+    it("bare `§ 13-25-130` with NO Colorado context is left untagged (#531)", () => {
       const text = "§ 13-25-130 alone."
       const cites = extractCitations(text)
       const sts = statutes(cites)
       expect(sts).toHaveLength(1)
-      expect(sts[0].jurisdiction).toBe("NM")
+      // Per #531, the bare 3-hyphen shape is too generic to default to NM
+      // without an explicit signal. The cite is still extracted, just
+      // jurisdiction-less.
+      expect(sts[0].jurisdiction).toBeUndefined()
     })
   })
 

--- a/tests/extract/issue534ConstitutionalShortForms.test.ts
+++ b/tests/extract/issue534ConstitutionalShortForms.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #534 — Constitutional short forms with ordinal abbreviation and word
+ * forms for amendments. The canonical pattern accepts only Roman numerals
+ * or Arabic numbers; opinions also use ordinal abbreviations (`5th`,
+ * `14th`) and spelled-out word forms (`Fifth`, `Fourteenth`), plus the
+ * unabbreviated `Amendment` token.
+ */
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { ConstitutionalCitation } from "@/types/citation"
+
+const constitutionals = (cits: ReturnType<typeof extractCitations>) =>
+  cits.filter((c): c is ConstitutionalCitation => c.type === "constitutional")
+
+describe("issue #534 — constitutional short forms", () => {
+  describe("ordinal abbreviation forms (5th, 14th, etc.)", () => {
+    it("`U.S. Const., 5th Amend.` extracts as amendment 5", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., 5th Amend."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].jurisdiction).toBe("US")
+      expect(cs[0].amendment).toBe(5)
+    })
+
+    it("`U.S. Const., 14th Amend.` extracts as amendment 14", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., 14th Amend."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+    })
+
+    it("`U.S. Const., 1st Amend.` extracts as amendment 1", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., 1st Amend."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(1)
+    })
+
+    it("`U.S. Const., 2nd Amend.` extracts as amendment 2", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., 2nd Amend."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(2)
+    })
+
+    it("`U.S. Const., 3rd Amend.` extracts as amendment 3", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., 3rd Amend."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(3)
+    })
+
+    it("`U.S. Const., 27th Amend.` extracts as amendment 27", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., 27th Amend."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(27)
+    })
+  })
+
+  describe("spelled-out word forms (Fifth, Fourteenth, etc.)", () => {
+    it("`U.S. Const., Fifth Amendment.` extracts as amendment 5", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., Fifth Amendment."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].jurisdiction).toBe("US")
+      expect(cs[0].amendment).toBe(5)
+    })
+
+    it("`U.S. Const., Fourteenth Amendment.` extracts as amendment 14", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., Fourteenth Amendment."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+    })
+
+    it("`U.S. Const., First Amendment.` extracts as amendment 1", () => {
+      const cs = constitutionals(extractCitations("U.S. Const., First Amendment."))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(1)
+    })
+
+    it("`U.S. Const., Twenty-Seventh Amendment.` extracts as amendment 27", () => {
+      const cs = constitutionals(
+        extractCitations("U.S. Const., Twenty-Seventh Amendment."),
+      )
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(27)
+    })
+
+    it("`U.S. Const., Twenty-First Amendment.` extracts as amendment 21", () => {
+      const cs = constitutionals(
+        extractCitations("U.S. Const., Twenty-First Amendment."),
+      )
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(21)
+    })
+  })
+
+  describe("`Amendment` accepted as alternative to `amend.`", () => {
+    it("`U.S. Const. amend. XIV` (canonical) still works", () => {
+      const cs = constitutionals(extractCitations("U.S. Const. amend. XIV"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+    })
+
+    it("`U.S. Const. Amendment XIV` extracts as amendment 14", () => {
+      const cs = constitutionals(extractCitations("U.S. Const. Amendment XIV"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+    })
+  })
+
+  describe("bare word forms (optional but ideal)", () => {
+    it("`the Fourteenth Amendment` extracts as amendment 14", () => {
+      const cs = constitutionals(extractCitations("the Fourteenth Amendment"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+    })
+
+    it("`the Fifth Amendment` extracts as amendment 5", () => {
+      const cs = constitutionals(extractCitations("the Fifth Amendment"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(5)
+    })
+  })
+
+  describe("regression — existing forms still work", () => {
+    it("Roman numeral amendment still works", () => {
+      const cs = constitutionals(extractCitations("U.S. Const. amend. XIV, § 1"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+      expect(cs[0].section).toBe("1")
+    })
+
+    it("Arabic numeral amendment still works", () => {
+      const cs = constitutionals(extractCitations("U.S. Const. amend. 14"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+    })
+
+    it("Article forms still work", () => {
+      const cs = constitutionals(extractCitations("U.S. Const. art. III, § 2"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(3)
+      expect(cs[0].section).toBe("2")
+    })
+
+    it("Amdt. abbreviation still works", () => {
+      const cs = constitutionals(extractCitations("U. S. Const., Amdt. 14, §1"))
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(14)
+    })
+  })
+})

--- a/tests/extract/statutes/extractNamedCode.test.ts
+++ b/tests/extract/statutes/extractNamedCode.test.ts
@@ -81,6 +81,17 @@ describe("extractNamedCode", () => {
       expect(c.jurisdiction).toBe("VA")
       expect(c.section).toBe("54.1-2400")
     })
+    // #530 — `code` should be the full prefix-qualified code name, not the
+    // bare suffix `"Code"`. Pre-fix, the cleanCodeName() stripping reduced
+    // both `Va. Code` and `Va. Code Ann.` to `"Code"`.
+    it("preserves the `Va. Code` prefix in the `code` field (#530)", () => {
+      const c = extractNamedCode(makeToken("Va. Code § 8.01-243"), map)
+      expect(c.code).toBe("Va. Code")
+    })
+    it("preserves the `Va. Code Ann.` prefix in the `code` field (#530)", () => {
+      const c = extractNamedCode(makeToken("Va. Code Ann. § 8.2-725(2)"), map)
+      expect(c.code).toBe("Va. Code Ann.")
+    })
   })
 
   describe("Alabama", () => {
@@ -88,6 +99,16 @@ describe("extractNamedCode", () => {
       const c = extractNamedCode(makeToken("Ala. Code § 13A-6-61"), map)
       expect(c.jurisdiction).toBe("AL")
       expect(c.section).toBe("13A-6-61")
+    })
+    // #530 — `code` should be the full prefix-qualified code name, not the
+    // bare suffix `"Code"`.
+    it("preserves the `Ala. Code` prefix in the `code` field (#530)", () => {
+      const c = extractNamedCode(makeToken("Ala. Code § 13A-6-61"), map)
+      expect(c.code).toBe("Ala. Code")
+    })
+    it("preserves the `Ala. Code Ann.` prefix in the `code` field (#530)", () => {
+      const c = extractNamedCode(makeToken("Ala. Code Ann. § 13A-6-61"), map)
+      expect(c.code).toBe("Ala. Code Ann.")
     })
   })
 

--- a/tests/fixtures/expanded-corpus.json
+++ b/tests/fixtures/expanded-corpus.json
@@ -1715,6 +1715,10 @@
       "text": "The First Amendment's protection of free speech has been interpreted broadly by the Supreme Court. See Brandenburg v. Ohio, 395 U.S. 444 (1969); New York Times Co. v. Sullivan, 376 U.S. 254 (1964). Under 42 U.S.C. § 1983, individuals may bring suit against state actors who violate their constitutional rights. See Monroe v. Pape, 365 U.S. 167 (1961). For scholarly analysis, see John Doe, Free Speech in the Digital Age, 120 Harv. L. Rev. 1000 (2007). The Court in Brandenburg held that the government cannot punish inflammatory speech unless it is directed to inciting imminent lawless action. Id. at 447.",
       "expected": [
         {
+          "type": "constitutional",
+          "amendment": 1
+        },
+        {
           "type": "case",
           "volume": 395,
           "reporter": "U.S.",
@@ -1840,6 +1844,10 @@
       "text": "The Fourth Amendment prohibits unreasonable searches and seizures. Katz v. United States, 389 U.S. 347 (1967). The exclusionary rule, established in Mapp v. Ohio, 367 U.S. 643 (1961), requires suppression of evidence obtained in violation of the Fourth Amendment. Exceptions include the good faith exception, see United States v. Leon, 468 U.S. 897 (1984), the inevitable discovery doctrine, see Nix v. Williams, 467 U.S. 431 (1984), and the independent source doctrine, see Segura v. United States, 468 U.S. 796 (1984). The automobile exception permits warrantless searches of vehicles based on probable cause. Carroll v. United States, 267 U.S. 132 (1925).",
       "expected": [
         {
+          "type": "constitutional",
+          "amendment": 4
+        },
+        {
           "type": "case",
           "volume": 389,
           "reporter": "U.S.",
@@ -1852,6 +1860,10 @@
           "reporter": "U.S.",
           "page": 643,
           "year": 1961
+        },
+        {
+          "type": "constitutional",
+          "amendment": 4
         },
         {
           "type": "case",
@@ -2670,6 +2682,10 @@
       "text": "The Due Process Clause of the Fourteenth Amendment provides both procedural and substantive protection. Procedural due process requires notice and an opportunity to be heard before the government deprives a person of life, liberty, or property. Mathews v. Eldridge, 424 U.S. 319 (1976). The three-factor balancing test from Mathews considers the private interest affected, the risk of erroneous deprivation, and the government's interest. Id. at 335. Substantive due process protects fundamental rights against government interference regardless of the procedures used. Washington v. Glucksberg, 521 U.S. 702 (1997). See also Obergefell v. Hodges, 576 U.S. 644 (2015); Lawrence v. Texas, 539 U.S. 558 (2003).",
       "expected": [
         {
+          "type": "constitutional",
+          "amendment": 14
+        },
+        {
           "type": "case",
           "volume": 424,
           "reporter": "U.S.",
@@ -2709,6 +2725,10 @@
       "description": "Second Amendment paragraph with recent decisions",
       "text": "The Second Amendment protects an individual right to keep and bear arms. District of Columbia v. Heller, 554 U.S. 570 (2008). This right was incorporated against the states in McDonald v. City of Chicago, 561 U.S. 742 (2010). The historical test for firearms regulations was established in New York State Rifle & Pistol Association Inc. v. Bruen, 597 U.S. 1 (2022). Under Bruen, the government must demonstrate that a regulation is consistent with the historical tradition of firearm regulation. Id. at 17. Lower courts have applied this framework extensively. See United States v. Rahimi, 61 F.4th 443 (5th Cir. 2023), cert. granted, 143 S. Ct. 2688 (2023).",
       "expected": [
+        {
+          "type": "constitutional",
+          "amendment": 2
+        },
         {
           "type": "case",
           "volume": 554,
@@ -3199,6 +3219,10 @@
       "description": "Eighth Amendment cruel and unusual punishment",
       "text": "The Eighth Amendment prohibits cruel and unusual punishment. The proportionality principle requires that sentences not be grossly disproportionate to the crime. Solem v. Helm, 463 U.S. 277 (1983). Capital punishment for juvenile offenders was held unconstitutional in Roper v. Simmons, 543 U.S. 551 (2005). Life without parole for juvenile non-homicide offenders was banned in Graham v. Florida, 560 U.S. 48 (2010), and mandatory life without parole for all juvenile offenders was prohibited in Miller v. Alabama, 567 U.S. 460 (2012). Id. at 465. See also Montgomery v. Louisiana, 577 U.S. 190 (2016).",
       "expected": [
+        {
+          "type": "constitutional",
+          "amendment": 8
+        },
         {
           "type": "case",
           "volume": 463,

--- a/tests/fixtures/thorny-corpus.json
+++ b/tests/fixtures/thorny-corpus.json
@@ -1160,6 +1160,10 @@
       "text": "The Eighth Amendment forbids the execution of intellectually disabled persons. Atkins v. Virginia, 536 U.S. 304 (2002). The Court later held that juveniles cannot receive the death penalty. Roper v. Simmons, 543 U.S. 551, 578 (2005) (holding that the Eighth and Fourteenth Amendments forbid imposition of the death penalty on offenders who were under 18 when their crimes were committed). See also Kennedy v. Louisiana, 554 U.S. 407 (2008) (striking down the death penalty for child rape) (citing Coker v. Georgia, 433 U.S. 584 (1977)). The Sixth Amendment requires jury findings on aggravating factors. Ring v. Arizona, 536 U.S. 584 (2002), overruling Walton v. Arizona, 497 U.S. 639 (1990). For analysis, see 120 Yale L.J. 1578 (2011).",
       "expected": [
         {
+          "type": "constitutional",
+          "amendment": 8
+        },
+        {
           "type": "case",
           "volume": 536,
           "reporter": "U.S.",
@@ -1175,6 +1179,10 @@
           "year": 2005
         },
         {
+          "type": "constitutional",
+          "amendment": 14
+        },
+        {
           "type": "case",
           "volume": 554,
           "reporter": "U.S.",
@@ -1187,6 +1195,10 @@
           "reporter": "U.S.",
           "page": 584,
           "year": 1977
+        },
+        {
+          "type": "constitutional",
+          "amendment": 6
         },
         {
           "type": "case",
@@ -1532,6 +1544,10 @@
         {
           "type": "id",
           "pincite": 17
+        },
+        {
+          "type": "constitutional",
+          "amendment": 2
         },
         {
           "type": "case",


### PR DESCRIPTION
## Summary

Five statute / non-case fixes.

| Issue | Fix |
|---|---|
| [#530](https://github.com/medelman17/eyecite-ts/issues/530) | `Va.`/`Ala. Code` prefix re-attached when registry produces bare `"Code"`. Bare-code extractor surfaces canonical `"Va. Code"` regardless of surface form. |
| [#531](https://github.com/medelman17/eyecite-ts/issues/531) | Bare `§ N-N-N` no longer auto-tags as NM. Post-pass guard requires `NMSA`/`N.M.`/`New Mexico` within 200 chars; otherwise clears jurisdiction/code. |
| [#532](https://github.com/medelman17/eyecite-ts/issues/532) | Neutral patterns now have year-range guard `(1[789]\d{2}\|2[01]\d{2})` and a negative lookbehind for `Case\|Cause\|Docket No.`. |
| [#533](https://github.com/medelman17/eyecite-ts/issues/533) | Public Law pattern accepts spelled-out `Public Law` alongside `Pub. L.`. |
| [#534](https://github.com/medelman17/eyecite-ts/issues/534) | Constitutional patterns accept ordinal (`1st`-`27th`) and word forms (`First`-`Twenty-Seventh`). New `bare-amendment-word` pattern catches "the Fifth Amendment". |

Five changesets, one per issue.

## Test plan

- [x] `pnpm exec vitest run` — 3177 passed, 9 skipped
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)