### PR TITLE
test: backfill Sprint A coverage gaps — Ibid. parametric + shortFormCase line-crossing

### DIFF
--- a/tests/extract/issue547FullspanOvershoot.test.ts
+++ b/tests/extract/issue547FullspanOvershoot.test.ts
@@ -33,7 +33,7 @@ import { beforeAll, describe, expect, it } from "vitest"
 import { extractCitations } from "@/extract/extractCitations"
 import { applyFalsePositiveFilters } from "@/extract/filterFalsePositives"
 import { loadReporters } from "@/data/reporters"
-import type { FullCaseCitation } from "@/types/citation"
+import type { FullCaseCitation, ShortFormCaseCitation } from "@/types/citation"
 import type { Span } from "@/types/span"
 
 /** Helper to create a minimal case citation with explicit original-text span */
@@ -61,6 +61,34 @@ function makeCaseAt(
     volume,
     reporter,
     page,
+  }
+}
+
+/** Helper to create a minimal shortFormCase citation with explicit original-text span */
+function makeShortFormCaseAt(
+  reporter: string,
+  volume: number | string,
+  pincite: number,
+  originalStart: number,
+  originalEnd: number,
+): ShortFormCaseCitation {
+  const span: Span = {
+    cleanStart: originalStart,
+    cleanEnd: originalEnd,
+    originalStart,
+    originalEnd,
+  }
+  return {
+    type: "shortFormCase",
+    text: "",
+    span,
+    confidence: 0.8,
+    matchedText: "",
+    processTimeMs: 0,
+    patternsChecked: 1,
+    volume,
+    reporter,
+    pincite,
   }
 }
 
@@ -132,6 +160,32 @@ describe("issue #547: fullSpan overshoots on line-crossing false positives", () 
       }
       const result = applyFalsePositiveFilters([cit], false, text)
       expect((result[0] as FullCaseCitation).fullSpan).toBeDefined()
+    })
+
+    it("flags a shortFormCase whose original-text slice contains \\n (penalize mode)", () => {
+      // The predicate explicitly handles `shortFormCase` alongside `case`,
+      // but the integration repros above only exercise `case`. This pins
+      // the `shortFormCase` branch so a future refactor can't silently
+      // drop it.
+      const text = "foo 100 Bar\nat 5 qux"
+      const cit = makeShortFormCaseAt("Bar", 100, 5, 4, 16)
+      // sanity: confirm the synthetic span spans the newline
+      expect(text.slice(4, 16)).toContain("\n")
+
+      const result = applyFalsePositiveFilters([cit], false, text)
+      expect(result).toHaveLength(1)
+      expect(result[0].confidence).toBe(0.1)
+      const lineWarning = result[0].warnings?.find((w) =>
+        w.message.toLowerCase().includes("line break"),
+      )
+      expect(lineWarning, "should attach a line-break warning").toBeDefined()
+    })
+
+    it("removes a shortFormCase line-crossing cite in remove mode", () => {
+      const text = "foo 100 Bar\nat 5 quxxxxxxx Smith, 500 F.2d at 125"
+      const lineCrossingShort = makeShortFormCaseAt("Bar", 100, 5, 4, 16)
+      const result = applyFalsePositiveFilters([lineCrossingShort], true, text)
+      expect(result).toHaveLength(0)
     })
   })
 

--- a/tests/extract/issue549OverlappingSpans.test.ts
+++ b/tests/extract/issue549OverlappingSpans.test.ts
@@ -143,12 +143,30 @@ describe("issue #549 — no overlapping spans across tokenizer collisions", () =
       expect(cites.find((c) => c.type === "id")).toBeDefined()
       expect(cites.filter((c) => c.type === "case").length).toBe(2)
     })
+
+    it("`vol Ibid. page` produces id-only (Ibid. variant of #549)", () => {
+      // Mirrors the `45 Id. 318` repro. IBID_PATTERN received the same
+      // negative-lookahead fix as ID_PATTERN; this test pins that the fix
+      // covers both regex shapes, not just `Id.`.
+      const text = "Hawkins v. Giles, 45 Ibid. 318"
+      const cites = extractCitations(text)
+      expect(findOverlapPairs(cites)).toEqual([])
+
+      const id = cites.find((c) => c.type === "id")
+      expect(id).toBeDefined()
+
+      const phantomCase = cites.find(
+        (c) => c.type === "case" && c.span.cleanStart >= 18 && c.matchedText?.includes("Ibid."),
+      )
+      expect(phantomCase).toBeUndefined()
+    })
   })
 
   describe("audit-style sanity check: no overlap pairs across all three repros", () => {
     const repros = [
       "Barrett, supra, 229 Conn. 274-76",
       "Hawkins v. Giles, 45 Id. 318",
+      "Hawkins v. Giles, 45 Ibid. 318",
       "Chapter 29.82.160. Chapter 29.82 RCW",
     ]
 


### PR DESCRIPTION
## Summary

Two small test-coverage backfills from the post-Sprint-A audit. No source changes, no changeset.

- **#549 (PR #600)** suite — `IBID_PATTERN` got the same negative-lookahead fix as `ID_PATTERN` but had no dedicated test. Added a `Ibid.` parametric + dedicated `vol Ibid. page` Mode B test. A future refactor could silently regress the Ibid. handling without this.
- **#547 (PR #602)** suite — `isLineCrossingCitation` handles `shortFormCase` alongside `case`, but existing integration repros only exercise `case`. Added two `shortFormCase` unit tests (penalize-mode flag + remove-mode strip).

## Test plan

- [x] `pnpm exec vitest run` — 3268 passed (+3 new), 9 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)