### PR TITLE
docs: document bughunt workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+pnpm install                      # Install dependencies (uses corepack, pinned in packageManager field)
+pnpm test                         # Run all tests (vitest, watch mode)
+pnpm exec vitest run              # Run all tests once (no watch)
+pnpm exec vitest run tests/extract/extractCase.test.ts  # Run a single test file
+pnpm exec vitest run -t "extracts volume"               # Run tests matching name pattern
+pnpm build                        # Build with tsdown (ESM + CJS + DTS)
+pnpm typecheck                    # Type-check with tsc --noEmit
+pnpm lint                         # Lint with Biome
+pnpm format                       # Format with Biome (auto-fix)
+pnpm size                         # Check bundle size limits
+pnpm changeset                    # Create a changeset for the next release
+```
+
+## Architecture
+
+This is a TypeScript port of Python [eyecite](https://github.com/freelawproject/eyecite) — a legal citation extraction library with zero runtime dependencies.
+
+### Pipeline
+
+Citations flow through a 4-stage pipeline: **clean → tokenize → extract → (resolve)**
+
+1. **Clean** (`src/clean/`): Strip HTML, normalize whitespace/Unicode, fix smart quotes. Builds a `TransformationMap` to track position shifts.
+2. **Tokenize** (`src/tokenize/`): Apply regex patterns from `src/patterns/` to find citation candidates. Intentionally broad — captures potential matches without validation.
+3. **Extract** (`src/extract/`): Parse metadata from tokens (volume, reporter, page, court, year). Each citation type has its own extractor (`extractCase.ts`, `extractStatute.ts`, etc.). The main orchestrator is `extractCitations.ts`.
+   - `extractCase.ts` also handles case name backward search (`extractCaseName`), full span calculation (`findParentheticalEnd`), unified parenthetical parsing (`parseParenthetical`), and disposition extraction.
+   - `dates.ts` provides date parsing utilities (`parseMonth`, `parseDate`, `toIsoDate`) for structured date extraction from parentheticals.
+4. **Resolve** (`src/resolve/`): Link short-form citations (Id., supra, short-form case) to their full antecedents. `DocumentResolver` uses scope boundaries and Levenshtein matching.
+
+### Footnote Detection
+
+Opt-in via `extractCitations(text, { detectFootnotes: true })`. Runs before cleaning on the raw text to preserve newline structure. Two strategies:
+- **HTML** (`src/footnotes/htmlDetector.ts`): Regex-based tag scanner for `<footnote>`, `<fn>`, and elements with footnote class/id attributes. No DOM dependency.
+- **Plain text** (`src/footnotes/textDetector.ts`): Finds separator lines (5+ dashes/underscores) followed by numbered markers (`1.`, `FN1.`, `[1]`, `n.1`).
+
+`detectFootnotes(text)` selects the strategy (HTML first, text fallback) and returns a `FootnoteMap` (array of `{ start, end, footnoteNumber }` zones). The pipeline maps zones through `TransformationMap` to clean-text coordinates, then tags citations with `inFootnote`/`footnoteNumber` via binary search. The `"footnote"` scope strategy in the resolver enforces zone-based isolation: Id. is strict (same zone only), supra/shortFormCase can cross from footnotes to body.
+
+Annotation (`src/annotate/`) and reporter data (`src/data/`) are separate entry points to enable tree-shaking.
+
+### Position Tracking
+
+The `Span` type carries dual positions: `cleanStart/cleanEnd` (for internal parsing) and `originalStart/originalEnd` (for user-facing results). `TransformationMap` maps between them using a lookahead algorithm (maxLookAhead=20) in `cleanText.ts:rebuildPositionMaps`.
+- `fullSpan` (optional) extends from case name through final closing parenthetical (including chained parens and subsequent history). The core `span` field remains citation-core-only for backward compatibility.
+
+### Type System
+
+Citations use a discriminated union on the `type` field: `case | statute | journal | neutral | publicLaw | federalRegister | statutesAtLarge | id | supra | shortFormCase`. All share `CitationBase` (text, span, confidence, matchedText, processTimeMs). Switch on `citation.type` for type-safe field access.
+- Volume is `number | string` — numeric for standard volumes, string for hyphenated (e.g., "1984-1")
+
+### Entry Points
+
+Three package entry points configured in `tsdown.config.ts` and `package.json`:
+- `eyecite-ts` → `src/index.ts` (core extraction + resolution)
+- `eyecite-ts/data` → `src/data/index.ts` (reporter database, lazy-loaded)
+- `eyecite-ts/annotate` → `src/annotate/index.ts` (text annotation)
+
+### Path Aliases
+
+`@/*` maps to `src/*` in both `tsconfig.json` and `vitest.config.ts`.
+
+## Code Style
+
+- **Formatter/Linter**: Biome 2.x — spaces, 100-char line width, double quotes, trailing commas, semicolons as needed
+- `noAssignInExpressions: off` — regex exec loops use assignment-in-while pattern
+- `noExplicitAny: error` and `noImplicitAnyLet: error` — strict typing enforced
+- `noForEach: off` — forEach is allowed
+- Patterns are defined in `src/patterns/` with a `Pattern` interface (`id`, `regex`, `description`, `type`)
+- Regex patterns must avoid nested quantifiers to prevent ReDoS
+
+## Test Structure
+
+Tests mirror source in `tests/` with the same directory structure. Integration tests live in `tests/integration/`. Vitest 4 is used — test options go as the second argument: `it(name, { timeout }, fn)`.
+
+## CI & Releases
+
+- **CI**: GitHub Actions — lint, typecheck, test (Node 18/20/22 matrix), build + size check
+- **Coverage**: Vitest `--coverage` requires Node 20+ (`node:inspector/promises`). CI only runs coverage on Node 22.
+- **Releases**: Changesets — `pnpm changeset` to add, merge to main creates "Version Packages" PR, merging that publishes to npm with provenance
+- **Package manager**: pnpm 10 via corepack. Build script allowlist in `pnpm-workspace.yaml`.
+- Each fix/feature branch needs a changeset: `pnpm changeset` → select patch/minor/major → write summary

--- a/README.md
+++ b/README.md
@@ -445,6 +445,35 @@ pnpm size              # Check bundle size limits
 
 Requires Node.js >= 18.0.0. See [ARCHITECTURE.md](ARCHITECTURE.md) for contributor orientation.
 
+### Internal Bughunt CLI
+
+`pnpm bughunt` is a repo-local development tool for reproducible citation-parser bug
+hunting. It is intentionally private to this repository: it is not exported as a
+package entry point and is not installed as a public binary.
+
+```bash
+pnpm bughunt run --lane all --seed 1234 --sample 5
+pnpm bughunt inspect .bughunt/latest.json --id <finding-id>
+pnpm bughunt promote .bughunt/latest.json --id <finding-id>
+```
+
+The `run` command writes local artifacts under `.bughunt/runs/<run-id>/` plus a
+`.bughunt/latest.json` pointer. Runs include `manifest.json`, `findings.jsonl`,
+`cases.jsonl`, `events.jsonl`, `report.json`, and `summary.md`; `.bughunt/` is
+gitignored and should not be committed.
+
+Available v1 lanes:
+
+- `corpus`: runs extraction and resolution over inline smoke cases and reports
+  crashes or performance outliers.
+- `invariants`: checks citation/span invariants and records violations.
+- `mutate`: uses `fast-check` with deterministic seeds and replay paths for
+  generated-input failures.
+
+`promote` is preview-only in v1. It prints a Vitest repro skeleton with the
+finding ID, original command, source context, and minimized/input text when
+available; it does not write files.
+
 ## License
 
 MIT

--- a/tests/bughunt/commands.test.ts
+++ b/tests/bughunt/commands.test.ts
@@ -1,0 +1,156 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createRunArtifacts } from "../../scripts/bughunt/core/artifacts";
+import { buildFinding, findingSignature } from "../../scripts/bughunt/core/findings";
+import { runCommand } from "../../scripts/bughunt/index";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("bughunt command runner", () => {
+  it("runs invariants lane and writes artifacts", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-command-"));
+    tempDirs.push(root);
+
+    const exitCode = await runCommand([
+      "run",
+      "--lane",
+      "invariants",
+      "--seed",
+      "1234",
+      "--root",
+      root,
+      "--run-id",
+      "test-run",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(join(root, "latest.json"), "utf8")).toContain("test-run");
+    expect(readFileSync(join(root, "runs", "test-run", "manifest.json"), "utf8")).toContain(
+      "invariants",
+    );
+  });
+
+  it("returns non-zero for an unknown command", async () => {
+    await expect(runCommand(["wat"])).resolves.toBe(1);
+  });
+});
+
+describe("bughunt inspect", () => {
+  it("prints one finding from latest.json", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-inspect-"));
+    tempDirs.push(root);
+    const artifacts = createRunArtifacts({
+      rootDir: root,
+      runId: "inspect-run",
+      seed: 1,
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      lanes: ["invariants"],
+      startedAt: "2026-05-20T14:30:00.000Z",
+    });
+    const finding = buildFinding({
+      runId: "inspect-run",
+      lane: "invariants",
+      severity: "invariant",
+      source: { kind: "inline", key: "inspect-case" },
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      signature: findingSignature("span_bounds", "bad span"),
+      message: "bad span",
+      contextSnippet: "Smith v. Jones",
+    });
+    artifacts.writeFinding(finding);
+    artifacts.finalize({ finishedAt: "2026-05-20T14:31:00.000Z" });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const exitCode = await runCommand(["inspect", join(root, "latest.json"), "--id", finding.id]);
+
+    expect(exitCode).toBe(0);
+    expect(logSpy.mock.calls.join("\n")).toContain(finding.id);
+    expect(logSpy.mock.calls.join("\n")).toContain("inspect-case");
+    expect(logSpy.mock.calls.join("\n")).toContain(finding.command);
+  });
+});
+
+describe("bughunt promote", () => {
+  it("previews a Vitest regression for one finding", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-promote-"));
+    tempDirs.push(root);
+    const artifacts = createRunArtifacts({
+      rootDir: root,
+      runId: "promote-run",
+      seed: 1,
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      lanes: ["invariants"],
+      startedAt: "2026-05-20T14:30:00.000Z",
+    });
+    const finding = buildFinding({
+      runId: "promote-run",
+      lane: "invariants",
+      severity: "invariant",
+      source: { kind: "inline", key: "promote-case" },
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      signature: findingSignature("span_bounds", "bad span"),
+      message: "bad span",
+      input: "Smith v. Jones, 1 U.S. 1 (1801).",
+      contextSnippet: "Smith v. Jones, 1 U.S. 1 (1801).",
+    });
+    artifacts.writeFinding(finding);
+    artifacts.finalize({ finishedAt: "2026-05-20T14:31:00.000Z" });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const exitCode = await runCommand(["promote", join(root, "latest.json"), "--id", finding.id]);
+
+    expect(exitCode).toBe(0);
+    const preview = logSpy.mock.calls.join("\n");
+    expect(preview).toContain(`Finding: ${finding.id}`);
+    expect(preview).toContain(finding.command);
+    expect(preview).toContain(finding.input);
+  });
+
+  it("keeps --write disabled in v1", async () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-promote-write-"));
+    tempDirs.push(root);
+    const artifacts = createRunArtifacts({
+      rootDir: root,
+      runId: "promote-write-run",
+      seed: 1,
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      lanes: ["invariants"],
+      startedAt: "2026-05-20T14:30:00.000Z",
+    });
+    const finding = buildFinding({
+      runId: "promote-write-run",
+      lane: "invariants",
+      severity: "invariant",
+      source: { kind: "inline", key: "promote-write-case" },
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      signature: findingSignature("span_bounds", "bad span"),
+      message: "bad span",
+      input: "Smith v. Jones, 1 U.S. 1 (1801).",
+      contextSnippet: "Smith v. Jones, 1 U.S. 1 (1801).",
+    });
+    artifacts.writeFinding(finding);
+    artifacts.finalize({ finishedAt: "2026-05-20T14:31:00.000Z" });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const exitCode = await runCommand([
+      "promote",
+      join(root, "latest.json"),
+      "--id",
+      finding.id,
+      "--write",
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(errorSpy.mock.calls.join("\n")).toContain("intentionally deferred");
+  });
+});

--- a/tests/bughunt/core.test.ts
+++ b/tests/bughunt/core.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createRunArtifacts } from "../../scripts/bughunt/core/artifacts";
+import { inlineCases } from "../../scripts/bughunt/core/corpus";
+import { runExtraction } from "../../scripts/bughunt/core/extract";
+import { buildFinding, findingSignature } from "../../scripts/bughunt/core/findings";
+import { checkCitationInvariants } from "../../scripts/bughunt/core/invariants";
+import { createRng } from "../../scripts/bughunt/core/rng";
+import { runInvariantLane } from "../../scripts/bughunt/lanes/invariants";
+import { runMutationLane } from "../../scripts/bughunt/lanes/mutate";
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+describe("bughunt extraction and invariants", () => {
+  it("runs extraction and records duration", () => {
+    const result = runExtraction("Smith v. Jones, 1 U.S. 1 (1801).", { resolve: true });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.citations.length).toBeGreaterThan(0);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("reports no invariant failures for a normal citation", () => {
+    const text = "Smith v. Jones, 1 U.S. 1 (1801).";
+    const result = runExtraction(text, { resolve: true });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const violations = checkCitationInvariants(text, result.citations);
+    expect(violations).toEqual([]);
+  });
+});
+
+describe("bughunt corpus and invariant lane", () => {
+  it("provides a deterministic inline smoke corpus", () => {
+    expect(inlineCases().map((bughuntCase) => bughuntCase.key)).toEqual([
+      "inline/full-case",
+      "inline/id-chain",
+      "inline/statute",
+    ]);
+  });
+
+  it("runs invariant lane over inline cases", () => {
+    const findings = runInvariantLane({
+      runId: "run-1",
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      cases: inlineCases(),
+    });
+
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("bughunt mutation lane", () => {
+  it("runs deterministic generated mutation checks", () => {
+    const findings = runMutationLane({
+      runId: "mutate-run",
+      command: "pnpm bughunt run --lane mutate --seed 1234",
+      seed: 1234,
+      numRuns: 10,
+    });
+
+    expect(Array.isArray(findings)).toBe(true);
+  });
+});
+
+describe("bughunt core helpers", () => {
+  it("creates deterministic random sequences from a seed", () => {
+    const a = createRng(1234);
+    const b = createRng(1234);
+
+    expect([a.next(), a.next(), a.next()]).toEqual([b.next(), b.next(), b.next()]);
+  });
+
+  it("builds stable finding IDs from lane, source, signature, and snippet", () => {
+    const input = {
+      runId: "run-1",
+      lane: "invariants",
+      severity: "invariant" as const,
+      source: { kind: "inline" as const, key: "example" },
+      command: "pnpm bughunt run --lane invariants --seed 1",
+      signature: findingSignature("span_bounds", "originalEnd outside source"),
+      message: "originalEnd outside source",
+      contextSnippet: "Smith v. Jones, 1 U.S. 1 (1801)",
+    };
+
+    expect(buildFinding(input).id).toBe(buildFinding(input).id);
+  });
+
+  it("writes manifest, JSONL files, summary, and latest pointer", () => {
+    const root = mkdtempSync(join(tmpdir(), "bughunt-artifacts-"));
+    tempDirs.push(root);
+    const artifacts = createRunArtifacts({
+      rootDir: root,
+      runId: "2026-05-20T143000Z-seed-1234",
+      seed: 1234,
+      command: "pnpm bughunt run --lane invariants --seed 1234",
+      lanes: ["invariants"],
+      startedAt: "2026-05-20T14:30:00.000Z",
+    });
+
+    artifacts.writeFinding(
+      buildFinding({
+        runId: artifacts.manifest.runId,
+        lane: "invariants",
+        severity: "invariant",
+        source: { kind: "inline", key: "case-1" },
+        command: artifacts.manifest.command,
+        signature: findingSignature("span_bounds", "bad span"),
+        message: "bad span",
+        contextSnippet: "bad span input",
+      }),
+    );
+    artifacts.finalize({ finishedAt: "2026-05-20T14:30:01.000Z" });
+
+    const latest = JSON.parse(readFileSync(join(root, "latest.json"), "utf8")) as {
+      runDir: string;
+    };
+    expect(latest.runDir).toContain("2026-05-20T143000Z-seed-1234");
+    expect(readFileSync(join(artifacts.runDir, "findings.jsonl"), "utf8")).toContain(
+      "bad span",
+    );
+    expect(readFileSync(join(artifacts.runDir, "summary.md"), "utf8")).toContain(
+      "invariants",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- document the internal pnpm bughunt workflow in the README
- add AGENTS.md repo guidance for future Codex work
- add missing bughunt CLI contract tests

## Test Plan
- pnpm exec vitest run tests/bughunt/core.test.ts tests/bughunt/commands.test.ts