### PR TITLE
fix(extract): Sprint D — paren + history cluster (#522, #527, #528, #529)

### DIFF
--- a/.changeset/fix-522-nested-paren-year-leak.md
+++ b/.changeset/fix-522-nested-paren-year-leak.md
@@ -1,0 +1,26 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): stop nested-paren content from leaking page numbers as `year`
+and prose body as `court` (#522)
+
+The metadata-paren regexes (`PAREN_REGEX`, `LOOKAHEAD_PAREN_REGEX`) match
+non-greedy `[^)]+`, so a paren that contains a nested paren —
+`(quoting United States v. Janis, 428 U.S. 433, 458, 96 S.Ct. 3021, 49
+L.Ed.2d 1046 (1976))` — was truncated at the first `)`. `parseParenthetical`
+then picked up the first 4-digit token as the year (the page number `3021`)
+and the entire truncated prose body as the court. SCOTUS opinions hit this
+constantly because explanatory `(quoting/citing/see ... (YYYY))` patterns
+are everywhere.
+
+The fix adds `isNonMetadataParenContent(content)`, used everywhere a
+parenthetical is about to be fed to `parseParenthetical`. The helper
+recognises three explanatory-paren shapes that must never produce metadata:
+unbalanced parens (regex truncated past an inner `(`), a leading signal
+word, or a nested `(YYYY)` paren in the body. Hit any of these → skip
+metadata extraction. Year/court fields stay unset on the outer cite, and
+the SCOTUS / circuit / state reporter inference downstream applies as if
+the paren were absent. The full balanced paren is then captured by
+`collectParentheticals` (depth-tracking) and surfaced through
+`parentheticals` with the correct signal type (`quoting`, `citing`, etc.).

--- a/.changeset/fix-527-chained-history.md
+++ b/.changeset/fix-527-chained-history.md
@@ -1,0 +1,30 @@
+---
+"eyecite-ts": minor
+---
+
+fix(extract): chained subsequent history attaches each link's entry to its
+immediate parent, not the chain root (#527)
+
+In a chain like `<root>, aff'd, <A>, cert. denied, <B>`, A is the
+affirmance of the root and B is the cert. denial OF A (not of the
+original root). The scanner already correctly attached `affirmed` to the
+root and `cert. denied` to A. The Union-Find linker then collapsed
+everything into a single component and aggregated all entries onto the
+root, with two visible defects:
+
+- A lost its own `subsequentHistoryEntries` (the linker cleared them
+  during aggregation), so the trailing chain link was effectively
+  dropped from A.
+- B's `subsequentHistoryOf` pointed back at the root rather than at A,
+  breaking downstream `citationGraph` "history-of" edges.
+
+The linker now skips Union-Find aggregation entirely. Each child resolves
+to the lowest-indexed parent that paired with it (the primary cite of the
+immediately-preceding chain link, naturally found via the scanner's own
+position-based pairing). Entries stay where the scanner attached them.
+
+This is a behavior change for the shape of `subsequentHistoryEntries`
+across multi-link chains — the original cite now holds ONLY its direct
+child's signal, with downstream signals living on the intermediate cites.
+Existing tests that asserted "all entries on root" were updated to the
+correct semantics.

--- a/.changeset/fix-528-paren-lookahead.md
+++ b/.changeset/fix-528-paren-lookahead.md
@@ -1,0 +1,20 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): raise `collectParentheticals` lookahead so long explanatory
+parens and any trailing history clause survive (#528)
+
+The scanner's `maxLookahead=500` silently dropped any explanatory
+parenthetical whose closing `)` fell past the 500-char window — and the
+trailing history clause (`cert. denied, ...`, `aff'd, ...`) after it.
+Modern caselaw explanatory parens routinely run hundreds of characters,
+so this fired often enough to be a real defect.
+
+The default soft cap is now 2000 chars (4× the old limit), and once an
+opening `(` is seen inside the window the depth-tracking inner loop is
+allowed to chase the matching `)` up to a 10,000-char hard ceiling. That
+way a paren whose body overflows the soft window is still captured intact,
+and the scanner can keep walking after it to pick up trailing history
+signals. Perf is unchanged on representative opinions (linear walk, early
+termination on the first non-paren / non-signal character).

--- a/.changeset/fix-529-disposition-court-leak.md
+++ b/.changeset/fix-529-disposition-court-leak.md
@@ -1,0 +1,15 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): stop disposition keywords from leaking into the `court` field (#529)
+
+`(per curiam)`, `(en banc)`, `(in bank)`, `(plurality opinion)`, `(mem.)`,
+and `(unpublished table decision)` parens were being written to both
+`court` and `disposition`. The disposition string overwrote the
+reporter-based court inference, so `455 U.S. 478 (1982) (per curiam)`
+returned `court="per curiam"` instead of `court="scotus"`. Disposition is
+orthogonal to court — it describes how an opinion was issued, not which
+court issued it. The parser now clears `court` (and the matching span
+offsets) whenever it equals the disposition text it just recognised, so
+SCOTUS / circuit / state inference survives a trailing disposition paren.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1900,24 +1900,48 @@ interface CollectedParentheticals {
 }
 
 /**
+ * Hard safety ceiling on how far the paren depth-tracker scans past
+ * `maxLookahead` when chasing a matching close paren that lives beyond the
+ * window. 10,000 chars is well past anything legal text produces (the
+ * longest explanatory parentheticals in modern caselaw run ~1500 chars).
+ * The scanner exits the moment depth returns to 0, so the ceiling is only
+ * touched on pathological inputs (unclosed parens). See #528.
+ */
+const PAREN_CLOSE_HARD_CEILING = 10000
+
+/**
  * Collect all top-level parenthetical blocks starting from a position.
  * Uses depth tracking to handle nested parens. Continues scanning through
  * chained parentheticals and subsequent history signals.
  *
  * @param text - Full text to scan
  * @param startPos - Position to start scanning (typically after citation core)
- * @param maxLookahead - Maximum characters to scan forward (default 500)
+ * @param maxLookahead - Soft cap on how far the scanner looks for a NEW
+ *   parenthetical or signal (default 2000 chars — comfortably larger than
+ *   the worst-case modern explanatory paren and any trailing history
+ *   clause). The pre-#528 default was 500, which silently dropped any
+ *   explanatory paren whose closing `)` fell past the limit AND any history
+ *   clause that followed it.
+ *
+ *   Once an opening `(` is found inside the window, the depth-tracking loop
+ *   chases the matching `)` up to `PAREN_CLOSE_HARD_CEILING` chars from the
+ *   citation, so a paren whose body overflows `maxLookahead` is still
+ *   captured intact. Linear walk + early termination keeps the perf cost
+ *   bounded.
  * @returns Collected parentheticals with associated signals
  */
 function collectParentheticals(
   text: string,
   startPos: number,
-  maxLookahead = 500,
+  maxLookahead = 2000,
 ): CollectedParentheticals {
   const parens: RawParenthetical[] = []
   const signals: CollectedParentheticals["signals"] = []
   let pos = startPos
   const endLimit = Math.min(text.length, startPos + maxLookahead)
+  // Hard ceiling for the inner depth-tracking loop. Allows a paren whose
+  // closing `)` lives outside `endLimit` to still be captured intact (#528).
+  const hardEndLimit = Math.min(text.length, startPos + PAREN_CLOSE_HARD_CEILING)
   let pendingSignal: RawSignal | undefined
 
   // Skip past any pincite text between core citation and parentheticals.
@@ -1961,12 +1985,14 @@ function collectParentheticals(
       break
     }
 
-    // Found opening paren — track depth to find matching close
+    // Found opening paren — track depth to find matching close.
+    // Allow the inner loop to run up to `hardEndLimit` so a paren whose
+    // body overflows the soft `maxLookahead` is still captured intact.
     const parenStart = pos
     let depth = 0
     const contentStart = pos + 1
 
-    while (pos < endLimit) {
+    while (pos < hardEndLimit) {
       const char = text[pos]
       if (char === "(") {
         depth++

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -547,6 +547,58 @@ function isSignalWord(word: string): word is ParentheticalType {
 /** Matches a leading word (used to extract signal word candidate) */
 const LEADING_WORD_REGEX = /^([a-z]+)\b/i
 
+/**
+ * Detect parenthetical content that *cannot* be a metadata paren —
+ * three shapes, all symptoms of #522 (nested-paren leak):
+ *
+ * 1. Unbalanced parens (more `(` than `)`): the regex truncated past an
+ *    inner open paren and the actual paren extends further. Common shape:
+ *    `quoting X v. Y, ... (1995` (closing `)` consumed as the regex's own).
+ *
+ * 2. Leading signal word (`quoting`, `citing`, `holding`, etc.): explanatory
+ *    prose, never metadata.
+ *
+ * 3. Nested `(YYYY)` inside the content: the inner year belongs to a quoted
+ *    citation (`see Foo v. Bar, 100 U.S. 1 (1995)`) — and broader Bluebook
+ *    metadata parens never contain a nested year paren. Catches `see`/`but
+ *    see`/`accord`/etc. lead-ins that aren't in `SIGNAL_WORDS` but still
+ *    follow the same explanatory shape with a nested year paren.
+ *
+ * Before this guard, all three shapes ran through `parseParenthetical`, which
+ * picked up the first 4-digit token as a year (often a page number from
+ * inside the nested paren) and the entire prose body as a court — corrupting
+ * the outer cite. The lookahead, in-token paren, and classification paths
+ * gate metadata extraction on this check before calling `parseParenthetical`.
+ *
+ * NOTE: `collectParentheticals` uses depth-tracking and returns balanced
+ * content, but the balanced content can still fall into shape #3 (e.g., the
+ * full `see ... (1995)`). The check applies uniformly across all paren paths.
+ */
+function isNonMetadataParenContent(content: string): boolean {
+  // Unbalanced parens: more `(` than `)` means the lookahead regex stopped at
+  // an inner `)` and the actual paren extends further.
+  let depth = 0
+  for (const ch of content) {
+    if (ch === "(") depth++
+    else if (ch === ")") depth--
+  }
+  if (depth > 0) return true
+
+  // Leading signal word — explanatory paren, not metadata.
+  const leadingMatch = LEADING_WORD_REGEX.exec(content)
+  if (leadingMatch) {
+    const candidate = leadingMatch[1].toLowerCase()
+    if (isSignalWord(candidate)) return true
+  }
+
+  // Nested `(YYYY)` inside the content — the inner year paren marks an
+  // embedded citation (`see Foo, 100 U.S. 1 (1995)`). A real metadata paren
+  // never contains another year paren.
+  if (/\(\d{4}\)/.test(content)) return true
+
+  return false
+}
+
 /** Standard "v." or "vs." case name format.
  *
  *  The trailing alternation accepts either a comma (Bluebook form:
@@ -2201,6 +2253,12 @@ function classifyParenthetical(raw: string):
     }
   }
 
+  // Non-metadata shape (nested year paren, unbalanced, etc.) — classify as
+  // explanatory `other` so it never feeds `parseParenthetical`. See #522.
+  if (isNonMetadataParenContent(raw)) {
+    return { kind: "explanatory", text: raw, type: "other" }
+  }
+
   // Try metadata parse: court, year, date, disposition
   // Note: "other"-type parens with embedded years (e.g., "the court, in 2019, held X")
   // will be classified as metadata. This is a known limitation — most explanatory
@@ -2626,7 +2684,7 @@ export function extractCase(
   // When a nominative reporter is present, the first paren in token text is the
   // nominative (e.g., "(2 Black)") — skip it so the year/court look-ahead runs.
   const parenMatch = PAREN_REGEX.exec(text)
-  if (parenMatch && !nominativeVolume) {
+  if (parenMatch && !nominativeVolume && !isNonMetadataParenContent(parenMatch[1])) {
     parentheticalContent = parenMatch[1]
     // Parse parenthetical using unified parser
     metaParenResult = parseParenthetical(parentheticalContent)
@@ -2694,7 +2752,7 @@ export function extractCase(
       parenAfterToken = parenAfterToken.substring(unpubMatch[0].length)
     }
     const lookAheadMatch = LOOKAHEAD_PAREN_REGEX.exec(parenAfterToken)
-    if (lookAheadMatch) {
+    if (lookAheadMatch && !isNonMetadataParenContent(lookAheadMatch[1])) {
       parentheticalContent = lookAheadMatch[1]
       // Parse parenthetical using unified parser
       metaParenResult = parseParenthetical(parentheticalContent)

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -2112,14 +2112,17 @@ export function parseParenthetical(content: string): {
   // unpublished table decision. Checked before en banc/per curiam.
   if (/^plurality\s+opinion\b/i.test(content.trim())) {
     result.disposition = "plurality opinion"
+    clearCourtIfDisposition(result, "plurality opinion")
     return result
   }
   if (/^mem\.\s*$/i.test(content.trim())) {
     result.disposition = "mem."
+    clearCourtIfDisposition(result, "mem.")
     return result
   }
   if (/^unpublished\s+table\s+decision\b/i.test(content.trim())) {
     result.disposition = "unpublished table decision"
+    clearCourtIfDisposition(result, "unpublished table decision")
     return result
   }
 
@@ -2131,13 +2134,41 @@ export function parseParenthetical(content: string): {
   // — added as a separate disposition value to preserve the CA distinction.
   if (/\ben banc\b\s*$/i.test(content.trim())) {
     result.disposition = "en banc"
+    clearCourtIfDisposition(result, "en banc")
   } else if (/\bin bank\b\s*$/i.test(content.trim())) {
     result.disposition = "in bank"
+    clearCourtIfDisposition(result, "in bank")
   } else if (/\bper curiam\b\s*$/i.test(content.trim())) {
     result.disposition = "per curiam"
+    clearCourtIfDisposition(result, "per curiam")
   }
 
   return result
+}
+
+/**
+ * Strip a disposition phrase from `result.court` when the court field is *only*
+ * the disposition text (e.g., `(per curiam)` content yields
+ * `court="per curiam"` from `stripDateFromCourt`, since it returns any
+ * letter-bearing string after stripping date components). Disposition is
+ * orthogonal to court — keeping both with the same value lets the disposition
+ * leak into the court field downstream, overriding reporter-based inference
+ * (e.g., SCOTUS for `455 U.S. 478 (1982) (per curiam)`). See #529.
+ *
+ * If court contains additional non-disposition text (e.g., `9th Cir. (en banc)`
+ * — pathological but theoretically possible), preserve it.
+ */
+function clearCourtIfDisposition(
+  result: { court?: string; courtStart?: number; courtEnd?: number },
+  disposition: string,
+): void {
+  if (!result.court) return
+  const normalized = result.court.trim().toLowerCase()
+  if (normalized === disposition.toLowerCase()) {
+    result.court = undefined
+    result.courtStart = undefined
+    result.courtEnd = undefined
+  }
 }
 
 /**

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -12,7 +12,6 @@
  */
 
 import { cleanText } from "@/clean"
-import { UnionFind } from "@/extract/unionFind"
 import { detectFootnotes } from "@/footnotes/detectFootnotes"
 import { mapFootnoteZones } from "@/footnotes/mapZones"
 import { tagCitationsWithFootnotes } from "@/footnotes/tagging"
@@ -614,8 +613,11 @@ export async function extractCitationsAsync(
  * Replaces the old mutation-during-iteration pattern with cleanly separated phases.
  */
 function linkSubsequentHistory(citations: Citation[]): void {
-  // Phase 1: Signal matching — collect (parent, child) pairs without mutating citations.
-  // Also record each child's signal text for back-pointer assignment in Phase 3.
+  // Phase 1: Signal matching — collect (parent, child) pairs without mutating
+  // citations. Each parent walks its own scanner-captured
+  // `subsequentHistoryEntries`; each entry is paired with the nearest case
+  // citation that starts after the entry's signal text. Multiple parents may
+  // pair with the same child when parallel cites share a trailing signal.
   const pairs: Array<{ parentIdx: number; childIdx: number; signal: HistorySignal }> = []
 
   for (let i = 0; i < citations.length; i++) {
@@ -639,50 +641,36 @@ function linkSubsequentHistory(citations: Citation[]): void {
 
   if (pairs.length === 0) return
 
-  // Phase 2: Union — build connected components from parent-child pairs.
-  const uf = new UnionFind(citations.length)
+  // Phase 2: Resolve each child to its canonical parent. When several pairs
+  // target the same child (e.g., a parent + its parallel-cite siblings all
+  // carry the same trailing signal on their own `subsequentHistoryEntries`),
+  // the parent with the LOWEST index wins — that's the primary cite of the
+  // immediately-preceding chain link. The scanner only attaches signals it
+  // sees BEFORE encountering the next citation token, so a non-primary
+  // upstream cite cannot pair with this child unless it sits in the same
+  // parallel group as the primary — picking the lowest index naturally points
+  // at the primary. The previous Union-Find approach collapsed every chain
+  // link onto a single root, which (a) wrongly attributed second-tier history
+  // entries to the original cite (`cert. denied` of an `aff'd` child became
+  // the original's cert. denial) and (b) destroyed the second-tier child's
+  // own `subsequentHistoryEntries`. Closes #527.
+  const bestParent = new Map<number, { parentIdx: number; signal: HistorySignal }>()
   for (const pair of pairs) {
-    uf.union(pair.parentIdx, pair.childIdx)
-  }
-
-  // Build lookup: childIdx → signal (for back-pointer assignment)
-  const childSignals = new Map<number, HistorySignal>()
-  for (const pair of pairs) {
-    childSignals.set(pair.childIdx, pair.signal)
-  }
-
-  // Phase 3: Aggregation — set back-pointers and collect entries onto chain roots.
-  for (const [root, members] of uf.components()) {
-    if (members.length === 1) continue
-
-    const rootCitation = citations[root]
-    if (rootCitation.type !== "case") continue
-
-    const allEntries = [...(rootCitation.subsequentHistoryEntries ?? [])]
-
-    for (const memberIdx of members) {
-      if (memberIdx === root) continue
-
-      const member = citations[memberIdx]
-      if (member.type !== "case") continue
-
-      // Set back-pointer to chain root.
-      // Signal is guaranteed to exist: every non-root member was recorded as a
-      // child in Phase 1, which always stores the signal in childSignals.
-      const signal = childSignals.get(memberIdx)
-      if (!signal) continue
-      member.subsequentHistoryOf = { index: root, signal }
-
-      // Aggregate entries from non-root members onto the root
-      if (member.subsequentHistoryEntries) {
-        for (const entry of member.subsequentHistoryEntries) {
-          allEntries.push({ ...entry, order: allEntries.length })
-        }
-        member.subsequentHistoryEntries = undefined
-      }
+    const current = bestParent.get(pair.childIdx)
+    if (!current || pair.parentIdx < current.parentIdx) {
+      bestParent.set(pair.childIdx, { parentIdx: pair.parentIdx, signal: pair.signal })
     }
+  }
 
-    rootCitation.subsequentHistoryEntries = allEntries
+  // Phase 3: Set back-pointers on children. Entries stay where the scanner
+  // attached them — the root's own scanner-captured entries are correct
+  // (just `affirmed`, not the downstream `cert. denied`), and each downstream
+  // cite keeps its own scanner-captured entries (e.g., the affirming cite
+  // keeps `[cert. denied]`).
+  for (const [childIdx, { parentIdx, signal }] of bestParent) {
+    const child = citations[childIdx]
+    if (child.type !== "case") continue
+    child.subsequentHistoryOf = { index: parentIdx, signal }
   }
 }
 

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -1856,17 +1856,26 @@ describe("subsequent history signals (#73)", () => {
     }
   })
 
-  it("captures chained history signals with correct order", () => {
+  it("captures chained history signals — each on its immediate parent (#527)", () => {
+    // Chain: <root>, aff'd, <A>, cert. denied, <B>.
+    //   Root keeps only its own child signal (`affirmed`).
+    //   The affirming cite (A) keeps the downstream `cert. denied` signal —
+    //   that's HIS cert. denial, not the root's.
+    // Before #527 fix, Union-Find aggregated both signals onto the root and
+    // wired B back to the root.
     const citations = extractCitations(
       "Smith v. Jones, 500 F.2d 123 (2d Cir. 1990), aff'd, 501 U.S. 1 (1991), cert. denied, 502 U.S. 2 (1992)",
     )
     expect(citations[0].type).toBe("case")
     if (citations[0].type === "case") {
-      expect(citations[0].subsequentHistoryEntries).toHaveLength(2)
+      expect(citations[0].subsequentHistoryEntries).toHaveLength(1)
       expect(citations[0].subsequentHistoryEntries?.[0].signal).toBe("affirmed")
       expect(citations[0].subsequentHistoryEntries?.[0].order).toBe(0)
-      expect(citations[0].subsequentHistoryEntries?.[1].signal).toBe("cert_denied")
-      expect(citations[0].subsequentHistoryEntries?.[1].order).toBe(1)
+    }
+    expect(citations[1].type).toBe("case")
+    if (citations[1].type === "case") {
+      expect(citations[1].subsequentHistoryEntries).toHaveLength(1)
+      expect(citations[1].subsequentHistoryEntries?.[0].signal).toBe("cert_denied")
     }
   })
 
@@ -5211,8 +5220,14 @@ describe("California year-first citation format (#19)", () => {
  * `rehearing denied` signal entries.
  */
 describe("multi-stage subsequent history chains (#246)", () => {
-  describe("two-link chains lock in correct parent entries + back-pointers", () => {
-    it("`aff'd, X, overruled by Y` produces two entries on the parent", () => {
+  describe("two-link chains: each entry on its immediate parent (#527)", () => {
+    // After #527, each chain link's signal stays on the cite it semantically
+    // belongs to: `<root>, aff'd, <A>, overruled by Y` → root has [affirmed]
+    // (root's own affirmance), and A (the affirming cite) has [overruled]
+    // (A's overruling — the cert/over decision targets the most-recent
+    // appellate disposition, not the original). The back-pointer chain still
+    // captures the same information, just along the correct edges.
+    it("`aff'd, X, overruled by Y` — affirmed on root, overruled on the affirming cite", () => {
       const text =
         "Smith v. Jones, 100 F.2d 100 (2d Cir. 1990), aff'd, 200 U.S. 1 (1992), overruled by Doe v. Roe, 300 U.S. 50 (2010)."
       const cits = extractCitations(text)
@@ -5227,41 +5242,51 @@ describe("multi-stage subsequent history chains (#246)", () => {
         link3.type === "case"
       ) {
         expect(parent.text).toBe("100 F.2d 100")
-        expect(parent.subsequentHistoryEntries?.length).toBe(2)
+        expect(parent.subsequentHistoryEntries?.length).toBe(1)
         expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe("affirmed")
-        expect(parent.subsequentHistoryEntries?.[1]?.signal).toBe("overruled")
+        // The overruled signal sits on the affirming cite (link2), not root.
+        expect(link2.subsequentHistoryEntries?.length).toBe(1)
+        expect(link2.subsequentHistoryEntries?.[0]?.signal).toBe("overruled")
+        // Back-pointers thread through the chain.
         expect(link2.subsequentHistoryOf?.signal).toBe("affirmed")
+        expect(link2.subsequentHistoryOf?.index).toBe(cases.indexOf(parent))
         expect(link3.subsequentHistoryOf?.signal).toBe("overruled")
+        // link3's parent is the affirming cite (link2), NOT root.
+        expect(link3.subsequentHistoryOf?.index).toBe(cases.indexOf(link2))
       }
     })
 
-    it("`modified, X, cert. denied, Y` produces two entries on the parent", () => {
+    it("`modified, X, cert. denied, Y` — modified on root, cert. denied on the modified cite", () => {
       const text =
         "Brown v. State, 100 S.W.3d 1 (Tex. 2003), modified, 200 S.W.3d 100 (Tex. 2004), cert. denied, 600 U.S. 1 (2005)."
       const cits = extractCitations(text)
       const cases = cits.filter((c) => c.type === "case")
       expect(cases).toHaveLength(3)
       const parent = cases[0]
-      if (parent.type === "case") {
-        expect(parent.subsequentHistoryEntries?.length).toBe(2)
+      const link2 = cases[1]
+      if (parent.type === "case" && link2.type === "case") {
+        expect(parent.subsequentHistoryEntries?.length).toBe(1)
         expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe("modified")
-        expect(parent.subsequentHistoryEntries?.[1]?.signal).toBe("cert_denied")
+        expect(link2.subsequentHistoryEntries?.length).toBe(1)
+        expect(link2.subsequentHistoryEntries?.[0]?.signal).toBe("cert_denied")
       }
     })
 
-    it("`reh'g denied, X, cert. granted, Y` produces two entries on the parent", () => {
+    it("`reh'g denied, X, cert. granted, Y` — rehearing on root, cert. granted on the rehearing cite", () => {
       const text =
         "Acme Corp. v. Beta, 50 F.4th 1 (9th Cir. 2022), reh'g denied, 60 F.4th 50 (9th Cir. 2023), cert. granted, 700 U.S. 1 (2024)."
       const cits = extractCitations(text)
       const cases = cits.filter((c) => c.type === "case")
       expect(cases).toHaveLength(3)
       const parent = cases[0]
-      if (parent.type === "case") {
-        expect(parent.subsequentHistoryEntries?.length).toBe(2)
+      const link2 = cases[1]
+      if (parent.type === "case" && link2.type === "case") {
+        expect(parent.subsequentHistoryEntries?.length).toBe(1)
         expect(parent.subsequentHistoryEntries?.[0]?.signal).toBe(
           "rehearing_denied",
         )
-        expect(parent.subsequentHistoryEntries?.[1]?.signal).toBe(
+        expect(link2.subsequentHistoryEntries?.length).toBe(1)
+        expect(link2.subsequentHistoryEntries?.[0]?.signal).toBe(
           "cert_granted",
         )
       }

--- a/tests/extract/issue522NestedParenYear.test.ts
+++ b/tests/extract/issue522NestedParenYear.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Issue #522 — Year extracted from nested parenthetical content.
+ *
+ * Repro: `104 S.Ct. 3479 (quoting United States v. Janis, 428 U.S. 433, 458, 96 S.Ct. 3021, 49 L.Ed.2d 1046 (1976))`
+ *
+ *   Before fix:
+ *     outer `104 S.Ct. 3479`:
+ *       year=3021       ← page number from inside `(quoting ...)`
+ *       court="quoting United States v. Janis, 428 U.S. 433, 458, 96 S.Ct.
+ *              3021, 49 L.Ed.2d 1046 ("   ← entire (broken) paren body
+ *
+ *   After fix:
+ *     outer `104 S.Ct. 3479`:
+ *       year=undefined  (no year in the outer cite — the inner `(1976)`
+ *                        belongs to the quoted Janis cite, not to S.Ct. 3479)
+ *       court="scotus"  (preserved by reporter inference)
+ *       parentheticals=[{type: "quoting", text: "quoting United States v.
+ *                        Janis, ... (1976)"}]
+ *
+ * SCOTUS opinions trigger this constantly because explanatory `(quoting X v.
+ * Y, ## U.S. ##, ## (YYYY))` patterns are everywhere.
+ */
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { CaseCitation, Citation } from "@/types/citation"
+
+const caseCites = (text: string): CaseCitation[] =>
+  (extractCitations(text) as Citation[]).filter(
+    (c): c is CaseCitation => c.type === "case",
+  )
+
+describe("issue #522 — nested parenthetical leaks year/court into outer cite", () => {
+  it("outer S.Ct. cite does not capture inner paren year as own year", () => {
+    const cites = caseCites(
+      "104 S.Ct. 3479 (quoting United States v. Janis, 428 U.S. 433, 458, 96 S.Ct. 3021, 49 L.Ed.2d 1046 (1976))",
+    )
+    const outer = cites.find((c) => c.matchedText === "104 S.Ct. 3479")
+    expect(outer).toBeDefined()
+    if (!outer) return
+    // year MUST NOT be 3021 (page number from inside the quoted paren) — the
+    // page-as-year capture is the obvious symptom of the bug.
+    expect(outer.year).not.toBe(3021)
+    // court MUST NOT be the entire quoted body
+    expect(outer.court).not.toContain("Janis")
+    expect(outer.court).not.toContain("(")
+    // court should be the inferred SCOTUS string (S.Ct. → scotus)
+    expect(outer.court).toBe("scotus")
+  })
+
+  it("inner Janis cites are extracted with their own year", () => {
+    const cites = caseCites(
+      "104 S.Ct. 3479 (quoting United States v. Janis, 428 U.S. 433, 458, 96 S.Ct. 3021, 49 L.Ed.2d 1046 (1976))",
+    )
+    const janisFedReporter = cites.find((c) => c.matchedText === "428 U.S. 433")
+    expect(janisFedReporter).toBeDefined()
+    if (janisFedReporter) {
+      expect(janisFedReporter.year).toBe(1976)
+      expect(janisFedReporter.court).toBe("scotus")
+    }
+  })
+
+  it("explanatory `quoting` paren is captured as a parenthetical (signal=quoting)", () => {
+    const cites = caseCites(
+      "104 S.Ct. 3479 (quoting United States v. Janis, 428 U.S. 433, 458, 96 S.Ct. 3021, 49 L.Ed.2d 1046 (1976))",
+    )
+    const outer = cites.find((c) => c.matchedText === "104 S.Ct. 3479")
+    expect(outer).toBeDefined()
+    if (!outer) return
+    // The `quoting ...` parenthetical should surface as an explanatory paren
+    expect(outer.parentheticals).toBeDefined()
+    const quoting = outer.parentheticals?.find((p) => p.type === "quoting")
+    expect(quoting).toBeDefined()
+    expect(quoting?.text).toContain("United States v. Janis")
+    expect(quoting?.text).toContain("(1976)")
+  })
+
+  it("`see` signal with nested paren behaves the same as quoting", () => {
+    const cites = caseCites(
+      "500 F.3d 100 (see Doe v. Roe, 200 U.S. 1, 5, 50 S.Ct. 999, 999 (1995))",
+    )
+    const outer = cites.find((c) => c.matchedText === "500 F.3d 100")
+    expect(outer).toBeDefined()
+    if (!outer) return
+    // Year MUST NOT be the inner-paren value (1995 belongs to Doe v. Roe).
+    expect(outer.year).not.toBe(1995)
+    // Court MUST NOT capture the inner prose body.
+    expect(outer.court ?? "").not.toContain("Doe")
+  })
+
+  it("`citing` signal with nested paren behaves the same", () => {
+    const cites = caseCites(
+      "500 F.3d 100 (citing Foo v. Bar, 200 U.S. 1, 5, 50 S.Ct. 999, 999 (2010))",
+    )
+    const outer = cites.find((c) => c.matchedText === "500 F.3d 100")
+    expect(outer).toBeDefined()
+    if (!outer) return
+    // Year MUST NOT be the inner-paren value (2010 belongs to Foo v. Bar).
+    expect(outer.year).not.toBe(2010)
+    // Court MUST NOT capture the inner prose body.
+    expect(outer.court ?? "").not.toContain("Foo")
+  })
+
+  it("regular court+year paren (not nested) still works", () => {
+    // Sanity check: the fix must not break the common single-paren case.
+    const cites = caseCites("Smith v. Jones, 500 F.2d 123 (9th Cir. 2020)")
+    expect(cites).toHaveLength(1)
+    expect(cites[0].year).toBe(2020)
+    expect(cites[0].court).toBe("9th Cir.")
+  })
+
+  it("multi-cite parallel chain with nested-paren explanatory still extracts each", () => {
+    // 410 U.S. 113, 93 S.Ct. 705 is a parallel pair. The trailing
+    // explanatory paren must not corrupt either cite.
+    const cites = caseCites(
+      "Roe v. Wade, 410 U.S. 113, 117, 93 S.Ct. 705 (1973) (quoting Foo v. Bar, 100 U.S. 1 (1900))",
+    )
+    expect(cites.length).toBeGreaterThanOrEqual(2)
+    const us = cites.find((c) => c.matchedText === "410 U.S. 113")
+    expect(us?.year).toBe(1973)
+    expect(us?.court).toBe("scotus")
+  })
+})

--- a/tests/extract/issue527ChainedHistory.test.ts
+++ b/tests/extract/issue527ChainedHistory.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Issue #527 — Chained subsequent history on a history-child citation is lost.
+ *
+ * Repro: `Foo v. Bar, 1 U.S. 1, 5 (1990), aff'd, 543 U.S. 1098, 125 S.Ct. 992 (2005), cert. denied, 547 U.S. 1099, 126 S.Ct. 1344 (2006)`
+ *
+ *   Before fix:
+ *     `1 U.S. 1`:
+ *       subsequentHistoryEntries: [aff'd, cert. denied]   ← both signals
+ *                                                            collapsed onto
+ *                                                            the chain root
+ *     `543 U.S. 1098`:
+ *       subsequentHistoryOf: {index: 0 (= 1 U.S. 1), signal: aff'd}
+ *       subsequentHistoryEntries: undefined               ← MISSING — the
+ *                                                            cert. denied of
+ *                                                            this child is
+ *                                                            dropped from it
+ *     `547 U.S. 1099`:
+ *       subsequentHistoryOf: {index: 0 (= 1 U.S. 1), signal: cert_denied}
+ *                                                          ← WRONG PARENT.
+ *                                                            cert. denied
+ *                                                            belongs to
+ *                                                            `543 U.S. 1098`,
+ *                                                            not `1 U.S. 1`.
+ *
+ *   After fix:
+ *     `1 U.S. 1`:
+ *       subsequentHistoryEntries: [aff'd]                  ← only its own
+ *     `543 U.S. 1098`:
+ *       subsequentHistoryOf: {index: 0, signal: aff'd}
+ *       subsequentHistoryEntries: [cert. denied]           ← chained child
+ *     `547 U.S. 1099`:
+ *       subsequentHistoryOf: {index: 1 (= 543 U.S. 1098), signal: cert_denied}
+ *
+ * Same shape applies to `overruled ..., cert. denied, ...` and any other
+ * multi-link history chain.
+ */
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { CaseCitation, Citation } from "@/types/citation"
+
+const caseCites = (text: string): CaseCitation[] =>
+  (extractCitations(text) as Citation[]).filter(
+    (c): c is CaseCitation => c.type === "case",
+  )
+
+const findByMatched = (cites: CaseCitation[], text: string): CaseCitation | undefined =>
+  cites.find((c) => c.matchedText === text)
+
+describe("issue #527 — chained subsequent history on a history-child citation", () => {
+  it("`aff'd, ..., cert. denied, ...` chain attaches cert. denied to the affirming cite", () => {
+    const text =
+      "Foo v. Bar, 1 U.S. 1, 5 (1990), aff'd, 543 U.S. 1098, 125 S.Ct. 992 (2005), cert. denied, 547 U.S. 1099, 126 S.Ct. 1344 (2006)"
+    const cites = caseCites(text)
+    const root = findByMatched(cites, "1 U.S. 1")
+    const affirmed = findByMatched(cites, "543 U.S. 1098")
+    const certDenied = findByMatched(cites, "547 U.S. 1099")
+    expect(root).toBeDefined()
+    expect(affirmed).toBeDefined()
+    expect(certDenied).toBeDefined()
+    if (!root || !affirmed || !certDenied) return
+
+    // The cert. denied entry should land on the AFFIRMING cite, not the root.
+    expect(affirmed.subsequentHistoryEntries?.map((e) => e.signal)).toContain(
+      "cert_denied",
+    )
+    // The root's history entries should only include its own direct child,
+    // not the second-tier cert. denial.
+    expect(root.subsequentHistoryEntries?.map((e) => e.signal)).not.toContain(
+      "cert_denied",
+    )
+
+    // The cert-denied cite's back-pointer should point at the AFFIRMING cite,
+    // not the original root.
+    const cites2 = cites
+    const affirmedIdx = cites2.indexOf(affirmed)
+    expect(certDenied.subsequentHistoryOf?.index).toBe(affirmedIdx)
+    expect(certDenied.subsequentHistoryOf?.signal).toBe("cert_denied")
+  })
+
+  it("`overruled on other grounds by ..., cert. denied, ...` chain (issue exact repro)", () => {
+    const text =
+      "Estate v. Smith, 100 U.S. 1, 5 (2000), overruled on other grounds by Badilla v. United States, 543 U.S. 1098, 125 S.Ct. 992, 160 L.Ed.2d 1010 (2005), cert. denied, 547 U.S. 1099, 126 S.Ct. 1344, 164 L.Ed.2d 58 (2005)"
+    const cites = caseCites(text)
+    const root = findByMatched(cites, "100 U.S. 1")
+    const overruling = findByMatched(cites, "543 U.S. 1098")
+    const certDenied = findByMatched(cites, "547 U.S. 1099")
+    expect(root).toBeDefined()
+    expect(overruling).toBeDefined()
+    expect(certDenied).toBeDefined()
+    if (!root || !overruling || !certDenied) return
+
+    // The cert. denied entry should land on the OVERRULING cite, not the root.
+    expect(overruling.subsequentHistoryEntries?.map((e) => e.signal)).toContain(
+      "cert_denied",
+    )
+    // The root's entries should not include cert_denied.
+    expect(root.subsequentHistoryEntries?.map((e) => e.signal)).not.toContain(
+      "cert_denied",
+    )
+    // Back-pointer: cert. denied → overruling, not root.
+    const overrulingIdx = cites.indexOf(overruling)
+    expect(certDenied.subsequentHistoryOf?.index).toBe(overrulingIdx)
+  })
+
+  it("two-link chain: original `aff'd` link still wired correctly", () => {
+    const text =
+      "Foo v. Bar, 1 U.S. 1, 5 (1990), aff'd, 543 U.S. 1098, 125 S.Ct. 992 (2005), cert. denied, 547 U.S. 1099, 126 S.Ct. 1344 (2006)"
+    const cites = caseCites(text)
+    const root = findByMatched(cites, "1 U.S. 1")
+    const affirmed = findByMatched(cites, "543 U.S. 1098")
+    if (!root || !affirmed) return
+
+    // First link wiring: affirmed cite back-points at root with signal=affirmed
+    const rootIdx = cites.indexOf(root)
+    expect(affirmed.subsequentHistoryOf?.index).toBe(rootIdx)
+    expect(affirmed.subsequentHistoryOf?.signal).toBe("affirmed")
+    // Root has affirmed in its entries (regardless of how many entries total)
+    expect(root.subsequentHistoryEntries?.map((e) => e.signal)).toContain(
+      "affirmed",
+    )
+  })
+
+  it("single-link chain (no chained child) — no regression", () => {
+    // Sanity check: a plain `aff'd, ...` with no further history must still
+    // wire the way it always has.
+    const text = "Foo v. Bar, 1 U.S. 1, 5 (1990), aff'd, 543 U.S. 1098 (2005)"
+    const cites = caseCites(text)
+    const root = findByMatched(cites, "1 U.S. 1")
+    const affirmed = findByMatched(cites, "543 U.S. 1098")
+    if (!root || !affirmed) return
+
+    const rootIdx = cites.indexOf(root)
+    expect(affirmed.subsequentHistoryOf?.index).toBe(rootIdx)
+    expect(affirmed.subsequentHistoryOf?.signal).toBe("affirmed")
+    expect(root.subsequentHistoryEntries?.map((e) => e.signal)).toEqual([
+      "affirmed",
+    ])
+    // No second-tier history → no extra entries on the child.
+    expect(affirmed.subsequentHistoryEntries).toBeUndefined()
+  })
+})

--- a/tests/extract/issue528MaxLookahead.test.ts
+++ b/tests/extract/issue528MaxLookahead.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Issue #528 — Long explanatory parens (>~480 chars) overflow the scanner's
+ * 500-char `maxLookahead`, dropping both the long paren AND any history
+ * clause that follows it.
+ *
+ * The `collectParentheticals(text, startPos, maxLookahead = 500)` scanner
+ * caps its forward walk at 500 chars. When a citation has an explanatory
+ * paren close to that limit, the matching close paren falls outside the
+ * window — the scanner sees the OPENING `(` of the explanatory paren but
+ * never finds its closing `)`, so the paren is dropped. Any `cert. denied,
+ * ...`/`aff'd, ...` clause that follows the explanatory paren is also
+ * dropped because the scanner walks linearly past the end of the truncated
+ * paren and gives up.
+ *
+ * Bluebook explanatory parentheticals routinely run hundreds of characters
+ * in modern caselaw. A 480-char threshold drops the trailing history
+ * clause silently, which can change the citation graph.
+ */
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { CaseCitation, Citation } from "@/types/citation"
+
+const caseCites = (text: string): CaseCitation[] =>
+  (extractCitations(text) as Citation[]).filter(
+    (c): c is CaseCitation => c.type === "case",
+  )
+
+const longHolding = (charCount: number): string => {
+  // Build a realistic long holding paren of roughly the requested length.
+  const base = "holding that the question presented is a question of statutory interpretation and that the statute in question must be construed to give effect to congressional intent as reflected in the plain language of the text and its surrounding context; "
+  let acc = base
+  while (acc.length < charCount) acc += base
+  return acc.slice(0, charCount).trim()
+}
+
+describe("issue #528 — long explanatory parens overflow maxLookahead", () => {
+  it("explanatory paren of ~560 chars is captured (not dropped)", () => {
+    const holding = longHolding(560)
+    expect(holding.length).toBeGreaterThan(500)
+    const text = `Smith v. Jones, 543 U.S. 1098 (2005) (${holding})`
+    const cites = caseCites(text)
+    expect(cites).toHaveLength(1)
+    expect(cites[0].parentheticals?.length ?? 0).toBeGreaterThanOrEqual(1)
+    const holdingParen = cites[0].parentheticals?.find((p) => p.type === "holding")
+    expect(holdingParen).toBeDefined()
+  })
+
+  it("history clause AFTER a 560-char explanatory paren survives", () => {
+    const holding = longHolding(560)
+    const text = `Smith v. Jones, 543 U.S. 1098 (2005) (${holding}), cert. denied, 547 U.S. 1, 126 S.Ct. 1344 (2006)`
+    const cites = caseCites(text)
+    const primary = cites.find((c) => c.matchedText === "543 U.S. 1098")
+    expect(primary).toBeDefined()
+    if (!primary) return
+    // The `cert. denied` signal must reach the parent's history entries.
+    expect(primary.subsequentHistoryEntries?.map((e) => e.signal)).toContain(
+      "cert_denied",
+    )
+    // The cert-denied child cite must be wired back to primary.
+    const certDeniedChild = cites.find((c) => c.matchedText === "547 U.S. 1")
+    expect(certDeniedChild?.subsequentHistoryOf).toBeDefined()
+    expect(certDeniedChild?.subsequentHistoryOf?.signal).toBe("cert_denied")
+  })
+
+  it("history clause AFTER a 1500-char explanatory paren still survives", () => {
+    const holding = longHolding(1500)
+    const text = `Smith v. Jones, 543 U.S. 1098 (2005) (${holding}), cert. denied, 547 U.S. 1, 126 S.Ct. 1344 (2006)`
+    const cites = caseCites(text)
+    const primary = cites.find((c) => c.matchedText === "543 U.S. 1098")
+    if (!primary) return
+    expect(primary.subsequentHistoryEntries?.map((e) => e.signal)).toContain(
+      "cert_denied",
+    )
+  })
+
+  it("regression: short explanatory paren still works", () => {
+    // Sanity check that bumping maxLookahead doesn't break the common case.
+    const text = "Smith v. Jones, 500 F.2d 123 (2020) (holding X), aff'd, 501 U.S. 1 (2021)"
+    const cites = caseCites(text)
+    const primary = cites.find((c) => c.matchedText === "500 F.2d 123")
+    if (!primary) return
+    expect(primary.parentheticals?.[0]?.type).toBe("holding")
+    expect(primary.subsequentHistoryEntries?.map((e) => e.signal)).toContain(
+      "affirmed",
+    )
+  })
+})

--- a/tests/extract/issue529DispositionCourtLeak.test.ts
+++ b/tests/extract/issue529DispositionCourtLeak.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Issue #529 — Disposition keywords (`per curiam`, `plurality opinion`,
+ * `en banc`, `mem.`, `in bank`) must NOT leak into the `court` field.
+ *
+ * Repro: `Murphy v. Hunt, 455 U.S. 478, 102 S.Ct. 1181, 71 L.Ed.2d 353 (1982) (per curiam)`
+ *  - Before fix: each cite gets `court="per curiam"` (overriding the SCOTUS
+ *    inference) and `disposition="per curiam"`.
+ *  - After fix: `court="scotus"` (from reporter inference) and
+ *    `disposition="per curiam"`.
+ *
+ * `~0.5% rate — most common defect of the paren audit.` Disposition is
+ * orthogonal to court — it describes HOW the opinion was issued, not WHICH
+ * court issued it.
+ */
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { CaseCitation, Citation } from "@/types/citation"
+
+const caseCites = (text: string): CaseCitation[] =>
+  (extractCitations(text) as Citation[]).filter(
+    (c): c is CaseCitation => c.type === "case",
+  )
+
+describe("issue #529 — disposition does not leak into court field", () => {
+  it("per curiam alone preserves SCOTUS inference", () => {
+    const cites = caseCites(
+      "Murphy v. Hunt, 455 U.S. 478, 102 S.Ct. 1181, 71 L.Ed.2d 353 (1982) (per curiam)",
+    )
+    expect(cites).toHaveLength(3)
+    for (const c of cites) {
+      expect(c.disposition).toBe("per curiam")
+      expect(c.court).toBe("scotus")
+    }
+  })
+
+  it("per curiam without a year paren still preserves SCOTUS inference", () => {
+    const cites = caseCites("500 U.S. 1 (per curiam)")
+    expect(cites).toHaveLength(1)
+    expect(cites[0].disposition).toBe("per curiam")
+    expect(cites[0].court).toBe("scotus")
+  })
+
+  it("plurality opinion alone preserves SCOTUS inference", () => {
+    const cites = caseCites(
+      "Sample v. Other, 500 U.S. 1, 5 (1991) (plurality opinion)",
+    )
+    expect(cites).toHaveLength(1)
+    expect(cites[0].disposition).toBe("plurality opinion")
+    expect(cites[0].court).toBe("scotus")
+  })
+
+  it("en banc alone preserves SCOTUS inference (rare but possible)", () => {
+    const cites = caseCites("500 U.S. 1 (en banc)")
+    expect(cites).toHaveLength(1)
+    expect(cites[0].disposition).toBe("en banc")
+    expect(cites[0].court).toBe("scotus")
+  })
+
+  it("mem. alone preserves SCOTUS inference", () => {
+    const cites = caseCites("500 U.S. 1 (mem.)")
+    expect(cites).toHaveLength(1)
+    expect(cites[0].disposition).toBe("mem.")
+    expect(cites[0].court).toBe("scotus")
+  })
+
+  it("in bank alone preserves SCOTUS inference", () => {
+    // `in bank` is the California Supreme Court's equivalent of `en banc`.
+    // Not realistic on a SCOTUS reporter, but the contract is the same: a
+    // disposition keyword must not overwrite an inferred court.
+    const cites = caseCites("500 U.S. 1 (in bank)")
+    expect(cites).toHaveLength(1)
+    expect(cites[0].disposition).toBe("in bank")
+    expect(cites[0].court).toBe("scotus")
+  })
+
+  it("court + disposition chain still extracts the real court", () => {
+    const cites = caseCites(
+      "Smith v. Jones, 500 F.2d 123 (9th Cir. 2020) (en banc)",
+    )
+    expect(cites).toHaveLength(1)
+    expect(cites[0].court).toBe("9th Cir.")
+    expect(cites[0].year).toBe(2020)
+    expect(cites[0].disposition).toBe("en banc")
+  })
+
+  it("disposition + court chain still extracts the real court", () => {
+    // `(per curiam) (9th Cir. 2020)` — disposition first, then real court paren
+    const cites = caseCites(
+      "Smith v. Jones, 500 F.2d 123 (per curiam) (9th Cir. 2020)",
+    )
+    expect(cites).toHaveLength(1)
+    expect(cites[0].court).toBe("9th Cir.")
+    expect(cites[0].year).toBe(2020)
+    expect(cites[0].disposition).toBe("per curiam")
+  })
+
+  it("court field is empty for a state reporter with disposition-only paren", () => {
+    // Non-SCOTUS reporter with only disposition keyword: no court inference.
+    // `court` should remain undefined (not "per curiam").
+    const cites = caseCites("500 F.2d 123 (per curiam)")
+    expect(cites).toHaveLength(1)
+    expect(cites[0].disposition).toBe("per curiam")
+    expect(cites[0].court).toBeUndefined()
+  })
+})

--- a/tests/integration/subsequentHistory.test.ts
+++ b/tests/integration/subsequentHistory.test.ts
@@ -18,27 +18,36 @@ describe("subsequent history linking (#73)", () => {
     }
   })
 
-  it("links chained history — all entries on original parent", () => {
+  it("links chained history — each entry stays on its immediate parent (#527)", () => {
+    // Chain semantics: in `<root>, aff'd, <A>, cert. denied, <B>`, A is the
+    // affirmance of the root, and B is the cert. denial OF A (not of root).
+    // Each chain link's signal entry therefore belongs to the immediately-
+    // preceding cite, not to the original chain root. Before the #527 fix,
+    // Union-Find collapsed everything onto the root.
     const citations = extractCitations(
       "Smith v. Jones, 500 F.2d 123 (2d Cir. 1990), aff'd, 501 U.S. 1 (1991), cert. denied, 502 U.S. 2 (1992)",
     )
     expect(citations.length).toBeGreaterThanOrEqual(3)
     expect(citations[0].type).toBe("case")
     if (citations[0].type === "case") {
-      expect(citations[0].subsequentHistoryEntries).toHaveLength(2)
+      // Root has only its own direct child signal (affirmed) — NOT cert_denied.
+      expect(citations[0].subsequentHistoryEntries).toHaveLength(1)
       expect(citations[0].subsequentHistoryEntries?.[0].signal).toBe("affirmed")
       expect(citations[0].subsequentHistoryEntries?.[0].order).toBe(0)
-      expect(citations[0].subsequentHistoryEntries?.[1].signal).toBe("cert_denied")
-      expect(citations[0].subsequentHistoryEntries?.[1].order).toBe(1)
     }
-    // Both children point back to parent
+    // 501 U.S. 1 is the affirming cite; its own scanner-captured entries hold
+    // the downstream `cert. denied`.
     expect(citations[1].type).toBe("case")
     if (citations[1].type === "case") {
       expect(citations[1].subsequentHistoryOf).toEqual({ index: 0, signal: "affirmed" })
+      expect(citations[1].subsequentHistoryEntries).toHaveLength(1)
+      expect(citations[1].subsequentHistoryEntries?.[0].signal).toBe("cert_denied")
     }
+    // 502 U.S. 2 (the cert. denied result) points at the AFFIRMING cite (1),
+    // not the original root (0).
     expect(citations[2].type).toBe("case")
     if (citations[2].type === "case") {
-      expect(citations[2].subsequentHistoryOf).toEqual({ index: 0, signal: "cert_denied" })
+      expect(citations[2].subsequentHistoryOf).toEqual({ index: 1, signal: "cert_denied" })
     }
   })
 


### PR DESCRIPTION
## Summary

Sprint D — 4 paren/history bugs in `extractCase.ts` + `extractCitations.ts`.

| Issue | Fix |
|---|---|
| [#529](https://github.com/medelman17/eyecite-ts/issues/529) | New `clearCourtIfDisposition()` helper — after every disposition-detection branch in `parseParenthetical`, clears `result.court` if it equals the disposition string. Reporter-based court inference downstream survives. |
| [#522](https://github.com/medelman17/eyecite-ts/issues/522) | New `isNonMetadataParenContent()` helper rejects three explanatory-paren shapes: unbalanced parens, leading signal word, nested `(YYYY)` in body. Gates `parseParenthetical` at all three call sites. |
| [#527](https://github.com/medelman17/eyecite-ts/issues/527) | **Rewrote `linkSubsequentHistory`** in `extractCitations.ts`. Root cause: Union-Find aggregation collapsed every chain link into one component and dumped entries onto the root, stealing each member's scanner-captured entries. New linker keeps signal-matching, drops Union-Find, resolves each child to its actual parent. Updated 4 pre-existing tests that locked in the buggy behavior. **Minor bump** — `subsequentHistoryEntries` shape contract changed (now appears on multiple cites along a chain). |
| [#528](https://github.com/medelman17/eyecite-ts/issues/528) | Two-tier window in `collectParentheticals` — soft `maxLookahead` raised 500→2000, hard `PAREN_CLOSE_HARD_CEILING=10000` chases matching close paren beyond soft window. Perf unchanged (13ms→13ms on 200-cite synthetic). |

## Test plan

- [x] 15 net new tests; 4 pre-existing tests updated (locked in pre-#527 bug)
- [x] `pnpm exec vitest run` — 3383 passing, 9 skipped
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)