### PR TITLE
fix: statute extraction cluster and full-caption supra resolution

### DIFF
--- a/.changeset/bare-section-list-prefix.md
+++ b/.changeset/bare-section-list-prefix.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): emit citations for bare-prefix `§§ N, N` lists (#563)
+
+`§§ X, Y, Z` lists without an explicit code identifier in front of the
+`§§` marker produced ZERO citations. The existing `expandPluralSectionList`
+post-pass only fires *after* a head citation already exists in the result
+set, so naked sequences like `See §§ 12940, 12945` or `Code §§ 19.2-81 and
+18.2-266` never seeded a head and the whole list dropped silently.
+
+Adds `detectBareSectionLists` running just before the expander. The pass
+scans the cleaned text for `[Code ]§§ N(, N)+` shapes that don't overlap
+an existing citation and seeds a head with `code` set to the prefix (or
+`"§"` when none is present) so the expander picks up the siblings. The
+section grammar in both the new detector and the expander now allows
+dotted section numbers (`19.2-81`, `12940.5`).
+
+Confidence on the seeded head is intentionally low (0.5) because no code
+identifier means no jurisdiction grounding — downstream inheritance passes
+remain authoritative for jurisdictional context.

--- a/.changeset/bare-shortform-statute.md
+++ b/.changeset/bare-shortform-statute.md
@@ -1,0 +1,20 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): bare `§ N` after a full statute is a short-form reference (#567)
+
+Cross-reference forms like `42 U.S.C. § 1983; see also § 1985` previously
+produced only one citation — the bare `§ 1985` was dropped because no
+tokenizer pattern fires without a code identifier. Adds
+`detectBareSectionShortForms` that walks each full statute citation and
+scans up to 300 chars forward (capped at the next statute) for bare
+`§ N` shapes. Each match emits an inherited StatuteCitation carrying the
+antecedent's `title`, `code`, and `jurisdiction`.
+
+Guards:
+- Antecedent must have a code identifier; bare-section antecedents owned
+  by the NM dispatcher (NMSA 1978) are skipped.
+- Three-hyphen state-section shapes (`32A-2-7`) remain owned by the NM
+  pipeline.
+- The pass respects existing citation spans (no overlap re-emission).

--- a/.changeset/et-seq-fanout-owner.md
+++ b/.changeset/et-seq-fanout-owner.md
@@ -1,0 +1,17 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): only the owning sibling carries `hasEtSeq` in `§§` lists (#566)
+
+`expandPluralSectionList` previously spread `{ ...cite }` from the head
+onto every sibling, so if `et seq.` modified ONE specific section in a
+plural list (`§§ 12940 et seq., 12945`), the flag rode along to every
+sibling in the fanout. Symmetrically, `§§ 1331, 1332 et seq.` left `1332`
+without the flag because the head was `1331` (no trailing `et seq.`).
+
+Fix: after positioning each sibling, peek ~20 chars past the section end
+and set `hasEtSeq` only when `et seq.` immediately follows. Siblings
+without a trailing `et seq.` token now drop the flag regardless of the
+head's value. Also clears `sectionRange` on siblings — the structured
+range applied only to the head.

--- a/.changeset/mass-chapter-field.md
+++ b/.changeset/mass-chapter-field.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): Mass `c. NNN` chapter no longer leaks into `code` (#569)
+
+Massachusetts citations like `G.L. c. 93A` previously placed the chapter
+number (`93A`) into the `code` field and set `section=""`, conflating
+two distinct identifiers. Adds a dedicated `chapter` field to
+`StatuteCitation` and updates the mass-chapter extractor:
+
+- `code` carries the corpus identifier as it appeared in the source
+  (`G.L.`, `Mass. Gen. Laws`, `M.G.L.A.`, `A.L.M.`, `General Laws`).
+- `chapter` carries the chapter (`93A`, `93`, `268A`, `90`).
+- `section` is the trailing section number when present, otherwise
+  `undefined` (no more empty-string sentinels).
+
+`StatuteCitation.section` is now `string | undefined` to model
+chapter-only citations. The bluebook formatter now emits `<code> c.
+<chapter>` for chapter-only forms and `<code> c. <chapter>, § <section>`
+for the full chapter+section shape. Pre-existing tests / fixture updated.

--- a/.changeset/named-code-full-identifier.md
+++ b/.changeset/named-code-full-identifier.md
@@ -1,0 +1,20 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): named-code `code` carries the full identifier (#568)
+
+Named-code citations like `Cal. Civ. Code § 51` previously dropped both
+the jurisdiction prefix and the trailing `Code` / `Law` suffix, storing
+only the cleaned body — `Civ.` instead of `Cal. Civ. Code`, `Penal`
+instead of `N.Y. Penal Law`. Consumers couldn't reconstruct the original
+identifier from the parsed citation.
+
+`extractNamedCode` now stores the full identifier in `code`: the
+jurisdiction prefix as it appeared in the source, plus the body (Code
+name + suffix), e.g. `Cal. Civ. Code`, `Cal. Penal Code`, `California
+Civil Code`, `N.Y. Penal Law`, `Tex. Penal Code`. Internal registry
+lookups continue to use the cleaned body as the lookup key.
+
+Three pre-existing tests (and one golden-corpus fixture) that asserted
+the truncated body shape have been updated to the full identifier.

--- a/.changeset/nm-decimal-subsection-and-guard.md
+++ b/.changeset/nm-decimal-subsection-and-guard.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): NM bare-section decimal subsection + jurisdiction guard (#565)
+
+Two paired bugs on the NM bare-section path:
+
+1. The `nm-bare-section` regex didn't accept `.` inside parens, so
+   `§ 32A-2-7(A)(1.5)` silently dropped the `(1.5)` portion of the
+   subsection chain. Pattern + extractor regex now allow decimals and
+   bracket subscripts inside subsection parens.
+2. The default `NM` / `NMSA 1978` tag fired on every bare `§ N-N-N`
+   shape, even with no nearby NM signal — the same misattribution
+   pattern that drove #531 for the named-code path. Adds a jurisdiction
+   guard: if the cleaned text within 200 chars before the citation
+   doesn't contain `NMSA`, `N.M.`, or `New Mexico`, both `jurisdiction`
+   and `code` are dropped so consumers don't trust a guess.
+
+`StatuteCitation.code` is now `string | undefined` to model the
+guard-dropped case. The bluebook formatter renders `§ <section>` without
+a code prefix when code is missing. Three pre-existing tests that asserted
+the implicit NM default have been rewritten to either supply NM context
+or assert the new dropped-jurisdiction contract.

--- a/.changeset/section-range-field.md
+++ b/.changeset/section-range-field.md
@@ -1,0 +1,16 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): `§§ N-M` federal ranges populate `sectionRange` (#564)
+
+`28 U.S.C. §§ 591-99 (2000)` previously produced one citation with
+`section="591-99"`, ambiguous with hyphenated state-style sections
+(`19.2-81`, `32A-2-7`). Adds a structured `sectionRange: { start, end }`
+field on `StatuteCitation` and populates it for federal `§§` ranges. The
+`section` field now holds the range start (e.g. `"591"`) so consumers that
+only read `section` keep working on the common case.
+
+Detection guard: hyphenated state-style sections (anything with a dot, a
+letter, or more than one hyphen) are NOT treated as ranges and continue
+to surface in `section` unchanged.

--- a/.changeset/supra-full-caption-target.md
+++ b/.changeset/supra-full-caption-target.md
@@ -1,0 +1,10 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): prefer same-case full-caption supra matches
+
+`Plaintiff v. Defendant, supra` resolution now first looks for a single
+antecedent whose plaintiff and defendant both match the caption. This prevents
+an unrelated case with a stronger one-sided fuzzy match from beating the
+intended antecedent.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -439,6 +439,11 @@ export function extractCitations(
   // `§§ N and N`) into one statute citation per section. (#453)
   expandPluralSectionList(citations, cleaned, transformationMap)
 
+  // Step 4.42: Bare `§ N` after a full statute citation is a short-form
+  // statute reference that inherits title / code / jurisdiction from its
+  // antecedent (`§ X; see also § Y`). (#567)
+  detectBareSectionShortForms(citations, cleaned, transformationMap)
+
   // Step 4.5: Link subsequent history citations using Union-Find.
   // Three-phase approach: match signals → union chains → aggregate entries.
   // Invariant: citations are in text order (guaranteed by token-order processing above).
@@ -1082,6 +1087,110 @@ function expandPluralSectionList(
       newCitations.push(continuation)
 
       cursor = sectionEnd
+    }
+  }
+
+  if (newCitations.length === 0) return
+  citations.push(...newCitations)
+  citations.sort((a, b) => a.span.cleanStart - b.span.cleanStart)
+}
+
+/**
+ * Detect bare `§ N` short-form statute references that inherit title /
+ * code / jurisdiction from an earlier full statute citation. After a full
+ * cite establishes a code, follow-on bare `§ N` is a Bluebook short-form
+ * statute reference (analogous to Id. for cases). The tokenizer never
+ * matches these because the patterns all require a code identifier; this
+ * pass walks the text between full statute citations and emits an inherited
+ * sibling for each bare `§ N` it finds. (#567)
+ *
+ * Conservative anchoring:
+ *   - Must follow a full statute citation (one with `title` AND `code`).
+ *   - The antecedent's code must be a well-known full-form code (`U.S.C.`,
+ *     `C.F.R.`, or a state named-code with `jurisdiction` set) — the bare
+ *     `§ N-N-N` shape that the NM dispatcher already handles is left alone.
+ *   - Three-hyphen state section shapes (`32A-2-7`, `41-2-2`) are skipped
+ *     here so the NM dispatcher pipeline keeps owning them.
+ *   - The section grammar is `\d[\w]*(?:\.[\w]+)*` — purely numeric or
+ *     numeric+letter (`1985`, `1028A`), optionally dotted (`122.26`). No
+ *     hyphens, so state-style sections don't false-match.
+ *   - Skip any region that already overlaps an existing citation.
+ *   - Maximum scan window of 300 chars from the antecedent's end so we
+ *     don't link references too far apart.
+ */
+function detectBareSectionShortForms(
+  citations: Citation[],
+  cleaned: string,
+  transformationMap: TransformationMap,
+): void {
+  const BARE_SECTION_RE =
+    /(?<![A-Za-z\d-])§\s*(\d[\w]*(?:\.[\w]+)*(?:\([A-Za-z0-9.]+\))*)/g
+  const SCAN_WINDOW = 300
+
+  // Snapshot the input list — we'll push results to newCitations and sort.
+  const newCitations: Citation[] = []
+
+  for (let i = 0; i < citations.length; i++) {
+    const cite = citations[i]
+    if (cite.type !== "statute") continue
+    // Antecedent must have a code identifier — full citations always do.
+    // State named-codes (Cal. Penal, NY Penal Law) carry no `title` but
+    // still establish a code, so we don't require title.
+    if (!cite.code) continue
+    // Skip when the antecedent itself was a bare-section that the NM
+    // dispatcher already owns — those are heuristic and we don't want
+    // inherited follow-ons riding on a guess.
+    if (cite.code === "NMSA 1978") continue
+
+    const start = cite.span.cleanEnd
+    // Stop scanning at the next statute citation (it'll become its own
+    // antecedent) or at the scan window.
+    let end = Math.min(start + SCAN_WINDOW, cleaned.length)
+    for (let j = i + 1; j < citations.length; j++) {
+      const next = citations[j]
+      if (next.span.cleanStart >= start && next.span.cleanStart < end) {
+        end = next.span.cleanStart
+      }
+    }
+    if (end <= start) continue
+
+    const window = cleaned.slice(start, end)
+    BARE_SECTION_RE.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = BARE_SECTION_RE.exec(window)) !== null) {
+      const absStart = start + match.index
+      const absEnd = absStart + match[0].length
+      if (overlapsExistingCitation(citations, absStart, absEnd)) continue
+
+      const sectionText = match[1]
+      // Skip three-hyphen state-section shapes — the NM pipeline owns these.
+      if (/^\d+[A-Z]?-\d+[A-Z]?-\d+/.test(sectionText)) continue
+
+      const { originalStart, originalEnd } = resolveOriginalSpan(
+        { cleanStart: absStart, cleanEnd: absEnd },
+        transformationMap,
+      )
+
+      const inherited: import("@/types/citation").StatuteCitation = {
+        type: "statute",
+        text: match[0],
+        span: {
+          cleanStart: absStart,
+          cleanEnd: absEnd,
+          originalStart,
+          originalEnd,
+        },
+        // Slightly lower than head; the inheritance is heuristic.
+        confidence: Math.max(0.6, cite.confidence - 0.1),
+        matchedText: match[0],
+        processTimeMs: 0,
+        patternsChecked: 1,
+        title: cite.title,
+        code: cite.code,
+        section: sectionText,
+        jurisdiction: cite.jurisdiction,
+      }
+      newCitations.push(inherited)
     }
   }
 

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -1028,6 +1028,8 @@ function expandPluralSectionList(
   const continuationRe = new RegExp(
     `^(?:${connectorPart})(${sectionPart})`,
   )
+  // `et seq.` immediately after a sibling — owner detection. (#566)
+  const TRAILING_ET_SEQ_RE = /^\s*et\s+seq\.?/i
 
   const newCitations: Citation[] = []
 
@@ -1051,11 +1053,19 @@ function expandPluralSectionList(
         transformationMap,
       )
 
+      // Owner detection for `et seq.` (#566): only set `hasEtSeq` on the
+      // sibling that the token immediately follows. The blanket spread of
+      // `...cite` would otherwise propagate the head's flag (if any) to
+      // every sibling.
+      const trailing = cleaned.slice(sectionEnd, sectionEnd + 20)
+      const siblingHasEtSeq = TRAILING_ET_SEQ_RE.test(trailing)
+
       const continuation: import("@/types/citation").StatuteCitation = {
         ...cite,
         text: sectionText,
         matchedText: sectionText,
         section: sectionText,
+        sectionRange: undefined,
         span: {
           cleanStart: sectionStart,
           cleanEnd: sectionEnd,
@@ -1066,6 +1076,7 @@ function expandPluralSectionList(
         // to the head section.
         subsection: undefined,
         pincite: undefined,
+        hasEtSeq: siblingHasEtSeq || undefined,
         spans: undefined,
       }
       newCitations.push(continuation)

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -786,6 +786,22 @@ const BARE_SECTION_CONTEXT_OVERRIDES: Record<string, BareSectionContext> = {
   MT: { jurisdiction: "MT", code: "MCA" },
 }
 
+/**
+ * Look for an explicit New Mexico signal (`NMSA`, `N.M.`, `N. M.`,
+ * `New Mexico`) in the cleaned text within ~200 chars before the citation
+ * start. Used to gate the default `NM` jurisdiction tag attached to bare
+ * `§ N-N-N` citations — without a nearby signal the shape is too generic
+ * to claim NM. (#565, originally #531)
+ */
+const NM_CONTEXT_WINDOW = 200
+const NM_CONTEXT_RE = /\bNMSA\b|\bN\.\s*M\.|\bNew\s+Mexico\b/
+
+function hasNmContextNearby(cleaned: string, cleanStart: number): boolean {
+  const start = Math.max(0, cleanStart - NM_CONTEXT_WINDOW)
+  const window = cleaned.slice(start, cleanStart)
+  return NM_CONTEXT_RE.test(window)
+}
+
 function inheritBareSectionJurisdiction(
   citations: Citation[],
   cleaned: string,
@@ -826,6 +842,15 @@ function inheritBareSectionJurisdiction(
     if (context) {
       cite.jurisdiction = context.jurisdiction
       cite.code = context.code
+      continue
+    }
+
+    // #565 (originally #531): the NM default for bare `§ N-N-N` shapes is
+    // too generic — without an explicit NM signal nearby, drop the
+    // jurisdiction so downstream consumers don't trust a guess.
+    if (!hasNmContextNearby(cleaned, cite.span.cleanStart)) {
+      cite.jurisdiction = undefined
+      cite.code = undefined
     }
   }
 }

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -430,6 +430,11 @@ export function extractCitations(
     citations.push(citation)
   }
 
+  // Step 4.35: Detect bare-prefix `§§ N, N` lists that lack any code
+  // identifier in front of the §§ marker. These never produce a head cite
+  // through normal tokenization, so seed a head before expansion. (#563)
+  detectBareSectionLists(citations, cleaned, transformationMap)
+
   // Step 4.4: Expand plural-section statute lists (`§§ N, N` /
   // `§§ N and N`) into one statute citation per section. (#453)
   expandPluralSectionList(citations, cleaned, transformationMap)
@@ -875,6 +880,102 @@ const BARE_PARTY_BLOCKED_NAMES = new Set([
 ])
 
 /**
+ * Detect bare-prefix `§§ N, N[, N]…` lists that the tokenizer skipped because
+ * there is no recognizable code identifier in front of the `§§` marker. The
+ * tokenizer only emits a head when a code-name regex matches; naked sequences
+ * like `§§ 12940, 12945, 12950` or `Code §§ 19.2-81 and 18.2-266` thus drop
+ * silently. This pass scans the cleaned text for such sequences and seeds a
+ * head citation for each section so the existing `expandPluralSectionList`
+ * pass can pick up the remainder. (#563)
+ *
+ * Conservative anchoring:
+ *   - Requires `§§` literally (singular `§ N` is too ambiguous on its own).
+ *   - Section grammar matches the same shape as `expandPluralSectionList`.
+ *   - At least two sections must appear (single bare `§§ N` is suspect).
+ *   - Skips ranges of the form `§§ N-M` so the head/tail get a single span.
+ *   - Skips any range that overlaps an existing citation.
+ *   - The `code` field is set to a generic marker (`"§"`) when no prefix is
+ *     identified; jurisdiction is left undefined so downstream inheritance
+ *     passes can populate it. When a `Code` prefix immediately precedes the
+ *     `§§`, `code` is set to `"Code"` to preserve the user's intent.
+ */
+function detectBareSectionLists(
+  citations: Citation[],
+  cleaned: string,
+  transformationMap: TransformationMap,
+): void {
+  const sectionPart =
+    "\\d[\\w-]*(?:\\.[\\d\\w-]+)*(?:\\([A-Za-z0-9]+\\))*"
+  // Allow optional `Code` (or `Code Ann.`) prefix immediately before `§§`.
+  // Anchor on `§§` followed by whitespace + a section. The list itself is
+  // detected by `expandPluralSectionList` once the head is in place; we only
+  // need to identify a starting position. The two-section minimum is enforced
+  // by lookahead.
+  const headRe = new RegExp(
+    `(?:\\b(Code(?:\\s+Ann\\.?)?)\\s+)?§§\\s+(${sectionPart})(?=\\s*(?:,\\s*|\\s+and\\s+|\\s+to\\s+)${sectionPart})`,
+    "g",
+  )
+
+  const newCitations: Citation[] = []
+  let match: RegExpExecArray | null
+  while ((match = headRe.exec(cleaned)) !== null) {
+    const fullMatch = match[0]
+    const prefix = match[1]
+    const sectionText = match[2]
+    const start = match.index
+    const end = start + fullMatch.length
+
+    if (overlapsExistingCitation(citations, start, end)) continue
+
+    const sectionStart = start + fullMatch.length - sectionText.length
+    const sectionEnd = end
+
+    const { originalStart, originalEnd } = resolveOriginalSpan(
+      { cleanStart: start, cleanEnd: end },
+      transformationMap,
+    )
+    const sectionOrig = resolveOriginalSpan(
+      { cleanStart: sectionStart, cleanEnd: sectionEnd },
+      transformationMap,
+    )
+
+    const code = prefix ? prefix.replace(/\s+/g, " ").trim() : "§"
+
+    const head: import("@/types/citation").StatuteCitation = {
+      type: "statute",
+      text: fullMatch,
+      span: {
+        cleanStart: start,
+        cleanEnd: end,
+        originalStart,
+        originalEnd,
+      },
+      // Bare-prefix lists are inherently low-confidence — no code identifier
+      // means no jurisdiction grounding.
+      confidence: 0.5,
+      matchedText: fullMatch,
+      processTimeMs: 0,
+      patternsChecked: 1,
+      code,
+      section: sectionText,
+      spans: {
+        section: {
+          cleanStart: sectionStart,
+          cleanEnd: sectionEnd,
+          originalStart: sectionOrig.originalStart,
+          originalEnd: sectionOrig.originalEnd,
+        },
+      },
+    }
+    newCitations.push(head)
+  }
+
+  if (newCitations.length === 0) return
+  citations.push(...newCitations)
+  citations.sort((a, b) => a.span.cleanStart - b.span.cleanStart)
+}
+
+/**
  * Expand a plural `§§ N, N` (or `§§ N and N`) statute reference into one
  * StatuteCitation per section. The tokenizer captures only the FIRST
  * section; this pass walks the text right after a `§§`-marked statute
@@ -892,7 +993,12 @@ function expandPluralSectionList(
   cleaned: string,
   transformationMap: TransformationMap,
 ): void {
-  const sectionPart = "\\d[\\w-]*(?:\\([A-Za-z0-9]+\\))*"
+  // Section grammar accepts: leading digit, then any word/hyphen run, with
+  // optional dotted suffixes (`19.2-81`, `12940.5`) and optional subsection
+  // chain (`(A)`, `(1)`, `(b)(14)`). The dotted extension was added in #563
+  // so bare `Code §§ 19.2-81 and 18.2-266` siblings are picked up.
+  const sectionPart =
+    "\\d[\\w-]*(?:\\.[\\d\\w-]+)*(?:\\([A-Za-z0-9]+\\))*"
   const connectorPart = "\\s*,\\s*|\\s+and\\s+|\\s+to\\s+"
   const continuationRe = new RegExp(
     `^(?:${connectorPart})(${sectionPart})`,

--- a/src/extract/statutes/extractFederal.ts
+++ b/src/extract/statutes/extractFederal.ts
@@ -61,7 +61,17 @@ export function extractFederal(
     title = undefined
   }
 
-  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+  const { section: parsedSection, sectionRangeEnd, subsection, hasEtSeq } = parseBody(rawBody)
+
+  // Federal `§§ N-M` range form (#564): split into structured range with
+  // `section` = start so existing consumers keep working. The matchedText
+  // §§ marker is the disambiguator — a singular `§ N-M` on a USC citation
+  // would be unprecedented and stays as a single section.
+  const isRange = sectionRangeEnd !== undefined && /§§/.test(text)
+  const section = isRange ? parsedSection.split("-")[0] : parsedSection
+  const sectionRange = isRange
+    ? { start: section, end: sectionRangeEnd as string }
+    : undefined
 
   // Translate positions
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
@@ -115,6 +125,7 @@ export function extractFederal(
     title,
     code,
     section,
+    sectionRange,
     subsection,
     pincite: subsection,
     jurisdiction: "US",

--- a/src/extract/statutes/extractNamedCode.ts
+++ b/src/extract/statutes/extractNamedCode.ts
@@ -106,6 +106,7 @@ export function extractNamedCode(
   let jurisdiction: string | undefined
   let code: string
   let rawBody: string
+  let chapter: string | undefined
   let massMatch: RegExpExecArray | null = null
   let namedMatch: RegExpExecArray | null = null
 
@@ -113,7 +114,12 @@ export function extractNamedCode(
     massMatch = MASS_CHAPTER_RE.exec(text)
     if (massMatch) {
       jurisdiction = "MA"
-      code = massMatch[2] // chapter number (e.g., "93A")
+      // #569 — `code` holds the corpus identifier as it appeared
+      // (`G.L.`, `Mass. Gen. Laws`, `M.G.L.A.`, `A.L.M.`,
+      // `General Laws`). The chapter number moves to the dedicated
+      // `chapter` field; section is the trailing `§ N` (when present).
+      code = massMatch[1].trim().replace(/\s+/g, " ")
+      chapter = massMatch[2]
       // Section body is optional — chapter-only citations like `G.L. c. 93A`
       // are valid. When absent, leave the section empty. (#364)
       rawBody = massMatch[3] ?? ""
@@ -202,6 +208,11 @@ export function extractNamedCode(
   if (subsection) confidence += 0.05
   confidence = Math.min(confidence, 1.0)
 
+  // For Mass-chapter forms, an empty section means a chapter-only citation
+  // (`G.L. c. 93A`) — return `undefined` rather than empty string. (#569)
+  const sectionOut: string | undefined =
+    section === "" && chapter ? undefined : section
+
   return {
     type: "statute",
     text,
@@ -211,7 +222,8 @@ export function extractNamedCode(
     processTimeMs: 0,
     patternsChecked: 1,
     code,
-    section,
+    chapter,
+    section: sectionOut,
     subsection,
     pincite: subsection,
     jurisdiction,

--- a/src/extract/statutes/extractNamedCode.ts
+++ b/src/extract/statutes/extractNamedCode.ts
@@ -126,17 +126,18 @@ export function extractNamedCode(
     namedMatch = NAMED_CODE_RE.exec(text)
     if (namedMatch) {
       jurisdiction = resolveJurisdiction(namedMatch[1])
+      const rawPrefix = namedMatch[1].trim()
       const rawCodeName = namedMatch[2]
+      // #568 — `code` is the FULL identifier (jurisdiction prefix +
+      // body + trailing `Code`/`Law`), not just the cleaned body. The
+      // previous behavior stored `Civ.` for `Cal. Civ. Code § 51`,
+      // losing both jurisdiction and the `Code` suffix.
+      // Lookup still uses the cleaned key for registry hits.
       const cleaned = cleanCodeName(rawCodeName)
-
       if (jurisdiction) {
-        // Look up in registry — use cleaned name as the lookup key
-        const entry = findNamedCode(jurisdiction, cleaned)
-        // Store the cleaned name (e.g., "Penal" not "Penal Code"); fall back to raw if no registry hit
-        code = entry ? cleaned : rawCodeName.trim()
-      } else {
-        code = rawCodeName.trim()
+        findNamedCode(jurisdiction, cleaned) // side-effect-free validity check
       }
+      code = `${rawPrefix} ${rawCodeName.trim()}`
 
       rawBody = namedMatch[3]
     } else {

--- a/src/extract/statutes/extractNmBareSection.ts
+++ b/src/extract/statutes/extractNmBareSection.ts
@@ -16,7 +16,7 @@ import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from 
 import { parseBody } from "./parseBody"
 
 const NM_BARE_SECTION_RE =
-  /^(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9]+\))*)$/d
+  /^(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9.]+\)|\[[A-Za-z0-9.]+\])*)$/d
 
 export function extractNmBareSection(
   token: Token,

--- a/src/extract/statutes/parseBody.ts
+++ b/src/extract/statutes/parseBody.ts
@@ -15,8 +15,18 @@ const SUBSECTION_RE = /^([^([]+?)\s*((?:\([^)]*\)|\[[^\]]*\])*)$/
 /** Et seq. at end of string */
 const ET_SEQ_RE = /\s*et\s+seq\.?\s*$/i
 
+/**
+ * Plain numeric range (`591-99`, `1330-1332`) — used to detect federal
+ * `§§ N-M` ranges. State-style hyphenated sections (`19.2-81`, `32A-2-7`)
+ * are NOT matched: they either contain a dot (`19.2-81`), have a letter
+ * (`32A-2-7`), or have more than one hyphen (`41-2-2`). #564
+ */
+const PLAIN_NUMERIC_RANGE_RE = /^(\d+)-(\d+)$/
+
 export interface ParsedBody {
   section: string
+  /** Structured range end when section is a plain numeric range. #564 */
+  sectionRangeEnd?: string
   subsection?: string
   hasEtSeq: boolean
 }
@@ -39,13 +49,21 @@ export function parseBody(rawBody: string): ParsedBody {
   const subMatch = SUBSECTION_RE.exec(trimmed)
   const subGroups = subMatch?.[2]
 
+  const sectionBody = subMatch !== null && subGroups ? subMatch[1].trim() : trimmed
+
+  // Detect plain numeric range (e.g. `591-99`, `1330-1332`). Callers may use
+  // this to populate `sectionRange` and reset `section` to the start. #564
+  const rangeMatch = PLAIN_NUMERIC_RANGE_RE.exec(sectionBody)
+  const sectionRangeEnd = rangeMatch ? rangeMatch[2] : undefined
+
   if (subMatch !== null && subGroups) {
     return {
-      section: subMatch[1].trim(),
+      section: sectionBody,
+      sectionRangeEnd,
       subsection: subGroups,
       hasEtSeq,
     }
   }
 
-  return { section: trimmed, hasEtSeq }
+  return { section: sectionBody, sectionRangeEnd, hasEtSeq }
 }

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -546,10 +546,13 @@ export const statutePatterns: Pattern[] = [
     // optional uppercase-letter suffixes and optional parenthetical
     // subsection (`(A)`, `(B)`, `(1)`).
     id: "nm-bare-section",
+    // Subsection chain accepts decimals (`(1.5)`) and bracket subscripts
+    // (`[3]`) so `§ N-N-N(A)(1.5)` is captured in full. The dot inside
+    // parens was missing previously, dropping decimal subsections. (#565)
     regex:
-      /(?<![A-Za-z])(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9]+\))*)/g,
+      /(?<![A-Za-z])(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9.]+\)|\[[A-Za-z0-9.]+\])*)/g,
     description:
