### PR TITLE
fix(extract): flag line-crossing cites as FP + strip fullSpan overshoot (#547)

### DIFF
--- a/.changeset/fix-547-fullspan-line-crossing.md
+++ b/.changeset/fix-547-fullspan-line-crossing.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `fullSpan` overshoot into preceding prose on regex false-positive citations (#547).
+
+The broad state-reporter regex (`\d+ Capitalized+ \d+`) sometimes matched volume-reporter-page shapes that straddled a hard line break in the source — section headings concatenated with body sentences (`2. Denials of 1-602 Applications\nOn October 19`), form-field addresses (`5713 Monona Drive\nMonona WI 53716`), and smart-quote-artifact rule references (`56\nFed. R. Civ.' P. 56`). The cleaner collapsed `\n` to space, so the tokenizer never saw the break. The case-name backward scan then absorbed the preceding heading or form-label line into `caseName` and extended `fullSpan` across it, producing user-visible spans that mixed unrelated prose into the citation.
+
+`applyFalsePositiveFilters` now inspects the original (pre-cleaning) source text. A `case` (or `shortFormCase`) citation whose original-text span contains a `\n` is treated as a structural false positive — real reporter abbreviations never wrap a line break, and OCR-wrapped citations like `F. Sup-\np. 3d` are already stitched by `rejoinHyphenatedWords` before whitespace normalization. Flagged citations get confidence `0.1` plus a `#547` warning; their `fullSpan` is stripped so downstream consumers (`annotate`, `citationBounds`, `document/proseOffsets`) fall back to the cite-core span instead of surfacing surrounding prose. With `filterFalsePositives: true`, the phantom is dropped entirely. Across 758 case citations in a 100-opinion CAP sample, every cite crossing a newline was a confirmed false positive — no observed false negatives.
+
+`applyFalsePositiveFilters` gained an optional third parameter `originalText`; existing call sites that pass only two arguments continue to work, with the line-crossing check skipped.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -487,8 +487,15 @@ export function extractCitations(
   // only scan backward for citations that still lack a signal.
   detectLeadingSignals(citations, cleaned)
 
-  // Step 4.9: Apply false positive filters (blocklist + year heuristic)
-  const filtered = applyFalsePositiveFilters(citations, options?.filterFalsePositives ?? false)
+  // Step 4.9: Apply false positive filters (blocklist + year heuristic).
+  // Passing `text` (the original pre-cleaning input) lets the filter detect
+  // citations whose span crosses a hard line break in the source — those are
+  // structural false positives that the cleaner makes invisible (#547).
+  const filtered = applyFalsePositiveFilters(
+    citations,
+    options?.filterFalsePositives ?? false,
+    text,
+  )
 
   // Step 4.95: Tag citations with footnote metadata
   if (cleanFootnoteMap) {

--- a/src/extract/filterFalsePositives.ts
+++ b/src/extract/filterFalsePositives.ts
@@ -324,15 +324,50 @@ function isSuspiciousSmallVolume(citation: Citation): boolean {
 }
 
 /**
+ * Issue #547: A `case` (or `shortFormCase`) citation whose original-text span
+ * contains a `\n` is a structural false positive.
+ *
+ * Real reporter abbreviations are atomic — they never wrap a hard line break,
+ * and a single citation's volume-reporter-page core is short enough to fit on
+ * one line in any reasonable formatting. (Truly OCR-wrapped citations like
+ * `F. Sup-\np. 3d` are stitched by `rejoinHyphenatedWords` before whitespace
+ * normalization, leaving no `\n` inside the span.) When the cleaner collapses
+ * `\n` → space, the broad state-reporter tokenizer can match across the
+ * (now-invisible) line break — pulling section headings, form-label lines,
+ * or address blocks into a phantom citation. Across 758 case citations in a
+ * 100-opinion CAP sample, every cite crossing a newline was a confirmed
+ * false positive.
+ *
+ * Requires the original `text` to inspect the pre-cleaning slice. Returns
+ * false when `originalText` is not provided (preserves backward compatibility
+ * for callers that hold only the parsed citation).
+ */
+function isLineCrossingCitation(citation: Citation, originalText?: string): boolean {
+  if (!originalText) return false
+  if (citation.type !== "case" && citation.type !== "shortFormCase") return false
+  const { originalStart, originalEnd } = citation.span
+  if (
+    originalStart < 0 ||
+    originalEnd > originalText.length ||
+    originalEnd <= originalStart
+  ) {
+    return false
+  }
+  const nlIdx = originalText.indexOf("\n", originalStart)
+  return nlIdx !== -1 && nlIdx < originalEnd
+}
+
+/**
  * Check if a citation is a likely false positive (short-circuit, no allocations).
  */
-function isFalsePositive(citation: Citation): boolean {
+function isFalsePositive(citation: Citation, originalText?: string): boolean {
   const reporter = getReporter(citation)
   if (reporter && BLOCKED_REPORTERS.has(reporter.toLowerCase().trim())) return true
   if (reporter && (citation.type === "case" || citation.type === "shortFormCase") && isImplausibleReporter(reporter)) return true
   if (isImplausibleVolume(citation)) return true
   if (isDocketNumberVolume(citation)) return true
   if (isSuspiciousSmallVolume(citation)) return true
+  if (isLineCrossingCitation(citation, originalText)) return true
 
   const year = getYear(citation)
   if (year !== undefined && year < MIN_PLAUSIBLE_YEAR) return true
@@ -345,7 +380,7 @@ function isFalsePositive(citation: Citation): boolean {
  * Returns an empty array if the citation is clean.
  * Only called in penalize mode where we need the reason strings for warnings.
  */
-function collectFalsePositiveReasons(citation: Citation): string[] {
+function collectFalsePositiveReasons(citation: Citation, originalText?: string): string[] {
   const reasons: string[] = []
 
   const reporter = getReporter(citation)
@@ -380,6 +415,12 @@ function collectFalsePositiveReasons(citation: Citation): string[] {
     )
   }
 
+  if (isLineCrossingCitation(citation, originalText)) {
+    reasons.push(
+      "Citation span crosses a hard line break in the source — likely a section heading, form field, or address mis-tokenized as volume + reporter + page (issue #547)",
+    )
+  }
+
   const year = getYear(citation)
   if (year !== undefined && year < MIN_PLAUSIBLE_YEAR) {
     reasons.push(`Year ${year} predates US legal reporting (threshold: ${MIN_PLAUSIBLE_YEAR})`)
@@ -393,9 +434,17 @@ function collectFalsePositiveReasons(citation: Citation): string[] {
  *
  * @param citations - Extracted citations (may be mutated in penalize mode)
  * @param remove - If true, remove flagged citations. If false, penalize confidence + add warning.
+ * @param originalText - Original (pre-cleaning) source text. Required for the
+ *   line-crossing check (#547) which inspects the raw bytes of the cite span.
+ *   When omitted, the line-crossing check is skipped to preserve backward
+ *   compatibility for callers that hold only parsed citations.
  * @returns Filtered array (same reference if remove=false, new array if remove=true and items removed)
  */
-export function applyFalsePositiveFilters(citations: Citation[], remove: boolean): Citation[] {
+export function applyFalsePositiveFilters(
+  citations: Citation[],
+  remove: boolean,
+  originalText?: string,
+): Citation[] {
   // Hard-reject pass: unconditionally drop unambiguous garbage like
   // `<day> <Month> <year>` date misparses (#302). These are never legitimate
   // citations under any policy, so they should not survive even when the
@@ -403,14 +452,14 @@ export function applyFalsePositiveFilters(citations: Citation[], remove: boolean
   const hardFiltered = citations.filter((c) => !isMonthNameDateMisparse(c))
 
   if (remove) {
-    return hardFiltered.filter((c) => !isFalsePositive(c))
+    return hardFiltered.filter((c) => !isFalsePositive(c, originalText))
   }
 
   for (const citation of hardFiltered) {
     // Skip if already penalized (idempotency guard)
     if (citation.confidence === FLAGGED_CONFIDENCE && citation.warnings?.length) continue
 
-    const reasons = collectFalsePositiveReasons(citation)
+    const reasons = collectFalsePositiveReasons(citation, originalText)
     if (reasons.length > 0) {
       citation.confidence = FLAGGED_CONFIDENCE
       const warnings: Warning[] = reasons.map((message) => ({
@@ -419,6 +468,18 @@ export function applyFalsePositiveFilters(citations: Citation[], remove: boolean
         position: { start: citation.span.originalStart, end: citation.span.originalEnd },
       }))
       citation.warnings = [...(citation.warnings || []), ...warnings]
+      // Strip `fullSpan` on flagged `case` citations (#547). The case-name
+      // backward scan that produced fullSpan ran against the same false-
+      // positive shape, so the span almost always overshoots into surrounding
+      // prose (section headings, form labels, addresses). Removing it lets
+      // downstream consumers (annotate, citationBounds, document/proseOffsets)
+      // fall back to the cite-core span, which remains internally consistent.
+      if (citation.type === "case") {
+        const caseCit = citation as FullCaseCitation
+        if (caseCit.fullSpan !== undefined) {
+          caseCit.fullSpan = undefined
+        }
+      }
     }
   }
 

--- a/tests/extract/issue547FullspanOvershoot.test.ts
+++ b/tests/extract/issue547FullspanOvershoot.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for issue #547: fullSpan overshoots into preceding prose on regex
+ * false-positive citations.
+ *
+ * Three CAP audit repros where the broad state-reporter regex matches
+ * `\d+\s+Capitalized+\s+\d+` shapes that straddle a hard line break in
+ * the original text:
+ *   1. f-supp-3d/232 0695-01: "1-602 Applications\nOn October 19"
+ *      — section-heading + body sentence concatenated by cleaner
+ *   2. frd/231 0550-01:       "5713 Monona Drive\nMonona WI 53716"
+ *      — form-field address spanning lines
+ *   3. f-supp-3d/150 0228-01: "56\nFed. R. Civ.' P. 56"
+ *      — section heading + smart-quote-artifact rule reference
+ *
+ * Root cause: the cleaner collapses `\n` to space, hiding the line break in
+ * cleaned text. The broad state-reporter tokenizer happily matches across
+ * the (now-invisible) line break. The case-name backward scanner then pulls
+ * the preceding heading/form-label line into `caseName` / `fullSpan`.
+ *
+ * Fix: a `case` (or `shortFormCase`) citation whose original-text span
+ * contains `\n` is a structural false positive. Real reporter abbreviations
+ * are atomic — they never wrap a hard line break, and the body of a single
+ * citation (volume + reporter + page) is short enough to fit on one line in
+ * any reasonable formatting. (Truly wrapped citations are stitched by
+ * `rejoinHyphenatedWords` before whitespace normalization.)
+ *
+ * Across 758 case citations in 100 random CAP opinions, exactly 3 cross a
+ * newline — and all 3 are obvious false positives (confidence ≤ 0.2 before
+ * this fix). Zero observed false negatives.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import { applyFalsePositiveFilters } from "@/extract/filterFalsePositives"
+import { loadReporters } from "@/data/reporters"
+import type { FullCaseCitation } from "@/types/citation"
+import type { Span } from "@/types/span"
+
+/** Helper to create a minimal case citation with explicit original-text span */
+function makeCaseAt(
+  reporter: string,
+  volume: number | string,
+  page: number,
+  originalStart: number,
+  originalEnd: number,
+): FullCaseCitation {
+  const span: Span = {
+    cleanStart: originalStart,
+    cleanEnd: originalEnd,
+    originalStart,
+    originalEnd,
+  }
+  return {
+    type: "case",
+    text: "",
+    span,
+    confidence: 0.8,
+    matchedText: "",
+    processTimeMs: 0,
+    patternsChecked: 1,
+    volume,
+    reporter,
+    page,
+  }
+}
+
+describe("issue #547: fullSpan overshoots on line-crossing false positives", () => {
+  beforeAll(async () => {
+    await loadReporters()
+  })
+
+  describe("unit: applyFalsePositiveFilters detects newline in cite span", () => {
+    it("flags a case cite whose original-text slice contains \\n (penalize mode)", () => {
+      const text = "foo 100 Bar\nBaz 5 qux"
+      // matched: "100 Bar\nBaz 5" at offsets [4, 17]
+      const cit = makeCaseAt("Bar Baz", 100, 5, 4, 17)
+      const result = applyFalsePositiveFilters([cit], false, text)
+      expect(result).toHaveLength(1)
+      expect(result[0].confidence).toBe(0.1)
+      const lineWarning = result[0].warnings?.find((w) =>
+        w.message.toLowerCase().includes("line break"),
+      )
+      expect(lineWarning, "should attach a line-break warning").toBeDefined()
+    })
+
+    it("removes a line-crossing cite in remove mode", () => {
+      // text positions matter: lineCrossing spans the \n; the clean F.2d
+      // cite (offsets [27, 39]) lives entirely AFTER the \n on a single line.
+      const text = "foo 100 Bar\nBaz 5 quxxxxxxx 500 F.2d 123 (1990)"
+      //            0         1         2         3         4
+      //            0123456789012345678901234567890123456789012345678
+      const lineCrossing = makeCaseAt("Bar Baz", 100, 5, 4, 17)
+      const valid = makeCaseAt("F.2d", 500, 123, 28, 40)
+      // sanity: confirm test fixture spans
+      expect(text.slice(4, 17)).toContain("\n")
+      expect(text.slice(28, 40)).toBe("500 F.2d 123")
+      const result = applyFalsePositiveFilters([lineCrossing, valid], true, text)
+      expect(result).toHaveLength(1)
+      expect((result[0] as FullCaseCitation).reporter).toBe("F.2d")
+    })
+
+    it("does NOT flag a cite whose original-text slice has no newline", () => {
+      const text = "Smith v. Jones, 500 F.2d 123 (1990)"
+      const cit = makeCaseAt("F.2d", 500, 123, 16, 28)
+      const result = applyFalsePositiveFilters([cit], false, text)
+      expect(result[0].confidence).toBe(0.8)
+      expect(result[0].warnings ?? []).toHaveLength(0)
+    })
+
+    it("strips fullSpan from a flagged line-crossing cite (penalize mode)", () => {
+      const text = "foo 100 Bar\nBaz 5 qux"
+      const cit = makeCaseAt("Bar Baz", 100, 5, 4, 17)
+      cit.fullSpan = {
+        cleanStart: 0,
+        cleanEnd: 17,
+        originalStart: 0,
+        originalEnd: 17,
+      }
+      const result = applyFalsePositiveFilters([cit], false, text)
+      expect(result[0].confidence).toBe(0.1)
+      expect((result[0] as FullCaseCitation).fullSpan).toBeUndefined()
+    })
+
+    it("preserves fullSpan on non-flagged cites", () => {
+      const text = "Smith v. Jones, 500 F.2d 123 (1990)"
+      const cit = makeCaseAt("F.2d", 500, 123, 16, 28)
+      cit.fullSpan = {
+        cleanStart: 0,
+        cleanEnd: 35,
+        originalStart: 0,
+        originalEnd: 35,
+      }
+      const result = applyFalsePositiveFilters([cit], false, text)
+      expect((result[0] as FullCaseCitation).fullSpan).toBeDefined()
+    })
+  })
+
+  describe("integration: repro 1 — section heading + body sentence", () => {
+    // From f-supp-3d/232 → json/0695-01.json
+    const text =
+      "SUMF ¶¶ 67, 70.\n" +
+      "2. Denials of 1-⅕85 and 1-602 Applications\n" +
+      "On October 19, 2015, USCIS issued Notices of Intent."
+
+    it("flags the line-crossing cite to confidence ≤ 0.1", () => {
+      const cits = extractCitations(text)
+      const phantom = cits.find((c) =>
+        c.matchedText.includes("1-602 Applications"),
+      )
+      expect(phantom, "phantom cite should be extracted under broad regex").toBeDefined()
+      expect(phantom!.confidence).toBeLessThanOrEqual(0.1)
+    })
+
+    it("strips fullSpan from the flagged phantom (no preceding prose leaks)", () => {
+      const cits = extractCitations(text)
+      const phantom = cits.find((c) =>
+        c.matchedText.includes("1-602 Applications"),
+      )
+      expect(phantom).toBeDefined()
+      expect((phantom as FullCaseCitation).fullSpan).toBeUndefined()
+    })
+
+    it("removes the phantom entirely when filterFalsePositives is true", () => {
+      const cits = extractCitations(text, { filterFalsePositives: true })
+      const phantom = cits.find((c) =>
+        c.matchedText.includes("1-602 Applications"),
+      )
+      expect(phantom).toBeUndefined()
+    })
+  })
+
+  describe("integration: repro 2 — form-field address spanning lines", () => {
+    // From frd/231 → json/0550-01.json
+    const text =
+      "EMPLOYER’S NAME: The Ultimate Spa Salon\n" +
+      "EMPLOYER’S ADDRESS: 5713 Monona Drive\n" +
+      "Monona WI 53716\n" +
+      "You have 60 days from the date of this notification."
+
+    it("flags the address-shaped phantom", () => {
+      const cits = extractCitations(text)
+      const phantom = cits.find((c) =>
+        c.matchedText.includes("5713 Monona Drive"),
+      )
+      expect(phantom).toBeDefined()
+      expect(phantom!.confidence).toBeLessThanOrEqual(0.1)
+    })
+
+    it("does not surface address text in fullSpan", () => {
+      const cits = extractCitations(text)
+      const phantom = cits.find((c) =>
+        c.matchedText.includes("5713 Monona Drive"),
+      )
+      expect((phantom as FullCaseCitation).fullSpan).toBeUndefined()
+    })
+  })
+
+  describe("integration: repro 3 — section heading + FRCP rule with smart-quote artifact", () => {
+    // From f-supp-3d/150 → json/0228-01.json
+    const text =
+      "the parties’ dispute despite the fact that it finds that it is permitted.\n" +
+      "2. Fed. R. Civ. P. 56\n" +
+      "Fed. R. Civ.’ P. 56(a) provides that a court may grant summary judgment."
+
+    it("flags the smart-quote-artifact FRCP phantom (was conf 0.45 before fix)", () => {
+      const cits = extractCitations(text)
+      // Smart-quote `’` is normalized to `'` by the cleaner, so the matchedText
+      // contains "Fed. R. Civ.' P." (ASCII apostrophe).
+      const phantom = cits.find(
+        (c) => c.type === "case" && c.matchedText.includes("Fed. R. Civ.' P."),
+      )
+      expect(phantom, "phantom cite from FRCP rule should extract under broad regex").toBeDefined()
+      expect(phantom!.confidence).toBeLessThanOrEqual(0.1)
+    })
+
+    it("strips fullSpan so heading line above does not leak", () => {
+      const cits = extractCitations(text)
+      const phantom = cits.find(
+        (c) => c.type === "case" && c.matchedText.includes("Fed. R. Civ.' P."),
+      )
+      expect((phantom as FullCaseCitation).fullSpan).toBeUndefined()
+    })
+  })
+
+  describe("regression: a real citation that happens to sit on a line boundary", () => {
+    it("does NOT flag a real cite that lives entirely on one line", () => {
+      // A wrapped paragraph where the cite is intact on one line.
+      const text =
+        "The court relied on Smith v. Jones, 500 F.2d 123 (2d Cir. 1980),\n" +
+        "which held that the doctrine applies broadly."
+      const cits = extractCitations(text)
+      const cite = cits.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).reporter === "F.2d",
+      )
+      expect(cite).toBeDefined()
+      // The matched text for the core cite should NOT cross a newline.
+      const slice = text.slice(cite!.span.originalStart, cite!.span.originalEnd)
+      expect(slice.includes("\n")).toBe(false)
+      // Confidence stays high.
+      expect(cite!.confidence).toBeGreaterThan(0.5)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #547. Three CAP repros all share one root cause: the cleaner's `normalizeWhitespace` collapses `\n` to space, so the broad state-reporter tokenizer matches volume-reporter-page shapes that straddle a hard line break. The case-name backward scan then walks across the (now-invisible) break, absorbing the preceding heading or form-label line into `caseName` and extending `fullSpan` to cover unrelated text.

**Evidence:** across 758 case citations in 100 random CAP opinions, **every single citation whose original-text span contains `\n` was a confirmed false positive** (confidence ≤ 0.2 before this fix). Zero false negatives — real reporter abbreviations are atomic; OCR-wrapped citations like `F. Sup-\np. 3d` are already stitched by `rejoinHyphenatedWords` before whitespace normalization.

## Fix

`src/extract/filterFalsePositives.ts`:
1. New `isLineCrossingCitation(citation, originalText)` predicate
2. Wired into `isFalsePositive` (remove mode) and `collectFalsePositiveReasons` (penalize mode)
3. `applyFalsePositiveFilters` gained optional `originalText` parameter — backward-compatible (line-crossing check skipped when omitted)
4. **In penalize mode, strips `fullSpan` from any flagged `case` citation** — lets downstream consumers (annotate, citationBounds, document/proseOffsets) fall back to the internally-consistent cite-core span

## Test plan

- [x] 13 new tests in `tests/extract/issue547FullspanOvershoot.test.ts`
- [x] `pnpm exec vitest run` — 3249 passed (+13 new), 9 skipped
- [x] `pnpm typecheck` clean
- [x] Red-green-revert confirmed: 7/13 tests fail without the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)