### PR TITLE
chore: docs housekeeping + ignore loose audit scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,12 @@ mise.local.toml
 .planning/
 .serena/
 playground.html
+
+# One-off audit / repro scripts (use scripts/bughunt/ for committed harnesses)
+scripts/audit-*.ts
+scripts/repro-*.ts
+scripts/repro_*.ts
+!scripts/repro_546.ts
+!scripts/repro_sprint_g.ts
+scripts/sample-and-judge.ts
+scripts/judge/

--- a/docs/research/2026-05-20-bughunt-cli-best-practices.md
+++ b/docs/research/2026-05-20-bughunt-cli-best-practices.md
@@ -1,0 +1,485 @@
+# Research: Local Bughunt CLI for eyecite-ts
+
+**Date:** 2026-05-20
+**Query:** Deep dive on best practices, dependencies, and architecture for a repo-local eyecite-ts bug-hunting CLI inspired by Python eyecite's PR benchmark, optimized for local discovery rather than public API or CI gating.
+**Depth:** deep
+**Status:** Recommends a dependency-light internal CLI that consolidates existing audit/repro scripts into reproducible local runs.
+
+## Summary
+
+Build a repo-local `pnpm bughunt` CLI, but keep the first version small and deterministic. The core should use Node's built-in argument parsing, local JSONL artifacts, deterministic seeds, and custom domain-specific generators. Add `fast-check` where shrinking and replay help, add `tsx` so TypeScript scripts run predictably, and use `adm-zip` only for CAP corpus loading if that corpus remains the primary real-world source.
+
+Do not expose the CLI as a package binary. Do not make AI judging, PR comments, GitHub artifacts, or Python-compatible CourtListener CSV benchmarking the first milestone. Those are useful later lanes, but the local bug-hunting product is: run a focused lane, get a small repro, preserve the seed, inspect the exact invariant failure, and promote it into a Vitest regression.
+
+## Current Repo Context
+
+The repository already has many local exploratory scripts:
+
+- `scripts/sample-and-judge.ts`: CAP corpus sampling plus optional Anthropic judging.
+- `scripts/audit-crashes.ts`: seeded CAP crash hunt.
+- `scripts/audit-span-fidelity.ts`: span and full-span invariant audit over CAP plus synthetic HTML/Unicode/footnote transforms.
+- `scripts/audit-annotate-roundtrip.ts`, `scripts/audit-resolution.ts`, `scripts/audit-perf-outliers.ts`, and many `scripts/repro-*` files.
+- `scripts/judge/*`: large accumulated JSONL/text/log outputs from previous sampling runs.
+
+This means v1 should consolidate rather than invent. The first milestone should factor shared pieces: argument parsing, corpus loading, seeded sampling, finding schema, artifact writer, invariant runners, and promotion.
+
+## Recommended CLI Shape
+
+```bash
+pnpm bughunt run --lane all --sample 200 --seed 1234
+pnpm bughunt run --lane resolver --focus supra --seed 1234
+pnpm bughunt inspect .bughunt/latest.json --id F123
+pnpm bughunt minimize .bughunt/runs/2026-05-20T.../findings.jsonl --id F123
+pnpm bughunt promote .bughunt/runs/2026-05-20T.../findings.jsonl --id F123
+pnpm bughunt diff .bughunt/runs/before .bughunt/runs/after
+pnpm bughunt report .bughunt/runs/2026-05-20T...
+```
+
+Package wiring:
+
+```json
+{
+  "scripts": {
+    "bughunt": "tsx scripts/bughunt/index.ts"
+  }
+}
+```
+
+Keep it internal:
+
+- no `bin`
+- no export path
+- no `dist` entry
+- no public CLI docs in the package README yet
+- `.bughunt/` gitignored
+
+## Dependency Recommendations
+
+### Add in v1
+
+| Dependency | Type | Why | Notes |
+|---|---:|---|---|
+| `tsx` | dev | Predictable TypeScript script execution from `pnpm bughunt` | Existing package scripts already assume `tsx` through `npx tsx`; make it explicit. |
+| `fast-check` | dev | Property-based mutation lanes with shrinking, seed replay, and bounded runs | Use for synthetic/metamorphic inputs, not for every lane. |
+| `adm-zip` | dev | Read local CAP zip volumes, matching existing scripts | Acceptable for local-only corpus loading. Revisit if streaming large zips becomes necessary. |
+
+### Defer
+
+| Dependency | Decision | Rationale |
+|---|---|---|
+| `commander` | Defer | Good CLI framework, but v1 can use Node `util.parseArgs` plus a small subcommand dispatcher. |
+| `tinybench` | Defer as direct dep | Vitest already uses Tinybench for benchmark mode; the bughunt CLI mostly needs per-document timing and outlier detection, not microbench precision. |
+| `zod` | Defer | Useful for AI output and external artifact validation, but hand-typed artifact writers are enough for deterministic v1. |
+| `p-limit` | Avoid | A tiny internal worker pool is enough and avoids another dep. |
+| `@anthropic-ai/sdk` | Optional plugin only | AI judging is powerful but non-deterministic, costly, and not part of the core local bughunt loop. |
+| CSV/BZip libraries | Defer | Start from existing CAP zip corpus and fixtures. Add CourtListener CSV support after the local harness is stable. |
+
+## Why These Choices
+
+### CLI Parsing
+
+Node's `node:util.parseArgs` returns structured `values` and `positionals` from a declared option spec, which is enough for an internal CLI with a handful of subcommands. This avoids a dependency while keeping parsing less brittle than manual `process.argv` slicing. If help text, nested commands, and validation become painful, migrate to Commander later; Commander is a mature and lightweight Node CLI framework, but it does not need to be in v1.
+
+Recommendation:
+
+- Use `parseArgs` per subcommand.
+- Treat the first positional as the command.
+- Keep command modules explicit: `run.ts`, `inspect.ts`, `promote.ts`, `diff.ts`, `report.ts`.
+- Add a small hand-written `help()` function instead of a CLI framework.
+
+### TypeScript Execution
+
+Use `tsx` explicitly as a dev dependency. It runs TypeScript/ESM scripts without a build step and supports watch mode, which is useful for iterating on the CLI itself. Because this is repo-local tooling, the extra dev dependency does not affect the runtime package.
+
+### Property-Based Testing and Mutations
+
+`fast-check` is valuable because it generates inputs, runs assertions across many cases, shrinks failures to smaller counterexamples, and exposes seed/path configuration for replay. Its docs also support model-based testing, but we should not start there.
+
+Use `fast-check` for:
+
+- whitespace/HTML/Unicode mutation of a known citation snippet
+- citation-chain generation for resolver stress
+- punctuation, parenthetical, and OCR-noise mutation
+- footnote boundary mutation
+
+Do not use `fast-check` for:
+
+- walking the CAP corpus
+- comparing branch-level corpus outputs
+- replacing domain-specific generators
+
+The right model is "domain generator first, fast-check runner/shrinker second." For real corpus failures, use a custom minimizer; property shrinkers are not ideal when the failing input is a whole opinion from disk.
+
+Recommended `fast-check` API usage for the CLI:
+
+- Use `fc.check(property, params)` rather than only `fc.assert(...)` inside the CLI. `check` returns structured run details that can be serialized into `findings.jsonl` instead of scraping thrown error text.
+- Persist `seed`, `counterexamplePath`, `counterexample`, `numRuns`, `numShrinks`, `numSkips`, and the run configuration for every generated-input failure.
+- Replay normal property failures with `{ seed, path, endOnFailure: true }`. `endOnFailure` skips re-shrinking and jumps straight to the counterexample path when inspecting a known finding.
+- Replay external failures with `examples: [[...valueTuple]]` and `numRuns: 1` when the source is not a fast-check-generated case but we want fast-check to try shrinking it.
+- Use `verbose: 1` only for debug runs or minimized repro work. `verbose: 2` can capture successes and skipped cases as an execution tree, but it is too noisy for normal bughunt artifacts.
+- For future command/model-based resolver tests, persist both `seed`/`path` for `fc.assert` and `replayPath` for `fc.commands(...)`. That combination replays the minimal failing command sequence.
+
+Example local wrapper shape:
+
+```ts
+const details = fc.check(
+  fc.property(domainCitationMutation(), (input) => {
+    const citations = extractCitations(input.text, input.options);
+    return invariantHolds(input, citations);
+  }),
+  {
+    seed,
+    numRuns,
+    endOnFailure: false,
+    verbose: debug ? 1 : 0,
+  },
+);
+
+if (details.failed) {
+  writeFinding({
+    seed: details.seed,
+    path: details.counterexamplePath,
+    counterexample: details.counterexample,
+    numRuns: details.numRuns,
+    numShrinks: details.numShrinks,
+  });
+}
+```
+
+### Minimize Strategy
+
+Use two minimizers:
+
+1. **Structural minimizer for real documents**
+   - paragraph deletion
+   - sentence/window narrowing around citations
+   - line deletion
+   - token deletion
+   - whitespace normalization toggles
+
+2. **fast-check shrinking for generated inputs**
+   - record `seed`, `path`, and, for model/command-based generators, `replayPath`
+   - emit a reproduction command and a Vitest skeleton
+
+Every finding should preserve the original input reference even when a minimized input exists.
+
+### ReDoS and Timeout Isolation
+
+Citation extraction is regex-heavy. OWASP describes ReDoS as crafted inputs causing regex engines to hit extreme slow paths, and JavaScript/Node regex work can block the event loop. For performance and ReDoS lanes, in-process timeouts are not enough.
+
+Recommendation:
+
+- Run normal invariant/corpus lanes in-process for speed.
+- Run ReDoS/perf-probe cases in a child process with a hard timeout.
+- Prefer `child_process.execFile`/`fork` over shell execution.
+- Capture timeout findings as first-class findings with `phase`, `durationMs`, `timeoutMs`, `inputLength`, and a minimized input.
+
+### Benchmarking
+
+Do not begin with microbenchmarks. Python eyecite's benchmark is closer to a corpus differential and throughput chart than a rigorous microbenchmark. For local bug hunting, use:
+
+- per-document elapsed time
+- per-lane elapsed time
+- slowest N documents
+- timeout findings
+- before/after diff across two bughunt runs
+
+If we later add microbenchmarks, use Vitest's `bench` mode instead of adding a separate benchmark stack. Vitest benchmark mode uses Tinybench underneath and can output JSON for comparison.
+
+## Artifact Design
+
+Write all local outputs under `.bughunt/runs/<timestamp>-<seed>/`.
+
+Use files:
+
+```text
+.bughunt/
+  latest.json
+  runs/
+    2026-05-20T143000Z-seed-1234/
+      manifest.json
+      findings.jsonl
+      cases.jsonl
+      events.jsonl
+      summary.md
+      report.json
+```
+
+Avoid a `latest` symlink. Symlinks are awkward on Windows and in some sandboxed environments. Use `.bughunt/latest.json`:
+
+```json
+{
+  "runDir": ".bughunt/runs/2026-05-20T143000Z-seed-1234",
+  "createdAt": "2026-05-20T14:30:00.000Z"
+}
+```
+
+Finding shape:
+
+```ts
+type BughuntFinding = {
+  id: string;
+  runId: string;
+  lane: string;
+  severity: "crash" | "invariant" | "suspicious" | "perf" | "diff";
+  source: {
+    kind: "cap" | "fixture" | "synthetic" | "inline";
+    key?: string;
+    seed?: number;
+    replayPath?: string;
+  };
+  command: string;
+  signature: string;
+  message: string;
+  input?: string;
+  minimalInput?: string;
+  contextSnippet?: string;
+  citations?: unknown[];
+  before?: unknown;
+  after?: unknown;
+  invariant?: string;
+  timing?: {
+    durationMs: number;
+    timeoutMs?: number;
+  };
+  suggestedTest?: {
+    path: string;
+    name: string;
+  };
+};
+```
+
+Finding IDs should be stable hashes of lane, source key, signature, and the relevant normalized snippet. Stable IDs make `inspect`, `diff`, and `promote` usable across repeated runs.
+
+## Lane Design
+
+### 1. Corpus Sweep
+
+Purpose: find crashes, suspicious extraction behavior, and performance outliers in real opinions.
+
+Sources:
+
+- existing CAP corpus loader
+- `tests/fixtures/*.json`
+- later: CourtListener CSV/BZip lane
+
+Checks:
+
+- extraction does not crash
+- resolution does not crash
+- citation count outliers
+- type distribution outliers
+- slow documents
+- suspicious long matches
+- citation spans outside source bounds
+
+### 2. Invariant Sweep
+
+Purpose: catch impossible internal states.
+
+Checks:
+
+- `span.cleanEnd > span.cleanStart`
+- `span.originalEnd > span.originalStart`
+- original span within source bounds
+- matched text can be related back to source slice under documented normalization
+- `fullSpan` contains the core citation and, when applicable, case name
+- citations sorted by original span
+- no incoherent overlaps except documented parenthetical/parallel cases
+- metadata fields match type expectations
+
+### 3. Metamorphic Mutation
+
+Purpose: take known snippets and perturb them without changing the intended citation semantics.
+
+Mutations:
+
+- whitespace expansion/collapse
+- line breaks between reporter tokens
+- smart quotes, em dashes, NBSP
+- HTML tag insertion between words
+- footnote marker insertion
+- OCR confusions like `l`/`1`, `O`/`0` where safe
+- parenthetical wrapping and punctuation movement
+
+Checks:
+
+- core citation still found
+- type remains stable
+- original span remains valid
+- resolver target remains stable when mutation should be semantics-preserving
+
+### 4. Resolver Stress
+
+Purpose: find wrong targets for `Id.`, supra, short-form case, bare party forms, parenthetical children, footnote boundaries, and full-caption split cases.
+
+Generate documents with:
+
+- multiple full citations with overlapping party names
+- full captions with plaintiff/defendant halves
+- short forms near distractor citations
+- `Id.` chains through unresolved or parenthetical citations
+- footnote/body boundaries
+- parallel citations and subsequent history
+
+Checks:
+
+- no future target
+- no self target
+- `Id.` stays inside required scope
+- supra/short-form target is the intended full citation under generated model
+- resolver does not choose a split-caption half when the full citation is the modeled antecedent
+
+### 5. Annotation Round Trip
+
+Purpose: ensure extracted spans can drive annotation without corrupting source text.
+
+Checks:
+
+- annotation preserves unannotated text order
+- inserted tags are balanced
+- no citation produces invalid start/end ranges
+- overlapping/adjacent citations are handled deterministically
+- annotation over HTML-cleaned inputs does not use clean offsets as original offsets
+
+### 6. Perf/ReDoS Probe
+
+Purpose: find regex or cleaner paths that hang or blow up.
+
+Inputs:
+
+- nested punctuation
+- repeated reporter-like tokens
+- long repeated section markers
+- pathological parenthetical chains
+- long strings with near-miss citation forms
+- HTML tag storms around reporter-like tokens
+
+Execution:
+
+- child process per case or small batch
+- strict timeout
+- collect timing histogram
+- promote timeouts into regression tests with conservative thresholds only when stable
+
+### 7. Differential Run
+
+Purpose: compare two local runs before/after a fix.
+
+Command:
+
+```bash
+pnpm bughunt diff .bughunt/runs/before .bughunt/runs/after
+```
+
+Report:
+
+- fixed crashes
+- new crashes
+- stable findings
+- citation count deltas
+- type deltas
+- span drift
+- resolver target deltas
+
+This becomes the local predecessor to a future PR comment.
+
+## Promotion Workflow
+
+The strongest part of the CLI should be promotion.
+
+```bash
+pnpm bughunt promote .bughunt/latest.json --id F123
+```
+
+Promotion should generate one of:
+
+- a Vitest test snippet printed to stdout
+- a new fixture under `tests/fixtures/bughunt/`
+- a targeted test appended to an existing test file, only with explicit `--write`
+
+Default should be non-writing preview. This avoids accidental churn while debugging.
+
+Promoted tests must include:
+
+- finding ID
+- original command
+- seed/path/replayPath if any
+- minimized input
+- expected behavior
+- comment with source key if from CAP
+
+## CI and PR Comments Later
+
+Once local runs are useful, add CI wrappers:
+
+- `pnpm bughunt run --preset smoke`: small deterministic sample, required gate.
+- `pnpm bughunt run --preset nightly`: larger corpus and mutation run, scheduled.
+- `pnpm bughunt report --format markdown`: future sticky PR comment.
+- `actions/upload-artifact`: store `.bughunt/runs/...` with short retention.
+
+GitHub Actions supports uploading files/directories as artifacts and configuring retention days, so CI can keep bughunt reports without copying Python eyecite's long-lived `artifacts` branch pattern at first.
+
+## Dependency Decision Matrix
+
+| Capability | Best v1 Choice | Why |
+|---|---|---|
+| CLI parsing | `node:util.parseArgs` | Built-in, typed enough, no dep. |
+| TS execution | `tsx` | Existing repo style, fast local iteration, dev-only. |
+| Deterministic RNG | Internal Mulberry32 or similar | Already used in scripts; no dep required. |
+| Property shrinking | `fast-check` | Best JS/TS option; seeds and shrinking are the point. |
+| Real corpus zips | `adm-zip` | Existing scripts already use it; local dev-only. |
+| Artifact validation | TypeScript types first | Add `zod` later if artifact ingestion gets complex. |
+| Microbench | Vitest bench later | Already in stack, Tinybench underneath. |
+| Timeout isolation | Node child process | Robust against event-loop blocking ReDoS. |
+| AI judging | Optional plugin | Keep deterministic core clean. |
+
+## Recommended v1 Scope
+
+Build only:
+
+1. `run`
+   - lanes: `corpus`, `invariants`, `resolver`, `mutate`, `annotate`, `perf`
+   - artifact writer
+   - deterministic seed
+
+2. `inspect`
+   - pretty-print a finding
+   - show repro command and minimal/context input
+
+3. `promote`
+   - preview Vitest repro
+   - optional `--write`
+
+4. Shared internals
+   - corpus loader
+   - seeded sampler
+   - finding schema
+   - invariant helpers
+   - minimizer interface, even if only one minimizer is implemented
+
+Defer:
+
+- PR comments
+- CourtListener CSV/BZip download
+- branch-vs-main Git automation
+- AI judge integration
+- public CLI exposure
+- model-based fast-check commands
+
+## Sources
+
+- [Python eyecite benchmark workflow](https://github.com/freelawproject/eyecite/blob/main/.github/workflows/benchmark.yml) — upstream differential benchmark model.
+- [Python eyecite benchmark script](https://github.com/freelawproject/eyecite/blob/main/benchmark/benchmark.py) — gains/losses and timing chart behavior.
+- [fast-check introduction](https://fast-check.dev/docs/introduction/) — property-based testing, shrinking, and generated cases.
+- [fast-check configuration](https://fast-check.dev/docs/configuration/) — seed, run count, input size, timeout, and reporting configuration.
+- [fast-check test reports](https://fast-check.dev/docs/tutorials/quick-start/read-test-reports/) — failure report shape, `seed`, `path`, `endOnFailure`, counterexamples, and verbosity.
+- [fast-check fuzzing](https://fast-check.dev/docs/advanced/fuzzing/) — replaying external reported errors with `examples` and `numRuns: 1`.
+- [fast-check model-based testing](https://fast-check.dev/docs/advanced/model-based-testing/) — command replay and `replayPath`; useful later for resolver scenarios.
+- [Node.js `util.parseArgs`](https://nodejs.org/api/util.html#utilparseargsconfig) — built-in command-line parsing.
+- [Commander.js docs](https://tj.github.io/commander.js/) — mature fallback if built-in parsing becomes too small.
+- [Vitest benchmark configuration](https://vitest.dev/config/benchmark.html) — future microbenchmark comparison using existing test stack.
+- [OWASP ReDoS](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS) — regex denial-of-service risk and evil-regex shapes.
+- [Snyk ReDoS and catastrophic backtracking](https://snyk.io/blog/redos-and-catastrophic-backtracking/) — JavaScript event-loop blocking risk.
+- [Node.js child_process docs](https://nodejs.org/api/child_process.html) — child process timeouts and abort signals for isolation.
+- [GitHub Actions artifacts docs](https://docs.github.com/en/actions/tutorials/store-and-share-data) — later CI artifact upload and retention.

--- a/docs/superpowers/handoffs/2026-05-10-200029-issue-triage-and-parser-improvements.md
+++ b/docs/superpowers/handoffs/2026-05-10-200029-issue-triage-and-parser-improvements.md
@@ -1,0 +1,164 @@
+---
+name: 2026-05-10 issue triage + parser improvements handoff
+description: Briefing for the next agent who will triage the 20 newly-filed parser-improvement issues and start landing fixes.
+---
+
+# Session Handoff: Issue Triage + Parser Improvements
+
+**Created:** 2026-05-10 20:00
+**Branch:** main (synced; just merged PR #227)
+**Previous handoff:** none
+
+## Goal
+
+Hand off a clean slate to the next agent. They will triage 20 newly-filed parser-improvement GitHub issues (#228–247) and start implementing fixes. The previous session completed a large case-name abbreviation expansion (PR #227, merged); the issues are everything *else* the cross-jurisdictional research surfaced.
+
+## Current State
+
+- **Branch:** `main`, up to date with origin. `v0.13.1` tag just landed.
+- **Open PRs:** **#248** — changesets bot's "chore: version packages" PR consolidating the 5 patch bumps from PR #227. Worth verifying it's clean and then merging when ready.
+- **Open issues filed by the prior session:** 20 (#228–247), all labeled `enhancement,extraction,claude`. Plus cross-reference comments on three pre-existing issues: **#13** (`infra` support), **#19** (CA date-first format), **#204** (paragraph pincites).
+- **Untracked files in working tree** (carry-overs from before, NOT this session's work — leave alone): `.agents/`, `.codex/`, `AGENTS.md`, `citation-diagram.html`, `docs/superpowers/{plans,specs}/`, `issue-drafts/`.
+
+### Completed (compressed)
+
+- [x] **PR #227 merged** — case-name lookback abbreviation expansion. 5 squashed commits → +68 stems, 28 synthetic tests + 34 corpus-sourced real-world tests, 5 changesets, 16 research reports in `docs/research/`.
+- [x] **20 GH issues filed** (#228–247) — one per parser-improvement target identified in the audit.
+- [x] **Cross-reference comments** added to #13, #19, #204 linking them to the audit's recommended approach.
+- [x] **Parser-improvement roadmap** retained as `docs/research/2026-05-10-citation-style-quirks.md` (~970 lines, 10 numbered sections + lettered remediation proposals A–N + 20 failing-test fixtures).
+
+### In Progress (full detail)
+
+**Nothing.** The next agent picks up from a clean main.
+
+### Not Started (pointers only — see issues for full detail)
+
+The 20 new issues fall into clusters. Suggested triage priority below; full self-contained problem statements with failing inputs and proposed fixes live in each issue body.
+
+## Key Decisions Made
+
+1. **Bug-fix branch convention:** every fix lands on a feature branch (`fix/<short-slug>`), gets a changeset (`pnpm changeset`), and lands via PR. **Never commit directly to main.**
+2. **Test pattern:** synthetic tests with `extractCitations(text)` → `find(c => c.type === "case")` → `expect(caseCite.caseName).toBe(...)`. See `tests/extract/extractCase.test.ts` and `tests/extract/realWorldCaptions.test.ts` for patterns.
+3. **Corpus-sourced regression tests:** preferred over synthetic when possible. The Harvard CAP corpus is available locally (organized by reporter dir → volume zips → JSON per opinion). Mining script template in this session's transcript (search "mine_v3.py" / "mine_v4.py" if needed); produced `tests/extract/realWorldCaptions.test.ts`.
+4. **PR title/body convention:** "fix: ..." or "feat: ..." or "test: ..." prefix. Body has a `## Summary` and `## Test plan` section. Always sign with `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+5. **No client / firm names in any committed artifact** (PR, issue, changeset, commit message, source file, doc). This includes the case-law corpus path — if mining, reference it generically.
+6. **The pincite parser refactor (audit §A) unblocks several issues.** Doing it first is the cheapest path to fixing #204 (paragraph pincites), #236 (CSM at p./pp.), #247 (multiple discrete pincites), and parts of #13 (infra).
+
+## Failed Approaches & Gotchas
+
+- **Some abbreviation stems added in PR #227 don't have corpus evidence in case-name position** (`coun`, `discipl`, `civ`, `vet`, `petr`, `respt`, etc.). Real captions either spell the word out (`Council`, `Disciplinary`) or use the abbreviation only in court designations / reporter abbreviations (`Tex. Civ. App.`, `Vet. App.`). The stems were added defensively based on style-manual research; they don't hurt because they don't collide with English sentence-end words.
+- **Synthetic captions with parenthesized middle tokens trip the case-name scanner.** Example: `"Amaya Grp. Hldgs. (IOM) Ltd. v. Smith"` extracts as `"Ltd. v. Smith"` because `(IOM)` is treated as a court parenthetical and resets the lookback. Avoid embedding parentheticals in test inputs unless that's what you're testing.
+- **Corpus uses Unicode curly apostrophe `'` (U+2019), not ASCII `'`.** Mining regexes must use `['’‘]` character class. Synthetic test captions for the codebase should use ASCII apostrophe — eyecite-ts already normalizes both via `[]+→stem` stripping.
+- **Some "deferred" stems** (`supers`, `vol`, `retire`, `lic`) had **zero corpus matches** even after a wide sweep because the abbreviated form is rare in published opinions. They're covered by synthetic tests; their inclusion in `CASE_NAME_ABBREVS` is defensible regardless.
+- **Pre-existing diagnostic noise:** the LSP reports `Cannot find module '@/index'` errors in `tests/extract/extractCase.test.ts` and the new `realWorldCaptions.test.ts`. This is LSP-side only; `pnpm typecheck` is clean. Ignore those diagnostics.
+- **Pre-existing TS6133 unused-var diagnostic** on `metaParenFromToken` in `src/extract/extractCase.ts`. Not introduced by recent work. Address if convenient.
+
+## Critical File Locations
+
+- **Case-name abbreviation set:** `src/extract/extractCase.ts:394-863` (`CASE_NAME_ABBREVS`). 3-tier matching logic at `isLikelyAbbreviationPeriod` (~line 870–910).
+- **Pincite parsing:** `src/extract/extractCase.ts` (search for `PINCITE_REGEX`, `LOOKAHEAD_PINCITE_REGEX`, `parsePincite`, `PinciteInfo`). The roadmap proposes a grammar refactor here.
+- **Citation patterns:** `src/patterns/` — particularly `casePatterns.state-vendor-neutral` (referenced by #233 hyphenated neutral cites and #230 multi-word neutral courts).
+- **Short-form patterns:** `src/extract/extractShortForms.ts`, `src/resolve/` (for #13 infra, #204 paragraph pincites).
+- **Signal table:** `src/extract/extractCase.ts:SIGNAL_TABLE` (referenced by #229 TX writ history, #238 CA review denied, #239 combined signals).
+- **Parenthetical parsing:** `src/extract/extractCase.ts:parseParenthetical` (referenced by #232 LA slash-dates, #235 justice attribution, #229 TX em-dash + bracket).
+- **Procedural prefix regex:** `src/extract/extractCase.ts:PROCEDURAL_PREFIX_REGEX` (referenced by #242 procedural prefix expansion, #244 BIA `Matter of A-B-`).
+- **Normalize party name (slash-aliases):** `src/extract/extractCase.ts:normalizePartyName` around line 1352 (referenced by #240).
+- **Tests:** `tests/extract/extractCase.test.ts` (main), `tests/extract/realWorldCaptions.test.ts` (corpus-sourced).
+- **Audit / roadmap doc:** `docs/research/2026-05-10-citation-style-quirks.md` — 10 numbered sections + lettered remediation proposals A–N + 20 failing-test fixtures.
+- **Regional research docs:** `docs/research/2026-05-10-citation-abbrevs-{ny-nj,pa-de-md-dc-wv,new-england,ca,tx-ok,southeast,deep-south,great-lakes,plains-upper-midwest,western-pacific,federal-courts,federal-specialty,govt-corp-entities,alwd-reporters-db,foreign-tribal-territorial}.md`.
+
+## Environment State
+
+- Node 22 (CI also tests 18 + 20)
+- pnpm 10 via corepack
+- Working tree clean of *our* work; pre-existing untracked files listed above
+- `pnpm test` baseline: **1922 tests passing**, 9 skipped (post-merge from #227)
+- `pnpm typecheck` clean
+- `pnpm lint` has 163 pre-existing warnings (no errors) — not blocking
+
+## Next Steps (prioritized)
+
+### Step 1: Verify and merge #248
+
+The changesets bot opened **PR #248** ("chore: version packages") consolidating the 5 patch changesets from #227. Verify it's clean (it should bump from `0.13.1` to `0.13.2`), then merge. This triggers the npm publish.
+
+```bash
+gh pr view 248
+gh pr checks 248
+gh pr merge 248 --squash --delete-branch
+```
+
+### Step 2: Triage the 20 new issues
+
+Recommended priority tiers (titles abbreviated; see issues for full self-contained problem statements):
+
+**Tier A — Quick wins, low risk, learn the codebase:**
+- **#234** Reporter edition future-proofing (`F.5th`, `Cal.6th`) — small regex change, preventative. Good warm-up.
+- **#242** Procedural prefix expansion (`Commonwealth ex rel.`, `In the Interest of`, etc.) — adds entries to one regex. Mechanical.
+- **#239** Combined signals (`See, e.g.,`, `Compare ... with ...`) — adds to `VALID_SIGNALS`. Mechanical.
+- **#238** CA `review denied/granted` history — adds to `SIGNAL_TABLE`. Mechanical.
+
+**Tier B — High corpus impact:**
+- **#240** Party-name slash-aliases (`d/b/a`, `f/k/a`, `n/k/a`, `a/k/a`) — flagged as **~96k corpus matches**. Single-file change in `normalizePartyName`. Highest-ROI fix.
+- **#229** Texas writ/petition history inside court parenthetical — touches `SIGNAL_TABLE` and `parseParenthetical`. Adds ~13 entries; em-dash and nested-bracket court handling is the harder half.
+
+**Tier C — Pincite parser refactor (audit §A):**
+- **#204** Paragraph pincites `¶ N` — *the single highest-impact extraction gap*. Touches `PinciteInfo` to add `kind: "page" | "starPage" | "paragraph"` discriminator. Read the cross-reference comment I added.
+- **#236** CSM `at p.` / `at pp.` pincites — same refactor unblocks this.
+- **#247** Multiple discrete pincites (`410 U.S. 113, 115, 153`) — same refactor area.
+- **#13** (pre-existing) `infra` short-form — partly same area; also needs a two-pass resolver model since `infra` points forward.
+
+**Tier D — Multi-word / hyphenated neutral citations:**
+- **#233** Hyphenated neutral cites (`2010-NMSC-007`, `2024-Ohio-764`) — extend `state-vendor-neutral` regex.
+- **#230** Multi-word neutral court designations (`IL App (1st)`, `OK CIV APP`) — same regex area.
+- **#231** NY Slip Op `(U)`/`[U]` markers — adjacent (NY uses brackets-around-page).
+
+**Tier E — California Style Manual cluster** (consider doing together — they all rely on a "CSM mode" flag):
+- **#19** (pre-existing) CA year-first format `(YYYY) vol Cal.Nth`
+- **#237** CSM bracketed parallel `[266 Cal.Rptr. 569]`
+- **#236** CSM `at p.` / `at pp.` (also Tier C)
+
+**Tier F — Specialty / less-common:**
+- **#228** State LEXIS variants
+- **#232** Louisiana date-in-number format
+- **#235** Justice-attribution parens
+- **#241** Bankruptcy `(In re X)` admin parens
+- **#244** BIA `Matter of A-B-` hyphenated initials
+- **#243** ITC `Certain X` no-`v.` captions
+- **#245** PTAB/ITC docket-form citations
+- **#246** Multi-stage subsequent history chains
+
+### Step 3: Pick one, branch, fix, PR
+
+```bash
+# Per issue, the convention is:
+git checkout -b fix/<issue-slug>
+# ... make changes, add tests ...
+pnpm test
+pnpm typecheck
+pnpm changeset  # interactive — patch/minor/major + summary
+git add <files>
+git commit -m "..."  # with Co-Authored-By Claude footer (see prior commits for format)
+git push -u origin <branch>
+gh pr create --title "..." --body "..."  # link to the issue
+```
+
+The user explicitly required:
+- **No client / firm names** in any committed artifact (PR, issue, changeset, commit, source, doc).
+
+### Step 4: When clusters of related issues land
+
+Consider whether to bundle related fixes into a single PR or split. The user previously preferred bundled when the changes share a refactor (e.g., the pincite parser refactor could land #204 + #236 + #247 in one PR). For independent fixes, separate PRs are cleaner.
+
+## Linked Artifacts
+
+- **PR #227** (merged): https://github.com/medelman17/eyecite-ts/pull/227 — the abbreviation expansion + research artifacts
+- **PR #248** (open, awaiting merge): https://github.com/medelman17/eyecite-ts/pull/248 — version packages chore
+- **Audit roadmap**: `docs/research/2026-05-10-citation-style-quirks.md`
+- **Per-issue self-contained briefs**: each of #228–247 has a complete problem statement, failing inputs, expected behavior, proposed fix, and acceptance criteria. The next agent can pick any issue and start from its body alone.
+- **Cross-reference comments on**: #13, #19, #204 (linking the audit's recommendations into pre-existing issues)
+- **Project conventions**: `CLAUDE.md` at repo root
+
+## Open Question for the Next Agent
+
+The user's `/loop` / autonomous workflows weren't used in this session. If you want to batch-fix multiple Tier A issues in parallel, the `superpowers:dispatching-parallel-agents` skill works well for non-overlapping fixes (proven during the 16-agent research dispatch in this session). Each agent gets its own branch + PR.

--- a/docs/superpowers/handoffs/2026-05-20-165124-bughunt-cli-planning.md
+++ b/docs/superpowers/handoffs/2026-05-20-165124-bughunt-cli-planning.md
@@ -1,0 +1,148 @@
+# Session Handoff: eyecite-ts Internal Bughunt CLI Planning
+
+**Created:** 2026-05-20 16:51 EDT
+**Branch:** `main`
+**Previous handoff:** [`docs/handoffs/2026-05-10-200029-issue-triage-and-parser-improvements.md`](2026-05-10-200029-issue-triage-and-parser-improvements.md)
+
+## Goal
+
+Build a repo-local, internal `pnpm bughunt` CLI for `eyecite-ts` that consolidates the existing ad hoc audit/repro scripts into reproducible local bug-hunting lanes. The CLI should optimize for local discovery, not public package surface or PR automation: run lanes, write `.bughunt/` artifacts, inspect findings, and preview promotion into Vitest regressions.
+
+## Current State
+
+No implementation has started. The session produced research, a design spec, and an implementation plan. The next agent should start from the plan and implement task-by-task.
+
+### Completed
+
+- [x] Investigated Python `freelawproject/eyecite` benchmark workflow and script.
+- [x] Decided to adapt it as one future "corpus differential" lane, not as the whole system.
+- [x] Decided the first product is a repo-local CLI optimized for local bug hunting.
+- [x] Confirmed the CLI must remain internal: no `bin`, no package export, no `dist` entry.
+- [x] Added `CONTEXT7_API_KEY` to ignored local `mise.local.toml`.
+- [x] Updated Codex MCP config so future `context7` launches include `CONTEXT7_API_KEY`; Context7 now works after reload.
+- [x] Used Context7 to validate `fast-check` details: `fc.check`, `seed`, `path`, `counterexamplePath`, `examples`, `endOnFailure`, verbosity, and future `replayPath`.
+- [x] Wrote research note: [`docs/research/2026-05-20-bughunt-cli-best-practices.md`](../research/2026-05-20-bughunt-cli-best-practices.md).
+- [x] Wrote design spec: [`docs/superpowers/specs/2026-05-20-bughunt-cli-design.md`](../superpowers/specs/2026-05-20-bughunt-cli-design.md).
+- [x] Wrote implementation plan: [`docs/superpowers/plans/2026-05-20-bughunt-cli.md`](../superpowers/plans/2026-05-20-bughunt-cli.md).
+
+### In Progress
+
+Implementation is ready to begin but has not started. The approved next step is to execute [`docs/superpowers/plans/2026-05-20-bughunt-cli.md`](../superpowers/plans/2026-05-20-bughunt-cli.md).
+
+The plan's first milestone builds:
+
+- dev dependencies and `pnpm bughunt`
+- `.bughunt/` gitignore entry
+- core types, seeded RNG, finding IDs, JSONL artifact writer
+- extraction wrapper and invariant checks
+- inline corpus, corpus lane, invariant lane
+- CLI dispatcher and `run`
+- `inspect`
+- `promote` preview
+- a first `fast-check` mutation lane
+
+### Not Started
+
+- [ ] Implement `scripts/bughunt/`.
+- [ ] Add `tests/bughunt/`.
+- [ ] Add `tsx`, `fast-check`, and `adm-zip` as dev dependencies.
+- [ ] Add `.bughunt/` to `.gitignore`.
+- [ ] Run targeted tests and smoke CLI.
+- [ ] Decide after v1 whether to add CAP zip loading, `diff`, `report`, ReDoS child-process isolation, annotation lane, PR comments, or CourtListener CSV support.
+
+## Key Decisions Made
+
+- **Local-first CLI:** The first useful workflow is local bug discovery, not CI. CI/PR comments wait until `.bughunt/` artifacts prove useful.
+- **Private tooling:** The CLI lives under `scripts/bughunt/` and is invoked only through `package.json` scripts. It must not alter public exports.
+- **Dependency-light:** Use `node:util.parseArgs` for v1 instead of Commander. Add `tsx`, `fast-check`, and `adm-zip` as dev dependencies.
+- **`fast-check` scope:** Use it for generated/metamorphic lanes where shrinking and replay matter. Do not use it for CAP corpus walking or as a substitute for legal citation domain generators.
+- **Artifact contract:** Use `.bughunt/latest.json` instead of a symlink for portability. Write `manifest.json`, `findings.jsonl`, `cases.jsonl`, `events.jsonl`, `report.json`, and `summary.md`.
+- **Promotion is preview-first:** `promote` should print a Vitest repro by default. Writing files is deliberately deferred until the preview path is useful.
+
+## Failed Approaches & Gotchas
+
+- Context7 initially failed with a quota message because the running MCP server had no `CONTEXT7_API_KEY`.
+- Adding the key to `mise.local.toml` was not enough for the already-running MCP process.
+- `codex mcp get context7` showed the global MCP entry had `env: -`.
+- Updating Codex MCP config with `codex mcp add --env CONTEXT7_API_KEY=... context7 -- npx -y @upstash/context7-mcp` fixed future launches. The tool worked only after the session/app reloaded the MCP server.
+- The repo has many untracked local scripts and artifacts. Do not assume the worktree is clean, and do not remove or stage unrelated files.
+- `tsconfig.json` currently includes only `src`, so `pnpm typecheck` may not typecheck `scripts/bughunt`. The plan explicitly relies on Vitest and Biome for v1 script coverage unless the implementing agent chooses to add a dedicated script tsconfig.
+
+## Critical File Locations
+
+- Research: [`docs/research/2026-05-20-bughunt-cli-best-practices.md`](../research/2026-05-20-bughunt-cli-best-practices.md)
+- Design: [`docs/superpowers/specs/2026-05-20-bughunt-cli-design.md`](../superpowers/specs/2026-05-20-bughunt-cli-design.md)
+- Plan: [`docs/superpowers/plans/2026-05-20-bughunt-cli.md`](../superpowers/plans/2026-05-20-bughunt-cli.md)
+- Current package config: `package.json`
+- Current ignore file: `.gitignore`
+- Existing audit source material:
+  - `scripts/sample-and-judge.ts`
+  - `scripts/audit-crashes.ts`
+  - `scripts/audit-span-fidelity.ts`
+  - `scripts/audit-annotate-roundtrip.ts`
+  - `scripts/audit-resolution.ts`
+  - `scripts/audit-perf-outliers.ts`
+  - `scripts/judge/*`
+- Existing tests and fixtures:
+  - `tests/extract/*`
+  - `tests/integration/*`
+  - `tests/fixtures/*`
+
+## Environment State
+
+- Current branch: `main`.
+- Recent HEAD: `6f10815 feat(extract): Sprint I — new extractor types + Fed.R. FP cluster (#576, #577, #578, #579, #581, #582, #585) (#626)`.
+- `package.json` currently has version `0.22.1`.
+- `mise.local.toml` is ignored and now contains `CONTEXT7_API_KEY`; do not print the key.
+- Codex global MCP `context7` is configured with `CONTEXT7_API_KEY` and Context7 works after reload.
+- The visible `git status --short` is mostly untracked local files, including the new docs from this session and many pre-existing scripts/artifacts. There are no tracked diffs from the planning docs because the files are untracked.
+
+## Current Git Status Snapshot
+
+Notable new files from this session:
+
+- `docs/research/2026-05-20-bughunt-cli-best-practices.md`
+- `docs/superpowers/specs/2026-05-20-bughunt-cli-design.md`
+- `docs/superpowers/plans/2026-05-20-bughunt-cli.md`
+- `docs/handoffs/2026-05-20-165124-bughunt-cli-planning.md`
+
+Pre-existing/unrelated local files include:
+
+- `.agents/`
+- `.codex/`
+- `AGENTS.md`
+- `citation-diagram.html`
+- `docs/superpowers/plans/2026-04-11-readme-overhaul.md`
+- `docs/superpowers/specs/2026-04-11-readme-overhaul-design.md`
+- `issue-drafts/`
+- many `scripts/audit-*`, `scripts/repro-*`, `scripts/judge/*`
+- `tests/fixtures/docket-citations.json`
+
+Do not clean these unless the user explicitly asks.
+
+## Next Steps
+
+1. Start a goal for implementation using the prompt below.
+2. Read the research, design, and plan in that order.
+3. Execute [`docs/superpowers/plans/2026-05-20-bughunt-cli.md`](../superpowers/plans/2026-05-20-bughunt-cli.md) task-by-task.
+4. Use TDD as written in the plan: failing targeted test, minimal implementation, targeted pass.
+5. Keep staging narrow. Do not stage unrelated untracked files.
+6. Treat the plan's **Definition Of Done** as the completion gate. In short, implementation is not done until:
+   - the CLI remains internal-only (`bughunt` script, no `bin`, no public export, no `dist` entry)
+   - `run`, `inspect`, and `promote` preview work
+   - `corpus`, `invariants`, and `mutate` lanes exist
+   - `.bughunt/latest.json` and all expected run artifacts are written
+   - findings are stable, reproducible, and inspectable
+   - no `.bughunt/` artifacts or secrets are staged
+7. Before finalizing implementation, run:
+   - `pnpm exec vitest run tests/bughunt/core.test.ts tests/bughunt/commands.test.ts`
+   - `pnpm lint`
+   - `pnpm typecheck`
+   - `pnpm bughunt run --lane all --seed 1234 --sample 5`
+8. Report any typecheck limitation caused by `tsconfig.json` excluding `scripts/`.
+
+## Linked Artifacts
+
+- Research: [`docs/research/2026-05-20-bughunt-cli-best-practices.md`](../research/2026-05-20-bughunt-cli-best-practices.md)
+- Design: [`docs/superpowers/specs/2026-05-20-bughunt-cli-design.md`](../superpowers/specs/2026-05-20-bughunt-cli-design.md)
+- Plan: [`docs/superpowers/plans/2026-05-20-bughunt-cli.md`](../superpowers/plans/2026-05-20-bughunt-cli.md)

--- a/docs/superpowers/plans/2026-04-11-readme-overhaul.md
+++ b/docs/superpowers/plans/2026-04-11-readme-overhaul.md
@@ -1,0 +1,1401 @@
+# README Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite README.md as a "Pipeline Story" showcase (~350-400 lines) and create 6 supporting docs files for deep dives.
+
+**Architecture:** The README becomes a curated front door: badges, intro, hero workflow, feature table, 6 brief examples, type system, bundle size, Python comparison, dev setup, migration pointer, credits. Detailed content migrates to `docs/guides/` (5 files) and `docs/api/` (1 file). Each doc file is self-contained with its own examples pulled from the current README plus new material.
+
+**Tech Stack:** Markdown only. Code examples must be valid TypeScript that compiles against the library's public API.
+
+**Key facts (verified):**
+- Version: 0.10.1
+- Tests: 1,748 across 72 files
+- Bundle: ~20 KB brotli (core), ~1.8 KB brotli (utils)
+- Jurisdictions: 52 total (50 states + DC + US federal)
+- Node requirement: >=18.0.0
+- Python eyecite comparison: verified 2026-04-11 (see spec)
+
+---
+
+### Task 1: Create docs directory structure and `advanced-extraction.md`
+
+**Files:**
+- Create: `docs/guides/advanced-extraction.md`
+
+This is the largest doc file — it absorbs the most content from the current README.
+
+- [ ] **Step 1: Create `docs/guides/` directory**
+
+Run: `mkdir -p docs/guides docs/api`
+
+- [ ] **Step 2: Write `docs/guides/advanced-extraction.md`**
+
+```markdown
+# Advanced Extraction
+
+Detailed guide for customizing the eyecite-ts extraction pipeline beyond the defaults.
+
+## Table of Contents
+
+- [Statute Citations](#statute-citations)
+- [Constitutional Citations](#constitutional-citations)
+- [Custom Patterns](#custom-patterns)
+- [Custom Cleaners](#custom-cleaners)
+- [Structured Dates](#structured-dates)
+- [Blank Page Citations](#blank-page-citations)
+- [Component Spans](#component-spans)
+- [Subsequent History](#subsequent-history)
+- [Disposition Extraction](#disposition-extraction)
+- [Reporter Validation](#reporter-validation)
+- [False Positive Filtering](#false-positive-filtering)
+
+## Statute Citations
+
+Extract citations from 52 jurisdictions (50 states + DC + federal) across four pattern families:
+
+| Family | Jurisdictions | Example |
+|--------|--------------|---------|
+| Federal | USC, CFR, prose ("section X of title Y") | `42 U.S.C. § 1983(a)(1) et seq.` |
+| Named-code | NY (21 laws), CA (29 codes), TX (29 codes), MD (36 articles), VA, AL, MA | `N.Y. Penal Law § 125.25(1)(a)` |
+| Abbreviated-code | FL, OH, MI, UT, CO, WA, NC, GA, PA, IN, NJ, DE + 31 more states | `Fla. Stat. § 775.082` |
+| Chapter-act | IL (ILCS) | `735 ILCS 5/2-1001` |
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+
+const text = `
+  See 42 U.S.C. § 1983(a)(1) et seq.
+  Also Cal. Penal Code § 187.
+  And N.Y. Penal Law § 125.25(1)(a).
+  Compare 735 ILCS 5/2-1001.
+`
+const citations = extractCitations(text)
+
+// Federal with subsections + et seq.
+// { type: 'statute', title: 42, code: 'U.S.C.', section: '1983',
+//   subsection: '(a)(1)', jurisdiction: 'US', hasEtSeq: true, confidence: 1.0 }
+
+// California named-code
+// { type: 'statute', code: 'Penal', section: '187', jurisdiction: 'CA', confidence: 0.95 }
+
+// New York named-code with subsections
+// { type: 'statute', code: 'Penal Law', section: '125.25',
+//   subsection: '(1)(a)', jurisdiction: 'NY', confidence: 1.0 }
+
+// Illinois chapter-act format
+// { type: 'statute', title: 735, code: '5', section: '2-1001',
+//   jurisdiction: 'IL', confidence: 0.95 }
+```
+
+## Constitutional Citations
+
+Extract U.S. and state constitutional citations with article, amendment, section, and clause parsing:
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+
+const text = `
+  Under U.S. Const. amend. XIV, § 1, equal protection is guaranteed.
+  See also Cal. Const. art. I, § 7.
+  And U.S. Const. art. I, § 8, cl. 3.
+`
+const citations = extractCitations(text)
+
+// U.S. amendment with section
+// { type: 'constitutional', jurisdiction: 'US', amendment: 14,
+//   section: '1', confidence: 0.95 }
+
+// California article with section
+// { type: 'constitutional', jurisdiction: 'CA', article: 1,
+//   section: '7', confidence: 0.9 }
+
+// Commerce Clause (article + section + clause)
+// { type: 'constitutional', jurisdiction: 'US', article: 1,
+//   section: '8', clause: 3, confidence: 0.95 }
+```
+
+Roman numerals (I-XXVII) are automatically parsed to integers. All 50 state abbreviations are supported.
+
+## Custom Patterns
+
+Restrict extraction to specific citation types by passing custom patterns:
+
+```typescript
+import { extractCitations, casePatterns } from "eyecite-ts"
+
+// Extract only case citations
+const citations = extractCitations(text, {
+  patterns: casePatterns,
+})
+```
+
+Available pattern sets: `casePatterns`, `statutePatterns`, `journalPatterns`, `neutralPatterns`, `shortFormPatterns`, `constitutionalPatterns`.
+
+## Custom Cleaners
+
+Override the default cleaning pipeline (HTML stripping, Unicode normalization, smart quote fixing):
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+
+// Use only HTML stripping
+const citations = extractCitations(html, {
+  cleaners: [(text) => text.replace(/<[^>]+>/g, "")],
+})
+```
+
+## Structured Dates
+
+Parentheticals with full dates return structured date objects:
+
+```typescript
+const text = "500 F.3d 100 (2d Cir. Jan. 15, 2020)"
+const citations = extractCitations(text)
+
+if (citations[0].type === "case") {
+  console.log(citations[0].date)
+  // { iso: '2020-01-15', parsed: { year: 2020, month: 1, day: 15 } }
+}
+```
+
+Three date formats are supported: `Jan. 15, 2020`, `January 15, 2020`, and `1/15/2020`. Year-only parentheticals produce `{ iso: '1973', parsed: { year: 1973 } }`.
+
+## Blank Page Citations
+
+Citations can reference blank pages using placeholder notation in slip opinions or unpublished decisions:
+
+```typescript
+const text = "500 F.2d ___ (2020)"
+const citations = extractCitations(text)
+
+if (citations[0].type === "case") {
+  console.log(citations[0].hasBlankPage) // true
+  console.log(citations[0].page) // undefined
+}
+```
+
+Both `___` (triple underscore) and `---` (triple dash) are recognized as blank page placeholders.
+
+## Component Spans
+
+Every citation carries a `spans` record with per-component position data (added in v0.10.0):
+
+```typescript
+const text = "Smith v. Jones, 500 F.2d 123 (9th Cir. 2020)"
+const citations = extractCitations(text)
+
+if (citations[0].type === "case") {
+  console.log(citations[0].spans)
+  // {
+  //   volume: { cleanStart: 16, cleanEnd: 19, originalStart: 16, originalEnd: 19 },
+  //   reporter: { cleanStart: 20, cleanEnd: 24, originalStart: 20, originalEnd: 24 },
+  //   page: { cleanStart: 25, cleanEnd: 28, originalStart: 25, originalEnd: 28 },
+  //   court: { ... },
+  //   year: { ... },
+  //   caseName: { ... },
+  //   ...
+  // }
+}
+```
+
+Use `spanFromGroupIndex()` to build spans from regex capture groups in custom extractors.
+
+## Subsequent History
+
+Case citations automatically extract subsequent history chains:
+
+```typescript
+const text = "Smith v. Jones, 500 F.2d 123 (9th Cir. 2020), aff'd, 600 U.S. 456 (2021)"
+const citations = extractCitations(text)
+
+if (citations[0].type === "case") {
+  console.log(citations[0].subsequentHistoryEntries)
+  // [{ signal: 'affirmed', rawSignal: "aff'd", signalSpan: { ... }, order: 0 }]
+}
+```
+
+Recognized signals include: `aff'd`, `rev'd`, `vacated`, `remanded`, `cert. denied`, `cert. granted`, `overruled`, and more.
+
+## Disposition Extraction
+
+Disposition parentheticals (en banc, per curiam) are parsed from case citations:
+
+```typescript
+const text = "500 F.2d 123 (9th Cir. 2020) (en banc)"
+const citations = extractCitations(text)
+
+if (citations[0].type === "case") {
+  console.log(citations[0].disposition) // 'en banc'
+}
+```
+
+## Reporter Validation
+
+Validate case citations against the reporters database for confidence adjustments:
+
+```typescript
+import { extractWithValidation } from "eyecite-ts"
+
+const validated = await extractWithValidation(text, { validate: true })
+// Confidence adjustments:
+//   +0.2 boost for reporter match
+//   -0.3 penalty for unknown reporter
+//   -0.1 per extra match for ambiguous reporter
+```
+
+## False Positive Filtering
+
+The library detects likely false positive citations using a blocklist of international (non-US) reporter abbreviations and year plausibility heuristics:
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+
+// Flag false positives with reduced confidence (default)
+const citations = extractCitations(text)
+// False positives get confidence: 0.1 and a warning
+
+// Or remove them entirely
+const clean = extractCitations(text, { filterFalsePositives: true })
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/guides/advanced-extraction.md
+git commit -m "docs: add advanced extraction guide (moved from README)"
+```
+
+---
+
+### Task 2: Create `docs/guides/resolution.md`
+
+**Files:**
+- Create: `docs/guides/resolution.md`
+
+- [ ] **Step 1: Write `docs/guides/resolution.md`**
+
+```markdown
+# Short-Form Resolution
+
+Guide to resolving short-form citations (Id., supra, short-form case) to their full antecedents.
+
+## Convenience API
+
+The simplest way to resolve citations is passing `{ resolve: true }` to `extractCitations`:
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+
+const text = `
+  Smith v. Jones, 500 F.2d 123 (2020).
+  Id. at 125.
+  Smith, supra, at 130.
+  500 F.2d at 140.
+`
+
+const citations = extractCitations(text, { resolve: true })
+
+// citations[1] is Id. — resolves to index 0 (Smith v. Jones)
+console.log(citations[1].resolution)
+// { resolvedTo: 0, confidence: 1.0 }
+```
+
+## Power-User API
+
+For fine-grained control, extract first and then resolve separately:
+
+```typescript
+import { extractCitations, resolveCitations } from "eyecite-ts"
+
+const citations = extractCitations(text)
+
+const resolved = resolveCitations(citations, text, {
+  scopeStrategy: "paragraph",
+  fuzzyPartyMatching: true,
+  partyMatchThreshold: 0.8,
+  reportUnresolved: true,
+})
+```
+
+## Resolution Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `scopeStrategy` | `'paragraph' \| 'section' \| 'footnote' \| 'none'` | `'none'` | How far back to search for antecedents |
+| `autoDetectParagraphs` | `boolean` | `true` | Auto-detect paragraph boundaries from text |
+| `paragraphBoundaryPattern` | `RegExp` | `/\n\n+/` | Pattern to detect paragraphs |
+| `fuzzyPartyMatching` | `boolean` | `true` | Enable fuzzy party name matching for supra |
+| `partyMatchThreshold` | `number` | `0.8` | Similarity threshold (0-1) for fuzzy matching |
+| `reportUnresolved` | `boolean` | `true` | Report failure reasons for unresolved citations |
+
+## Scope Strategies
+
+- **`'none'`** (default): Resolve across the entire document. Best for HTML-stripped text where paragraph boundaries are unreliable.
+- **`'paragraph'`**: Only resolve within the same paragraph. Stricter but prevents cross-paragraph false matches.
+- **`'section'`**: Only resolve within the same section.
+- **`'footnote'`**: Zone-based isolation. Id. is strict (same footnote only), supra and short-form case can cross from footnotes to body. Requires `footnoteMap` from `detectFootnotes()`.
+
+## Resolution by Citation Type
+
+### Id. Citations
+
+Id. resolves to the most recently cited full citation (or most recently resolved short-form):
+
+```typescript
+const text = "Smith v. Jones, 500 F.2d 123. Id. at 125."
+const citations = extractCitations(text, { resolve: true })
+// citations[1].resolution.resolvedTo === 0
+```
+
+### Supra Citations
+
+Supra resolves by matching the party name against previously seen case names:
+
+```typescript
+const text = "Smith v. Jones, 500 F.2d 123. Smith, supra, at 130."
+const citations = extractCitations(text, { resolve: true })
+// citations[1].resolution.resolvedTo === 0 (party name "Smith" matches)
+```
+
+With `fuzzyPartyMatching: true`, minor typos and variations are tolerated using Levenshtein distance.
+
+### Short-Form Case Citations
+
+Short-form case citations resolve by matching volume and reporter:
+
+```typescript
+const text = "Brown v. Board, 347 U.S. 483. See 347 U.S. at 495."
+const citations = extractCitations(text, { resolve: true })
+// citations[1].resolution.resolvedTo === 0 (volume/reporter matches)
+```
+
+## Unresolved Citations
+
+When `reportUnresolved: true`, failed resolutions include a reason:
+
+```typescript
+const text = "Id. at 100." // Orphan Id. with no preceding citation
+const citations = extractCitations(text, { resolve: true })
+// citations[0].resolution.failureReason === 'No preceding citation found'
+```
+
+## Resolution Result Type
+
+```typescript
+interface ResolutionResult {
+  resolvedTo?: number // Index of the antecedent citation
+  failureReason?: string // Why resolution failed
+  warnings?: string[] // Ambiguity warnings
+  confidence: number // 0-1 confidence score
+}
+```
+
+On full citations, `resolution` is typed as `undefined`. On short-form citations, it is `ResolutionResult | undefined`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/guides/resolution.md
+git commit -m "docs: add resolution guide (moved from README)"
+```
+
+---
+
+### Task 3: Create `docs/guides/annotation.md`
+
+**Files:**
+- Create: `docs/guides/annotation.md`
+
+- [ ] **Step 1: Write `docs/guides/annotation.md`**
+
+```markdown
+# Citation Annotation
+
+Guide to marking up citations with HTML or custom markup in the original text.
+
+## Template Mode
+
+Wrap citation text with before/after strings:
+
+```typescript
+import { annotate } from "eyecite-ts/annotate"
+import { extractCitations } from "eyecite-ts"
+
+const text = "See Smith v. Jones, 500 F.2d 123 (2020)."
+const citations = extractCitations(text)
+
+const result = annotate(text, citations, {
+  template: { before: "<cite>", after: "</cite>" },
+})
+// result.text === 'See Smith v. Jones, <cite>500 F.2d 123</cite> (2020).'
+```
+
+## Callback Mode
+
+Full control over annotation output per citation:
+
+```typescript
+const result = annotate(text, citations, {
+  callback: (citation, surrounding) => {
+    if (citation.type === "case") {
+      return `<a href="/cases/${citation.volume}-${citation.page}">${citation.matchedText}</a>`
+    }
+    return `<span>${citation.matchedText}</span>`
+  },
+})
+```
+
+The `surrounding` parameter provides ~30 characters of context around the citation for context-aware decisions.
+
+## XSS Auto-Escape
+
+Auto-escape is **enabled by default** to prevent XSS injection. Special HTML characters are escaped in non-markup text:
+
+- `<` -> `&lt;`, `>` -> `&gt;`, `&` -> `&amp;`, `"` -> `&quot;`, `'` -> `&#39;`, `/` -> `&#x2F;`
+
+```typescript
+// Secure by default
+const result = annotate(text, citations, {
+  template: { before: "<cite>", after: "</cite>" },
+  autoEscape: true, // default
+})
+```
+
+**Security warning:** Only disable `autoEscape` if you are certain the text comes from a trusted source.
+
+## Full Span Annotation
+
+By default, annotation wraps only the citation core (volume-reporter-page). Use `useFullSpan` to annotate from the case name through the closing parenthetical:
+
+```typescript
+const text = "In Smith v. Jones, 500 F.2d 123 (9th Cir. 2020) (en banc), the court held..."
+const citations = extractCitations(text)
+
+// Default: annotates only "500 F.2d 123"
+const coreOnly = annotate(text, citations, {
+  template: { before: "<cite>", after: "</cite>" },
+})
+// "In Smith v. Jones, <cite>500 F.2d 123</cite> (9th Cir. 2020) (en banc), the court held..."
+
+// useFullSpan: annotates "Smith v. Jones, 500 F.2d 123 (9th Cir. 2020) (en banc)"
+const fullSpan = annotate(text, citations, {
+  template: { before: "<cite>", after: "</cite>" },
+  useFullSpan: true,
+})
+// "In <cite>Smith v. Jones, 500 F.2d 123 (9th Cir. 2020) (en banc)</cite>, the court held..."
+```
+
+Full span covers: case name, volume-reporter-page, court/date parenthetical, disposition parenthetical, chained parentheticals, and subsequent history.
+
+## Annotation Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `useCleanText` | `boolean` | `false` | Annotate cleaned text (true) or original text (false) |
+| `autoEscape` | `boolean` | `true` | Auto-escape HTML entities for XSS protection |
+| `useFullSpan` | `boolean` | `false` | Annotate full citation span vs. core only |
+| `template` | `{ before, after }` | - | Template mode: strings to wrap citation text |
+| `callback` | `(citation, surrounding) => string` | - | Callback mode: custom annotation function |
+
+## Position Tracking
+
+The `AnnotationResult` includes a `positionMap` for mapping original positions to annotated positions:
+
+```typescript
+const result = annotate(text, citations, {
+  template: { before: "<cite>", after: "</cite>" },
+})
+
+// result.positionMap: Map<number, number>
+// Maps original character positions to new positions after markup insertion
+// Useful for updating external indices (search highlights, cursor positions)
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/guides/annotation.md
+git commit -m "docs: add annotation guide (moved from README)"
+```
+
+---
+
+### Task 4: Create `docs/guides/footnote-detection.md`
+
+**Files:**
+- Create: `docs/guides/footnote-detection.md`
+
+- [ ] **Step 1: Write `docs/guides/footnote-detection.md`**
+
+```markdown
+# Footnote Detection
+
+Opt-in feature that detects footnote zones in legal documents and tags citations with their footnote context.
+
+## Quick Start
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+
+const citations = extractCitations(text, { detectFootnotes: true })
+
+for (const cite of citations) {
+  if (cite.inFootnote) {
+    console.log(`Footnote ${cite.footnoteNumber}: ${cite.matchedText}`)
+  }
+}
+```
+
+## How It Works
+
+Footnote detection runs on the **raw text** (before cleaning) to preserve newline structure. Two strategies are tried in order:
+
+### HTML Strategy
+
+Regex-based tag scanner (no DOM dependency) that detects:
+- `<footnote>` and `<fn>` elements
+- Elements with footnote-related class or id attributes (e.g., `class="footnote"`, `id="fn1"`)
+
+### Plaintext Strategy
+
+Used as a fallback when no HTML footnote tags are found. Detects:
+- Separator lines (5+ dashes or underscores)
+- Numbered markers after the separator: `1.`, `FN1.`, `[1]`, `n.1`
+
+## Footnote Zones
+
+Detection produces a `FootnoteMap` — an array of `{ start, end, footnoteNumber }` zones. The pipeline maps these zones through the `TransformationMap` to clean-text coordinates, then tags citations via binary search.
+
+## Resolution Scope
+
+With `scopeStrategy: 'footnote'`, the resolver enforces zone-based isolation:
+
+- **Id. citations**: Strict — must resolve within the same footnote zone
+- **Supra / short-form case**: Can cross from footnotes to body text (footnotes commonly reference citations introduced in the main text)
+
+```typescript
+const citations = extractCitations(text, {
+  detectFootnotes: true,
+  resolve: true,
+  resolutionOptions: { scopeStrategy: "footnote" },
+})
+```
+
+## Standalone API
+
+For advanced use cases, detect footnotes independently:
+
+```typescript
+import { detectFootnotes } from "eyecite-ts"
+
+const zones = detectFootnotes(rawText)
+// [{ start: 1200, end: 1350, footnoteNumber: 1 }, ...]
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/guides/footnote-detection.md
+git commit -m "docs: add footnote detection guide"
+```
+
+---
+
+### Task 5: Create `docs/guides/migration-from-python.md`
+
+**Files:**
+- Create: `docs/guides/migration-from-python.md`
+
+This file requires verified claims about Python eyecite's API. The spec contains the verified comparison table from 2026-04-11.
+
+- [ ] **Step 1: Write `docs/guides/migration-from-python.md`**
+
+```markdown
+# Migrating from Python eyecite
+
+Guide for developers familiar with [Python eyecite](https://github.com/freelawproject/eyecite) who are switching to or evaluating eyecite-ts.
+
+## API Mapping
+
+| Python eyecite | eyecite-ts | Notes |
+|---|---|---|
+| `get_citations(text)` | `extractCitations(text)` | Returns typed array instead of generator |
+| `resolve_citations(citations)` | `resolveCitations(citations, text)` | Requires text parameter; or use `extractCitations(text, { resolve: true })` |
+| `annotate_citations(text, citations)` | `annotate(text, citations, options)` | Import from `eyecite-ts/annotate`; requires template or callback |
+| `clean_text(text)` | `cleanText(text)` | Returns `{ cleaned, transformationMap }` instead of just string |
+
+## Naming Conventions
+
+Python eyecite uses `snake_case`; eyecite-ts uses `camelCase`:
+
+| Python | TypeScript |
+|--------|-----------|
+| `FullCaseCitation` | `FullCaseCitation` (same) |
+| `FullLawCitation` | `StatuteCitation` |
+| `FullJournalCitation` | `JournalCitation` |
+| `ShortCaseCitation` | `ShortFormCaseCitation` |
+| `IdCitation` | `IdCitation` (same) |
+| `SupraCitation` | `SupraCitation` (same) |
+| `full_span_start` / `full_span_end` | `fullSpan.originalStart` / `fullSpan.originalEnd` |
+| `metadata.plaintiff` | `citation.plaintiff` (top-level field) |
+
+## Type System Differences
+
+Python uses class inheritance; eyecite-ts uses a discriminated union on the `type` field:
+
+```python
+# Python
+if isinstance(citation, FullCaseCitation):
+    print(citation.volume)
+```
+
+```typescript
+// TypeScript
+if (citation.type === "case") {
+  console.log(citation.volume) // fully typed
+}
+
+// Or with type guards
+if (isCaseCitation(citation)) {
+  console.log(citation.volume)
+}
+```
+
+## Position Mapping
+
+Python eyecite tracks positions via diff-based `SpanUpdater` at annotation time. eyecite-ts tracks positions incrementally during cleaning via `TransformationMap`:
+
+- Every citation carries dual coordinates: `span.cleanStart`/`span.cleanEnd` (cleaned text) and `span.originalStart`/`span.originalEnd` (original text)
+- No diffing step needed — positions are available immediately after extraction
+
+## Data Source Differences
+
+| Aspect | Python eyecite | eyecite-ts |
+|--------|---------------|-----------|
+| Reporter data | External `reporters-db` package (JSON) | Built-in, lazy-loaded via `eyecite-ts/data` |
+| Statute data | `reporters-db/laws.json` (all 50 states + DC + territories) | Built-in regex patterns (50 states + DC + federal) |
+| Journal data | `reporters-db/journals.json` | Built-in patterns |
+
+## Features Unique to eyecite-ts
+
+These features have no Python eyecite equivalent:
+
+- **Constitutional citations** — dedicated `ConstitutionalCitation` type with article/amendment/section/clause parsing
+- **Footnote detection** — opt-in `{ detectFootnotes: true }` with zone-based resolver scoping
+- **Citation signals** — `See`, `See also`, `Cf.` etc. captured as `signal` field on citations
+- **Component spans** — per-field position data via `spans` record (volume, reporter, page, court, year, caseName, etc.)
+- **Parallel citation grouping** — `groupId` and `parallelCitations` array for linked reporters
+
+## Features with Different Approaches
+
+| Feature | Python | eyecite-ts |
+|---------|--------|-----------|
+| Parallel detection | `is_parallel_citation()` copies metadata between citations | `groupId` links citations; `parallelCitations` array on primary |
+| Annotation HTML handling | Three modes: `unchecked`, `skip`, `wrap` | XSS auto-escape (default on), template or callback modes |
+| Case name extraction | `find_case_name()` / `find_case_name_in_html()` | Integrated backward search during case extraction |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/guides/migration-from-python.md
+git commit -m "docs: add Python eyecite migration guide"
+```
+
+---
+
+### Task 6: Create `docs/api/types.md`
+
+**Files:**
+- Create: `docs/api/types.md`
+
+- [ ] **Step 1: Write `docs/api/types.md`**
+
+```markdown
+# Type Reference
+
+Complete type catalog for eyecite-ts. All types are importable from the main `eyecite-ts` entry point unless noted otherwise.
+
+## Citation Types
+
+eyecite-ts uses a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) on the `type` field. Switch on `citation.type` for type-safe access to subtype-specific fields.
+
+### Union Types
+
+```typescript
+// All 11 citation types
+type Citation =
+  | FullCaseCitation
+  | StatuteCitation
+  | ConstitutionalCitation
+  | JournalCitation
+  | NeutralCitation
+  | PublicLawCitation
+  | FederalRegisterCitation
+  | StatutesAtLargeCitation
+  | IdCitation
+  | SupraCitation
+  | ShortFormCaseCitation
+
+// Full citations (8 types)
+type FullCitation =
+  | FullCaseCitation
+  | StatuteCitation
+  | ConstitutionalCitation
+  | JournalCitation
+  | NeutralCitation
+  | PublicLawCitation
+  | FederalRegisterCitation
+  | StatutesAtLargeCitation
+
+// Short-form citations (3 types)
+type ShortFormCitation = IdCitation | SupraCitation | ShortFormCaseCitation
+```
+
+### CitationBase (shared fields)
+
+All citations share these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `CitationType` | Discriminator: `'case'`, `'statute'`, etc. |
+| `text` | `string` | Matched citation text |
+| `matchedText` | `string` | Raw matched text (before cleaning) |
+| `span` | `Span` | Position in both cleaned and original text |
+| `confidence` | `number` | 0-1 confidence score |
+| `processTimeMs` | `number` | Extraction time in milliseconds |
+| `patternsChecked` | `number` | Number of patterns tested |
+| `signal` | `CitationSignal` | Citation signal (See, Cf., etc.) if present |
+| `warnings` | `Warning[]` | Extraction warnings |
+| `inFootnote` | `boolean` | Whether citation is inside a footnote zone |
+| `footnoteNumber` | `number` | Footnote number if `inFootnote` is true |
+
+### FullCaseCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'case'` | |
+| `volume` | `number \| string` | Volume number (string for hyphenated, e.g., "1984-1") |
+| `reporter` | `string` | Reporter abbreviation |
+| `page` | `number` | Starting page |
+| `pincite` | `PinciteInfo` | Pin cite reference |
+| `court` | `string` | Court abbreviation |
+| `year` | `number` | Decision year |
+| `caseName` | `string` | Full case name |
+| `plaintiff` | `string` | Plaintiff name |
+| `defendant` | `string` | Defendant name |
+| `date` | `{ iso: string, parsed: { year, month?, day? } }` | Structured date |
+| `disposition` | `string` | Disposition (en banc, per curiam) |
+| `hasBlankPage` | `boolean` | Whether page is a blank placeholder |
+| `groupId` | `string` | Parallel citation group identifier |
+| `parallelCitations` | `Array<{ volume, reporter, page }>` | Linked parallel citations (primary only) |
+| `parentheticals` | `Parenthetical[]` | Explanatory parentheticals |
+| `subsequentHistoryEntries` | `SubsequentHistoryEntry[]` | History chain |
+| `fullSpan` | `Span` | Case name through closing parenthetical |
+| `spans` | `CaseComponentSpans` | Per-field position data |
+
+### StatuteCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'statute'` | |
+| `title` | `number` | Title number (federal) |
+| `code` | `string` | Code abbreviation |
+| `section` | `string` | Section number |
+| `subsection` | `string` | Subsection reference |
+| `jurisdiction` | `string` | Two-letter jurisdiction code |
+| `hasEtSeq` | `boolean` | Whether "et seq." follows |
+| `spans` | `StatuteComponentSpans` | Per-field position data |
+
+### ConstitutionalCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'constitutional'` | |
+| `jurisdiction` | `string` | Two-letter jurisdiction code |
+| `article` | `number` | Article number |
+| `amendment` | `number` | Amendment number |
+| `section` | `string` | Section reference |
+| `clause` | `number` | Clause number |
+| `spans` | `ConstitutionalComponentSpans` | Per-field position data |
+
+### JournalCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'journal'` | |
+| `volume` | `number` | Volume number |
+| `journal` | `string` | Journal name |
+| `abbreviation` | `string` | Journal abbreviation |
+| `page` | `number` | Starting page |
+| `pincite` | `PinciteInfo` | Pin cite reference |
+| `author` | `string` | Author name |
+| `title` | `string` | Article title |
+| `year` | `number` | Publication year |
+| `spans` | `JournalComponentSpans` | Per-field position data |
+
+### NeutralCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'neutral'` | |
+| `year` | `number` | Decision year |
+| `court` | `string` | Court/vendor (WL, LEXIS) |
+| `documentNumber` | `string` | Document number |
+| `spans` | `NeutralComponentSpans` | Per-field position data |
+
+### PublicLawCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'publicLaw'` | |
+| `congress` | `number` | Congress number |
+| `lawNumber` | `number` | Law number |
+| `title` | `number` | Title reference |
+| `spans` | `PublicLawComponentSpans` | Per-field position data |
+
+### FederalRegisterCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'federalRegister'` | |
+| `volume` | `number` | Volume number |
+| `page` | `number` | Starting page |
+| `year` | `number` | Publication year |
+| `spans` | `FederalRegisterComponentSpans` | Per-field position data |
+
+### StatutesAtLargeCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'statutesAtLarge'` | |
+| `volume` | `number` | Volume number |
+| `page` | `number` | Starting page |
+| `year` | `number` | Publication year |
+| `spans` | `StatutesAtLargeComponentSpans` | Per-field position data |
+
+### IdCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'id'` | |
+| `pincite` | `PinciteInfo` | Pin cite reference |
+
+### SupraCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'supra'` | |
+| `partyName` | `string` | Party name for matching |
+| `pincite` | `PinciteInfo` | Pin cite reference |
+
+### ShortFormCaseCitation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'shortFormCase'` | |
+| `volume` | `number \| string` | Volume number |
+| `reporter` | `string` | Reporter abbreviation |
+| `page` | `number` | Starting page |
+| `pincite` | `PinciteInfo` | Pin cite reference |
+
+## Supporting Types
+
+### Span
+
+Dual-position type tracking both cleaned and original text coordinates:
+
+```typescript
+interface Span {
+  cleanStart: number
+  cleanEnd: number
+  originalStart: number
+  originalEnd: number
+}
+```
+
+### Warning
+
+```typescript
+interface Warning {
+  level: "error" | "warning" | "info"
+  message: string
+  position: { start: number; end: number }
+  context?: string
+}
+```
+
+### CitationSignal
+
+```typescript
+type CitationSignal =
+  | "see"
+  | "see also"
+  | "see generally"
+  | "cf"
+  | "but see"
+  | "but cf"
+  | "compare"
+  | "accord"
+  | "contra"
+```
+
+### Parenthetical
+
+```typescript
+interface Parenthetical {
+  text: string
+  type: ParentheticalType // 'holding' | 'finding' | 'stating' | ...
+  span?: Span
+}
+```
+
+### SubsequentHistoryEntry
+
+```typescript
+interface SubsequentHistoryEntry {
+  signal: HistorySignal // 'affirmed' | 'reversed' | 'vacated' | ...
+  rawSignal: string // Original text, e.g., "aff'd"
+  signalSpan: Span
+  order: number
+}
+```
+
+### PinciteInfo
+
+```typescript
+interface PinciteInfo {
+  page?: string
+  footnote?: string
+  raw: string
+}
+```
+
+## Configuration Types
+
+### ExtractOptions
+
+```typescript
+interface ExtractOptions {
+  cleaners?: Array<(text: string) => string>
+  patterns?: Pattern[]
+  resolve?: boolean
+  resolutionOptions?: ResolutionOptions
+  filterFalsePositives?: boolean
+  detectFootnotes?: boolean
+}
+```
+
+### ResolutionOptions
+
+See [Resolution Guide](../guides/resolution.md#resolution-options).
+
+### AnnotationOptions
+
+See [Annotation Guide](../guides/annotation.md#annotation-options).
+
+## Type Guards
+
+```typescript
+import {
+  isFullCitation, // (c: Citation) => c is FullCitation
+  isShortFormCitation, // (c: Citation) => c is ShortFormCitation
+  isCaseCitation, // (c: Citation) => c is FullCaseCitation
+  isCitationType, // (c: Citation, type: string) => c is CitationOfType<T>
+  assertUnreachable, // (value: never) => never
+} from "eyecite-ts"
+```
+
+## Conditional Types
+
+```typescript
+// Extract citation subtype by discriminator
+type CitationOfType<T extends CitationType> = Extract<Citation, { type: T }>
+
+// Usage: CitationOfType<'case'> === FullCaseCitation
+```
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/api/types.md
+git commit -m "docs: add full type reference"
+```
+
+---
+
+### Task 7: Rewrite README.md
+
+**Files:**
+- Modify: `README.md` (complete rewrite)
+
+This is the core task. The new README follows the "Pipeline Story" structure from the spec. All code examples use the verified public API.
+
+- [ ] **Step 1: Write the new README.md**
+
+Replace the entire contents of `README.md` with:
+
+```markdown
+# eyecite-ts
+
+[![CI](https://github.com/medelman17/eyecite-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/medelman17/eyecite-ts/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/medelman17/eyecite-ts/branch/main/graph/badge.svg)](https://codecov.io/gh/medelman17/eyecite-ts)
+[![npm version](https://img.shields.io/npm/v/eyecite-ts.svg)](https://www.npmjs.com/package/eyecite-ts)
+[![npm bundle size](https://img.shields.io/bundlephobia/minzip/eyecite-ts)](https://bundlephobia.com/package/eyecite-ts)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Node.js](https://img.shields.io/node/v/eyecite-ts.svg)](https://nodejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
+[![Zero Dependencies](https://img.shields.io/badge/dependencies-0-brightgreen.svg)](https://www.npmjs.com/package/eyecite-ts)
+
+TypeScript legal citation extraction — a port of Python [eyecite](https://github.com/freelawproject/eyecite) with extended capabilities.
+
+Extract structured data from legal citations in court opinions, briefs, and legal documents. A citation like `500 F.2d 123 (9th Cir. 2020)` encodes a volume (500), reporter (Federal Reporter, 2nd Series), page (123), court (Ninth Circuit), and year. This library parses all of that into typed objects, resolves short-form references like "Id." back to their antecedents, and can annotate the original text with HTML markup. Zero runtime dependencies, browser-compatible, ~20 KB brotli.
+
+## Installation
+
+```bash
+npm install eyecite-ts
+```
+
+## Quick Start
+
+A complete extract → resolve → annotate workflow:
+
+```typescript
+import { extractCitations } from "eyecite-ts"
+import { annotate } from "eyecite-ts/annotate"
+
+const text = `In Smith v. Jones, 500 F.2d 123 (9th Cir. 2020), the court
+applied 42 U.S.C. § 1983. Id. at 130. See also 123 Harv. L. Rev. 456 (2019).`
+
+// Step 1: Extract and resolve in one call
+const citations = extractCitations(text, { resolve: true })
+
+// Step 2: Inspect results
+for (const cite of citations) {
+  switch (cite.type) {
+    case "case":
+      console.log(cite.caseName, cite.reporter, cite.year)
+      // "Smith v. Jones" "F.2d" 2020
+      break
+    case "statute":
+      console.log(cite.title, cite.code, cite.section)
+      // 42 "U.S.C." "1983"
+      break
+    case "id":
+      console.log("Id. resolves to index", cite.resolution?.resolvedTo)
+      // Id. resolves to index 0
+      break
+    case "journal":
+      console.log(cite.journal, cite.volume, cite.page)
+      // "Harv. L. Rev." 123 456
+      break
+  }
+}
+
+// Step 3: Annotate the original text
+const result = annotate(text, citations, {
+  template: { before: '<cite>', after: '</cite>' },
+})
+console.log(result.text)
+```
+
+## What It Extracts
+
+| Type | Example | Key Fields |
+|------|---------|------------|
+| `case` | `500 F.2d 123 (9th Cir. 2020)` | volume, reporter, page, court, year, caseName |
+| `statute` | `42 U.S.C. § 1983(a)(1)` | title, code, section, subsection, jurisdiction |
+| `constitutional` | `U.S. Const. amend. XIV, § 1` | jurisdiction, amendment, section, clause |
+| `journal` | `123 Harv. L. Rev. 456` | volume, journal, page, year |
+| `neutral` | `2020 WL 123456` | year, court, documentNumber |
+| `publicLaw` | `Pub. L. No. 117-263` | congress, lawNumber |
+| `federalRegister` | `87 Fed. Reg. 1234` | volume, page, year |
+| `statutesAtLarge` | `136 Stat. 4459` | volume, page, year |
+| `id` | `Id. at 125` | pincite |
+| `supra` | `Smith, supra, at 130` | partyName, pincite |
+| `shortFormCase` | `500 F.2d at 140` | volume, reporter, pincite |
+
+Statute coverage spans 52 jurisdictions (50 states + DC + federal). See the [Advanced Extraction Guide](docs/guides/advanced-extraction.md) for jurisdiction details.
+
+## Key Features
+
+### Case Names & Full Spans
+
+The library backward-searches for party names and tracks full citation boundaries:
+
+```typescript
+const text = "In Smith v. Jones, 500 F.2d 123 (9th Cir. 2020) (en banc), the court held..."
+const [cite] = extractCitations(text)
+
+if (cite.type === "case") {
+  cite.caseName   // "Smith v. Jones"
+  cite.plaintiff  // "Smith"
+  cite.defendant  // "Jones"
+  cite.disposition // "en banc"
+  cite.span       // covers "500 F.2d 123" (citation core)
+  cite.fullSpan   // covers "Smith v. Jones, 500 F.2d 123 (9th Cir. 2020) (en banc)"
+}
+```
+
+Procedural prefixes like `In re`, `Ex parte`, and `Matter of` are recognized automatically.
+
+### Parallel Citations
+
+When multiple reporters cite the same case (common in older Supreme Court opinions), the library groups them automatically:
+
+```typescript
+const text = "See 410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)."
+const citations = extractCitations(text)
+
+citations[0].groupId // "410-U.S.-113"
+citations[1].groupId // "410-U.S.-113" (same group)
+citations[2].groupId // "410-U.S.-113" (same group)
+
+// Primary citation carries the linked array
+if (citations[0].type === "case") {
+  citations[0].parallelCitations
+  // [{ volume: 93, reporter: 'S. Ct.', page: 705 },
+  //  { volume: 35, reporter: 'L. Ed. 2d', page: 147 }]
+}
+```
+
+### Short-Form Resolution
+
+Pass `{ resolve: true }` to link Id., supra, and short-form case citations to their full antecedents:
+
+```typescript
+const text = `Smith v. Jones, 500 F.2d 123 (2020). Id. at 125.`
+const citations = extractCitations(text, { resolve: true })
+
+citations[1].resolution
+// { resolvedTo: 0, confidence: 1.0 }
+```
+
+The resolver supports paragraph/section/footnote scope boundaries, fuzzy party name matching, and configurable thresholds. See the [Resolution Guide](docs/guides/resolution.md) for the power-user API.
+
+### Citation Annotation
+
+Mark up citations with HTML using template or callback modes:
+
+```typescript
+import { annotate } from "eyecite-ts/annotate"
+
+const result = annotate(text, citations, {
+  template: { before: '<cite>', after: '</cite>' },
+})
+// "See Smith v. Jones, <cite>500 F.2d 123</cite> (2020)."
+```
+
+XSS auto-escape is enabled by default. Use `useFullSpan: true` to annotate from case name through closing parenthetical. See the [Annotation Guide](docs/guides/annotation.md) for callback mode and full options.
+
+### Confidence & Signals
+
+Each citation carries a `confidence` score (0-1) based on pattern match quality and reporter validation. Citations preceded by legal signals are tagged:
+
+```typescript
+const text = "See also Smith v. Jones, 500 F.2d 123 (2020)."
+const [cite] = extractCitations(text)
+
+cite.confidence // 0.85
+cite.signal     // "see also"
+```
+
+### Footnote Detection
+
+Opt-in feature that tags citations with their footnote context and enables zone-scoped resolution:
+
+```typescript
+const citations = extractCitations(text, { detectFootnotes: true })
+
+for (const cite of citations) {
+  if (cite.inFootnote) {
+    console.log(`Footnote ${cite.footnoteNumber}: ${cite.matchedText}`)
+  }
+}
+```
+
+Supports HTML footnote tags and plaintext footnote sections (separator + numbered markers). See the [Footnote Detection Guide](docs/guides/footnote-detection.md).
+
+## Type System
+
+All citation types use a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) on the `type` field:
+
+```typescript
+import type { Citation, FullCaseCitation, StatuteCitation } from "eyecite-ts"
+import { isFullCitation, isCaseCitation, assertUnreachable } from "eyecite-ts"
+
+// Type guards
+if (isCaseCitation(citation)) {
+  citation.reporter // typed as string
+}
+
+// Exhaustive switch
+switch (citation.type) {
+  case "case": /* ... */ break
+  case "statute": /* ... */ break
+  // ... all 11 types
+  default: assertUnreachable(citation.type)
+}
+```
+
+`CitationOfType<'case'>` extracts the subtype: `CitationOfType<'case'>` = `FullCaseCitation`. See the [Type Reference](docs/api/types.md) for the full catalog.
+
+## Bundle Size
+
+Three entry points for tree-shaking:
+
+| Entry Point | Import | Size (brotli) |
+|-------------|--------|---------------|
+| Core extraction | `eyecite-ts` | ~20 KB |
+| Annotation | `eyecite-ts/annotate` | ~1.3 KB |
+| Reporter data | `eyecite-ts/data` | lazy-loaded |
+
+Import only what you need — the reporter database is loaded on first use, not at import time.
+
+## Comparison with Python eyecite
+
+Every claim verified against [Python eyecite](https://github.com/freelawproject/eyecite) source code (April 2026).
+
+| Capability | Python eyecite | eyecite-ts | Notes |
+|---|---|---|---|
+| Case citations | Yes | Yes | Both extract volume/reporter/page/court/year |
+| Statute citations | Yes (all 50 states + DC + territories) | Yes (50 states + DC + federal) | Python uses `reporters-db`; TS uses built-in patterns |
+| Constitutional citations | No | Yes (U.S. + 50 states) | Dedicated type with article/amendment/section/clause |
+| Journal / law review | Yes | Yes | |
+| Neutral (WL/LEXIS) | Yes (as case citations) | Yes (dedicated type) | |
+| Short-form resolution | Yes | Yes | |
+| Case name extraction | Yes | Yes | Both use backward scanning |
+| Parallel citation linking | Partial (detection + metadata copy) | Yes (`groupId` + `parallelCitations`) | |
+| Full span tracking | Yes | Yes | TS carries dual clean/original positions |
+| Component spans | Minimal (pin cite only) | Yes (all fields) | |
+| Footnote detection | No | Yes | HTML + plaintext strategies |
+| Citation signals | No (stop words only) | Yes (extracted as metadata) | |
+| Annotation | Yes (HTML modes) | Yes (template/callback + XSS auto-escape) | |
+| Position mapping | Yes (diff-based) | Yes (incremental TransformationMap) | |
+| Type system | Class inheritance | Discriminated union | TS enables exhaustive switch |
+
+eyecite-ts started as a port and has diverged. Both are capable citation extractors — eyecite-ts adds constitutional citations, footnote detection, citation signals, rich component spans, and a TypeScript-native type system, while Python eyecite has broader statute coverage via `reporters-db` and a mature ecosystem.
+
+Coming from Python eyecite? See the [Migration Guide](docs/guides/migration-from-python.md).
+
+## Architecture
+
+Citations flow through a 4-stage pipeline: **clean → tokenize → extract → resolve**. Text cleaning builds a `TransformationMap` that tracks position shifts, so every citation carries dual coordinates (cleaned and original text). Resolution is optional and runs as a final pass.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+
+## Development
+
+```bash
+pnpm install           # Install dependencies (corepack, pnpm 10)
+pnpm test              # Run tests (vitest, watch mode)
+pnpm exec vitest run   # Run tests once (1,748 tests, 72 files)
+pnpm typecheck         # Type-check with tsc
+pnpm build             # Build (ESM + CJS + DTS)
+pnpm lint              # Lint with Biome
+pnpm format            # Format with Biome
+pnpm size              # Check bundle size limits
+```
+
+Requires Node.js >= 18.0.0. See [ARCHITECTURE.md](ARCHITECTURE.md) for contributor orientation.
+
+## License
+
+MIT
+
+## Credits
+
+Inspired by and ported from [eyecite](https://github.com/freelawproject/eyecite) (Python) by [Free Law Project](https://free.law/). This TypeScript implementation extends the original with constitutional citations, footnote detection, citation signals, parallel citation grouping, component spans, and a discriminated-union type system.
+```
+
+- [ ] **Step 2: Verify all internal links resolve**
+
+Run:
+```bash
+# Check that all linked files exist
+ls docs/guides/advanced-extraction.md docs/guides/resolution.md docs/guides/annotation.md docs/guides/footnote-detection.md docs/guides/migration-from-python.md docs/api/types.md ARCHITECTURE.md
+```
+
+Expected: All 7 files listed without errors.
+
+- [ ] **Step 3: Verify code examples compile**
+
+Run:
+```bash
+pnpm typecheck
+```
+
+Expected: No type errors (README examples aren't checked, but this confirms the API surface hasn't drifted).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: rewrite README as pipeline story showcase
+
+Restructure from ~550-line reference into ~380-line showcase with
+hero workflow, feature table, and brief examples. Deep dives moved
+to docs/guides/ and docs/api/. Adds previously undocumented features:
+footnote detection, citation signals, confidence scoring, component
+spans. Includes verified Python eyecite comparison table."
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Verify no broken links**
+
+Run:
+```bash
+# Check all markdown links in README point to existing files
+grep -oP '\[.*?\]\((docs/[^)]+|[A-Z]+\.md)\)' README.md | grep -oP '\((.*?)\)' | tr -d '()' | while read f; do [ -f "$f" ] && echo "OK: $f" || echo "MISSING: $f"; done
+```
+
+Expected: All links show "OK".
+
+- [ ] **Step 2: Verify README line count is in target range**
+
+Run:
+```bash
+wc -l README.md
+```
+
+Expected: 350-420 lines.
+
+- [ ] **Step 3: Verify docs files exist and are non-empty**
+
+Run:
+```bash
+wc -l docs/guides/*.md docs/api/*.md
+```
+
+Expected: 6 files, each with substantive content (50+ lines).
+
+- [ ] **Step 4: Run full test suite to confirm nothing broke**
+
+Run:
+```bash
+pnpm exec vitest run
+```
+
+Expected: All 1,748 tests pass. (Docs changes shouldn't affect tests, but confirm.)
+
+- [ ] **Step 5: Final commit if any fixups needed**
+
+Only if previous steps revealed issues. Otherwise, skip.
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-11-readme-overhaul.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-20-bughunt-cli.md
+++ b/docs/superpowers/plans/2026-05-20-bughunt-cli.md
@@ -1,0 +1,1684 @@
+# Internal Bughunt CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a repo-local `pnpm bughunt` CLI that runs deterministic local bug-hunting lanes, writes reproducible artifacts, supports finding inspection, and previews Vitest regression promotion.
+
+**Architecture:** Add internal TypeScript scripts under `scripts/bughunt/`, invoked by a package script and not exported as part of the library. The CLI writes local-only `.bughunt/` artifacts, uses deterministic seeds, shares invariant/finding helpers across lanes, and starts with corpus + invariant + generated mutation lanes.
+
+**Tech Stack:** Node 18+, TypeScript ESM, `tsx`, `fast-check`, `adm-zip`, Vitest 4, Biome.
+
+---
+
+## Definition Of Done
+
+This work is done only when all of the following are true:
+
+1. **Internal CLI boundary is preserved.**
+   - `package.json` has a `bughunt` script.
+   - `package.json` has no `bin` entry for bughunt.
+   - `package.json` exports do not mention bughunt.
+   - No `src/` public exports or `tsdown` entry points are added for the CLI.
+
+2. **The local command loop works end to end.**
+   - `pnpm bughunt run --lane all --seed 1234 --sample 5` completes.
+   - The command writes `.bughunt/latest.json`.
+   - The latest run directory contains `manifest.json`, `findings.jsonl`, `cases.jsonl`, `events.jsonl`, `report.json`, and `summary.md`.
+   - The manifest records the seed, selected lanes, command, start time, and finish time.
+
+3. **At least three useful lanes exist in v1.**
+   - `corpus` lane runs extraction/resolution over inline smoke cases and records crashes or perf outliers as findings.
+   - `invariants` lane checks citation/span invariants and records violations as findings.
+   - `mutate` lane uses `fast-check` with deterministic `seed`/`numRuns` and records generated-input failures with replay data.
+
+4. **Findings are reproducible and inspectable.**
+   - Finding IDs are stable for the same lane/source/signature/snippet.
+   - Each finding records its lane, source, command, signature, message, and useful context.
+   - Generated-input findings preserve `seed` and `counterexamplePath` when available.
+   - `pnpm bughunt inspect .bughunt/latest.json --id <finding-id>` prints enough detail to reproduce or reason about the failure.
+
+5. **Promotion has a safe first version.**
+   - `pnpm bughunt promote .bughunt/latest.json --id <finding-id>` prints a Vitest repro preview.
+   - `promote` does not write files unless a deliberate `--write` behavior is implemented and tested.
+   - The preview includes the finding ID, original command, source context, and minimized/input text when available.
+
+6. **Tests cover the contract, not just implementation details.**
+   - `tests/bughunt/core.test.ts` covers deterministic RNG, stable finding IDs, artifact writing, extraction wrapper, invariant checks, inline corpus, invariant lane, and mutation lane basics.
+   - `tests/bughunt/commands.test.ts` covers `run`, unknown command handling, `inspect`, and `promote` preview.
+   - Tests use temporary directories and do not write committed `.bughunt/` artifacts.
+
+7. **Repo hygiene is maintained.**
+   - `.bughunt/` is gitignored.
+   - No secrets are printed or committed.
+   - Existing unrelated untracked files are not removed, reformatted, staged, or committed.
+   - No generated `.bughunt/` artifacts are staged.
+
+8. **Verification is complete and honestly reported.**
+   - `pnpm exec vitest run tests/bughunt/core.test.ts tests/bughunt/commands.test.ts` passes.
+   - `pnpm lint` passes or any failures are documented with exact unrelated file paths.
+   - `pnpm typecheck` passes, or the final response explicitly explains if scripts are not covered because `tsconfig.json` includes only `src`.
+   - The smoke command `pnpm bughunt run --lane all --seed 1234 --sample 5` passes.
+   - The final response reports the exact verification commands run and whether each passed.
+
+Anything less is not done; it is a partial implementation.
+
+---
+
+## File Structure
+
+Create:
+
+- `scripts/bughunt/index.ts` — subcommand dispatcher.
+- `scripts/bughunt/cli.ts` — `node:util.parseArgs` wrappers and usage text.
+- `scripts/bughunt/core/types.ts` — artifact, finding, lane, and CLI option types.
+- `scripts/bughunt/core/rng.ts` — deterministic PRNG helpers.
+- `scripts/bughunt/core/findings.ts` — stable finding IDs, signatures, JSONL helpers.
+- `scripts/bughunt/core/artifacts.ts` — `.bughunt/` run directory writer.
+- `scripts/bughunt/core/extract.ts` — safe extraction wrappers and timing.
+- `scripts/bughunt/core/invariants.ts` — citation/span invariant checks.
+- `scripts/bughunt/core/corpus.ts` — fixture and optional CAP corpus loaders.
+- `scripts/bughunt/lanes/invariants.ts` — invariant lane.
+- `scripts/bughunt/lanes/corpus.ts` — corpus lane.
+- `scripts/bughunt/lanes/mutate.ts` — `fast-check` generated mutation lane.
+- `scripts/bughunt/commands/run.ts` — run selected lanes and write artifacts.
+- `scripts/bughunt/commands/inspect.ts` — print one finding.
+- `scripts/bughunt/commands/promote.ts` — preview Vitest regression.
+- `tests/bughunt/core.test.ts` — unit tests for helpers.
+- `tests/bughunt/commands.test.ts` — command-level tests using temporary artifact dirs.
+
+Modify:
+
+- `package.json` — add `bughunt` script and dev dependencies.
+- `pnpm-lock.yaml` — update via `pnpm install`.
+- `.gitignore` — add `.bughunt/`.
+
+Do not modify:
+
+- `exports` in `package.json`.
+- `files` in `package.json`.
+- `tsdown.config.ts`.
+- public `src/` exports.
+
+---
+
+## Task 1: Add Tooling Dependencies And Local Artifact Ignore
+
+**Files:**
+- Modify: `package.json`
+- Modify: `pnpm-lock.yaml`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add dependencies and package script**
+
+Run:
+
+```bash
+pnpm add -D tsx fast-check adm-zip
+```
+
+Expected: `package.json` gains dev dependencies for `tsx`, `fast-check`, and `adm-zip`; `pnpm-lock.yaml` updates.
+
+- [ ] **Step 2: Add the package script**
+
+Edit `package.json` so the scripts block includes:
+
+```json
+{
+  "scripts": {
+    "build": "tsdown",
+    "test": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome lint src tests",
+    "format": "biome format --write src tests",
+    "size": "size-limit",
+    "check:size": "npx tsx scripts/check-bundle-size.ts",
+    "bughunt": "tsx scripts/bughunt/index.ts"
+  }
+}
+```
+
+Do not add a `bin` field.
+
+- [ ] **Step 3: Ignore local artifacts**
+
+Append this block to `.gitignore`:
+
+```gitignore
+
+# Bughunt local artifacts
+.bughunt/
+```
+
+- [ ] **Step 4: Verify package metadata**
+
+Run:
+
+```bash
+node -e "const p=require('./package.json'); if (p.bin) throw new Error('bughunt must not be public bin'); if (!p.scripts.bughunt) throw new Error('missing bughunt script'); console.log(p.scripts.bughunt)"
+```
+
+Expected:
+
+```text
+tsx scripts/bughunt/index.ts
+```
+
+---
+
+## Task 2: Define Shared Types, RNG, Findings, And Artifacts
+
+**Files:**
+- Create: `scripts/bughunt/core/types.ts`
+- Create: `scripts/bughunt/core/rng.ts`
+- Create: `scripts/bughunt/core/findings.ts`
+- Create: `scripts/bughunt/core/artifacts.ts`
+- Test: `tests/bughunt/core.test.ts`
+
+- [ ] **Step 1: Write failing tests for deterministic IDs and artifact writer**
+
+Create `tests/bughunt/core.test.ts`:
+
+```ts
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRunArtifacts } from "../../scripts/bughunt/core/artifacts";
+import { buildFinding, findingSignature } from "../../scripts/bughunt/core/findings";
+import { createRng } from "../../scripts/bughunt/core/rng";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("bughunt core helpers", () => {
+  it("creates deterministic random sequences from a seed", () => {
+    const a = createRng(1234);
+    const b = createRng(1234);
+
+    expect([a.next(), a.next(), a.next()]).toEqual([b.next(), b.next(), b.next()]);
+  });
+
+  it("builds stable finding IDs from lane, source, signature, and snippet", () => {
+    const input = {
+      runId: "run-1",
+      lane: "invariants",
+      severity: "invariant" as const,
+      source: { kind: "inline" as const, key: "example" },
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      signature: findingSignature("span_bounds", "originalEnd outside source"),
+      message: "originalEnd outside source",
+      contextSnippet: "Smith v. Jones, 1 U.S. 1 (1801)",
+    };
+
+    expect(buildFinding(input).id).toBe(buildFinding(input).id);
+  });
+
+  it("writes manifest, JSONL files, summary, and latest pointer", () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-artifacts-"));
+    tempDirs.push(root);
+    const artifacts = createRunArtifacts({
+      rootDir: root,
+      runId: "2026-05-20T143000Z-seed-1234",
+      seed: 1234,
+      command: "pnpm bughunt run --lane invariants --seed 1234",
+      lanes: ["invariants"],
+      startedAt: "2026-05-20T14:30:00.000Z",
+    });
+
+    artifacts.writeFinding(
+      buildFinding({
+        runId: artifacts.manifest.runId,
+        lane: "invariants",
+        severity: "invariant",
+        source: { kind: "inline", key: "case-1" },
+        command: artifacts.manifest.command,
+        signature: findingSignature("span_bounds", "bad span"),
+        message: "bad span",
+        contextSnippet: "bad span input",
+      }),
+    );
+    artifacts.finalize({ finishedAt: "2026-05-20T14:30:01.000Z" });
+
+    const latest = JSON.parse(readFileSync(join(root, "latest.json"), "utf8")) as {
+      runDir: string;
+    };
+    expect(latest.runDir).toContain("2026-05-20T143000Z-seed-1234");
+    expect(readFileSync(join(artifacts.runDir, "findings.jsonl"), "utf8")).toContain("bad span");
+    expect(readFileSync(join(artifacts.runDir, "summary.md"), "utf8")).toContain("invariants");
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts
+```
+
+Expected: fails because `scripts/bughunt/core/*` modules do not exist.
+
+- [ ] **Step 3: Implement shared types**
+
+Create `scripts/bughunt/core/types.ts`:
+
+```ts
+export type BughuntSeverity = "crash" | "invariant" | "suspicious" | "perf" | "diff";
+
+export type BughuntLane = "corpus" | "invariants" | "mutate" | "resolver" | "annotate" | "perf";
+
+export interface BughuntSource {
+  kind: "cap" | "fixture" | "synthetic" | "inline";
+  key?: string;
+  seed?: number;
+  path?: string;
+  replayPath?: string;
+}
+
+export interface BughuntFinding {
+  id: string;
+  runId: string;
+  lane: string;
+  severity: BughuntSeverity;
+  source: BughuntSource;
+  command: string;
+  signature: string;
+  message: string;
+  input?: string;
+  minimalInput?: string;
+  contextSnippet?: string;
+  citations?: unknown[];
+  before?: unknown;
+  after?: unknown;
+  invariant?: string;
+  timing?: {
+    durationMs: number;
+    timeoutMs?: number;
+  };
+  suggestedTest?: {
+    path: string;
+    name: string;
+  };
+}
+
+export type FindingInput = Omit<BughuntFinding, "id">;
+
+export interface RunManifest {
+  runId: string;
+  seed: number;
+  command: string;
+  lanes: string[];
+  startedAt: string;
+  finishedAt?: string;
+}
+
+export interface RunSummary {
+  finishedAt: string;
+}
+
+export interface RunArtifacts {
+  runDir: string;
+  manifest: RunManifest;
+  writeFinding(finding: BughuntFinding): void;
+  writeCase(record: unknown): void;
+  writeEvent(record: unknown): void;
+  finalize(summary: RunSummary): void;
+}
+```
+
+- [ ] **Step 4: Implement deterministic RNG**
+
+Create `scripts/bughunt/core/rng.ts`:
+
+```ts
+export interface Rng {
+  next(): number;
+  integer(maxExclusive: number): number;
+  pick<T>(items: readonly T[]): T;
+}
+
+export function createRng(seed: number): Rng {
+  let state = seed >>> 0;
+
+  const next = (): number => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+
+  return {
+    next,
+    integer(maxExclusive: number): number {
+      if (!Number.isInteger(maxExclusive) || maxExclusive <= 0) {
+        throw new Error(`maxExclusive must be a positive integer; got ${maxExclusive}`);
+      }
+      return Math.floor(next() * maxExclusive);
+    },
+    pick<T>(items: readonly T[]): T {
+      if (items.length === 0) {
+        throw new Error("cannot pick from an empty array");
+      }
+      return items[this.integer(items.length)]!;
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Implement finding helpers**
+
+Create `scripts/bughunt/core/findings.ts`:
+
+```ts
+import { createHash } from "node:crypto";
+import type { BughuntFinding, FindingInput } from "./types";
+
+export function findingSignature(kind: string, message: string): string {
+  return `${kind}:${message.replace(/\s+/g, " ").trim().slice(0, 160)}`;
+}
+
+export function buildFinding(input: FindingInput): BughuntFinding {
+  const hashInput = [
+    input.lane,
+    input.source.kind,
+    input.source.key ?? "",
+    input.source.seed?.toString() ?? "",
+    input.signature,
+    normalizeSnippet(input.contextSnippet ?? input.input ?? input.message),
+  ].join("\u001f");
+
+  const digest = createHash("sha256").update(hashInput).digest("hex").slice(0, 12);
+  return { id: `F-${digest}`, ...input };
+}
+
+export function toJsonLine(value: unknown): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+function normalizeSnippet(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 500);
+}
+```
+
+- [ ] **Step 6: Implement artifact writer**
+
+Create `scripts/bughunt/core/artifacts.ts`:
+
+```ts
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { toJsonLine } from "./findings";
+import type { BughuntFinding, RunArtifacts, RunManifest, RunSummary } from "./types";
+
+export interface CreateRunArtifactsInput {
+  rootDir: string;
+  runId: string;
+  seed: number;
+  command: string;
+  lanes: string[];
+  startedAt: string;
+}
+
+export function createRunArtifacts(input: CreateRunArtifactsInput): RunArtifacts {
+  const runDir = join(input.rootDir, "runs", input.runId);
+  mkdirSync(runDir, { recursive: true });
+
+  const manifest: RunManifest = {
+    runId: input.runId,
+    seed: input.seed,
+    command: input.command,
+    lanes: input.lanes,
+    startedAt: input.startedAt,
+  };
+
+  writeFileSync(join(runDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+  writeFileSync(join(runDir, "findings.jsonl"), "");
+  writeFileSync(join(runDir, "cases.jsonl"), "");
+  writeFileSync(join(runDir, "events.jsonl"), "");
+  writeFileSync(join(runDir, "report.json"), `${JSON.stringify({ findings: 0 }, null, 2)}\n`);
+  writeFileSync(join(runDir, "summary.md"), `# Bughunt Run\n\nLanes: ${input.lanes.join(", ")}\n`);
+
+  mkdirSync(input.rootDir, { recursive: true });
+  writeFileSync(
+    join(input.rootDir, "latest.json"),
+    `${JSON.stringify({ runDir, createdAt: input.startedAt }, null, 2)}\n`,
+  );
+
+  let findingCount = 0;
+
+  return {
+    runDir,
+    manifest,
+    writeFinding(finding: BughuntFinding): void {
+      findingCount += 1;
+      appendFileSync(join(runDir, "findings.jsonl"), toJsonLine(finding));
+    },
+    writeCase(record: unknown): void {
+      appendFileSync(join(runDir, "cases.jsonl"), toJsonLine(record));
+    },
+    writeEvent(record: unknown): void {
+      appendFileSync(join(runDir, "events.jsonl"), toJsonLine(record));
+    },
+    finalize(summary: RunSummary): void {
+      manifest.finishedAt = summary.finishedAt;
+      writeFileSync(join(runDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+      writeFileSync(join(runDir, "report.json"), `${JSON.stringify({ findings: findingCount }, null, 2)}\n`);
+      writeFileSync(
+        join(runDir, "summary.md"),
+        [
+          "# Bughunt Run",
+          "",
+          `Run: ${manifest.runId}`,
+          `Lanes: ${manifest.lanes.join(", ")}`,
+          `Findings: ${findingCount}`,
+          `Finished: ${summary.finishedAt}`,
+          "",
+        ].join("\n"),
+      );
+    },
+  };
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts
+```
+
+Expected: passes.
+
+---
+
+## Task 3: Add Extraction Wrapper And Invariant Checks
+
+**Files:**
+- Create: `scripts/bughunt/core/extract.ts`
+- Create: `scripts/bughunt/core/invariants.ts`
+- Modify: `tests/bughunt/core.test.ts`
+
+- [ ] **Step 1: Add failing tests for extraction and invariants**
+
+Append to `tests/bughunt/core.test.ts`:
+
+```ts
+import { runExtraction } from "../../scripts/bughunt/core/extract";
+import { checkCitationInvariants } from "../../scripts/bughunt/core/invariants";
+
+describe("bughunt extraction and invariants", () => {
+  it("runs extraction and records duration", () => {
+    const result = runExtraction("Smith v. Jones, 1 U.S. 1 (1801).", { resolve: true });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.citations.length).toBeGreaterThan(0);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("reports no invariant failures for a normal citation", () => {
+    const text = "Smith v. Jones, 1 U.S. 1 (1801).";
+    const result = runExtraction(text, { resolve: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const violations = checkCitationInvariants(text, result.citations);
+    expect(violations).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts
+```
+
+Expected: fails because `extract.ts` and `invariants.ts` do not exist.
+
+- [ ] **Step 3: Implement extraction wrapper**
+
+Create `scripts/bughunt/core/extract.ts`:
+
+```ts
+import { performance } from "node:perf_hooks";
+import { extractCitations } from "../../src/index";
+import type { Citation } from "../../src/types/citation";
+
+export interface ExtractionOptions {
+  resolve?: boolean;
+  detectFootnotes?: boolean;
+}
+
+export type ExtractionResult =
+  | { ok: true; citations: Citation[]; durationMs: number }
+  | { ok: false; error: Error; durationMs: number };
+
+export function runExtraction(text: string, options: ExtractionOptions = {}): ExtractionResult {
+  const start = performance.now();
+  try {
+    const citations = extractCitations(text, options);
+    return { ok: true, citations, durationMs: performance.now() - start };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+      durationMs: performance.now() - start,
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Implement invariant checks**
+
+Create `scripts/bughunt/core/invariants.ts`:
+
+```ts
+import type { Citation } from "../../src/types/citation";
+
+export interface InvariantViolation {
+  invariant: string;
+  message: string;
+  citationIndex: number;
+  contextSnippet: string;
+}
+
+export function checkCitationInvariants(text: string, citations: Citation[]): InvariantViolation[] {
+  const violations: InvariantViolation[] = [];
+  let previousOriginalEnd = -1;
+
+  citations.forEach((citation, index) => {
+    const span = citation.span;
+    if (span.cleanEnd <= span.cleanStart) {
+      violations.push(buildViolation(text, index, span.originalStart, "clean_span", "clean span is empty or negative"));
+    }
+    if (span.originalEnd <= span.originalStart) {
+      violations.push(buildViolation(text, index, span.originalStart, "original_span", "original span is empty or negative"));
+    }
+    if (span.originalStart < 0 || span.originalEnd > text.length) {
+      violations.push(buildViolation(text, index, span.originalStart, "original_bounds", "original span is outside source bounds"));
+    }
+    if (span.originalStart < previousOriginalEnd) {
+      violations.push(buildViolation(text, index, span.originalStart, "sort_order", "citations are not sorted by originalStart"));
+    }
+    previousOriginalEnd = Math.max(previousOriginalEnd, span.originalEnd);
+
+    const fullSpan = citation.fullSpan;
+    if (fullSpan && (fullSpan.originalStart < 0 || fullSpan.originalEnd > text.length)) {
+      violations.push(buildViolation(text, index, fullSpan.originalStart, "full_span_bounds", "fullSpan is outside source bounds"));
+    }
+  });
+
+  return violations;
+}
+
+function buildViolation(
+  text: string,
+  citationIndex: number,
+  offset: number,
+  invariant: string,
+  message: string,
+): InvariantViolation {
+  const start = Math.max(0, offset - 120);
+  const end = Math.min(text.length, offset + 180);
+  return {
+    invariant,
+    message,
+    citationIndex,
+    contextSnippet: text.slice(start, end).replace(/\s+/g, " "),
+  };
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts
+```
+
+Expected: passes.
+
+---
+
+## Task 4: Add Corpus Loader And Corpus/Invariants Lanes
+
+**Files:**
+- Create: `scripts/bughunt/core/corpus.ts`
+- Create: `scripts/bughunt/lanes/corpus.ts`
+- Create: `scripts/bughunt/lanes/invariants.ts`
+- Modify: `tests/bughunt/core.test.ts`
+
+- [ ] **Step 1: Add failing tests for inline corpus and invariant lane**
+
+Append to `tests/bughunt/core.test.ts`:
+
+```ts
+import { inlineCases } from "../../scripts/bughunt/core/corpus";
+import { runInvariantLane } from "../../scripts/bughunt/lanes/invariants";
+
+describe("bughunt corpus and invariant lane", () => {
+  it("provides a deterministic inline smoke corpus", () => {
+    expect(inlineCases().map((c) => c.key)).toEqual([
+      "inline/full-case",
+      "inline/id-chain",
+      "inline/statute",
+    ]);
+  });
+
+  it("runs invariant lane over inline cases", () => {
+    const findings = runInvariantLane({
+      runId: "run-1",
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      cases: inlineCases(),
+    });
+
+    expect(findings).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts
+```
+
+Expected: fails because corpus and lane modules do not exist.
+
+- [ ] **Step 3: Implement corpus helpers**
+
+Create `scripts/bughunt/core/corpus.ts`:
+
+```ts
+export interface BughuntCase {
+  key: string;
+  text: string;
+  sourceKind: "inline" | "fixture" | "cap";
+}
+
+export function inlineCases(): BughuntCase[] {
+  return [
+    {
+      key: "inline/full-case",
+      sourceKind: "inline",
+      text: "Smith v. Jones, 1 U.S. 1, 3 (1801).",
+    },
+    {
+      key: "inline/id-chain",
+      sourceKind: "inline",
+      text: "Smith v. Jones, 1 U.S. 1 (1801). Id. at 3.",
+    },
+    {
+      key: "inline/statute",
+      sourceKind: "inline",
+      text: "The statute appears at 42 U.S.C. § 1983.",
+    },
+  ];
+}
+```
+
+- [ ] **Step 4: Implement invariant lane**
+
+Create `scripts/bughunt/lanes/invariants.ts`:
+
+```ts
+import { buildFinding, findingSignature } from "../core/findings";
+import { checkCitationInvariants } from "../core/invariants";
+import { runExtraction } from "../core/extract";
+import type { BughuntFinding } from "../core/types";
+import type { BughuntCase } from "../core/corpus";
+
+export interface InvariantLaneInput {
+  runId: string;
+  command: string;
+  cases: BughuntCase[];
+}
+
+export function runInvariantLane(input: InvariantLaneInput): BughuntFinding[] {
+  const findings: BughuntFinding[] = [];
+
+  for (const bughuntCase of input.cases) {
+    const result = runExtraction(bughuntCase.text, { resolve: true });
+    if (!result.ok) {
+      findings.push(
+        buildFinding({
+          runId: input.runId,
+          lane: "invariants",
+          severity: "crash",
+          source: { kind: bughuntCase.sourceKind, key: bughuntCase.key },
+          command: input.command,
+          signature: findingSignature("extract_crash", result.error.message),
+          message: result.error.message,
+          contextSnippet: bughuntCase.text.slice(0, 300),
+        }),
+      );
+      continue;
+    }
+
+    for (const violation of checkCitationInvariants(bughuntCase.text, result.citations)) {
+      findings.push(
+        buildFinding({
+          runId: input.runId,
+          lane: "invariants",
+          severity: "invariant",
+          source: { kind: bughuntCase.sourceKind, key: bughuntCase.key },
+          command: input.command,
+          signature: findingSignature(violation.invariant, violation.message),
+          message: violation.message,
+          contextSnippet: violation.contextSnippet,
+          invariant: violation.invariant,
+          citations: result.citations,
+        }),
+      );
+    }
+  }
+
+  return findings;
+}
+```
+
+- [ ] **Step 5: Implement corpus lane**
+
+Create `scripts/bughunt/lanes/corpus.ts`:
+
+```ts
+import { buildFinding, findingSignature } from "../core/findings";
+import { runExtraction } from "../core/extract";
+import type { BughuntFinding } from "../core/types";
+import type { BughuntCase } from "../core/corpus";
+
+export interface CorpusLaneInput {
+  runId: string;
+  command: string;
+  cases: BughuntCase[];
+  slowMs: number;
+}
+
+export function runCorpusLane(input: CorpusLaneInput): BughuntFinding[] {
+  const findings: BughuntFinding[] = [];
+
+  for (const bughuntCase of input.cases) {
+    const result = runExtraction(bughuntCase.text, { resolve: true });
+    if (!result.ok) {
+      findings.push(
+        buildFinding({
+          runId: input.runId,
+          lane: "corpus",
+          severity: "crash",
+          source: { kind: bughuntCase.sourceKind, key: bughuntCase.key },
+          command: input.command,
+          signature: findingSignature("extract_crash", result.error.message),
+          message: result.error.message,
+          contextSnippet: bughuntCase.text.slice(0, 300),
+          timing: { durationMs: result.durationMs },
+        }),
+      );
+      continue;
+    }
+
+    if (result.durationMs > input.slowMs) {
+      findings.push(
+        buildFinding({
+          runId: input.runId,
+          lane: "corpus",
+          severity: "perf",
+          source: { kind: bughuntCase.sourceKind, key: bughuntCase.key },
+          command: input.command,
+          signature: findingSignature("slow_document", `${Math.round(result.durationMs)}ms`),
+          message: `extraction exceeded ${input.slowMs}ms`,
+          contextSnippet: bughuntCase.text.slice(0, 300),
+          timing: { durationMs: result.durationMs, timeoutMs: input.slowMs },
+        }),
+      );
+    }
+  }
+
+  return findings;
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts
+```
+
+Expected: passes.
+
+---
+
+## Task 5: Implement CLI Dispatcher And `run`
+
+**Files:**
+- Create: `scripts/bughunt/cli.ts`
+- Create: `scripts/bughunt/index.ts`
+- Create: `scripts/bughunt/commands/run.ts`
+- Test: `tests/bughunt/commands.test.ts`
+
+- [ ] **Step 1: Add failing command tests**
+
+Create `tests/bughunt/commands.test.ts`:
+
+```ts
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCommand } from "../../scripts/bughunt/index";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs = [];
+});
+
+describe("bughunt command runner", () => {
+  it("runs invariants lane and writes artifacts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-command-"));
+    tempDirs.push(root);
+
+    const exitCode = await runCommand([
+      "run",
+      "--lane",
+      "invariants",
+      "--seed",
+      "1234",
+      "--root",
+      root,
+      "--run-id",
+      "test-run",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(root, "latest.json"), "utf8")).toContain("test-run");
+    expect(readFileSync(join(root, "runs", "test-run", "manifest.json"), "utf8")).toContain("invariants");
+  });
+
+  it("returns non-zero for an unknown command", async () => {
+    await expect(runCommand(["wat"])).resolves.toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/commands.test.ts
+```
+
+Expected: fails because CLI files do not exist.
+
+- [ ] **Step 3: Implement CLI helpers**
+
+Create `scripts/bughunt/cli.ts`:
+
+```ts
+import { parseArgs } from "node:util";
+
+export function usage(): string {
+  return [
+    "Usage:",
+    "  pnpm bughunt run --lane <lane> [--seed <n>] [--sample <n>]",
+    "  pnpm bughunt inspect <run-or-latest> --id <finding-id>",
+    "  pnpm bughunt promote <run-or-latest> --id <finding-id> [--write]",
+    "",
+    "Lanes: all, corpus, invariants, mutate, resolver, annotate, perf",
+  ].join("\n");
+}
+
+export function parseRunArgs(args: string[]) {
+  return parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      lane: { type: "string", default: "all" },
+      seed: { type: "string" },
+      sample: { type: "string", default: "50" },
+      root: { type: "string", default: ".bughunt" },
+      "run-id": { type: "string" },
+      "slow-ms": { type: "string", default: "250" },
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Implement `run` command**
+
+Create `scripts/bughunt/commands/run.ts`:
+
+```ts
+import { resolve } from "node:path";
+import { createRunArtifacts } from "../core/artifacts";
+import { inlineCases } from "../core/corpus";
+import { runCorpusLane } from "../lanes/corpus";
+import { runInvariantLane } from "../lanes/invariants";
+import { parseRunArgs } from "../cli";
+
+export async function runBughunt(args: string[]): Promise<number> {
+  const parsed = parseRunArgs(args);
+  const lane = String(parsed.values.lane ?? "all");
+  const seed = parsed.values.seed ? Number.parseInt(String(parsed.values.seed), 10) : Date.now();
+  const rootDir = resolve(String(parsed.values.root ?? ".bughunt"));
+  const startedAt = new Date().toISOString();
+  const runId = String(parsed.values["run-id"] ?? `${startedAt.replace(/[:.]/g, "")}-seed-${seed}`);
+  const command = `pnpm bughunt run --lane ${lane} --seed ${seed}`;
+  const selectedLanes = lane === "all" ? ["corpus", "invariants"] : [lane];
+  const cases = inlineCases().slice(0, Number.parseInt(String(parsed.values.sample ?? "50"), 10));
+  const artifacts = createRunArtifacts({
+    rootDir,
+    runId,
+    seed,
+    command,
+    lanes: selectedLanes,
+    startedAt,
+  });
+
+  for (const selectedLane of selectedLanes) {
+    const findings =
+      selectedLane === "corpus"
+        ? runCorpusLane({
+            runId,
+            command,
+            cases,
+            slowMs: Number.parseInt(String(parsed.values["slow-ms"] ?? "250"), 10),
+          })
+        : selectedLane === "invariants"
+          ? runInvariantLane({ runId, command, cases })
+          : [];
+
+    for (const finding of findings) artifacts.writeFinding(finding);
+  }
+
+  artifacts.finalize({ finishedAt: new Date().toISOString() });
+  console.log(`bughunt run written to ${artifacts.runDir}`);
+  return 0;
+}
+```
+
+- [ ] **Step 5: Implement dispatcher**
+
+Create `scripts/bughunt/index.ts`:
+
+```ts
+import { usage } from "./cli";
+import { runBughunt } from "./commands/run";
+
+export async function runCommand(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const [command, ...rest] = argv;
+
+  if (!command || command === "--help" || command === "-h") {
+    console.log(usage());
+    return command ? 0 : 1;
+  }
+
+  if (command === "run") {
+    return runBughunt(rest);
+  }
+
+  console.error(`Unknown bughunt command: ${command}\n\n${usage()}`);
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCommand().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+```
+
+- [ ] **Step 6: Run command tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/commands.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 7: Smoke-test CLI**
+
+Run:
+
+```bash
+pnpm bughunt run --lane invariants --seed 1234 --sample 3
+```
+
+Expected: prints `bughunt run written to ...` and creates `.bughunt/latest.json`.
+
+---
+
+## Task 6: Implement `inspect`
+
+**Files:**
+- Create: `scripts/bughunt/commands/inspect.ts`
+- Modify: `scripts/bughunt/index.ts`
+- Modify: `scripts/bughunt/cli.ts`
+- Modify: `tests/bughunt/commands.test.ts`
+
+- [ ] **Step 1: Add failing inspect test**
+
+Append to `tests/bughunt/commands.test.ts`:
+
+```ts
+import { createRunArtifacts } from "../../scripts/bughunt/core/artifacts";
+import { buildFinding, findingSignature } from "../../scripts/bughunt/core/findings";
+
+describe("bughunt inspect", () => {
+  it("prints one finding from latest.json", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-inspect-"));
+    tempDirs.push(root);
+    const artifacts = createRunArtifacts({
+      rootDir: root,
+      runId: "inspect-run",
+      seed: 1,
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      lanes: ["invariants"],
+      startedAt: "2026-05-20T14:30:00.000Z",
+    });
+    const finding = buildFinding({
+      runId: "inspect-run",
+      lane: "invariants",
+      severity: "invariant",
+      source: { kind: "inline", key: "inspect-case" },
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      signature: findingSignature("span_bounds", "bad span"),
+      message: "bad span",
+      contextSnippet: "Smith v. Jones",
+    });
+    artifacts.writeFinding(finding);
+    artifacts.finalize({ finishedAt: "2026-05-20T14:31:00.000Z" });
+
+    const exitCode = await runCommand(["inspect", join(root, "latest.json"), "--id", finding.id]);
+    expect(exitCode).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Implement inspect command**
+
+Create `scripts/bughunt/commands/inspect.ts`:
+
+```ts
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { parseArgs } from "node:util";
+import type { BughuntFinding } from "../core/types";
+
+export async function inspectFinding(args: string[]): Promise<number> {
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      id: { type: "string" },
+    },
+  });
+  const target = parsed.positionals[0] ?? ".bughunt/latest.json";
+  const id = parsed.values.id;
+  if (!id) {
+    console.error("inspect requires --id <finding-id>");
+    return 1;
+  }
+
+  const runDir = resolveRunDir(target);
+  const findingsPath = join(runDir, "findings.jsonl");
+  if (!existsSync(findingsPath)) {
+    console.error(`findings file not found: ${findingsPath}`);
+    return 1;
+  }
+
+  const finding = readJsonLines<BughuntFinding>(findingsPath).find((f) => f.id === id);
+  if (!finding) {
+    console.error(`finding not found: ${id}`);
+    return 1;
+  }
+
+  console.log(formatFinding(finding));
+  return 0;
+}
+
+function resolveRunDir(target: string): string {
+  if (target.endsWith("latest.json")) {
+    const latest = JSON.parse(readFileSync(target, "utf8")) as { runDir: string };
+    return latest.runDir.startsWith(".") ? join(dirname(target), latest.runDir.replace(/^\.bughunt\//, "")) : latest.runDir;
+  }
+  return target;
+}
+
+function readJsonLines<T>(path: string): T[] {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as T);
+}
+
+function formatFinding(finding: BughuntFinding): string {
+  return [
+    `Finding ${finding.id}`,
+    `Lane: ${finding.lane}`,
+    `Severity: ${finding.severity}`,
+    `Source: ${finding.source.kind}${finding.source.key ? ` ${finding.source.key}` : ""}`,
+    `Signature: ${finding.signature}`,
+    `Message: ${finding.message}`,
+    finding.contextSnippet ? `Context: ${finding.contextSnippet}` : "",
+    `Command: ${finding.command}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+```
+
+- [ ] **Step 3: Wire inspect into dispatcher**
+
+Modify `scripts/bughunt/index.ts`:
+
+```ts
+import { usage } from "./cli";
+import { inspectFinding } from "./commands/inspect";
+import { runBughunt } from "./commands/run";
+
+export async function runCommand(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const [command, ...rest] = argv;
+
+  if (!command || command === "--help" || command === "-h") {
+    console.log(usage());
+    return command ? 0 : 1;
+  }
+
+  if (command === "run") return runBughunt(rest);
+  if (command === "inspect") return inspectFinding(rest);
+
+  console.error(`Unknown bughunt command: ${command}\n\n${usage()}`);
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCommand().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+```
+
+- [ ] **Step 4: Run command tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/commands.test.ts
+```
+
+Expected: passes.
+
+---
+
+## Task 7: Implement `promote` Preview
+
+**Files:**
+- Create: `scripts/bughunt/commands/promote.ts`
+- Modify: `scripts/bughunt/index.ts`
+- Modify: `tests/bughunt/commands.test.ts`
+
+- [ ] **Step 1: Add failing promote preview test**
+
+Append to `tests/bughunt/commands.test.ts`:
+
+```ts
+describe("bughunt promote", () => {
+  it("previews a Vitest regression for one finding", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-promote-"));
+    tempDirs.push(root);
+    const artifacts = createRunArtifacts({
+      rootDir: root,
+      runId: "promote-run",
+      seed: 1,
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      lanes: ["invariants"],
+      startedAt: "2026-05-20T14:30:00.000Z",
+    });
+    const finding = buildFinding({
+      runId: "promote-run",
+      lane: "invariants",
+      severity: "invariant",
+      source: { kind: "inline", key: "promote-case" },
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      signature: findingSignature("span_bounds", "bad span"),
+      message: "bad span",
+      input: "Smith v. Jones, 1 U.S. 1 (1801).",
+      contextSnippet: "Smith v. Jones, 1 U.S. 1 (1801).",
+    });
+    artifacts.writeFinding(finding);
+    artifacts.finalize({ finishedAt: "2026-05-20T14:31:00.000Z" });
+
+    const exitCode = await runCommand(["promote", join(root, "latest.json"), "--id", finding.id]);
+    expect(exitCode).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Implement promote command**
+
+Create `scripts/bughunt/commands/promote.ts`:
+
+```ts
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { parseArgs } from "node:util";
+import type { BughuntFinding } from "../core/types";
+
+export async function promoteFinding(args: string[]): Promise<number> {
+  const parsed = parseArgs({
+    args,
+    allowPositionals: true,
+    options: {
+      id: { type: "string" },
+      write: { type: "boolean", default: false },
+    },
+  });
+  const target = parsed.positionals[0] ?? ".bughunt/latest.json";
+  const id = parsed.values.id;
+  if (!id) {
+    console.error("promote requires --id <finding-id>");
+    return 1;
+  }
+
+  const runDir = resolveRunDir(target);
+  const finding = readJsonLines<BughuntFinding>(join(runDir, "findings.jsonl")).find((f) => f.id === id);
+  if (!finding) {
+    console.error(`finding not found: ${id}`);
+    return 1;
+  }
+
+  const sourceText = finding.minimalInput ?? finding.input ?? finding.contextSnippet ?? "";
+  const testName = `preserves bughunt finding ${finding.id}`;
+  const testSource = [
+    'import { describe, expect, it } from "vitest";',
+    'import { extractCitations } from "../../src/index";',
+    "",
+    'describe("bughunt promoted regression", () => {',
+    `  it(${JSON.stringify(testName)}, () => {`,
+    `    // Source: ${finding.command}`,
+    `    // Finding: ${finding.id} ${finding.signature}`,
+    `    const text = ${JSON.stringify(sourceText)};`,
+    "    const citations = extractCitations(text, { resolve: true });",
+    "    expect(citations.length).toBeGreaterThan(0);",
+    "  });",
+    "});",
+    "",
+  ].join("\n");
+
+  if (parsed.values.write) {
+    console.error("promote --write is intentionally deferred; preview the test and place it manually");
+    return 1;
+  }
+
+  console.log(testSource);
+  return 0;
+}
+
+function resolveRunDir(target: string): string {
+  if (target.endsWith("latest.json")) {
+    const latest = JSON.parse(readFileSync(target, "utf8")) as { runDir: string };
+    return latest.runDir.startsWith(".") ? join(dirname(target), latest.runDir.replace(/^\.bughunt\//, "")) : latest.runDir;
+  }
+  return target;
+}
+
+function readJsonLines<T>(path: string): T[] {
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as T);
+}
+```
+
+- [ ] **Step 3: Wire promote into dispatcher**
+
+Modify `scripts/bughunt/index.ts`:
+
+```ts
+import { usage } from "./cli";
+import { inspectFinding } from "./commands/inspect";
+import { promoteFinding } from "./commands/promote";
+import { runBughunt } from "./commands/run";
+
+export async function runCommand(argv: string[] = process.argv.slice(2)): Promise<number> {
+  const [command, ...rest] = argv;
+
+  if (!command || command === "--help" || command === "-h") {
+    console.log(usage());
+    return command ? 0 : 1;
+  }
+
+  if (command === "run") return runBughunt(rest);
+  if (command === "inspect") return inspectFinding(rest);
+  if (command === "promote") return promoteFinding(rest);
+
+  console.error(`Unknown bughunt command: ${command}\n\n${usage()}`);
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCommand().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}
+```
+
+- [ ] **Step 4: Run command tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/commands.test.ts
+```
+
+Expected: passes.
+
+---
+
+## Task 8: Add `fast-check` Mutation Lane
+
+**Files:**
+- Create: `scripts/bughunt/lanes/mutate.ts`
+- Modify: `scripts/bughunt/commands/run.ts`
+- Modify: `tests/bughunt/core.test.ts`
+
+- [ ] **Step 1: Add failing mutation lane test**
+
+Append to `tests/bughunt/core.test.ts`:
+
+```ts
+import { runMutationLane } from "../../scripts/bughunt/lanes/mutate";
+
+describe("bughunt mutation lane", () => {
+  it("runs deterministic generated mutation checks", () => {
+    const findings = runMutationLane({
+      runId: "mutate-run",
+      command: "pnpm bughunt run --lane mutate --seed 1234",
+      seed: 1234,
+      numRuns: 10,
+    });
+
+    expect(Array.isArray(findings)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Implement mutation lane**
+
+Create `scripts/bughunt/lanes/mutate.ts`:
+
+```ts
+import * as fc from "fast-check";
+import { buildFinding, findingSignature } from "../core/findings";
+import { runExtraction } from "../core/extract";
+import type { BughuntFinding } from "../core/types";
+
+export interface MutationLaneInput {
+  runId: string;
+  command: string;
+  seed: number;
+  numRuns: number;
+}
+
+interface MutatedCitationInput {
+  text: string;
+}
+
+export function runMutationLane(input: MutationLaneInput): BughuntFinding[] {
+  const findings: BughuntFinding[] = [];
+  const property = fc.property(mutatedCitationInput(), (candidate) => {
+    const result = runExtraction(candidate.text, { resolve: true });
+    if (!result.ok) {
+      throw result.error;
+    }
+    return result.citations.length > 0;
+  });
+
+  const details = fc.check(property, {
+    seed: input.seed,
+    numRuns: input.numRuns,
+    endOnFailure: false,
+    verbose: 0,
+  });
+
+  if (details.failed) {
+    findings.push(
+      buildFinding({
+        runId: input.runId,
+        lane: "mutate",
+        severity: "invariant",
+        source: {
+          kind: "synthetic",
+          seed: details.seed,
+          path: details.counterexamplePath ?? undefined,
+        },
+        command: input.command,
+        signature: findingSignature("mutation_property", String(details.errorInstance?.message ?? "property failed")),
+        message: String(details.errorInstance?.message ?? "mutation property failed"),
+        input: JSON.stringify(details.counterexample),
+        contextSnippet: JSON.stringify(details.counterexample),
+        after: {
+          numRuns: details.numRuns,
+          numShrinks: details.numShrinks,
+          numSkips: details.numSkips,
+        },
+      }),
+    );
+  }
+
+  return findings;
+}
+
+function mutatedCitationInput(): fc.Arbitrary<MutatedCitationInput> {
+  return fc
+    .record({
+      leftBreak: fc.constantFrom(" ", "\n", "\n\n", " <span>"),
+      rightBreak: fc.constantFrom(" ", "\n", "</span> ", "  "),
+      reporter: fc.constantFrom("U.S.", "F.3d", "N.Y.3d"),
+      year: fc.integer({ min: 1800, max: 2026 }),
+    })
+    .map(({ leftBreak, rightBreak, reporter, year }) => ({
+      text: `Smith v.${leftBreak}Jones, 1${rightBreak}${reporter} 1 (${year}).`,
+    }));
+}
+```
+
+- [ ] **Step 3: Wire mutation lane into run command**
+
+Modify `scripts/bughunt/commands/run.ts` so selected lanes include `mutate` for `all`:
+
+```ts
+import { resolve } from "node:path";
+import { createRunArtifacts } from "../core/artifacts";
+import { inlineCases } from "../core/corpus";
+import { runCorpusLane } from "../lanes/corpus";
+import { runInvariantLane } from "../lanes/invariants";
+import { runMutationLane } from "../lanes/mutate";
+import { parseRunArgs } from "../cli";
+
+export async function runBughunt(args: string[]): Promise<number> {
+  const parsed = parseRunArgs(args);
+  const lane = String(parsed.values.lane ?? "all");
+  const seed = parsed.values.seed ? Number.parseInt(String(parsed.values.seed), 10) : Date.now();
+  const rootDir = resolve(String(parsed.values.root ?? ".bughunt"));
+  const startedAt = new Date().toISOString();
+  const runId = String(parsed.values["run-id"] ?? `${startedAt.replace(/[:.]/g, "")}-seed-${seed}`);
+  const command = `pnpm bughunt run --lane ${lane} --seed ${seed}`;
+  const selectedLanes = lane === "all" ? ["corpus", "invariants", "mutate"] : [lane];
+  const cases = inlineCases().slice(0, Number.parseInt(String(parsed.values.sample ?? "50"), 10));
+  const artifacts = createRunArtifacts({
+    rootDir,
+    runId,
+    seed,
+    command,
+    lanes: selectedLanes,
+    startedAt,
+  });
+
+  for (const selectedLane of selectedLanes) {
+    const findings =
+      selectedLane === "corpus"
+        ? runCorpusLane({
+            runId,
+            command,
+            cases,
+            slowMs: Number.parseInt(String(parsed.values["slow-ms"] ?? "250"), 10),
+          })
+        : selectedLane === "invariants"
+          ? runInvariantLane({ runId, command, cases })
+          : selectedLane === "mutate"
+            ? runMutationLane({
+                runId,
+                command,
+                seed,
+                numRuns: Number.parseInt(String(parsed.values.sample ?? "50"), 10),
+              })
+            : [];
+
+    for (const finding of findings) artifacts.writeFinding(finding);
+  }
+
+  artifacts.finalize({ finishedAt: new Date().toISOString() });
+  console.log(`bughunt run written to ${artifacts.runDir}`);
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run mutation tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Smoke-test mutation CLI**
+
+Run:
+
+```bash
+pnpm bughunt run --lane mutate --seed 1234 --sample 25
+```
+
+Expected: run completes and writes `.bughunt/latest.json`.
+
+---
+
+## Task 9: Verification And Cleanup
+
+**Files:**
+- Modify only files touched by prior tasks if verification reveals issues.
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/bughunt/core.test.ts tests/bughunt/commands.test.ts
+```
+
+Expected: passes.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```bash
+pnpm lint
+```
+
+Expected: passes. If Biome reports formatting or style issues in `scripts/bughunt` or `tests/bughunt`, fix the exact reported files.
+
+- [ ] **Step 3: Run typecheck**
+
+Run:
+
+```bash
+pnpm typecheck
+```
+
+Expected: passes. If `tsconfig.json` does not typecheck scripts because it includes only `src`, use Vitest and Biome as the script checks for this v1 and record that limitation in the final response.
+
+- [ ] **Step 4: Run CLI smoke test**
+
+Run:
+
+```bash
+pnpm bughunt run --lane all --seed 1234 --sample 5
+```
+
+Expected: prints a run directory and writes `.bughunt/latest.json`.
+
+- [ ] **Step 5: Inspect one finding when present**
+
+Run:
+
+```bash
+node -e "const fs=require('fs'); const latest=JSON.parse(fs.readFileSync('.bughunt/latest.json','utf8')); const f=fs.readFileSync(`${latest.runDir}/findings.jsonl`,'utf8').trim().split('\n').filter(Boolean)[0]; if (f) console.log(JSON.parse(f).id)"
+```
+
+If it prints an ID, run:
+
+```bash
+pnpm bughunt inspect .bughunt/latest.json --id <printed-id>
+```
+
+Expected: prints finding details. If no ID is printed, note that the smoke run produced no findings.
+
+- [ ] **Step 6: Check public package surface**
+
+Run:
+
+```bash
+node -e "const p=require('./package.json'); if (p.bin) throw new Error('unexpected public bin'); if (JSON.stringify(p.exports).includes('bughunt')) throw new Error('unexpected public export'); console.log('internal-only CLI confirmed')"
+```
+
+Expected:
+
+```text
+internal-only CLI confirmed
+```
+
+- [ ] **Step 7: Review git status before handoff**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intended files from this plan are modified, plus pre-existing unrelated local files. Do not stage unrelated files.
+
+---
+
+## Notes For The Implementing Agent
+
+- This plan intentionally keeps `promote --write` deferred. Preview-only promotion is enough for v1 and avoids accidental test churn.
+- The first corpus implementation uses inline cases. CAP zip loading can be added after the artifact and command loop is working.
+- The mutation lane property is intentionally conservative: it checks that generated citation-like strings do not crash and still yield at least one citation. Stronger semantic invariants should be added after the first local loop is usable.
+- Do not expose the CLI publicly. It stays under `scripts/` and package `scripts`.
+- Do not commit `.bughunt/` artifacts.

--- a/docs/superpowers/specs/2026-04-11-readme-overhaul-design.md
+++ b/docs/superpowers/specs/2026-04-11-readme-overhaul-design.md
@@ -1,0 +1,165 @@
+# README Overhaul Design
+
+**Date:** 2026-04-11
+**Status:** Draft
+
+## Goal
+
+Exhaustively update the eyecite-ts README from its current ~550-line reference-style format into a "Pipeline Story" README (~300–350 lines) that showcases the library's value, with deep dives moved to `docs/guides/` and `docs/api/`.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Audience | Both legal tech and general TS devs | Layered: inline glosses for domain terms, no assumed legal knowledge |
+| Python eyecite positioning | Emphasize lineage + migration guide | Comparison table in README, full migration guide in docs |
+| README length strategy | Showcase + essentials | Hero workflow, feature table, brief examples; deep dives in docs |
+| Code example style | Hero workflow + brief per-feature | One connected extract→resolve→annotate flow, then minimal per-feature examples |
+
+## README Structure
+
+### Section 1: Header & Intro
+- **Badges:** Keep existing 8 shields (CI, coverage, npm, bundle size, license, Node, TypeScript, zero deps)
+- **Title + tagline:** `eyecite-ts` — TypeScript legal citation extraction — a port of Python eyecite with extended capabilities
+- **"What is this?" paragraph:** One paragraph for devs unfamiliar with legal citations. Explains what a citation like `500 F.2d 123 (9th Cir. 2020)` encodes (volume, reporter, page, court, year), that the library parses these into typed objects, resolves short-form references, and annotates text. Mentions zero deps, browser-compatible, ~10KB gzipped.
+
+### Section 2: Install + Hero Workflow
+- **Install:** `npm install eyecite-ts`
+- **Hero example:** ~20 lines showing a connected 3-stage pipeline:
+  1. `extractCitations(text, { resolve: true })` on realistic legal text with 3+ citation types
+  2. Filter/inspect resolved citations
+  3. `annotate(text, citations, { template })` to produce marked-up output
+- Output shows 2-3 key fields per citation, not full objects. Demonstrates pipeline composing end-to-end.
+
+### Section 3: What It Extracts (feature table)
+Single table replacing the current bullet list. Columns: **Type | Example | Key Fields**.
+
+| Type | Example | Key Fields |
+|------|---------|------------|
+| case | `500 F.2d 123 (9th Cir. 2020)` | volume, reporter, page, court, year, caseName |
+| statute | `42 U.S.C. § 1983(a)(1)` | title, code, section, subsection, jurisdiction |
+| constitutional | `U.S. Const. amend. XIV, § 1` | jurisdiction, amendment, section |
+| journal | `123 Harv. L. Rev. 456` | volume, journal, page, author |
+| neutral | `2020 WL 123456` | year, court, documentNumber |
+| publicLaw | `Pub. L. No. 117-263` | congress, lawNumber |
+| federalRegister | `87 Fed. Reg. 1234` | volume, page, year |
+| statutesAtLarge | `136 Stat. 4459` | volume, page, year |
+| id | `Id. at 125` | pincite |
+| supra | `Smith, supra, at 130` | partyName, pincite |
+| shortFormCase | `500 F.2d at 140` | volume, reporter, pincite |
+
+### Section 4: Key Features (5-6 brief examples)
+Each feature: heading, 1-2 sentence explanation, ~5-10 line code block.
+
+1. **Case Names & Full Spans** — backward search for party names (`Smith v. Jones`, `In re Smith`, `Ex parte Young`). `fullSpan` covers case name through closing parenthetical. Example shows `caseName`, `plaintiff`, `defendant`, `fullSpan` fields.
+
+2. **Parallel Citations** — automatic grouping when comma-separated reporters share a parenthetical. Example with triple cite (Roe v. Wade), showing `groupId` linking all three. Brief note on primary vs. secondary.
+
+3. **Short-Form Resolution** — `{ resolve: true }` links Id., supra, and short-form case citations to full antecedents. Example showing convenience API only. Link to `docs/guides/resolution.md` for power-user API, scope strategies, fuzzy matching options.
+
+4. **Citation Annotation** — template and callback modes. XSS auto-escape on by default. One template-mode example. Mention `useFullSpan` option. Link to `docs/guides/annotation.md` for callback mode and advanced usage.
+
+5. **Confidence & Signals** — brief explanation of confidence scoring (reporter match → boost, unknown → penalty). Citation signals (`See`, `See also`, `Cf.`) captured on extraction. Example showing `confidence` and `signal` fields.
+
+6. **Footnote Detection** — opt-in `{ detectFootnotes: true }`. HTML and plaintext strategies. Citations tagged with `inFootnote` and `footnoteNumber`. Resolver enforces footnote-body scope isolation. Link to `docs/guides/footnote-detection.md`.
+
+### Section 5: Type System (compact)
+- Discriminated union on `type` field — list all 11 types
+- `Citation`, `FullCitation`, `ShortFormCitation` union types
+- Type guard example (`isFullCitation`, `isCaseCitation`)
+- `switch` + `assertUnreachable` pattern
+- `CitationOfType<'case'>` conditional type
+- Link to `docs/api/types.md` for full type catalog
+
+### Section 6: Bundle Size
+Table with 3 entry points:
+
+| Entry Point | Import | Gzipped |
+|-------------|--------|---------|
+| Core extraction | `eyecite-ts` | ~10 KB |
+| Annotation | `eyecite-ts/annotate` | ~0.7 KB |
+| Reporter data | `eyecite-ts/data` | ~86.5 KB (lazy-loaded) |
+
+One sentence on tree-shaking: import only what you need.
+
+### Section 7: Comparison with Python eyecite
+Table comparing capabilities. Every claim verified against Python eyecite source code (2026-04-11).
+
+| Capability | Python eyecite | eyecite-ts | Notes |
+|---|---|---|---|
+| Case citations | Yes | Yes | Both extract volume/reporter/page/court/year |
+| Statute citations | Yes (all 50 states + DC + territories via reporters-db) | Yes (50 states + DC + federal, built-in patterns) | Python uses external reporters-db JSON; TS has self-contained regex |
+| Constitutional citations | No | Yes (U.S. + 50 states) | Dedicated type with article/amendment/section/clause parsing |
+| Journal / law review | Yes | Yes | |
+| Neutral (WL/LEXIS) | Yes (as case citations) | Yes (dedicated type) | TS has a separate `NeutralCitation` type |
+| Short-form resolution | Yes | Yes | Both resolve Id., supra, short-form case |
+| Case name extraction | Yes (`find_case_name()`) | Yes (backward search) | Both use backward scanning heuristics |
+| Parallel citation linking | Partial (detection + metadata copy) | Yes (`groupId` + `parallelCitations` array) | Python detects but doesn't group; TS groups with shared ID |
+| Full span tracking | Yes (`full_span_start/end`) | Yes (`fullSpan` with clean/original coords) | TS carries dual clean/original positions |
+| Component spans | Minimal (pin cite only) | Yes (per-field positions for all components) | TS provides spans for volume, reporter, page, court, year, caseName, etc. |
+| Footnote detection | No | Yes (HTML + plaintext strategies) | Opt-in; resolver enforces footnote-body scope isolation |
+| Citation signals | No (used as stop words only) | Yes (extracted as metadata) | Python uses signals only as boundary markers for case name search |
+| Annotation | Yes (HTML modes: unchecked/skip/wrap) | Yes (template/callback, XSS auto-escape) | Different approaches to HTML handling |
+| Position mapping | Yes (diff-based at annotation time) | Yes (incremental TransformationMap during cleaning) | Python reconciles via diffing; TS tracks incrementally |
+| Type system | Class inheritance hierarchy | Discriminated union on `type` field | Different paradigms; TS enables exhaustive switch |
+
+Brief note: "eyecite-ts started as a port of Python eyecite by Free Law Project and has diverged. Both libraries are capable citation extractors — eyecite-ts adds constitutional citations, footnote detection, citation signals, rich component spans, and a TypeScript-native type system, while Python eyecite has broader statute coverage via reporters-db and a mature ecosystem."
+
+### Section 8: Architecture (brief)
+3-4 sentences: clean → tokenize → extract → resolve pipeline. Position tracking via `TransformationMap`. Link to `ARCHITECTURE.md`.
+
+### Section 9: Development
+Command table: install, test, test-once, typecheck, build, lint, format, size. Node 18+ requirement. Test count (accurate). Link to `ARCHITECTURE.md` for contributor orientation.
+
+### Section 10: Migration from Python eyecite
+One paragraph acknowledging Python users. Link to `docs/guides/migration-from-python.md` for: API mapping (`extract_citations` → `extractCitations`), naming conventions, behavioral differences, new features to adopt.
+
+### Section 11: Credits & License
+Credit to Free Law Project's eyecite. MIT license.
+
+## Docs Structure (new files)
+
+```
+docs/
+  guides/
+    migration-from-python.md    — API mapping, naming, behavioral differences
+    footnote-detection.md       — strategies, configuration, scope isolation
+    resolution.md               — power-user API, scope strategies, fuzzy matching
+    annotation.md               — callback mode, full-span, position tracking
+    advanced-extraction.md      — custom patterns, custom cleaners, false positives,
+                                  component spans, subsequent history, dispositions,
+                                  structured dates, blank pages
+  api/
+    types.md                    — full type catalog (all 11 citation types,
+                                  options interfaces, supporting types, type guards)
+```
+
+## What Moves Out of README
+
+These sections from the current README become docs content:
+- Detailed statute jurisdiction table → `advanced-extraction.md`
+- Constitutional citation details → `advanced-extraction.md`
+- Power-user resolution API + options table → `resolution.md`
+- Full-span annotation details → `annotation.md`
+- Custom patterns / custom cleaners → `advanced-extraction.md`
+- Blank page citations → `advanced-extraction.md`
+- Structured dates → `advanced-extraction.md`
+- Reporter validation details → `advanced-extraction.md`
+- Detailed type definitions and resolved citation types → `types.md`
+
+## What's New in README (currently missing)
+
+- "What is this?" intro paragraph for non-legal devs
+- Hero workflow example (extract → resolve → annotate connected)
+- Feature table (all 11 types at a glance)
+- Confidence & signals section
+- Footnote detection section
+- Comparison with Python eyecite table
+- Migration section (with link to guide)
+- Accurate jurisdiction count (50 states + DC + federal, not 20)
+
+## Out of Scope
+
+- API reference generation (typedoc or similar) — separate effort
+- Playground / interactive demo hosting
+- Changelog restructuring

--- a/docs/superpowers/specs/2026-05-20-bughunt-cli-design.md
+++ b/docs/superpowers/specs/2026-05-20-bughunt-cli-design.md
@@ -1,0 +1,383 @@
+# Design: Internal Bughunt CLI
+
+**Date:** 2026-05-20
+**Status:** Draft for user review
+**Related research:** [`docs/research/2026-05-20-bughunt-cli-best-practices.md`](../../research/2026-05-20-bughunt-cli-best-practices.md)
+
+## Background
+
+`eyecite-ts` already has a strong but fragmented local bug-hunting surface:
+
+- one-off repro scripts under `scripts/repro-*`
+- audit scripts under `scripts/audit-*`
+- CAP corpus sampling in `scripts/sample-and-judge.ts`
+- accumulated judge artifacts under `scripts/judge/*`
+- many promoted Vitest regressions under `tests/`
+
+Python `eyecite` has a useful PR benchmark that compares extraction output against `main` on a real CourtListener sample. That model is worth adapting later, but this design optimizes for local bug hunting first. The goal is a repo-local CLI that helps an implementer run focused sweeps, inspect failures, minimize inputs, and promote the best findings into durable tests.
+
+## Goals
+
+1. Provide a single internal entry point: `pnpm bughunt`.
+2. Preserve reproducibility for every finding: command, lane, seed, source key, input, minimal input when available, and failure signature.
+3. Consolidate existing audit/repro logic instead of creating another parallel script family.
+4. Make generated-input lanes use `fast-check` where shrinking and replay are valuable.
+5. Keep all artifacts local by default under `.bughunt/`.
+6. Keep the CLI private to the repository. It is development tooling, not a package feature.
+
+## Non-Goals
+
+- No public `bin` in `package.json`.
+- No export path or `dist` output for the CLI.
+- No PR comment workflow in v1.
+- No AI judging in the deterministic core.
+- No automatic GitHub artifact branch.
+- No CourtListener CSV download in v1.
+- No broad rewrite of every existing audit script before the first useful run.
+
+## Architecture
+
+Add a new internal script module:
+
+```text
+scripts/bughunt/
+  index.ts                 # subcommand dispatcher
+  cli.ts                   # parseArgs helpers, usage text
+  commands/
+    run.ts
+    inspect.ts
+    promote.ts
+    report.ts
+    diff.ts
+  core/
+    artifacts.ts           # .bughunt writer and latest.json management
+    findings.ts            # finding IDs, signatures, JSONL serialization
+    rng.ts                 # deterministic PRNG
+    corpus.ts              # fixtures + CAP corpus loading
+    extract.ts             # safe extraction wrappers and timing
+    invariants.ts          # shared citation/span/resolution checks
+    minimize.ts            # minimizer interfaces and structural minimizer
+  lanes/
+    corpus.ts
+    invariants.ts
+    mutate.ts
+    resolver.ts
+    annotate.ts
+    perf.ts
+```
+
+Wire it through a package script:
+
+```json
+{
+  "scripts": {
+    "bughunt": "tsx scripts/bughunt/index.ts"
+  }
+}
+```
+
+The CLI uses `node:util.parseArgs` for v1. If subcommand ergonomics become costly, move to Commander later. That should be a follow-up decision, not a first dependency.
+
+## Dependencies
+
+Add dev dependencies:
+
+| Dependency | Use |
+|---|---|
+| `tsx` | Run TypeScript CLI scripts without a build step. |
+| `fast-check` | Generated mutation and resolver stress lanes with shrinking/replay. |
+| `adm-zip` | Read local CAP corpus zip volumes, matching existing scripts. |
+
+Defer `commander`, `tinybench`, `zod`, `p-limit`, AI SDKs, and CSV/BZip libraries.
+
+## CLI Surface
+
+### `run`
+
+```bash
+pnpm bughunt run --lane all --sample 200 --seed 1234
+pnpm bughunt run --lane resolver --focus supra --seed 1234
+pnpm bughunt run --lane mutate --num-runs 1000 --seed 1234
+pnpm bughunt run --lane perf --timeout-ms 1000 --seed 1234
+```
+
+Responsibilities:
+
+- create a new `.bughunt/runs/<timestamp>-seed-<seed>/` directory
+- run selected lanes
+- stream JSONL events
+- write `manifest.json`, `findings.jsonl`, `cases.jsonl`, `events.jsonl`, `report.json`, and `summary.md`
+- update `.bughunt/latest.json`
+- print a compact terminal summary with reproduction commands
+
+### `inspect`
+
+```bash
+pnpm bughunt inspect .bughunt/latest.json --id F123
+```
+
+Responsibilities:
+
+- resolve `.bughunt/latest.json` to its run directory
+- locate one finding by ID
+- print the source key, lane, command, signature, input/minimal input, relevant citations, resolver target, spans, and suggested test
+
+### `promote`
+
+```bash
+pnpm bughunt promote .bughunt/latest.json --id F123
+pnpm bughunt promote .bughunt/latest.json --id F123 --write
+```
+
+Default behavior is preview-only. With `--write`, the command writes either:
+
+- a fixture under `tests/fixtures/bughunt/`, or
+- a focused test file under the nearest matching test area.
+
+Promoted tests must include the finding ID, original command, seed/path/replay data, source key if any, minimized input, and expected behavior.
+
+### `report`
+
+```bash
+pnpm bughunt report .bughunt/latest.json
+pnpm bughunt report .bughunt/runs/2026-05-20T143000Z-seed-1234 --format markdown
+```
+
+Responsibilities:
+
+- summarize findings by lane, severity, type, and signature
+- list top crash signatures and perf outliers
+- produce Markdown suitable for a local handoff or later PR comment
+
+### `diff`
+
+```bash
+pnpm bughunt diff .bughunt/runs/before .bughunt/runs/after
+```
+
+Responsibilities:
+
+- compare finding IDs and signatures across two runs
+- report fixed, new, and persistent findings
+- report citation-count, type-count, span, and resolver-target deltas when both runs contain comparable cases
+
+## Artifacts
+
+Use local-only artifacts:
+
+```text
+.bughunt/
+  latest.json
+  runs/
+    2026-05-20T143000Z-seed-1234/
+      manifest.json
+      findings.jsonl
+      cases.jsonl
+      events.jsonl
+      report.json
+      summary.md
+```
+
+`.bughunt/` must be gitignored.
+
+`latest.json` is a small pointer instead of a symlink:
+
+```json
+{
+  "runDir": ".bughunt/runs/2026-05-20T143000Z-seed-1234",
+  "createdAt": "2026-05-20T14:30:00.000Z"
+}
+```
+
+## Finding Schema
+
+```ts
+export type BughuntSeverity =
+  | "crash"
+  | "invariant"
+  | "suspicious"
+  | "perf"
+  | "diff";
+
+export interface BughuntFinding {
+  id: string;
+  runId: string;
+  lane: string;
+  severity: BughuntSeverity;
+  source: {
+    kind: "cap" | "fixture" | "synthetic" | "inline";
+    key?: string;
+    seed?: number;
+    path?: string;
+    replayPath?: string;
+  };
+  command: string;
+  signature: string;
+  message: string;
+  input?: string;
+  minimalInput?: string;
+  contextSnippet?: string;
+  citations?: unknown[];
+  before?: unknown;
+  after?: unknown;
+  invariant?: string;
+  timing?: {
+    durationMs: number;
+    timeoutMs?: number;
+  };
+  suggestedTest?: {
+    path: string;
+    name: string;
+  };
+}
+```
+
+IDs are stable hashes over lane, source key, signature, and normalized snippet. Stable IDs make `inspect`, `diff`, and `promote` reliable across repeated runs.
+
+## Lanes
+
+### Corpus
+
+Runs extraction and optional resolution over real documents.
+
+Sources:
+
+- `tests/fixtures/*.json`
+- local CAP corpus when available through `CAP_ROOT`
+- existing `scripts/judge` processed keys as replay inputs when useful
+
+Findings:
+
+- extraction crash
+- resolution crash
+- suspicious count/type outlier
+- suspicious long match
+- slow document
+- span outside source bounds
+
+### Invariants
+
+Checks impossible internal states on extracted citations:
+
+- non-empty clean and original spans
+- original spans inside source bounds
+- matched text reconciles with source slice under documented normalization
+- `fullSpan` contains the citation core and case name when present
+- citations are sorted by original position
+- no incoherent overlap except documented parallel/parenthetical cases
+- type-specific metadata is internally consistent
+
+### Mutate
+
+Uses `fast-check` and domain-specific generators.
+
+Mutations:
+
+- whitespace expansion and collapse
+- line breaks inside citation-like tokens
+- HTML tag insertion
+- smart quotes, NBSP, em dash variants
+- footnote marker insertion
+- punctuation movement around parentheticals
+- OCR-like near misses where semantics are intended to remain stable
+
+Use `fc.check` so the CLI can serialize structured run details. Persist `seed`, `counterexamplePath`, `counterexample`, `numRuns`, `numShrinks`, and replay config. Replay normal failures with `{ seed, path, endOnFailure: true }`.
+
+### Resolver
+
+Generates and audits short-form chains:
+
+- full case citation followed by `Id.`
+- unresolved short form followed by `Id.`
+- supra with distractor full citations
+- full captions with overlapping party halves
+- footnote/body scope boundaries
+- parenthetical child citations
+- parallel citations and subsequent history
+
+Findings:
+
+- future target
+- self target
+- wrong generated-model target
+- `Id.` crosses a strict scope boundary
+- supra or short form prefers a distractor over the intended antecedent
+
+### Annotate
+
+Runs annotation on extracted spans and checks:
+
+- annotation preserves source text order
+- inserted tags are balanced
+- adjacent and overlapping citations are deterministic
+- original offsets are used for source annotation, not clean offsets
+
+### Perf
+
+Runs pathological regex and cleaner inputs in child-process isolation.
+
+Findings:
+
+- timeout
+- duration over threshold
+- memory/exit failure when observable
+
+Perf lane uses coarse per-case timing in v1. Vitest bench can be added later if microbenchmarking becomes useful.
+
+## Minimization
+
+Use two paths:
+
+1. Real document structural minimizer:
+   - paragraph deletion
+   - window narrowing around relevant citations
+   - line deletion
+   - token deletion
+   - whitespace normalization toggles
+
+2. Generated-input minimizer:
+   - rely on `fast-check` shrinking
+   - preserve `seed`, `path`, and future `replayPath`
+   - optionally replay external examples with `examples` and `numRuns: 1`
+
+Every minimized finding keeps the original source reference and original input or context snippet.
+
+## Error Handling
+
+- A lane failure should not corrupt the run directory.
+- Crashes are findings unless the CLI itself cannot continue.
+- Invalid CLI options exit non-zero with usage text.
+- Missing optional CAP corpus disables CAP source with a warning; fixture and synthetic lanes still run.
+- Perf/ReDoS candidates run in child processes with hard timeouts because event-loop blocking cannot be cancelled reliably in-process.
+- Artifact writes are append-only JSONL during a run, then summarized at the end.
+
+## Testing
+
+Implementation should add focused tests for:
+
+- CLI option parsing and invalid option behavior
+- artifact writer and `.bughunt/latest.json`
+- stable finding ID generation
+- invariant checks on small inline examples
+- `fast-check` failure serialization using a deterministic seed
+- `inspect` output for a fixture finding
+- `promote` preview output
+
+Do not begin by asserting exact output for every terminal line. Stable artifact shape matters more than terminal formatting.
+
+## Rollout
+
+Phase 1 should build a thin but usable loop:
+
+1. package script and dev dependencies
+2. CLI dispatcher
+3. artifact writer
+4. `corpus` and `invariants` lanes by extracting shared logic from existing scripts
+5. `inspect`
+6. `promote` preview
+
+Phase 2 adds generated mutation and resolver lanes with `fast-check`.
+
+Phase 3 adds annotation/perf lanes, diff/report polish, and optional `--write` promotion.
+
+CI/PR-comment integration should wait until the local artifacts prove useful.


### PR DESCRIPTION
## Summary

Two-commit housekeeping branch — no runtime change.

**Commit 1 — `.gitignore`**: ignore one-off `audit-*.ts`, `repro-*.ts`, `repro_*.ts`, `sample-and-judge.ts`, and `judge/` in `scripts/`. These were sprint-time scratch; the regression tests in `tests/` are the durable record, and `scripts/bughunt/` (PR #631) is the supported replacement. Exempts the two committed `repro_*.ts` files (#546, sprint G).

**Commit 2 — docs**: commit the design/plan/research that document landed features, plus consolidate two stray handoffs from `docs/handoffs/` into `docs/superpowers/handoffs/` to match the existing convention.
- README overhaul (commit 4179278) → 2026-04-11 plan + spec
- Bughunt CLI (#631) → 2026-05-20 plan + spec + deep research doc
- 2 session handoffs moved to canonical location

## Test Plan
- [x] `git status` after merge shows no `docs/handoffs/` or audit-script noise
- [x] No source files touched; no changeset