### PR TITLE
fix(score): recompute parallel-secondary confidence after caseName inheritance (#556)

### DIFF
--- a/.changeset/parallel-secondary-confidence-recompute.md
+++ b/.changeset/parallel-secondary-confidence-recompute.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+Recompute confidence for parallel-cite secondary citations after `inheritParallelCaseName` propagates the shared caption (#556).
+
+`inheritParallelCaseName` runs as a post-pass and mutates `caseName` / `plaintiff` / `defendant` onto each secondary cite in a parallel-cite group (e.g. `93 S. Ct. 705` and `35 L. Ed. 2d 147` in `Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)`). But each secondary's `confidence` was already locked in by `buildCaseCitation()` when its `caseName` was still `undefined`, so the score missed the `+0.15` caseName signal it now qualifies for. CAP-corpus audit (300 opinions): roughly 94% of citations that had a full case name, a year, and a court but landed under 0.7 confidence were parallel secondaries stuck at the pre-inheritance score.
+
+Fix:
+
+- Extract the case-citation confidence formula out of `buildCaseCitation` into a pure helper `computeCaseConfidence({ reporter, year, caseName, court, hasBlankPage })`.
+- Call it from the original site (no behavior change for citations that don't go through inheritance).
+- After `inheritParallelCaseName` mutates the caption fields on a secondary, recompute its confidence with the same helper so the inherited `caseName` registers in the score.
+
+The recompute only fires on secondaries whose `caseName` was previously undefined (the inheritance loop already short-circuits for ones that already have one). Primary cites and non-parallel cites are untouched.
+
+Concrete deltas for repros in the issue:
+
+- `Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)` — each secondary picks up +0.15 (`0.5 → 0.65` for the SCOTUS secondaries, bounded by the reporter-database lookup tracked separately by #555).
+- `Nixon v. Nixon, 329 Pa. 256, 198 A. 154 (1938)` — `198 A. 154` rises from 0.70 to 0.85.
+- `People v. Smith (2001) 24 Cal.4th 849 [102 Cal.Rptr.2d 731]` — `102 Cal.Rptr.2d 731` rises from 0.20 to 0.35.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -168,6 +168,63 @@ export const COMMON_REPORTERS: ReadonlySet<string> = new Set([
   "F. App'x",
 ])
 
+/**
+ * Compute the multi-factor confidence score for a case citation.
+ *
+ * Pure helper over the five signals the case-citation scorer cares about.
+ * Factored out so post-pass mutations that change one of those signals
+ * (notably `inheritParallelCaseName`, which propagates `caseName` onto
+ * parallel-cite secondaries — #556) can re-derive confidence with the
+ * same formula instead of being silently stuck at the pre-mutation value.
+ *
+ * Formula:
+ *   - base 0.2
+ *   - +0.3 if reporter is known (reporters-db hit, falling back to COMMON_REPORTERS)
+ *   - +0.2 if year is present and <= current year
+ *   - +0.15 if caseName is present
+ *   - +0.1 if court is present
+ *   - cap 1.0, rounded to 0.01
+ *   - finally, blank-page placeholders floor at 0.5
+ */
+export function computeCaseConfidence(opts: {
+  reporter: string
+  year: number | undefined
+  caseName: string | undefined
+  court: string | undefined
+  hasBlankPage: boolean
+}): number {
+  const { reporter, year, caseName, court, hasBlankPage } = opts
+  let confidence = 0.2
+
+  const reportersDb = getReportersSync()
+  const dbMatch = reportersDb?.byAbbreviation.get(reporter.toLowerCase())
+  if (dbMatch && dbMatch.length > 0) {
+    confidence += 0.3
+  } else if (COMMON_REPORTERS.has(reporter)) {
+    confidence += 0.3
+  }
+
+  if (year !== undefined && year <= CURRENT_YEAR) {
+    confidence += 0.2
+  }
+
+  if (caseName) {
+    confidence += 0.15
+  }
+
+  if (court) {
+    confidence += 0.1
+  }
+
+  confidence = Math.round(Math.min(confidence, 1.0) * 100) / 100
+
+  if (hasBlankPage) {
+    confidence = Math.max(confidence, 0.5)
+  }
+
+  return confidence
+}
+
 /** Matches volume-reporter-page format in citation core, with optional nominative reporter parenthetical.
  *  Reporter character class includes `&` so the BIA `I&N Dec.` / `I. & N. Dec.`
  *  variants parse correctly (#244). */
@@ -3118,46 +3175,15 @@ export function extractCase(
   // Translate positions from clean → original (citation core only - span unchanged)
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
-  // Calculate confidence score using multi-factor model.
-  // Base is low — unvalidated matches are uncertain. Real signals earn confidence.
-  let confidence = 0.2
-
-  // Known reporter: strong signal.
-  // Check reporters-db first (precise), fall back to common reporter set.
-  const reportersDb = getReportersSync()
-  const dbMatch = reportersDb?.byAbbreviation.get(reporter.toLowerCase())
-  if (dbMatch && dbMatch.length > 0) {
-    confidence += 0.3
-  } else if (COMMON_REPORTERS.has(reporter)) {
-    confidence += 0.3
-  }
-
-  // Year present and plausible: moderate signal
-  if (year !== undefined) {
-    if (year <= CURRENT_YEAR) {
-      confidence += 0.2
-    }
-  }
-
-  // Case name found: moderate signal
-  if (caseName) {
-    confidence += 0.15
-  }
-
-  // Court identified: confirmatory signal
-  if (court) {
-    confidence += 0.1
-  }
-
-  // Cap at 1.0 and round to avoid floating point artifacts (e.g., 0.7999...9)
-  confidence = Math.round(Math.min(confidence, 1.0) * 100) / 100
-
-  // Blank page citations: intentional placeholders (3+ underscores/dashes in legal
-  // briefs). The pattern is very specific so they deserve at least moderate confidence,
-  // but don't let them exceed the signals they actually have.
-  if (hasBlankPage) {
-    confidence = Math.max(confidence, 0.5)
-  }
+  // Confidence comes from a shared pure helper so post-pass mutations
+  // (e.g. inheritParallelCaseName, #556) can re-derive with the same formula.
+  const confidence = computeCaseConfidence({
+    reporter,
+    year,
+    caseName,
+    court,
+    hasBlankPage: hasBlankPage ?? false,
+  })
 
   return {
     type: "case",

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -18,6 +18,7 @@ import { mapFootnoteZones } from "@/footnotes/mapZones"
 import { tagCitationsWithFootnotes } from "@/footnotes/tagging"
 import type { FootnoteMap } from "@/footnotes/types"
 import {
+  computeCaseConfidence,
   extractCase,
   extractConstitutional,
   extractDocket,
@@ -1407,5 +1408,19 @@ function inheritParallelCaseName(citations: Citation[]): void {
     secondary.plaintiffNormalized = primary.plaintiffNormalized
     secondary.defendantNormalized = primary.defendantNormalized
     secondary.proceduralPrefix = primary.proceduralPrefix
+
+    // The confidence score on `secondary` was computed by buildCaseCitation()
+    // when caseName was still undefined, so it missed the +0.15 caseName signal
+    // it now qualifies for. Re-derive with the same formula so the inherited
+    // caption registers in the score (#556). Reporter / year / court are
+    // unchanged by this pass, so this only swings score for secondaries that
+    // had their caseName mutated above.
+    secondary.confidence = computeCaseConfidence({
+      reporter: secondary.reporter,
+      year: secondary.year,
+      caseName: secondary.caseName,
+      court: secondary.court,
+      hasBlankPage: secondary.hasBlankPage ?? false,
+    })
   }
 }

--- a/tests/integration/parallelSecondaryConfidence.test.ts
+++ b/tests/integration/parallelSecondaryConfidence.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Issue #556 — Parallel-cite secondaries score before `inheritParallelCaseName`.
+ *
+ * `inheritParallelCaseName` (`extractCitations.ts`) runs as a post-pass and
+ * mutates `caseName` / `plaintiff` / `defendant` onto secondary citations in
+ * a parallel-cite group (e.g. the `93 S. Ct. 705` secondary of
+ * `Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705 (1973)`). But by the time it runs,
+ * each secondary's `confidence` was already locked in by `buildCaseCitation()`
+ * in `extractCase.ts`, missing the `+0.15` caseName signal it now qualifies
+ * for. Result: ~94% of "full caption + year + court but confidence < 0.7"
+ * citations in the CAP-corpus audit are parallel secondaries.
+ *
+ * Fix invariant: after inheritance, the secondary's `confidence` should equal
+ * what the case-citation scorer would have produced for *its own* signals
+ * (reporter / year / court / hasBlankPage) PLUS the inherited caseName.
+ *
+ * That is NOT the same thing as "secondary.confidence === primary.confidence":
+ *   - the U.S. reporter is in COMMON_REPORTERS, so the primary may get a
+ *     reporter-match bonus that the normalized "S.Ct." secondary doesn't
+ *     (that mismatch is tracked separately by issue #555);
+ *   - some parallel groups carry court info on the primary only (court is
+ *     extracted from the trailing paren and not propagated by this pass).
+ *
+ * What MUST hold after the fix is that the +0.15 caseName signal fires for
+ * every secondary that ends up with a non-empty inherited caseName.
+ */
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+describe("Issue #556: parallel-secondary confidence after caseName inheritance", () => {
+  it("secondary with inherited caseName earns the +0.15 caseName signal (SCOTUS)", () => {
+    // Roe: U.S. (primary), S.Ct. (secondary), L.Ed.2d (secondary). All three
+    // share SCOTUS courtInference, year 1973, and the same case name.
+    const text = "Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705 (1973)."
+    const cites = extractCitations(text).filter((c) => c.type === "case")
+    expect(cites.length).toBeGreaterThanOrEqual(2)
+
+    const primary = cites.find((c) => c.type === "case" && c.reporter === "U.S.")
+    // Reporter normalization collapses "S. Ct." → "S.Ct." in the extracted form.
+    const secondary = cites.find((c) => c.type === "case" && c.reporter === "S.Ct.")
+    expect(primary).toBeDefined()
+    expect(secondary).toBeDefined()
+    if (primary?.type !== "case" || secondary?.type !== "case") return
+
+    // Pre-conditions: inheritParallelCaseName ran (caseName propagated, same group).
+    expect(primary.caseName).toBe("Roe v. Wade")
+    expect(secondary.caseName).toBe("Roe v. Wade")
+    expect(primary.groupId).toBe(secondary.groupId)
+
+    // Secondary signals: year 1973 (+0.2), court "scotus" (+0.1), caseName
+    // (+0.15). Reporter "S.Ct." is NOT in COMMON_REPORTERS and may or may not
+    // hit reporters-db depending on autoload state (tracked by #555).
+    // Lower-bound the score against the year+court+caseName floor.
+    //   0.2 base + 0.2 year + 0.1 court + 0.15 caseName = 0.65
+    expect(secondary.year).toBe(1973)
+    expect(secondary.court).toBe("scotus")
+    expect(secondary.confidence).toBeGreaterThanOrEqual(0.65)
+  })
+
+  it("3-reporter parallel: every secondary earns the caseName signal", () => {
+    const text = "Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)."
+    const cites = extractCitations(text).filter((c) => c.type === "case")
+    expect(cites).toHaveLength(3)
+
+    for (const c of cites) {
+      if (c.type !== "case") continue
+      expect(c.caseName).toBe("Roe v. Wade")
+      // Every cite has year and court, and now caseName. Lower bound:
+      // 0.2 + 0.2 (year) + 0.1 (court) + 0.15 (caseName) = 0.65.
+      expect(c.confidence).toBeGreaterThanOrEqual(0.65)
+    }
+  })
+
+  it("Pennsylvania parallel: secondary's caseName signal fires", () => {
+    // Pa. primary, A. secondary. No court parenthetical, both have year.
+    // A. IS in COMMON_REPORTERS → +0.3 reporter bonus.
+    // After fix:  0.2 + 0.3 + 0.2 (year) + 0.15 (caseName) = 0.85.
+    const text = "Nixon v. Nixon, 329 Pa. 256, 198 A. 154 (1938)."
+    const cites = extractCitations(text).filter((c) => c.type === "case")
+    expect(cites).toHaveLength(2)
+
+    const secondary = cites.find((c) => c.type === "case" && c.reporter === "A.")
+    expect(secondary).toBeDefined()
+    if (secondary?.type !== "case") return
+
+    expect(secondary.caseName).toBe("Nixon v. Nixon")
+    expect(secondary.year).toBe(1938)
+    // Exact: A. is COMMON_REPORTERS member, year present, no court, caseName.
+    expect(secondary.confidence).toBe(0.85)
+  })
+
+  it("California bracketed parallel: secondary's caseName signal fires", () => {
+    // Cal.4th primary, Cal.Rptr.2d secondary. Cal.Rptr.2d isn't in
+    // COMMON_REPORTERS and the bracketed parallel doesn't carry year onto
+    // the secondary either, so the ONLY signal it can have after inheritance
+    // is caseName.
+    //   0.2 base + 0.15 caseName = 0.35.
+    // Without the fix it's 0.2 (base only). Asserting > 0.2 is the proof.
+    const text = "People v. Smith (2001) 24 Cal.4th 849 [102 Cal.Rptr.2d 731]."
+    const cites = extractCitations(text).filter((c) => c.type === "case")
+    expect(cites).toHaveLength(2)
+
+    const secondary = cites.find((c) => c.type === "case" && c.reporter === "Cal.Rptr.2d")
+    expect(secondary).toBeDefined()
+    if (secondary?.type !== "case") return
+
+    expect(secondary.caseName).toBe("People v. Smith")
+    // Bug pre-fix: 0.2. After fix: 0.35.
+    expect(secondary.confidence).toBe(0.35)
+  })
+
+  it("single non-parallel citation is unchanged by the fix", () => {
+    // Sanity: nothing about a non-parallel cite goes through inheritance.
+    const text = "Smith v. Jones, 500 F.2d 100 (1974)."
+    const cites = extractCitations(text).filter((c) => c.type === "case")
+    expect(cites).toHaveLength(1)
+    if (cites[0].type !== "case") return
+
+    expect(cites[0].caseName).toBe("Smith v. Jones")
+    expect(cites[0].groupId).toBeUndefined()
+    // 0.2 + 0.3 (F.2d) + 0.2 (year) + 0.15 (caseName) = 0.85.
+    expect(cites[0].confidence).toBe(0.85)
+  })
+
+  it("secondary without an inherited caseName keeps its original score", () => {
+    // No surrounding case name → inheritance loop never fires (primary has
+    // nothing to give). Secondaries stay at their pre-inheritance score.
+    const text = "410 U.S. 113, 93 S. Ct. 705 (1973)."
+    const cites = extractCitations(text).filter((c) => c.type === "case")
+    expect(cites.length).toBeGreaterThanOrEqual(2)
+    for (const c of cites) {
+      if (c.type !== "case") continue
+      expect(c.caseName).toBeUndefined()
+      // No caseName → no +0.15. Bounded above by year (+0.2) + court (+0.1)
+      // + reporter, never reaches the caseName-enabled range.
+      expect(c.confidence).toBeLessThan(0.9)
+    }
+  })
+
+  it("secondary that already has its own caseName is not double-counted", () => {
+    // Defensive: the inheritance loop has `if (secondary.caseName) continue`,
+    // so a secondary that already carried a caseName at extract time should
+    // not be recomputed. We can't easily trigger this in pure text input
+    // (parallel detection key`s off the absence of an intervening case name),
+    // but we can at least exercise the non-parallel path as a regression
+    // guard for shared-helper math: a cite that earned +0.15 the first time
+    // should still score the same when run through the helper directly.
+    const text = "Smith v. Jones, 500 F.2d 100 (1974)."
+    const cites = extractCitations(text).filter((c) => c.type === "case")
+    if (cites[0].type !== "case") return
+    expect(cites[0].confidence).toBe(0.85)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #556. `inheritParallelCaseName` (`extractCitations.ts:1386`) mutates `caseName`/`plaintiff`/`defendant` onto each parallel-cite secondary as a post-pass. But `confidence` was already locked in by the inline scoring block in `buildCaseCitation` when the secondary's `caseName` was still undefined — the `+0.15` caseName signal never fired.

## Fix

Two-step, surgical:

1. Factored the inline confidence formula into a pure exported helper `computeCaseConfidence({ reporter, year, caseName, court, hasBlankPage })` in `extractCase.ts` — no behavior change at the original site.
2. After `inheritParallelCaseName` mutates the caption fields on a secondary, re-derives `secondary.confidence` with the same helper. Recompute fires only on secondaries whose `caseName` was previously undefined (existing loop short-circuits when it's present).

Chose re-derive over delta-add so the inherited score is robust to future formula tweaks and respects cap/floor logic.

## Cross-PR notes

- **Independent of #555** — recompute uses the secondary's own reporter/year/court. When #555's reporter-DB autoload lands, the secondary will benefit automatically. Concretely: for Roe's `S.Ct.` secondary, this fix takes it from 0.50 → 0.65; with #555 also fixed it lands at 0.95 (matching primary).
- **Out of scope:** `inheritSubsequentHistoryCaseName` has the exact same bug pattern. Worth a follow-up issue.

## Test plan

- [x] 7 new tests in `tests/integration/parallelSecondaryConfidence.test.ts` — 4 fixed (Roe 2- and 3-reporter, Pa./A., Cal.4th/Cal.Rptr.2d) + 3 regression guards
- [x] Red-green verified: 4/7 fail without the recompute, 7/7 pass with it
- [x] `pnpm exec vitest run` — 3271 passed (+7), 9 skipped, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)