### PR TITLE
fix(extract): NY acronymized code citations (RPAPL, EPTL, BCL, etc.) — #640

### DIFF
--- a/.changeset/fix-640-ny-acronym-codes.md
+++ b/.changeset/fix-640-ny-acronym-codes.md
@@ -1,0 +1,32 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): recognize NY acronymized code citations (RPAPL, RPL, BCL, EPTL, SCPA, DRL, LLCL, VTL) — #640
+
+Documented examples:
+- `RPAPL 711 [5]` — Real Property Actions and Proceedings Law, bracket subdivision
+- `RPAPL 741 [4]`, `RPAPL 1304`
+- `N.Y. RPAPL 711 [5]` (with N.Y. prefix)
+- `EPTL § 5-1.1` — Estates Powers and Trusts Law
+- `BCL § 1104-a` — Business Corporation Law
+- `SCPA 1410` — Surrogate's Court Procedure Act
+- `DRL § 240` — Domestic Relations Law
+- `LLCL § 702` — Limited Liability Company Law
+- `VTL § 1192` — Vehicle and Traffic Law
+- `RPL § 5-703` — Real Property Law (distinct from RPAPL)
+
+Previously the entire family of NY acronymized codes was invisible to the
+tokenizer — only `CPLR` had a dedicated pattern (`ny-cplr-bare`, #592).
+This added a sibling pattern (`ny-acronym-bare`) using the same shape:
+closed alternation over a curated acronym list with mandatory trailing
+digits, so bare-acronym mentions in prose (`The RPAPL governs.`) still do
+not match.
+
+Subsection chaining accepts both bracket (`[5]`) and paren (`(5)`) groups
+and any mix (`RPAPL 711 [5] (a)` → `subsection: "[5](a)"`). The
+underlying `parseBody` already accepted both delimiters (#370); this PR
+just adds the missing tokenizer coverage.
+
+Each match emits `code: "N.Y. <ACRONYM>"` (canonical prefix) and
+`jurisdiction: "NY"` regardless of input shape.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -37,6 +37,7 @@ import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractNmBareSection } from "./statutes/extractNmBareSection"
 import { extractNyBareLaw } from "./statutes/extractNyBareLaw"
+import { extractNyAcronymBare } from "./statutes/extractNyAcronymBare"
 import { extractNyCplrBare } from "./statutes/extractNyCplrBare"
 import { extractNycAdminCode } from "./statutes/extractNycAdminCode"
 import { extractOhChapter } from "./statutes/extractOhChapter"
@@ -184,6 +185,8 @@ export function extractStatute(
       return extractNyBareLaw(token, transformationMap)
     case "ny-cplr-bare":
       return extractNyCplrBare(token, transformationMap)
+    case "ny-acronym-bare":
+      return extractNyAcronymBare(token, transformationMap)
     case "nyc-admin-code":
       return extractNycAdminCode(token, transformationMap)
     case "oh-chapter":

--- a/src/extract/statutes/extractNyAcronymBare.ts
+++ b/src/extract/statutes/extractNyAcronymBare.ts
@@ -1,0 +1,96 @@
+/**
+ * New York acronymized code extractor (#640)
+ *
+ * Parses tokenized NY statute citations in the bare-acronym style used
+ * dominantly in NY court opinions and briefs. Each acronym is an
+ * unambiguous all-caps abbreviation of a NY code that almost never
+ * appears in non-citation prose adjacent to a digit, so the closed
+ * alternation + mandatory trailing digit keeps false positives bounded.
+ *
+ * Supported acronyms (each may also appear with `N.Y.` prefix and/or
+ * `§`/`§§` connector):
+ *   - RPAPL — Real Property Actions and Proceedings Law
+ *   - RPL   — Real Property Law
+ *   - BCL   — Business Corporation Law
+ *   - EPTL  — Estates Powers and Trusts Law
+ *   - SCPA  — Surrogate's Court Procedure Act
+ *   - DRL   — Domestic Relations Law
+ *   - LLCL  — Limited Liability Company Law
+ *   - VTL   — Vehicle and Traffic Law
+ *
+ * Bracket-subdivision form (`RPAPL 711 [5]`) is supported alongside
+ * canonical parens (`RPAPL 711(5)`) and the chained mixed form
+ * (`RPAPL 711 [5] (a)`) — `parseBody` already accepts either delimiter
+ * inside the subsection chain.
+ *
+ * @module extract/statutes/extractNyAcronymBare
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+/** Match the same shape as the tokenizer's `ny-acronym-bare` pattern, anchored. */
+const NY_ACRONYM_BARE_RE =
+  /^(?:N\.\s*Y\.\s*)?(RPAPL|RPL|BCL|EPTL|SCPA|DRL|LLCL|VTL)\s*(?:§§?\s*)?(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*)((?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)$/d
+
+export function extractNyAcronymBare(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = NY_ACRONYM_BARE_RE.exec(text)!
+  const acronym = match[1]
+  const sectionRaw = match[2]
+  const subsectionRaw = match[3] ?? ""
+
+  // Concatenate section + collapsed paren/bracket chain so parseBody splits
+  // cleanly: `711` + ` [5]` → `711[5]` → section "711", subsection "[5]".
+  const body = `${sectionRaw}${subsectionRaw.replace(/\s+/g, "")}`
+  const { section, subsection, hasEtSeq } = parseBody(body)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const sectionIdx = match.indices[2]
+    if (sectionIdx && section) {
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [sectionIdx[0], sectionIdx[0] + sectionSpanLen],
+        transformationMap,
+      )
+    }
+    const subIdx = match.indices[3]
+    if (subIdx && subsection && subIdx[0] < subIdx[1]) {
+      spans.subsection = spanFromGroupIndex(span.cleanStart, subIdx, transformationMap)
+    }
+  }
+
+  // Confidence: each acronym is unambiguous and the trailing-digit anchor
+  // mirrors `extractNyCplrBare` — same baseline.
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    code: `N.Y. ${acronym}`,
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "NY",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -214,6 +214,29 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // New York acronymized codes — RPAPL, RPL, BCL, EPTL, SCPA, DRL, LLCL,
+    // VTL. NY court opinions cite these as bare-acronym + bare-section in
+    // running prose (`RPAPL 711 [5]`, `EPTL § 5-1.1`, `VTL § 1192`).
+    // Bracket-subdivision (`[5]`, `[3-a]`) is the dominant NY style — see
+    // `parseBody`'s SUBSECTION_RE which already accepts either delimiter.
+    //
+    // Each acronym is distinctive enough (3-5 caps, no normal English word
+    // collides) that the closed alternation + mandatory trailing digit is
+    // safe. Bare-acronym-in-prose (`The RPAPL governs.`) does not match —
+    // the trailing `\s*(?:§§?\s*)?\d` is the disambiguator.
+    //
+    // Listed adjacent to `ny-cplr-bare` since the shape and overflow
+    // handling are identical. #640
+    //
+    // Captures: (1) acronym, (2) section body, (3) optional subsection chain.
+    id: "ny-acronym-bare",
+    regex:
+      /\b(?:N\.\s*Y\.\s*)?(RPAPL|RPL|BCL|EPTL|SCPA|DRL|LLCL|VTL)\s*(?:§§?\s*)?(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*)((?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)/g,
+    description:
+      'New York acronymized codes (RPAPL/RPL/BCL/EPTL/SCPA/DRL/LLCL/VTL) with bracket-or-paren subdivisions: "RPAPL 711 [5]", "EPTL § 5-1.1" — #640',
+    type: "statute",
+  },
+  {
     id: "named-code",
     // Matches: [State abbrev]. [Code/Law Name] § [section]
     // Captures: (1) jurisdiction prefix, (2) code name text, (3) section+subsections+et seq

--- a/tests/extract/issue640NyAcronymCodes.test.ts
+++ b/tests/extract/issue640NyAcronymCodes.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { StatuteCitation } from "@/types/citation"
+
+const statutesOf = (text: string): StatuteCitation[] =>
+  extractCitations(text).filter((c): c is StatuteCitation => c.type === "statute")
+
+describe("#640 NY acronymized code citations", () => {
+  describe("RPAPL (Real Property Actions and Proceedings Law)", () => {
+    it("recognizes bracket-subdivision form (`RPAPL 711 [5]`)", () => {
+      const cs = statutesOf("RPAPL 711 [5]")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("711")
+      expect(cs[0].subsection).toBe("[5]")
+      expect(cs[0].code).toMatch(/RPAPL/)
+    })
+
+    it("recognizes paren-subdivision form (`RPAPL 711(5)`)", () => {
+      const cs = statutesOf("RPAPL 711(5)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("711")
+      expect(cs[0].subsection).toBe("(5)")
+    })
+
+    it("recognizes second bracket form (`RPAPL 741 [4]`)", () => {
+      const cs = statutesOf("RPAPL 741 [4]")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("741")
+      expect(cs[0].subsection).toBe("[4]")
+    })
+
+    it("recognizes N.Y. prefix (`N.Y. RPAPL 711 [5]`)", () => {
+      const cs = statutesOf("N.Y. RPAPL 711 [5]")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("711")
+      expect(cs[0].subsection).toBe("[5]")
+    })
+
+    it("recognizes §-prefixed form (`RPAPL § 711(5)`)", () => {
+      const cs = statutesOf("RPAPL § 711(5)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("711")
+      expect(cs[0].subsection).toBe("(5)")
+    })
+
+    it("recognizes bare section without subdivision (`RPAPL 1304`)", () => {
+      const cs = statutesOf("RPAPL 1304")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("1304")
+      expect(cs[0].subsection).toBeUndefined()
+    })
+
+    it("recognizes chained bracket+paren subdivisions (`RPAPL 711 [5] (a)`)", () => {
+      const cs = statutesOf("RPAPL 711 [5] (a)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("711")
+      expect(cs[0].subsection).toBe("[5](a)")
+    })
+  })
+
+  describe("Other NY acronymized codes", () => {
+    it("EPTL (Estates Powers and Trusts Law)", () => {
+      const cs = statutesOf("EPTL § 5-1.1")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("5-1.1")
+      expect(cs[0].code).toMatch(/EPTL/)
+    })
+
+    it("BCL (Business Corporation Law)", () => {
+      const cs = statutesOf("BCL § 1104-a")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("1104-a")
+      expect(cs[0].code).toMatch(/BCL/)
+    })
+
+    it("SCPA (Surrogate's Court Procedure Act)", () => {
+      const cs = statutesOf("SCPA 1410")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("1410")
+      expect(cs[0].code).toMatch(/SCPA/)
+    })
+
+    it("DRL (Domestic Relations Law)", () => {
+      const cs = statutesOf("DRL § 240")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("240")
+      expect(cs[0].code).toMatch(/DRL/)
+    })
+
+    it("LLCL (Limited Liability Company Law)", () => {
+      const cs = statutesOf("LLCL § 702")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("702")
+      expect(cs[0].code).toMatch(/LLCL/)
+    })
+
+    it("VTL (Vehicle and Traffic Law)", () => {
+      const cs = statutesOf("VTL § 1192")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("1192")
+      expect(cs[0].code).toMatch(/VTL/)
+    })
+
+    it("RPL (Real Property Law) — distinct from RPAPL", () => {
+      const cs = statutesOf("RPL § 5-703")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("5-703")
+      expect(cs[0].code).toMatch(/^RPL$|N\.Y\. RPL/)
+    })
+
+    it("RPL is not confused with RPAPL", () => {
+      const cs = statutesOf("RPL § 5-703 and RPAPL 711")
+      expect(cs).toHaveLength(2)
+      const rpl = cs.find((c) => c.section === "5-703")
+      const rpapl = cs.find((c) => c.section === "711")
+      expect(rpl?.code).toMatch(/RPL/)
+      expect(rpapl?.code).toMatch(/RPAPL/)
+    })
+  })
+
+  describe("In running prose", () => {
+    it("extracts mid-sentence (`The court relied on RPAPL 711 [5] to dismiss.`)", () => {
+      const cs = statutesOf("The court relied on RPAPL 711 [5] to dismiss.")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("711")
+      expect(cs[0].subsection).toBe("[5]")
+    })
+
+    it("extracts both in a parallel cite list", () => {
+      const cs = statutesOf("See RPAPL 711 [5]; RPAPL 741 [4].")
+      expect(cs).toHaveLength(2)
+    })
+
+    it("does NOT match bare acronym in prose (`The RPAPL governs.`)", () => {
+      const cs = statutesOf("The RPAPL governs.")
+      expect(cs).toHaveLength(0)
+    })
+
+    it("does NOT false-positive on `RPL` as prose word", () => {
+      const cs = statutesOf("Plaintiff cited RPL during the hearing but no section.")
+      expect(cs).toHaveLength(0)
+    })
+  })
+
+  describe("Existing CPLR coverage still works (regression guard)", () => {
+    it("CPLR 3211 (a) (4)", () => {
+      const cs = statutesOf("CPLR 3211 (a) (4)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("3211")
+      expect(cs[0].subsection).toBe("(a)(4)")
+    })
+
+    it("N.Y. C.P.L.R. § 211", () => {
+      const cs = statutesOf("N.Y. C.P.L.R. § 211")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("211")
+    })
+  })
+})


### PR DESCRIPTION
Closes #640

## Summary

Adds the `ny-acronym-bare` tokenizer pattern + extractor for NY codes that follow the same bare-acronym + section + bracket-or-paren-subdivision shape as CPLR (#592):

- **RPAPL** Real Property Actions and Proceedings Law
- **RPL** Real Property Law
- **BCL** Business Corporation Law
- **EPTL** Estates Powers and Trusts Law
- **SCPA** Surrogate's Court Procedure Act
- **DRL** Domestic Relations Law
- **LLCL** Limited Liability Company Law
- **VTL** Vehicle and Traffic Law

Closed alternation + mandatory trailing digit keeps false-positives bounded — bare-acronym mentions in prose (`The RPAPL governs.`) still do not match.

## Test plan
- [x] 21 new tests in `tests/extract/issue640NyAcronymCodes.test.ts` covering all 8 acronyms, bracket + paren + mixed subdivisions, `N.Y.` prefix, prose negatives, and CPLR regression guards
- [x] `pnpm exec vitest run` — 3660 passed (3638 → +22)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean