### PR TITLE
fix(clean): repair TransformationMap catastrophic collapse (#546, also closes #550)

### DIFF
--- a/.changeset/transformation-map-collapse.md
+++ b/.changeset/transformation-map-collapse.md
@@ -1,0 +1,33 @@
+---
+"eyecite-ts": patch
+---
+
+fix(clean): repair catastrophic `TransformationMap` collapse (#546, #550)
+
+The text-cleaning pipeline was producing zero-width / orphan citation
+spans for two distinct inputs:
+
+1. **Plain text with a stray `<` and `>` pair** (OCR artifacts in CAP
+   opinions like `consenting te< waive any objection ... da>`).
+   `stripHtmlTags` greedily matched everything between the two
+   characters, deleting thousands of chars of legitimate prose.
+   The regex now requires a tag's first character to be a letter, `/`,
+   or `!`, and rejects matches that contain raw line breaks.
+2. **HTML with adjacent same-tag deletions** (every word wrapped in
+   `<span class="word">…</span>`). `rebuildPositionMaps` rejected the
+   correct lookahead because the character right after a tag deletion
+   is `<` (the start of the next tag), failing its strict 3-char
+   confirmation check. It then accepted a coincidental 3-gram match
+   far downstream, collapsing 41,000+ clean positions onto a single
+   original position.
+
+`rebuildPositionMaps` now tracks both a strong match (full 3-char
+confirmation) and a weak match (head + at least 1 confirm char where
+the next before-character is `<`, the structural signal of another
+adjacent deletion). When both exist, the shorter displacement wins.
+
+Effect on the CAP-corpus span-fidelity audit (100 opinions, seed 42):
+* Total violations: **393 → 29**
+* HTML-bucket zero-width spans: **76/105 cites → 0/105 cites**
+* Resolves #550 (pen-w/3/0072-01 zero-width spans) as a downstream
+  consequence.

--- a/scripts/repro_546.ts
+++ b/scripts/repro_546.ts
@@ -1,0 +1,102 @@
+/**
+ * Repro for issue #546 — TransformationMap catastrophic collapse.
+ *
+ * Loads the three documented CAP-corpus repros and reports any citations
+ * whose originalStart === originalEnd (zero-width orphan) or whose slice
+ * disagrees with the matchedText.
+ */
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import AdmZip from "adm-zip"
+import { extractCitations } from "../src/index"
+import type { Citation } from "../src/types/citation"
+
+const CAP_ROOT =
+  process.env.CAP_ROOT ??
+  "/Users/medelman/Projects/Ourfirm.ai/GitHub/opinion-text-explorer/case-law-data"
+
+interface Repro {
+  label: string
+  reporter: string
+  volume: string
+  entry: string
+  variant: "plain" | "html"
+}
+
+const REPROS: Repro[] = [
+  { label: "va-patt-heath/2/0795-01.json (plain)", reporter: "va-patt-heath", volume: "2", entry: "json/0795-01.json", variant: "plain" },
+  { label: "gibb-surr/1/0414-01.json (plain)", reporter: "gibb-surr", volume: "1", entry: "json/0414-01.json", variant: "plain" },
+  { label: "cal-app-2d/222/0626-01.json (HTML)", reporter: "cal-app-2d", volume: "222", entry: "json/0626-01.json", variant: "html" },
+]
+
+const loadOpinion = (r: Repro): string => {
+  const zip = new AdmZip(join(CAP_ROOT, r.reporter, `${r.volume}.zip`))
+  const entry = zip.getEntries().find((e) => e.entryName === r.entry)
+  if (!entry) throw new Error(`Entry ${r.entry} not found in ${r.reporter}/${r.volume}.zip`)
+  const doc = JSON.parse(entry.getData().toString("utf8")) as {
+    casebody?: { opinions?: { text?: string }[] }
+  }
+  return (doc.casebody?.opinions ?? [])
+    .map((o) => o.text ?? "")
+    .filter((t) => t.length > 0)
+    .join("\n\n")
+}
+
+/** Wrap every 3rd word in a <span class="word"> tag and bookend with <p>. */
+const toHtml = (text: string): string => {
+  let count = 0
+  const wrapped = text.replace(/\b(\w+)\b/g, (m) => {
+    count++
+    return count % 3 === 0 ? `<span class="word">${m}</span>` : m
+  })
+  return `<html><body><p>${wrapped}</p></body></html>`
+}
+
+for (const repro of REPROS) {
+  console.log("\n=====================================================")
+  console.log(`  ${repro.label}`)
+  console.log("=====================================================")
+
+  const plain = loadOpinion(repro)
+  const text = repro.variant === "html" ? toHtml(plain) : plain
+  const cites = extractCitations(text) as Citation[]
+
+  console.log(`text length:        ${text.length}`)
+  console.log(`citations extracted: ${cites.length}`)
+
+  const orphans: { c: Citation; slice: string }[] = []
+  for (const c of cites) {
+    const sp = c.span
+    const slice = text.slice(sp.originalStart, sp.originalEnd)
+    const zero = sp.originalEnd === sp.originalStart
+    const mismatch = slice.replace(/\s+/g, " ").trim() !== c.matchedText.replace(/\s+/g, " ").trim()
+    const tagsInSlice = /<[^>]+>/.test(slice)
+    // Loose mismatch: ignore tag-only differences
+    const looseSlice = slice.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim()
+    const looseMatch = looseSlice === c.matchedText.replace(/\s+/g, " ").trim()
+    if (zero || (!looseMatch && !tagsInSlice)) {
+      orphans.push({ c, slice })
+    }
+  }
+
+  console.log(`broken citations:   ${orphans.length} (${((orphans.length / Math.max(1, cites.length)) * 100).toFixed(1)}%)`)
+  if (orphans.length > 0) {
+    // Group by originalStart to identify collapse points
+    const byOrigStart = new Map<number, number>()
+    for (const o of orphans) {
+      const k = o.c.span.originalStart
+      byOrigStart.set(k, (byOrigStart.get(k) ?? 0) + 1)
+    }
+    const sortedPoints = [...byOrigStart.entries()].sort((a, b) => b[1] - a[1]).slice(0, 5)
+    console.log("\n  collapse points (top 5):")
+    for (const [pos, count] of sortedPoints) {
+      console.log(`    originalStart=${pos} count=${count}`)
+    }
+    console.log("\n  examples:")
+    for (const o of orphans.slice(0, 6)) {
+      console.log(`    [${o.c.type}] matchedText=${JSON.stringify(o.c.matchedText.slice(0, 60))}`)
+      console.log(`        clean=[${o.c.span.cleanStart},${o.c.span.cleanEnd}) original=[${o.c.span.originalStart},${o.c.span.originalEnd})`)
+      console.log(`        slice=${JSON.stringify(o.slice.slice(0, 80))}`)
+    }
+  }
+}

--- a/src/clean/cleanText.ts
+++ b/src/clean/cleanText.ts
@@ -188,47 +188,114 @@ function rebuildPositionMaps(
       // original position.  Scale to the length delta with a reasonable floor.
       const maxLookAhead = Math.max(40, Math.abs(beforeText.length - afterText.length) + 10)
 
-      // Find the closest CONFIRMED match in both directions simultaneously.
-      // A "confirmed" match requires that at least CONFIRM_LEN characters
-      // after the match point also align.  This prevents greedy false matches
-      // (Issue #161) where, e.g., normalizeDashes expands "—" → "---" and the
-      // deletion lookahead grabs a "-" from a nearby page range instead.
+      // Find the closest confirmed match in each direction.
+      //
+      // "Confirmation depth" is the run of consecutive matching characters
+      // starting at the candidate alignment point.  Strong confirmation
+      // (CONFIRM_LEN chars) is the high-confidence threshold that
+      // dismisses single-character false matches like #161 (normalizeDashes
+      // expanding "—" → "---" near a "-" in a page range).
+      //
+      // The strict-only rule is unsafe for HTML with adjacent tag
+      // deletions (Issue #546).  Two patterns break it:
+      //   (a) After the CORRECT la (one tag's worth), the very next
+      //       before-character is `<` (the next tag's opener), so strict
+      //       confirm fails — the algorithm then accepts a much farther
+      //       coincidental 3-gram match.
+      //   (b) Coincidental 3-gram matches frequently land *inside*
+      //       attribute values like `class="word"`, because short bigrams
+      //       like `an`/`th`/`on` happen often in both prose and HTML.
+      //
+      // Fix: track BOTH the shortest la with strong confirmation
+      // (`bestStrong*`) AND the shortest la with a weak match (the head
+      // matched, and the very next char in before-text is `<` — the
+      // structural signal that another deletion follows immediately,
+      // i.e. `bestWeak*`).  Then pick whichever has the smaller
+      // displacement.  When the strong match is closer (or no weak
+      // candidate exists), the longer-confirmation reading wins and
+      // still protects against single-character coincidences like #161.
       const CONFIRM_LEN = 3
-      let bestDelLA = -1
-      let bestInsLA = -1
+      let bestStrongDelLA = -1
+      let bestWeakDelLA = -1
+      let bestStrongInsLA = -1
+      let bestWeakInsLA = -1
+
+      const matchDepth = (bi0: number, ai0: number): number => {
+        let d = 1
+        while (
+          d < CONFIRM_LEN &&
+          bi0 + d < beforeText.length &&
+          ai0 + d < afterText.length &&
+          beforeText[bi0 + d] === afterText[ai0 + d]
+        ) {
+          d++
+        }
+        return d
+      }
 
       for (let la = 1; la <= maxLookAhead; la++) {
         // Check deletion direction (skipping chars in before)
-        if (bestDelLA < 0 && beforeIdx + la < beforeText.length) {
+        if (
+          (bestStrongDelLA < 0 || bestWeakDelLA < 0) &&
+          beforeIdx + la < beforeText.length
+        ) {
           if (beforeText[beforeIdx + la] === afterText[afterIdx]) {
-            let ok = true
-            for (let c = 1; c < CONFIRM_LEN; c++) {
-              const bi = beforeIdx + la + c
-              const ai = afterIdx + c
-              if (bi >= beforeText.length || ai >= afterText.length) break
-              if (beforeText[bi] !== afterText[ai]) { ok = false; break }
+            const depth = matchDepth(beforeIdx + la, afterIdx)
+            if (bestStrongDelLA < 0 && depth >= CONFIRM_LEN) {
+              bestStrongDelLA = la
             }
-            if (ok) bestDelLA = la
+            // Weak match: the failing chars in beforeText are `<`, which
+            // is a strong signal another deletion follows immediately.
+            // (depth includes the head match; we examine the very next
+            // char after the matched run.)
+            if (
+              bestWeakDelLA < 0 &&
+              beforeText[beforeIdx + la + depth] === "<"
+            ) {
+              bestWeakDelLA = la
+            }
           }
         }
 
         // Check insertion direction (skipping chars in after)
-        if (bestInsLA < 0 && afterIdx + la < afterText.length) {
+        if (
+          (bestStrongInsLA < 0 || bestWeakInsLA < 0) &&
+          afterIdx + la < afterText.length
+        ) {
           if (beforeText[beforeIdx] === afterText[afterIdx + la]) {
-            let ok = true
-            for (let c = 1; c < CONFIRM_LEN; c++) {
-              const bi = beforeIdx + c
-              const ai = afterIdx + la + c
-              if (bi >= beforeText.length || ai >= afterText.length) break
-              if (beforeText[bi] !== afterText[ai]) { ok = false; break }
+            const depth = matchDepth(beforeIdx, afterIdx + la)
+            if (bestStrongInsLA < 0 && depth >= CONFIRM_LEN) {
+              bestStrongInsLA = la
             }
-            if (ok) bestInsLA = la
+            if (
+              bestWeakInsLA < 0 &&
+              beforeText[beforeIdx + depth] === "<"
+            ) {
+              bestWeakInsLA = la
+            }
           }
         }
 
-        // Stop early if we found matches in both directions
-        if (bestDelLA >= 0 && bestInsLA >= 0) break
+        // Stop early once strong matches exist in both directions — the
+        // weak fallback only matters when strong matches are absent or
+        // unusably far away.
+        if (bestStrongDelLA >= 0 && bestStrongInsLA >= 0) break
       }
+
+      // Resolve weak vs strong per direction.  When both are present we
+      // prefer the SHORTER displacement: a weak match flagged by a `<`
+      // next-character is a strong structural signal that we're sitting
+      // exactly at a real tag boundary, so the shorter la is the local
+      // edit and the longer la is a coincidental match deeper in the
+      // document.  When the strong la is the shorter one (or weak is
+      // absent), keep the strong match.
+      const pick = (strong: number, weak: number): number => {
+        if (strong < 0) return weak
+        if (weak < 0) return strong
+        return weak < strong ? weak : strong
+      }
+      const bestDelLA = pick(bestStrongDelLA, bestWeakDelLA)
+      const bestInsLA = pick(bestStrongInsLA, bestWeakInsLA)
 
       // Pick the shorter confirmed match (prefer smaller displacement)
       if (bestDelLA >= 0 && (bestInsLA < 0 || bestDelLA <= bestInsLA)) {

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -18,6 +18,15 @@
  * Non-word neighbors (spaces, punctuation, the start or end of the
  * string) keep the original behavior: tags are removed with no insertion.
  *
+ * The tag-matching regex is intentionally conservative — only opening
+ * sequences that look like real HTML (`<` followed by a letter, `/`, or
+ * `!` for `<!doctype>`/`<!--…-->`) are stripped. This prevents OCR
+ * artifacts in CAP opinions — e.g. a stray `<` in `to< waive any
+ * objection` paired with a stray `>` thousands of characters later — from
+ * triggering a catastrophic greedy match that deletes legitimate prose
+ * (#546). Genuine `<` characters in prose (math, code samples) are left
+ * intact.
+ *
  * @example
  * stripHtmlTags("Smith v. <b>Doe</b>, 500 F.2d 123")
  * // => "Smith v. Doe, 500 F.2d 123"
@@ -25,11 +34,21 @@
  * @example
  * stripHtmlTags('100 F.3d 200<footnote>200 F.3d 300</footnote>')
  * // => "100 F.3d 200 200 F.3d 300 "
+ *
+ * @example
+ * stripHtmlTags("the value < 3 means")
+ * // => "the value < 3 means"   // stray `<` is not a tag — left alone
  */
 export function stripHtmlTags(text: string): string {
   // Collapse adjacent tag runs together so the boundary check sees the
   // characters surrounding the whole run, not each tag individually.
-  return text.replace(/(?:<[^>]+>)+/g, (match, offset: number) => {
+  //
+  // Tag shape: `<` followed by a letter / `/` / `!`, then any non-`>`
+  // characters except newline (real HTML tags never contain raw newlines —
+  // CR/LF inside an attribute value is technically allowed but vanishingly
+  // rare; this restriction is what stops the greedy match across a long
+  // body of prose containing stray angle brackets, #546).
+  return text.replace(/(?:<[a-zA-Z/!][^>\n\r]*>)+/g, (match, offset: number) => {
     const before = offset > 0 ? text[offset - 1] : ""
     const afterIdx = offset + match.length
     const after = afterIdx < text.length ? text[afterIdx] : ""

--- a/tests/clean/cleanText.test.ts
+++ b/tests/clean/cleanText.test.ts
@@ -284,6 +284,138 @@ describe("cleanText position tracking", () => {
     const result = cleanText(input, [stripHtmlTags])
     expect(result.cleaned).toBe("Smith v. Doe, 500 F.2d 123")
   })
+
+  // #546 — TransformationMap catastrophic collapse.
+  //
+  // Two failure modes both produce the same downstream symptom (originalStart ===
+  // originalEnd, downstream slice returns empty string or unrelated text):
+  //   1. `stripHtmlTags` greedily matches a stray `<` … `>` across thousands of
+  //      chars of legitimate prose (OCR artifacts in CAP opinions).
+  //   2. `rebuildPositionMaps` lookahead picks a false-positive alignment when
+  //      adjacent tag deletions sit back-to-back (e.g. `<span>A</span><span>B</span>`).
+  describe("issue #546: TransformationMap catastrophic collapse", () => {
+    it("stripHtmlTags does not eat prose between stray `<` and `>`", () => {
+      // Two stray angle brackets several hundred chars apart should not be
+      // treated as one giant tag — they're OCR/typesetter artifacts. The
+      // current greedy regex deletes everything in between (~hundreds of
+      // chars). The fix requires the first char after `<` to be a letter
+      // or `/`, otherwise it isn't a tag.
+      const filler = "a".repeat(200) + " plaintiff " + "b".repeat(200)
+      const input = `prefix te< waive ${filler} da> suffix`
+
+      const result = cleanText(input, [stripHtmlTags])
+
+      // Cleaner must not delete the prose between the stray brackets.
+      expect(result.cleaned).toContain("waive")
+      expect(result.cleaned).toContain("plaintiff")
+      expect(result.cleaned).toContain("suffix")
+      // Length should be unchanged (no real tags to strip).
+      expect(result.cleaned.length).toBe(input.length)
+    })
+
+    it("stripHtmlTags is still permissive for real tags with attributes", () => {
+      // Legit HTML must still strip correctly. The proposed fix tightens the
+      // regex but keeps `<letter or /...>` patterns valid.
+      const input = '<span class="citation" data-id="x">500 F.2d 123</span>'
+      const result = cleanText(input, [stripHtmlTags])
+      expect(result.cleaned).toBe("500 F.2d 123")
+    })
+
+    it("position map remains intact through adjacent same-tag deletions", () => {
+      // The cal-app-2d/222 pattern: every Nth word wrapped in
+      // `<span class="word">…</span>`. With adjacent tag deletions, the
+      // CONFIRM_LEN=3 check inside the lookahead fails (because the char
+      // right after a correct alignment is `<` — the start of the next
+      // deleted tag), so the algorithm picks a far-away false-positive
+      // match and collapses hundreds of clean positions to one orphan
+      // origPos.
+      const text =
+        "BRAY, P. J. In a consolidated appeal in three cases, appellants " +
+        "in each respective case, who were plaintiffs or petitioners " +
+        "therein, appeal from adverse judgments in favor of the respective " +
+        "defendants on the action between the parties hereto."
+      let count = 0
+      const html = text.replace(/\b(\w+)\b/g, (m) => {
+        count++
+        return count % 3 === 0 ? `<span class="word">${m}</span>` : m
+      })
+
+      const result = cleanText(html, [stripHtmlTags])
+
+      // Sanity: cleaning yielded the original prose.
+      expect(result.cleaned).toBe(text)
+
+      // No origPos should be the target of more than a handful of clean
+      // positions. A truly correct map yields ~3-5 collisions max around
+      // word/tag boundaries — the bug produces single origPositions with
+      // 100+ clean positions mapped to them.
+      const counts = new Map<number, number>()
+      for (const [, orig] of result.transformationMap.cleanToOriginal) {
+        counts.set(orig, (counts.get(orig) ?? 0) + 1)
+      }
+      const maxCollision = Math.max(...counts.values())
+      expect(maxCollision).toBeLessThanOrEqual(10)
+
+      // Every clean position should map to a strictly increasing origPos
+      // (within the small slack permitted by adjacent-deletion collisions).
+      let prev = -1
+      for (let i = 0; i < result.cleaned.length; i++) {
+        const orig = result.transformationMap.cleanToOriginal.get(i)
+        expect(orig).toBeDefined()
+        // Original positions must be monotonically non-decreasing — the
+        // catastrophic-collapse bug produces huge backwards/forwards jumps.
+        expect(orig as number).toBeGreaterThanOrEqual(prev)
+        prev = orig as number
+      }
+    })
+
+    it("clean→original mapping never points to an unrelated region", () => {
+      // Heavier variant of the cal-app-2d/222 pattern — every 3rd word in
+      // a multi-paragraph passage is wrapped in `<span class="word">…</span>`.
+      // The current bug produces collapsed `cleanToOriginal` mappings for
+      // ~all of the prose after a few hundred chars, sending downstream
+      // text slicing to a completely unrelated paragraph.
+      const text =
+        "BRAY, P. J. In a consolidated appeal in three cases, appellants " +
+        "in each respective case, who were plaintiffs or petitioners " +
+        "therein, appeal from adverse judgments in favor of the respective " +
+        "defendants on the action between the parties hereto. See " +
+        "500 F.2d 123 (5th Cir. 1974) and 81 Cal.App.2d 811 and 203 Cal. 665 " +
+        "and 265 P. 806 supra. Compare 100 F.3d 50 (9th Cir. 1996)."
+      let count = 0
+      const html = text.replace(/\b(\w+)\b/g, (m) => {
+        count++
+        return count % 3 === 0 ? `<span class="word">${m}</span>` : m
+      })
+
+      // Default cleaner pipeline (what extractCitations uses).
+      const result = cleanText(html)
+      expect(result.cleaned).toBe(text)
+
+      // For every clean position, the mapped origPos must point to a
+      // location whose 30-char window in the original HTML contains the
+      // cleaned character (tag-stripped) at that index. The bug sends
+      // clean positions to far-away regions where the corresponding char
+      // does not appear.
+      const errors: string[] = []
+      for (let cleanIdx = 0; cleanIdx < result.cleaned.length; cleanIdx++) {
+        const orig =
+          result.transformationMap.cleanToOriginal.get(cleanIdx) ?? -1
+        const expectedChar = result.cleaned[cleanIdx]
+        const window = html.slice(Math.max(0, orig - 5), orig + 30)
+        // Strip tags from the window to see prose only.
+        const proseWindow = window.replace(/<[^>]*>/g, "")
+        if (!proseWindow.includes(expectedChar)) {
+          errors.push(
+            `clean[${cleanIdx}]=${JSON.stringify(expectedChar)} → origPos=${orig}, ` +
+              `but ${JSON.stringify(proseWindow.slice(0, 30))} does not contain it`,
+          )
+          if (errors.length >= 3) break
+        }
+      }
+      expect(errors).toEqual([])
+    })
+  })
 })
 
 describe("normalizeDashes (issue #54)", () => {


### PR DESCRIPTION
## Summary

Closes #546. Also closes #550 (zero-width spans) as a downstream consequence — same root cause.

The bug had **two distinct triggers** producing the same downstream symptom (zero-width / orphan citation spans where `originalStart === originalEnd`):

1. **`stripHtmlTags` over-matching** (`src/clean/cleaners.ts:32`). Regex `/(?:<[^>]+>)+/g` greedily matched anything between `<` and `>`. CAP opinions with stray `<` / `>` OCR artifacts had thousands of chars of legitimate prose deleted. Affected the `va-patt-heath` and `gibb-surr` repros.

2. **`rebuildPositionMaps` CONFIRM_LEN=3 false rejections** (`src/clean/cleanText.ts:196`). When adjacent same-direction deletions sit back-to-back (HTML like `<span class="word">A</span><span class="word">B</span>`), the char right after the correct alignment is `<` (next tag's opener). Strict 3-char confirmation fails, then the algorithm finds a coincidental match (often inside an attribute) and accepts a catastrophically wrong alignment — collapsing tens of thousands of clean positions onto one. Affected the `cal-app-2d` HTML repro.

## Fix

- **`cleaners.ts`** — Tightened `stripHtmlTags` regex to `/(?:<[a-zA-Z/!][^>\n\r]*>)+/g`. Real tags start with letter, `/`, or `!`, and never contain raw newlines. Stray prose `<`/`>` left intact.
- **`cleanText.ts`** — In the lookahead loop, track BOTH a strong candidate (full `CONFIRM_LEN=3` match) AND a weak candidate (head match where the next before-text char is `<` — the structural signal of an adjacent deletion). Shorter displacement wins. Strong wins when closer or weak absent — preserves the #161 single-character false-match protection.

## Verification

- **Audit, 100 CAP opinions:** total violations 393 → 29; HTML zero-width spans 76/105 → **0/105**
- **All three #546 CAP repros**: 100% broken → 0% broken
- **#550 (`pen-w/3` zero-width spans)**: 0 zero-width spans; `"11 Co. 44"` slices correctly
- **Tests**: 3240 pass (+4 new), 9 skipped, typecheck clean

## Known residual

The audit still surfaces 2 zero-width spans in `ohio-misc/21/0127-01.json` — same algorithmic family but inside `normalizeReporterSpacing`-collapsed runs (`O. O. 2d`, `N. E. 2d`) that don't involve `<`. Pre-existing, distinct bug — would need a different approach (cleaner emits position hints directly). Out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)