-      'New Mexico bare-section form: "Section 32A-2-7(A)" / "§ 41-2-2" — #382',
+      'New Mexico bare-section form: "Section 32A-2-7(A)" / "§ 41-2-2" — #382 (#565 decimal subsection)',
     type: "statute",
   },
   {

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -641,6 +641,18 @@ export class DocumentResolver {
     if (!citation.partyName) return undefined // Standalone supra — cannot resolve by party name
     const currentIndex = this.context.citationIndex
     const fullPartyName = this.normalizePartyName(citation.partyName)
+    const vSplit = fullPartyName.split(/\s+vs?\.\s+/)
+
+    if (vSplit.length === 2) {
+      const captionMatch = this.queryFullCaptionSupra(
+        vSplit[0].trim(),
+        vSplit[1].trim(),
+        currentIndex,
+      )
+      if (captionMatch) {
+        return this.createSupraSuccess(citation, captionMatch)
+      }
+    }
 
     // #504: split `Plaintiff v. Defendant` into individual party-name queries
     // so each half can match the BK-tree's per-name index. Querying the
@@ -648,7 +660,6 @@ export class DocumentResolver {
     // The combined query is kept first as a tiebreaker for non-caption forms
     // (e.g., `Walker & Horwich, supra` should still query the joined string).
     const queries: string[] = [fullPartyName]
-    const vSplit = fullPartyName.split(/\s+vs?\.\s+/)
     if (vSplit.length === 2) {
       for (const half of vSplit) {
         const trimmed = half.trim()
@@ -675,18 +686,64 @@ export class DocumentResolver {
       )
     }
 
+    return this.createSupraSuccess(citation, bestMatch)
+  }
+
+  private createSupraSuccess(
+    citation: SupraCitation,
+    match: { index: number; similarity: number },
+  ): ResolutionResult {
     // Return successful resolution with confidence based on similarity
     const warnings: string[] = []
-    if (bestMatch.similarity < 1.0) {
-      warnings.push(`Fuzzy match: similarity ${bestMatch.similarity.toFixed(2)}`)
+    if (match.similarity < 1.0) {
+      warnings.push(`Fuzzy match: similarity ${match.similarity.toFixed(2)}`)
     }
 
     return {
-      resolvedTo: bestMatch.index,
+      resolvedTo: match.index,
       antecedentIndex: this.findImmediatePredecessor(citation),
-      confidence: bestMatch.similarity,
+      confidence: match.similarity,
       warnings: warnings.length > 0 ? warnings : undefined,
     }
+  }
+
+  /**
+   * Match a full-caption supra (`Plaintiff v. Defendant, supra`) against a
+   * single prior case whose plaintiff and defendant both agree. This prevents
+   * an unrelated case with a stronger one-sided fuzzy match from beating the
+   * intended antecedent.
+   */
+  private queryFullCaptionSupra(
+    plaintiffQuery: string,
+    defendantQuery: string,
+    currentIndex: number,
+  ): { index: number; similarity: number } | undefined {
+    if (!plaintiffQuery || !defendantQuery) return undefined
+
+    let best: { index: number; similarity: number } | undefined
+    for (let i = currentIndex - 1; i >= 0; i--) {
+      const candidate = this.citations[i]
+      if (candidate.type !== "case") continue
+      if (!this.isWithinScope(i, currentIndex, true)) continue
+
+      const plaintiffSimilarity = this.partyNameSimilarity(
+        plaintiffQuery,
+        candidate.plaintiffNormalized ?? candidate.plaintiff,
+      )
+      const defendantSimilarity = this.partyNameSimilarity(
+        defendantQuery,
+        candidate.defendantNormalized ?? candidate.defendant,
+      )
+      if (plaintiffSimilarity < this.options.partyMatchThreshold) continue
+      if (defendantSimilarity < this.options.partyMatchThreshold) continue
+
+      const similarity = Math.min(plaintiffSimilarity, defendantSimilarity)
+      if (!best || similarity > best.similarity) {
+        best = { index: i, similarity }
+      }
+    }
+
+    return best
   }
 
   /**
@@ -726,6 +783,43 @@ export class DocumentResolver {
       }
     }
     return best
+  }
+
+  private partyNameSimilarity(query: string, candidate: string | undefined): number {
+    if (!candidate) return 0
+
+    const normalizedQuery = this.normalizePartyName(query)
+    const normalizedCandidate = this.normalizePartyName(candidate)
+    if (!normalizedQuery || !normalizedCandidate) return 0
+    if (normalizedQuery === normalizedCandidate) return 1.0
+    if (
+      this.containsTokenSequence(normalizedCandidate, normalizedQuery) ||
+      this.containsTokenSequence(normalizedQuery, normalizedCandidate)
+    ) {
+      return 0.95
+    }
+
+    const distance = levenshteinDistance(normalizedQuery, normalizedCandidate)
+    const maxLength = Math.max(normalizedQuery.length, normalizedCandidate.length)
+    return maxLength === 0 ? 1.0 : 1 - distance / maxLength
+  }
+
+  private containsTokenSequence(haystack: string, needle: string): boolean {
+    const haystackTokens = haystack.split(" ").filter(Boolean)
+    const needleTokens = needle.split(" ").filter(Boolean)
+    if (needleTokens.length === 0 || needleTokens.length > haystackTokens.length) return false
+
+    for (let i = 0; i <= haystackTokens.length - needleTokens.length; i++) {
+      let matches = true
+      for (let j = 0; j < needleTokens.length; j++) {
+        if (haystackTokens[i + j] !== needleTokens[j]) {
+          matches = false
+          break
+        }
+      }
+      if (matches) return true
+    }
+    return false
   }
 
   /**
@@ -1015,9 +1109,22 @@ export class DocumentResolver {
    * Normalizes party name for matching.
    */
   private normalizePartyName(name: string): string {
-    return name
+    let normalized = name
+
+    normalized = normalized.replace(/\bet\s+al\.?/gi, "")
+    normalized = normalized.replace(/\s+(?:d\/b\/a|[fna]\/k\/a)\b.*/gi, "")
+    normalized = normalized.replace(/\s+aka\b.*/gi, "")
+
+    let prev = ""
+    while (prev !== normalized) {
+      prev = normalized
+      normalized = normalized.replace(/,?\s*(Inc|LLC|Corp|Ltd|Co|LLP|LP|P\.C)\.?$/gi, "")
+    }
+
+    return normalized
+      .replace(/^(The|A|An)\s+/i, "")
       .toLowerCase()
-      .replace(/\s+/g, " ") // Normalize whitespace
+      .replace(/\s+/g, " ")
       .trim()
   }
 

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -459,6 +459,15 @@ export interface StatuteCitation extends CitationBase {
   title?: number
   code: string
   section: string
+  /**
+   * Structured representation of a `§§ N-M` range. Populated only for
+   * citations where the section field is unambiguously a numeric range
+   * (typically federal `28 U.S.C. §§ 591-99`). Hyphenated state-style
+   * sections (`19.2-81`, `32A-2-7`) are NOT ranges and leave this
+   * undefined. `start` is mirrored on the `section` field for backward
+   * compatibility. (#564)
+   */
+  sectionRange?: { start: string; end: string }
   /** Subsection/pincite chain, e.g. "(a)(1)(A)" */
   subsection?: string
   /** 2-letter state code or "US" when unambiguously identified */

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -464,7 +464,11 @@ export interface StatuteCitation extends CitationBase {
    * (#565, originally #531)
    */
   code?: string
-  section: string
+  /**
+   * Section identifier. Optional because some forms cite the chapter alone
+   * (e.g. Massachusetts `G.L. c. 93A` — see `chapter` below). #569
+   */
+  section?: string
   /**
    * Structured representation of a `§§ N-M` range. Populated only for
    * citations where the section field is unambiguously a numeric range
@@ -474,6 +478,13 @@ export interface StatuteCitation extends CitationBase {
    * compatibility. (#564)
    */
   sectionRange?: { start: string; end: string }
+  /**
+   * Chapter identifier for citations that use a chapter+section layout,
+   * notably Massachusetts (`G.L. c. 93A`, `M.G.L.A. c. 93, § 14`).
+   * Previously the chapter number was leaking into `code`; populated
+   * separately as of #569.
+   */
+  chapter?: string
   /** Subsection/pincite chain, e.g. "(a)(1)(A)" */
   subsection?: string
   /** 2-letter state code or "US" when unambiguously identified */

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -457,7 +457,13 @@ export interface FullCaseCitation extends CitationBase {
 export interface StatuteCitation extends CitationBase {
   type: "statute"
   title?: number
-  code: string
+  /**
+   * Code identifier (`U.S.C.`, `NMSA 1978`, `Penal`, etc.).
+   * Optional because bare-section citations with no nearby jurisdictional
+   * signal drop both `code` and `jurisdiction` rather than guessing.
+   * (#565, originally #531)
+   */
+  code?: string
   section: string
   /**
    * Structured representation of a `§§ N-M` range. Populated only for

--- a/src/utils/bluebook.ts
+++ b/src/utils/bluebook.ts
@@ -56,13 +56,22 @@ export function toBluebook(citation: Citation): string {
 
     case "statute": {
       const title = citation.title !== undefined ? `${citation.title} ` : ""
-      const section = `\u00A7 ${citation.section}`
+      // section may be absent (e.g. Massachusetts chapter-only like
+      // `G.L. c. 93A` \u2014 #569). Render the chapter form when present and
+      // omit the trailing `\u00A7 <section>` if there is no section.
+      const code = citation.code ? `${citation.code} ` : ""
+      const chapter = citation.chapter ? `c. ${citation.chapter}` : ""
       const subsection = citation.subsection ?? ""
       const etSeq = citation.hasEtSeq ? " et seq." : ""
-      // code may be undefined when the bare-section jurisdiction guard
-      // drops both code and jurisdiction (#565). Render as just `\u00A7 <section>`.
-      const code = citation.code ? `${citation.code} ` : ""
-      return `${title}${code}${section}${subsection}${etSeq}`
+      if (citation.section !== undefined && citation.section !== "") {
+        const section = `\u00A7 ${citation.section}`
+        const sep = chapter ? ", " : ""
+        return `${title}${code}${chapter}${sep}${section}${subsection}${etSeq}`
+      }
+      // chapter-only OR section absent: emit `code c. chapter` (Mass)
+      // or `code \u00A7` placeholder when neither field is present.
+      if (chapter) return `${title}${code}${chapter}${etSeq}`
+      return `${title}${code}\u00A7${etSeq}`
     }
 
     case "constitutional": {

--- a/src/utils/bluebook.ts
+++ b/src/utils/bluebook.ts
@@ -59,7 +59,10 @@ export function toBluebook(citation: Citation): string {
       const section = `\u00A7 ${citation.section}`
       const subsection = citation.subsection ?? ""
       const etSeq = citation.hasEtSeq ? " et seq." : ""
-      return `${title}${citation.code} ${section}${subsection}${etSeq}`
+      // code may be undefined when the bare-section jurisdiction guard
+      // drops both code and jurisdiction (#565). Render as just `\u00A7 <section>`.
+      const code = citation.code ? `${citation.code} ` : ""
+      return `${title}${code}${section}${subsection}${etSeq}`
     }
 
     case "constitutional": {

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2132,9 +2132,10 @@ describe("extractStatute", () => {
 
   describe("New Mexico bare-section form (#382)", () => {
     it("extracts `Section 32A-2-7(A)` (bare, letter-prefix first part)", () => {
-      const cites = extractCitations("Section 32A-2-7(A) requires.").filter(
-        (c) => c.type === "statute",
-      )
+      // With NMSA signal in scope, the bare-section claims NM.
+      const cites = extractCitations(
+        "Under NMSA 1978, Section 32A-2-7(A) requires.",
+      ).filter((c) => c.type === "statute")
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
         expect(cites[0].code).toBe("NMSA 1978")
@@ -2156,7 +2157,8 @@ describe("extractStatute", () => {
     })
 
     it("extracts `§ 41-2-2` (symbol form, no subsection)", () => {
-      const cites = extractCitations("See § 41-2-2.").filter(
+      // Requires NM context to claim NMSA — per #565 jurisdiction guard.
+      const cites = extractCitations("New Mexico law: see § 41-2-2.").filter(
         (c) => c.type === "statute",
       )
       expect(cites).toHaveLength(1)
@@ -2469,10 +2471,11 @@ describe("extractStatute", () => {
       }
     })
 
-    it("regression: NM bare-section `Section 32A-2-7(A)` still routes to NM", () => {
-      const cites = extractCitations("Section 32A-2-7(A) requires.").filter(
-        (c) => c.type === "statute",
-      )
+    it("regression: NM bare-section `Section 32A-2-7(A)` routes to NM with NM context", () => {
+      // Requires NM context per the #565 jurisdiction guard.
+      const cites = extractCitations(
+        "Under NMSA 1978, Section 32A-2-7(A) requires.",
+      ).filter((c) => c.type === "statute")
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
         expect(cites[0].jurisdiction).toBe("NM")
@@ -3303,14 +3306,16 @@ describe("extractStatute", () => {
       }
     })
 
-    it("bare-section with NO preceding context stays NM (default)", () => {
+    it("bare-section with NO preceding context drops jurisdiction (#565 guard)", () => {
+      // Previously defaulted to NM; the jurisdiction guard now drops the
+      // jurisdiction without an explicit NM signal nearby.
       const cites = extractCitations("Section 32A-2-7(A).").filter(
         (c) => c.type === "statute",
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].jurisdiction).toBe("NM")
-        expect(cites[0].code).toBe("NMSA 1978")
+        expect(cites[0].jurisdiction).toBeUndefined()
+        expect(cites[0].code).toBeUndefined()
       }
     })
 

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -393,12 +393,12 @@ describe("extractStatute", () => {
 
     it("does not regress fully-qualified `Cal. Penal Code § 148`", () => {
       // The fully-qualified form continues to go through extractNamedCode and
-      // produces its own `code` shape ("Penal"), so the bare-code extractor
-      // should not also fire.
+      // produces its own `code` shape ("Cal. Penal Code" — full identifier
+      // per #568), so the bare-code extractor should not also fire.
       const cits = extractCitations("violates Cal. Penal Code § 148.")
       expect(cits).toHaveLength(1)
       if (cits[0].type === "statute") {
-        expect(cits[0].code).toBe("Penal")
+        expect(cits[0].code).toBe("Cal. Penal Code")
         expect(cits[0].jurisdiction).toBe("CA")
       }
     })
@@ -750,8 +750,9 @@ describe("extractStatute", () => {
       const citations = extractCitations("Cal. Penal Code § 187")
       expect(citations).toHaveLength(1)
       if (citations[0].type === "statute") {
-        // named-code pattern now fires before state-code; code stores cleaned name
-        expect(citations[0].code).toBe("Penal")
+        // named-code pattern fires before state-code; code stores the full
+        // identifier (jurisdiction + body + Code/Law) per #568.
+        expect(citations[0].code).toBe("Cal. Penal Code")
         expect(citations[0].section).toBe("187")
         expect(citations[0].jurisdiction).toBe("CA")
       }
@@ -771,7 +772,7 @@ describe("extractStatute", () => {
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
         expect(cites[0].matchedText).toBe("California Penal Code § 549")
-        expect(cites[0].code).toBe("Penal")
+        expect(cites[0].code).toBe("California Penal Code")
         expect(cites[0].section).toBe("549")
         // matchedText must equal the slice from span coordinates
         const span = cites[0].span

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -1844,7 +1844,9 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("268A")
+        // #569 — chapter no longer leaks into code.
+        expect(cites[0].code).toBe("G.L.")
+        expect(cites[0].chapter).toBe("268A")
         expect(cites[0].jurisdiction).toBe("MA")
         expect(cites[0].section).toBe("25")
       }
@@ -1856,7 +1858,8 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("93A")
+        expect(cites[0].code).toBe("G.L.")
+        expect(cites[0].chapter).toBe("93A")
         expect(cites[0].jurisdiction).toBe("MA")
       }
     })
@@ -1867,9 +1870,12 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("93A")
+        // Spacing inside the corpus abbreviation collapses to "G. L." → "G. L."
+        // The chapter-only form leaves section undefined per #569.
+        expect(cites[0].code).toBe("G. L.")
+        expect(cites[0].chapter).toBe("93A")
         expect(cites[0].jurisdiction).toBe("MA")
-        expect(cites[0].section).toBe("")
+        expect(cites[0].section).toBeUndefined()
       }
     })
 
@@ -1879,7 +1885,8 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("90")
+        expect(cites[0].code).toBe("G.L.")
+        expect(cites[0].chapter).toBe("90")
         expect(cites[0].section).toBe("34M")
       }
     })
@@ -1890,7 +1897,8 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("272")
+        expect(cites[0].code).toBe("G.L.")
+        expect(cites[0].chapter).toBe("272")
         expect(cites[0].section).toBe("99E")
         expect(cites[0].subsection).toBe("(3)")
       }
@@ -1902,7 +1910,8 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("94C")
+        expect(cites[0].code).toBe("General Laws")
+        expect(cites[0].chapter).toBe("94C")
         expect(cites[0].section).toBe("32A")
         expect(cites[0].subsection).toBe("(a)")
       }
@@ -1914,7 +1923,8 @@ describe("extractStatute", () => {
       )
       expect(cites).toHaveLength(1)
       if (cites[0]?.type === "statute") {
-        expect(cites[0].code).toBe("93A")
+        expect(cites[0].code).toBe("Mass. Gen. Laws")
+        expect(cites[0].chapter).toBe("93A")
         expect(cites[0].jurisdiction).toBe("MA")
         expect(cites[0].section).toBe("2")
       }

--- a/tests/extract/issue464MtCoBareSection.test.ts
+++ b/tests/extract/issue464MtCoBareSection.test.ts
@@ -55,12 +55,15 @@ describe("issue #464 — MT/CO bare-section context routing", () => {
       expect(sts[1].jurisdiction).toBe("CO")
     })
 
-    it("bare `§ 13-25-130` with NO Colorado context still routes NM (default preserved)", () => {
+    it("bare `§ 13-25-130` with NO Colorado context drops jurisdiction (#565)", () => {
+      // Pre-#565 this defaulted to NM; the jurisdiction guard now drops
+      // jurisdiction/code without a Colorado or NM signal nearby.
       const text = "§ 13-25-130 alone."
       const cites = extractCitations(text)
       const sts = statutes(cites)
       expect(sts).toHaveLength(1)
-      expect(sts[0].jurisdiction).toBe("NM")
+      expect(sts[0].jurisdiction).toBeUndefined()
+      expect(sts[0].code).toBeUndefined()
     })
   })
 

--- a/tests/extract/issue563BarePluralSection.test.ts
+++ b/tests/extract/issue563BarePluralSection.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+/**
+ * #563 — `§§ X, Y, Z` lists without an explicit code prefix produce ZERO
+ * citations. `expandPluralSectionList` only runs *after* a head citation
+ * exists. Bare-prefix lists (`Code §§ 19.2-81 and 18.2-266`, or naked
+ * `§§ 12940, 12945`) never establish a head, so the entire list is dropped.
+ *
+ * Fix: extend the statute patterns / expander so a bare `§§ N, N[, N]…`
+ * sequence emits one StatuteCitation per section (with `code` defaulting
+ * to a generic value and jurisdiction left undefined when not derivable).
+ */
+describe("issue #563 — bare-prefix `§§` lists without code prefix", () => {
+  describe("naked `§§ N, N` lists", () => {
+    it("`§§ 12940, 12945` emits two citations", () => {
+      const text = "See §§ 12940, 12945 for related provisions."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(2)
+      expect(cites.map((s) => s.section)).toEqual(["12940", "12945"])
+    })
+
+    it("three-section list `§§ 100, 200, 300` emits three citations", () => {
+      const text = "See §§ 100, 200, 300."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(3)
+      expect(cites.map((s) => s.section)).toEqual(["100", "200", "300"])
+    })
+
+    it("`§§ N and N` (and-connector) emits two citations", () => {
+      const text = "Cf. §§ 18-8004 and 18-8005."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(2)
+      expect(cites.map((s) => s.section)).toEqual(["18-8004", "18-8005"])
+    })
+  })
+
+  describe("generic `Code §§ N, N` (no jurisdiction prefix)", () => {
+    it("`Code §§ 19.2-81 and 18.2-266` emits two citations", () => {
+      const text = "See Code §§ 19.2-81 and 18.2-266."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(2)
+      expect(cites.map((s) => s.section)).toEqual(["19.2-81", "18.2-266"])
+    })
+  })
+
+  describe("regression — already-handled forms still work", () => {
+    it("`Cal. Gov. Code §§ 12940, 12945` still works (named-code head)", () => {
+      const text = "See Cal. Gov. Code §§ 12940, 12945."
+      const cites = statutes(extractCitations(text))
+      expect(cites.length).toBeGreaterThanOrEqual(2)
+      const sections = cites.map((s) => s.section)
+      expect(sections).toContain("12940")
+      expect(sections).toContain("12945")
+    })
+
+    it("singular `§ 1331` alone in prose is NOT extracted (no head)", () => {
+      // A lone `§ 1331` with no surrounding code identifier is too ambiguous —
+      // this regression keeps us from inventing citations from any "§".
+      const text = "See § 1331."
+      const cites = statutes(extractCitations(text))
+      // Either zero (preferred — singular bare-§ is too ambiguous) or one;
+      // do NOT regress to multiple false positives.
+      expect(cites.length).toBeLessThanOrEqual(1)
+    })
+  })
+})

--- a/tests/extract/issue564SectionRange.test.ts
+++ b/tests/extract/issue564SectionRange.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+/**
+ * #564 — `§§ N-M` range form emits one cite with `section="591-99"` instead
+ * of a structured range.
+ *
+ * `28 U.S.C. §§ 591-99 (2000)` currently produces a single citation with
+ * `section="591-99"`, which is ambiguous because hyphenated state-style
+ * section numbers (e.g. Virginia's `19.2-81`) use the same shape. The fix
+ * populates a structured `sectionRange: { start, end }` field whenever the
+ * hyphen is unambiguously a range (purely numeric ends on a federal-style
+ * §§ cite); `section` continues to hold the start so existing consumers
+ * keep working.
+ *
+ * Hyphenated state-style sections (`19.2-81`, `41-2-2`) are NOT ranges —
+ * they remain as a single section with `sectionRange` undefined.
+ */
+describe("issue #564 — `§§ N-M` range form", () => {
+  describe("federal `§§` ranges (no dots) produce sectionRange", () => {
+    it("`28 U.S.C. §§ 591-99` emits sectionRange={start:'591',end:'99'}", () => {
+      const text = "28 U.S.C. §§ 591-99 (2000)"
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      const c = cites[0]
+      expect(c.section).toBe("591")
+      expect(c.sectionRange).toEqual({ start: "591", end: "99" })
+    })
+
+    it("`28 U.S.C. §§ 1330-1332` emits sectionRange", () => {
+      const text = "See 28 U.S.C. §§ 1330-1332."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      const c = cites[0]
+      expect(c.section).toBe("1330")
+      expect(c.sectionRange).toEqual({ start: "1330", end: "1332" })
+    })
+
+    it("`42 U.S.C. §§ 1983-1988` (legacy regression)", () => {
+      const text = "42 U.S.C. §§ 1983-1988"
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      const c = cites[0]
+      expect(c.section).toBe("1983")
+      expect(c.sectionRange).toEqual({ start: "1983", end: "1988" })
+    })
+  })
+
+  describe("hyphenated state-style sections are NOT ranges", () => {
+    it("`Va. Code Ann. § 19.2-81` keeps single section, no sectionRange", () => {
+      const text = "Va. Code Ann. § 19.2-81"
+      const cites = statutes(extractCitations(text))
+      expect(cites.length).toBeGreaterThanOrEqual(1)
+      const c = cites[0]
+      expect(c.section).toBe("19.2-81")
+      expect(c.sectionRange).toBeUndefined()
+    })
+
+    it("`Section 32A-2-7(A)` (NM three-hyphen) is not a range", () => {
+      const text = "Some NMSA prose. Section 32A-2-7."
+      const cites = statutes(extractCitations(text))
+      const target = cites.find((c) => c.section === "32A-2-7")
+      expect(target).toBeDefined()
+      expect(target?.sectionRange).toBeUndefined()
+    })
+  })
+
+  describe("singular `§` (regression)", () => {
+    it("`28 U.S.C. § 1331` does not set sectionRange", () => {
+      const text = "28 U.S.C. § 1331"
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      expect(cites[0].sectionRange).toBeUndefined()
+    })
+  })
+})

--- a/tests/extract/issue565NmDecimalSubsection.test.ts
+++ b/tests/extract/issue565NmDecimalSubsection.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+/**
+ * #565 — `§ N(1.5)` decimal subsection dropped, and the NM bare-section
+ * dispatcher mis-routes to NMSA even when no NM context is present.
+ *
+ * Two bugs:
+ *   1. `nm-bare-section` subsection regex doesn't accept `.` inside parens,
+ *      so `§ 32A-2-7(A)(1.5)` loses the `(1.5)` portion of the subsection.
+ *   2. The default NM jurisdiction tag fires without any NM signal nearby
+ *      (similar to the #531 issue). Without a `NMSA`, `N.M.`, or
+ *      `New Mexico` signal within ~200 chars, the bare-section cite should
+ *      drop `jurisdiction` / `code` rather than claim NM.
+ */
+describe("issue #565 — NM bare-section decimal subsection + jurisdiction guard", () => {
+  describe("decimal subsection captured", () => {
+    it("`NMSA 1978, § 32A-2-7(A)(1.5)` keeps full subsection", () => {
+      const text = "See NMSA 1978, § 32A-2-7(A)(1.5)."
+      const cites = statutes(extractCitations(text))
+      const nm = cites.find((c) => c.code === "NMSA 1978")
+      expect(nm).toBeDefined()
+      expect(nm?.subsection).toBe("(A)(1.5)")
+    })
+
+    it("decimal-only subsection `§ N(1.5)` captured", () => {
+      // Even with NM context, decimal in subsection must not be dropped.
+      const text = "NMSA 1978: see § 11-2-3(1.5) for details."
+      const cites = statutes(extractCitations(text))
+      const nm = cites.find((c) => c.section === "11-2-3")
+      expect(nm).toBeDefined()
+      expect(nm?.subsection).toBe("(1.5)")
+    })
+  })
+
+  describe("jurisdiction guard — drop NM without NM context", () => {
+    it("bare `§ 32A-2-7(A)` with NO NM context drops jurisdiction", () => {
+      const text = "Some unrelated prose. § 32A-2-7(A) further provides..."
+      const cites = statutes(extractCitations(text))
+      expect(cites.length).toBeGreaterThanOrEqual(1)
+      const bare = cites.find((c) => c.section === "32A-2-7")
+      expect(bare).toBeDefined()
+      // No NM signal nearby → must NOT claim NM. Consumers can't trust a guess.
+      expect(bare?.jurisdiction).toBeUndefined()
+      expect(bare?.code).toBeUndefined()
+    })
+
+    it("bare `§ N-N-N` after NMSA context keeps NM", () => {
+      const text =
+        "NMSA 1978, § 32A-2-1 establishes. Section 32A-2-7(A) further provides."
+      const cites = statutes(extractCitations(text))
+      const bare = cites.find(
+        (c) => c.section === "32A-2-7" && c.matchedText.startsWith("Section"),
+      )
+      expect(bare).toBeDefined()
+      expect(bare?.jurisdiction).toBe("NM")
+      expect(bare?.code).toBe("NMSA 1978")
+    })
+
+    it("bare `§ N-N-N` after `New Mexico` context keeps NM", () => {
+      const text = "The New Mexico statute § 41-2-2 provides..."
+      const cites = statutes(extractCitations(text))
+      const bare = cites.find((c) => c.section === "41-2-2")
+      expect(bare).toBeDefined()
+      expect(bare?.jurisdiction).toBe("NM")
+    })
+  })
+})

--- a/tests/extract/issue566EtSeqFanout.test.ts
+++ b/tests/extract/issue566EtSeqFanout.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+/**
+ * #566 — `hasEtSeq` leaks / drops in `expandPluralSectionList` fanout.
+ *
+ * The expander spreads the head citation's metadata to siblings via
+ * `{ ...cite, ... }` spread. `hasEtSeq` rides along even when the
+ * `et seq.` token actually applies only to ONE specific section.
+ *
+ * Fix: inspect the source text around each emitted sibling to decide
+ * whether the `et seq.` modifies it. Only the section the `et seq.`
+ * immediately follows should carry `hasEtSeq=true`.
+ */
+describe("issue #566 — hasEtSeq fanout in plural §§ lists", () => {
+  it("`§§ 1331, 1332 et seq.` — only the LAST section gets hasEtSeq", () => {
+    const text = "28 U.S.C. §§ 1331, 1332 et seq."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(2)
+    const s1331 = cites.find((c) => c.section === "1331")
+    const s1332 = cites.find((c) => c.section === "1332")
+    expect(s1331).toBeDefined()
+    expect(s1332).toBeDefined()
+    // 1331 was NOT modified by `et seq.` — it should not carry the flag.
+    expect(s1331?.hasEtSeq).toBeFalsy()
+    // 1332 was — it should.
+    expect(s1332?.hasEtSeq).toBe(true)
+  })
+
+  it("`§§ 12940 et seq., 12945` — only the FIRST (head) gets hasEtSeq", () => {
+    const text = "Cal. Gov. Code §§ 12940 et seq., 12945 applies."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(2)
+    const s12940 = cites.find((c) => c.section === "12940")
+    const s12945 = cites.find((c) => c.section === "12945")
+    expect(s12940?.hasEtSeq).toBe(true)
+    expect(s12945?.hasEtSeq).toBeFalsy()
+  })
+
+  it("`§§ 100, 200, 300 et seq.` — only `300` gets hasEtSeq", () => {
+    const text = "28 U.S.C. §§ 100, 200, 300 et seq."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(3)
+    const s100 = cites.find((c) => c.section === "100")
+    const s200 = cites.find((c) => c.section === "200")
+    const s300 = cites.find((c) => c.section === "300")
+    expect(s100?.hasEtSeq).toBeFalsy()
+    expect(s200?.hasEtSeq).toBeFalsy()
+    expect(s300?.hasEtSeq).toBe(true)
+  })
+
+  it("no `et seq.` anywhere — no fanout flag", () => {
+    const text = "28 U.S.C. §§ 1331, 1332."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(2)
+    for (const s of cites) expect(s.hasEtSeq).toBeFalsy()
+  })
+
+  it("regression — `42 U.S.C. § 1983 et seq.` (singular) still works", () => {
+    const text = "42 U.S.C. § 1983 et seq."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(1)
+    expect(cites[0].hasEtSeq).toBe(true)
+  })
+})

--- a/tests/extract/issue567BareShortFormStatute.test.ts
+++ b/tests/extract/issue567BareShortFormStatute.test.ts
@@ -41,7 +41,8 @@ describe("issue #567 — bare `§ N` short-form statute after full cite", () => 
     expect(cites).toHaveLength(2)
     const ref = cites[1]
     expect(ref.section).toBe("264")
-    expect(ref.code).toBe("Penal")
+    // code carries the full identifier per #568.
+    expect(ref.code).toBe("Cal. Penal Code")
     expect(ref.jurisdiction).toBe("CA")
   })
 

--- a/tests/extract/issue567BareShortFormStatute.test.ts
+++ b/tests/extract/issue567BareShortFormStatute.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+/**
+ * #567 — Cross-reference forms like `§ X; see also § Y` drop the bare
+ * second `§`. After a full statute citation establishes a code, follow-on
+ * bare `§ N` should be treated as a short-form statute reference that
+ * inherits title / code / jurisdiction from its antecedent.
+ */
+describe("issue #567 — bare `§ N` short-form statute after full cite", () => {
+  it("`42 U.S.C. § 1983; see also § 1985` produces 2 cites", () => {
+    const text = "See 42 U.S.C. § 1983; see also § 1985."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(2)
+    const head = cites[0]
+    const ref = cites[1]
+    expect(head.section).toBe("1983")
+    expect(ref.section).toBe("1985")
+    // The bare reference inherits title / code from the antecedent.
+    expect(ref.title).toBe(42)
+    expect(ref.code).toBe("U.S.C.")
+    expect(ref.jurisdiction).toBe("US")
+  })
+
+  it("`28 U.S.C. § 1331; § 1332` (semicolon connector) produces 2 cites", () => {
+    const text = "See 28 U.S.C. § 1331; § 1332."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(2)
+    expect(cites[1].section).toBe("1332")
+    expect(cites[1].code).toBe("U.S.C.")
+    expect(cites[1].title).toBe(28)
+  })
+
+  it("`Cal. Penal Code § 220; see also § 264` inherits Cal. Penal", () => {
+    const text = "Cal. Penal Code § 220; see also § 264."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(2)
+    const ref = cites[1]
+    expect(ref.section).toBe("264")
+    expect(ref.code).toBe("Penal")
+    expect(ref.jurisdiction).toBe("CA")
+  })
+
+  it("`42 U.S.C. § 1983. § 1985 also.` (sentence boundary) inherits", () => {
+    const text = "See 42 U.S.C. § 1983. § 1985 also applies."
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(2)
+    expect(cites[1].section).toBe("1985")
+    expect(cites[1].title).toBe(42)
+    expect(cites[1].code).toBe("U.S.C.")
+  })
+
+  describe("regression", () => {
+    it("bare `§ N-N-N` with no antecedent still gates by jurisdiction (#565)", () => {
+      const text = "Bare § 32A-2-7(A) standalone."
+      const cites = statutes(extractCitations(text))
+      // The NM guard from #565 drops jurisdiction — and there's no
+      // antecedent to inherit from, so jurisdiction stays undefined.
+      const bare = cites.find((c) => c.section === "32A-2-7")
+      expect(bare?.jurisdiction).toBeUndefined()
+    })
+
+    it("no bare-§ after a full cite — no spurious cites", () => {
+      const text = "42 U.S.C. § 1983 is the cause of action."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+    })
+  })
+})

--- a/tests/extract/issue568FullCodeIdentifier.test.ts
+++ b/tests/extract/issue568FullCodeIdentifier.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+/**
+ * #568 — Named-code citations dropped jurisdiction + the literal `Code` /
+ * `Law` suffix, leaving a bare body-name as `code` that loses context:
+ *
+ *   `Cal. Civ. Code § 51`     → code="Civ."          ← should be "Cal. Civ. Code"
+ *   `Cal. Penal Code § 187`   → code="Penal"         ← should be "Cal. Penal Code"
+ *   `N.Y. Penal Law § 120.05` → code="Penal Law"     ← should be "N.Y. Penal Law"
+ *
+ * Fix: `extractNamedCode` now retains the full jurisdiction prefix + body +
+ * suffix in `code`. The body-only short form moves to `codeName` so consumers
+ * that wanted it can still get the body.
+ */
+describe("issue #568 — named-code retains full identifier in `code`", () => {
+  it("`Cal. Civ. Code § 51` → code='Cal. Civ. Code'", () => {
+    const text = "Cal. Civ. Code § 51"
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(1)
+    expect(cites[0].code).toBe("Cal. Civ. Code")
+    expect(cites[0].jurisdiction).toBe("CA")
+  })
+
+  it("`Cal. Penal Code § 187` → code='Cal. Penal Code'", () => {
+    const text = "Cal. Penal Code § 187"
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(1)
+    expect(cites[0].code).toBe("Cal. Penal Code")
+    expect(cites[0].jurisdiction).toBe("CA")
+  })
+
+  it("`California Civil Code § 51` → code='California Civil Code'", () => {
+    const text = "California Civil Code § 51"
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(1)
+    expect(cites[0].code).toBe("California Civil Code")
+    expect(cites[0].jurisdiction).toBe("CA")
+  })
+
+  it("`N.Y. Penal Law § 120.05` → code='N.Y. Penal Law'", () => {
+    const text = "N.Y. Penal Law § 120.05"
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(1)
+    expect(cites[0].code).toBe("N.Y. Penal Law")
+    expect(cites[0].jurisdiction).toBe("NY")
+  })
+
+  it("`Tex. Penal Code § 22.01` → code='Tex. Penal Code'", () => {
+    const text = "Tex. Penal Code § 22.01"
+    const cites = statutes(extractCitations(text))
+    expect(cites).toHaveLength(1)
+    expect(cites[0].code).toBe("Tex. Penal Code")
+  })
+
+  describe("regression — non-prefix forms", () => {
+    it("NY bare named-code `Penal Law § 120` keeps code='Penal Law'", () => {
+      const text = "Penal Law § 120 prohibits assault."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      // Bare NY law (no `N.Y.` prefix) — the code is just the body+Law suffix.
+      expect(cites[0].code).toContain("Penal Law")
+    })
+  })
+})

--- a/tests/extract/issue569MassChapter.test.ts
+++ b/tests/extract/issue569MassChapter.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation, StatuteCitation } from "@/types/citation"
+
+const statutes = (cites: Citation[]): StatuteCitation[] =>
+  cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+/**
+ * #569 — Massachusetts chapter-only citations like `G.L. c. 93A` placed
+ * the chapter NUMBER (`93A`) in the `code` field and set `section=""`.
+ * That conflates chapter and code identifiers.
+ *
+ * Fix: introduce a `chapter` field on `StatuteCitation`. For Massachusetts:
+ *   - `code` holds the corpus identifier as it appeared (`G.L.`,
+ *     `Mass. Gen. Laws`, etc.) — never the chapter number.
+ *   - `chapter` holds the chapter (`93A`).
+ *   - `section` is the section number when present, otherwise undefined
+ *     (NOT empty string).
+ */
+describe("issue #569 — Massachusetts chapter-only citation modeling", () => {
+  describe("chapter-only (no section)", () => {
+    it("`G.L. c. 93A` → code='G.L.', chapter='93A', section undefined", () => {
+      const text = "see G.L. c. 93A for the consumer-protection scheme."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      const c = cites[0]
+      expect(c.code).toBe("G.L.")
+      expect(c.chapter).toBe("93A")
+      expect(c.section).toBeUndefined()
+      expect(c.jurisdiction).toBe("MA")
+    })
+
+    it("`Mass. Gen. Laws ch. 93A` → code='Mass. Gen. Laws', chapter='93A'", () => {
+      const text = "See Mass. Gen. Laws ch. 93A."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      const c = cites[0]
+      expect(c.code).toBe("Mass. Gen. Laws")
+      expect(c.chapter).toBe("93A")
+      expect(c.section).toBeUndefined()
+    })
+  })
+
+  describe("chapter + section", () => {
+    it("`G.L. c. 93A, § 2` → chapter='93A', section='2'", () => {
+      const text = "G.L. c. 93A, § 2 provides..."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      const c = cites[0]
+      expect(c.code).toBe("G.L.")
+      expect(c.chapter).toBe("93A")
+      expect(c.section).toBe("2")
+    })
+
+    it("`M.G.L.A. c. 93, § 14` → chapter='93', section='14'", () => {
+      const text = "M.G.L.A. c. 93, § 14 applies."
+      const cites = statutes(extractCitations(text))
+      expect(cites).toHaveLength(1)
+      const c = cites[0]
+      expect(c.code).toBe("M.G.L.A.")
+      expect(c.chapter).toBe("93")
+      expect(c.section).toBe("14")
+    })
+  })
+
+  describe("code field never holds the chapter number", () => {
+    it("regression — code is never a numeric chapter", () => {
+      const samples = ["G.L. c. 93A", "Mass. Gen. Laws ch. 211", "G.L. c. 93A, § 2"]
+      for (const text of samples) {
+        const cites = statutes(extractCitations(text))
+        expect(cites.length).toBeGreaterThanOrEqual(1)
+        // code must not be a numeric-prefix chapter shape
+        expect(cites[0].code).not.toMatch(/^\d/)
+      }
+    })
+  })
+})

--- a/tests/extract/statutes/extractFederal.test.ts
+++ b/tests/extract/statutes/extractFederal.test.ts
@@ -65,9 +65,10 @@ describe("extractFederal", () => {
       expect(c.hasEtSeq).toBe(true)
     })
 
-    it("should handle section ranges with §§", () => {
+    it("should handle section ranges with §§ (structured range, #564)", () => {
       const c = extractFederal(makeToken("42 U.S.C. §§ 1983-1988", "usc"), map)
-      expect(c.section).toBe("1983-1988")
+      expect(c.section).toBe("1983")
+      expect(c.sectionRange).toEqual({ start: "1983", end: "1988" })
     })
 
     it("should handle alphanumeric sections", () => {

--- a/tests/extract/statutes/extractNamedCode.test.ts
+++ b/tests/extract/statutes/extractNamedCode.test.ts
@@ -95,13 +95,16 @@ describe("extractNamedCode", () => {
     it("should extract Mass. Gen. Laws ch. 93A, § 2", () => {
       const c = extractNamedCode(makeToken("Mass. Gen. Laws ch. 93A, § 2", "mass-chapter"), map)
       expect(c.jurisdiction).toBe("MA")
-      expect(c.code).toBe("93A")
+      // #569 — chapter no longer leaks into code.
+      expect(c.code).toBe("Mass. Gen. Laws")
+      expect(c.chapter).toBe("93A")
       expect(c.section).toBe("2")
     })
     it("should extract M.G.L.A. c. 93, § 14", () => {
       const c = extractNamedCode(makeToken("M.G.L.A. c. 93, § 14", "mass-chapter"), map)
       expect(c.jurisdiction).toBe("MA")
-      expect(c.code).toBe("93")
+      expect(c.code).toBe("M.G.L.A.")
+      expect(c.chapter).toBe("93")
       expect(c.section).toBe("14")
     })
   })

--- a/tests/fixtures/statute-corpus.json
+++ b/tests/fixtures/statute-corpus.json
@@ -225,6 +225,6 @@
   },
   {
     "text": "Mass. Gen. Laws ch. 93A, § 2",
-    "expected": [{ "type": "statute", "code": "93A", "section": "2", "jurisdiction": "MA" }]
+    "expected": [{ "type": "statute", "code": "Mass. Gen. Laws", "section": "2", "jurisdiction": "MA" }]
   }
 ]

--- a/tests/fixtures/statute-corpus.json
+++ b/tests/fixtures/statute-corpus.json
@@ -96,8 +96,8 @@
   },
   {
     "text": "Cal. Penal Code § 187",
-    "expected": [{ "type": "statute", "code": "Penal", "section": "187", "jurisdiction": "CA" }],
-    "note": "State citation — routed to named-code extractor; code stores cleaned name"
+    "expected": [{ "type": "statute", "code": "Cal. Penal Code", "section": "187", "jurisdiction": "CA" }],
+    "note": "State citation — routed to named-code extractor; code holds the full identifier (#568)"
   },
   {
     "text": "Fla. Stat. § 768.81(1)(a)",
@@ -182,7 +182,7 @@
     "expected": [
       {
         "type": "statute",
-        "code": "Penal Law",
+        "code": "N.Y. Penal Law",
         "section": "125.25",
         "subsection": "(1)(a)",
         "jurisdiction": "NY"

--- a/tests/resolve/issue504_supraFullCaption.test.ts
+++ b/tests/resolve/issue504_supraFullCaption.test.ts
@@ -67,4 +67,29 @@ describe("Issue #504: supra resolution with `Party v. Party` caption", () => {
     const supra = citations.find((c) => c.type === "supra")!
     expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(full))
   })
+
+  it("prefers the full-caption antecedent over an unrelated stronger split-half match", () => {
+    const text =
+      "Ruth Realty Co. v. Tax Commission, 222 Or. 290, 294, 353 P.2d 524 (1960). " +
+      "Crane v. Commissioner, 331 U.S. 1, 67 S. Ct. 1047, 91 L. Ed. 1301 (1946). " +
+      "Ruth Realty Co. v. Commission, supra."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const ruthIndex = citations.findIndex(
+      (c) => c.type === "case" && c.caseName === "Ruth Realty Co. v. Tax Commission",
+    )
+    const craneIndex = citations.findIndex(
+      (c) => c.type === "case" && c.caseName === "Crane v. Commissioner",
+    )
+    const supra = citations.find((c) => c.type === "supra")
+
+    expect(ruthIndex).not.toBe(-1)
+    expect(craneIndex).not.toBe(-1)
+    expect(supra).toBeDefined()
+    const resolvedTarget = citations[supra?.resolution?.resolvedTo ?? -1]
+    expect(resolvedTarget?.type).toBe("case")
+    if (resolvedTarget?.type === "case") {
+      expect(resolvedTarget.caseName).toBe("Ruth Realty Co. v. Tax Commission")
+    }
+    expect(supra?.resolution?.resolvedTo).not.toBe(craneIndex)
+  })
 })


### PR DESCRIPTION
## Summary

Seven statute subsection fixes from the CAP corpus audit, plus one resolver fix from the follow-up bug hunt.

| Issue | Fix |
|---|---|
| [#563](https://github.com/medelman17/eyecite-ts/issues/563) | New `detectBareSectionLists` — `Code §§ N, N` lists without explicit code prefix now emit citations |
| [#564](https://github.com/medelman17/eyecite-ts/issues/564) | `§§ N-M` federal ranges populate new `sectionRange: { start, end }` field |
| [#565](https://github.com/medelman17/eyecite-ts/issues/565) | NM bare-section accepts decimal subsections (`(1.5)`); jurisdiction guard prevents NM mis-attribution |
| [#566](https://github.com/medelman17/eyecite-ts/issues/566) | Only the owning sibling carries `hasEtSeq` in `§§` lists (no more leak/drop) |
| [#567](https://github.com/medelman17/eyecite-ts/issues/567) | Bare `§ N` after a full statute citation is now extracted as a short-form ref (inherits code from antecedent) |
| [#568](https://github.com/medelman17/eyecite-ts/issues/568) | `Cal. Civ. Code § N` now produces `code="Cal. Civ. Code"` (not just `"Civ."`) |
| [#569](https://github.com/medelman17/eyecite-ts/issues/569) | Mass `G.L. c. 93A` now populates new `chapter` field; `code` no longer gets the chapter number |
| follow-up | `Plaintiff v. Defendant, supra` now prefers an antecedent whose plaintiff and defendant both match, preventing unrelated stronger one-sided fuzzy matches |

## Type changes

- `StatuteCitation.code` is now `string | undefined`
- `StatuteCitation.section` is now `string | undefined`
- New `StatuteCitation.chapter?: string`
- New `StatuteCitation.sectionRange?: { start, end }`

## Release notes

Eight patch changesets:

- seven for the statute issue cluster
- one for the full-caption `supra` resolver fix

## Test plan

- [x] `pnpm exec vitest run` — 3178 passed, 9 skipped
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm exec biome check src/resolve/DocumentResolver.ts tests/resolve/issue504_supraFullCaption.test.ts` — exits 0; reports pre-existing non-null assertion warnings in the test file
