### PR TITLE
feat(types): CFR citations emit type=regulation, not statute — #637

### DIFF
--- a/.changeset/fix-637-cfr-regulation-type.md
+++ b/.changeset/fix-637-cfr-regulation-type.md
@@ -1,0 +1,40 @@
+---
+"eyecite-ts": minor
+---
+
+feat(types): CFR citations emit `type: "regulation"` instead of `"statute"` — #637
+
+C.F.R. citations are regulations issued by executive agencies under
+delegated authority, not statutes enacted by a legislature. Previously
+every CFR citation came out as `type: "statute"`, indistinguishable
+from USC. Downstream consumers wanting to filter regulations vs
+statutes had to resort to `code === "C.F.R."` string matching.
+
+**New `RegulationCitation` interface** in the discriminated union — same
+field shape as `StatuteCitation` (title, code, section, subsection,
+chapter, sectionRange, subsectionRange, jurisdiction, pincite,
+hasEtSeq, year, publisher, recompiledYear, editionLabel, spans), but
+discriminated as `type: "regulation"`. `Citation` union, `CitationType`
+enum, and `attachStatuteYearParen` post-processor all extended.
+
+Documented examples:
+- `42 C.F.R. § 100.3` → `{ type: "regulation", title: 42, code: "C.F.R.", section: "100.3" }`
+- `29 C.F.R. § 779.238` → regulation
+- `19 C.F.R. § 351.412(e)` → regulation with subsection
+- `42 CFR 447` (no §, no periods) → regulation
+- `12 C.F.R., § 226` (#587 comma form) → regulation
+- `12 C.F.R. § 226.5(a)(2018)` (#588 year-glued) → regulation with year
+- `42 C.F.R. Part 100` → regulation
+
+USC remains `type: "statute"`. The internal `extractFederal` dispatcher
+routes both USC and CFR through the same parser; the only difference is
+the `type` discriminator chosen based on the canonicalized `code` field.
+
+**Bluebook rendering preserved**: `toBluebook()` handles `statute` and
+`regulation` identically — same `title code § section(subsection)` shape.
+
+**Migration**: consumers that previously did
+`citations.filter(c => c.type === "statute" && c.code === "C.F.R.")` can
+simplify to `citations.filter(c => c.type === "regulation")`. Code that
+unconditionally branches on `type === "statute"` for CFR will need to
+add a `regulation` branch or use `type === "statute" || type === "regulation"`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -806,7 +806,9 @@ const EDITION_LABEL_REGEX = /^(?:Repl|Supp|Cum\.?\s*Supp|Reissue)\.?$/i
  */
 function attachStatuteYearParen(citations: Citation[], cleaned: string): void {
   for (const cite of citations) {
-    if (cite.type !== "statute") continue
+    // Both statute and regulation citations carry year/publisher metadata
+    // and bind trailing `(YYYY)` / `(West YYYY)` parentheticals. #637
+    if (cite.type !== "statute" && cite.type !== "regulation") continue
     if (cite.year !== undefined) continue
     const after = cleaned.slice(cite.span.cleanEnd)
     const match = STATUTE_YEAR_PAREN_REGEX.exec(after)

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Token } from "@/tokenize"
-import type { StatuteCitation } from "@/types/citation"
+import type { RegulationCitation, StatuteCitation } from "@/types/citation"
 import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
 import { extractAbbreviated } from "./statutes/extractAbbreviated"
 import { extractAlaCode1940 } from "./statutes/extractAlaCode1940"
@@ -130,7 +130,7 @@ function extractLegacy(token: Token, transformationMap: TransformationMap): Stat
 export function extractStatute(
   token: Token,
   transformationMap: TransformationMap,
-): StatuteCitation {
+): StatuteCitation | RegulationCitation {
   switch (token.patternId) {
     case "usc":
     case "cfr":

--- a/src/extract/statutes/extractFederal.ts
+++ b/src/extract/statutes/extractFederal.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Token } from "@/tokenize"
-import type { StatuteCitation } from "@/types/citation"
+import type { RegulationCitation, StatuteCitation } from "@/types/citation"
 import type { StatuteComponentSpans } from "@/types/componentSpans"
 import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
 import { parseBody } from "./parseBody"
@@ -37,7 +37,7 @@ const FEDERAL_PART_RE =
 export function extractFederal(
   token: Token,
   transformationMap: TransformationMap,
-): StatuteCitation {
+): StatuteCitation | RegulationCitation {
   const { text, span } = token
 
   // Try § form first, then Part form
@@ -122,8 +122,14 @@ export function extractFederal(
   if (subsection) confidence += 0.05
   confidence = Math.min(confidence, 1.0)
 
+  // C.F.R. is a regulation, not a statute — emit the type discriminator
+  // that reflects that. Same field shape; downstream consumers filtering
+  // by `citation.type === "regulation"` need this without resorting to
+  // `code === "C.F.R."` string matching. #637
+  const type = code === "C.F.R." ? "regulation" : "statute"
+
   return {
-    type: "statute",
+    type,
     text,
     span: {
       cleanStart: span.cleanStart,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -21,6 +21,7 @@ export type CitationType =
   | "case"
   | "docket"
   | "statute"
+  | "regulation"
   | "journal"
   | "neutral"
   | "publicLaw"
@@ -546,6 +547,55 @@ export interface StatuteCitation extends CitationBase {
 }
 
 /**
+ * Regulation citation (Code of Federal Regulations and state regulatory
+ * codes that share the same shape: title + code + section + subsection).
+ *
+ * Distinct from `StatuteCitation` because regulations are issued by
+ * executive agencies under delegated authority, not enacted by a
+ * legislature. Downstream consumers filtering by citation kind (e.g.
+ * "show me only statutes" vs "show me only regs") need this type
+ * discriminator to avoid post-hoc string matching on `code`. #637
+ *
+ * Shape is otherwise identical to `StatuteCitation`.
+ *
+ * @example "42 C.F.R. § 100.3"
+ * @example "19 C.F.R. § 351.412(e)"
+ */
+export interface RegulationCitation extends CitationBase {
+  type: "regulation"
+  /** Title number (e.g. 42 for `42 C.F.R.`). */
+  title?: number
+  /** Code identifier (`C.F.R.`, etc.). */
+  code?: string
+  /** Section identifier. */
+  section?: string
+  /** Structured `§§ N-M` section range (mirrors StatuteCitation). */
+  sectionRange?: { start: string; end: string }
+  /** Chapter for chapter+section regulatory codes (rare). */
+  chapter?: string
+  /** Subsection/pincite chain, e.g. "(c)(2)" */
+  subsection?: string
+  /** Structured subsection range (`(a)-(b)`, `(9)—(16)`). */
+  subsectionRange?: { start: string; end: string }
+  /** 2-letter state code or "US" when unambiguously identified */
+  jurisdiction?: string
+  /** Alias for subsection. */
+  pincite?: string
+  /** True when "et seq." follows the citation */
+  hasEtSeq?: boolean
+  /** Year of the regulatory edition cited from trailing parenthetical. */
+  year?: number
+  /** Publisher of an annotated edition. */
+  publisher?: string
+  /** Recompilation year for codes that were re-issued. */
+  recompiledYear?: number
+  /** Edition-volume label (`Repl.`, `Supp.`, `Cum. Supp.`). */
+  editionLabel?: string
+  /** Precise text positions for each parsed component. */
+  spans?: StatuteComponentSpans
+}
+
+/**
  * Journal citation (law review, legal periodical).
  *
  * Format: [Author,] [Title,] Volume Journal Page [, Pincite] [(Year)]
@@ -1043,6 +1093,7 @@ export type Citation =
   | FullCaseCitation
   | DocketCitation
   | StatuteCitation
+  | RegulationCitation
   | JournalCitation
   | NeutralCitation
   | PublicLawCitation

--- a/src/utils/bluebook.ts
+++ b/src/utils/bluebook.ts
@@ -54,7 +54,12 @@ export function toBluebook(citation: Citation): string {
       return `${caseName}${core}${pincite}${year}`
     }
 
-    case "statute": {
+    case "statute":
+    case "regulation": {
+      // Statutes and regulations share the same Bluebook rendering shape
+      // (title + code + chapter? + \u00A7 section + subsection + et seq.).
+      // Regulations only differ in `type` discriminator; rendering is
+      // identical. #637
       const title = citation.title !== undefined ? `${citation.title} ` : ""
       // section may be absent (e.g. Massachusetts chapter-only like
       // `G.L. c. 93A` \u2014 #569). Render the chapter form when present and

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -2712,11 +2712,12 @@ describe("extractStatute", () => {
     })
 
     it("captures `37 C.F.R. § 42.107(a)-(b)`", () => {
+      // CFR is type=regulation since #637.
       const cites = extractCitations("see 37 C.F.R. § 42.107(a)-(b).").filter(
-        (c) => c.type === "statute",
+        (c) => c.type === "regulation",
       )
       expect(cites).toHaveLength(1)
-      if (cites[0]?.type === "statute") {
+      if (cites[0]?.type === "regulation") {
         expect(cites[0].section).toBe("42.107")
         expect(cites[0].subsection).toBe("(a)")
         expect(cites[0].subsectionRange).toEqual({ start: "(a)", end: "(b)" })
@@ -3585,11 +3586,12 @@ describe("extractStatute", () => {
     })
 
     it("`42 CFR 447` (no §) → C.F.R.", () => {
+      // CFR is type=regulation since #637.
       const cites = extractCitations("see 42 CFR 447.").filter(
-        (c) => c.type === "statute",
+        (c) => c.type === "regulation",
       )
       expect(cites).toHaveLength(1)
-      if (cites[0]?.type === "statute") {
+      if (cites[0]?.type === "regulation") {
         expect(cites[0].code).toBe("C.F.R.")
         expect(cites[0].title).toBe(42)
         expect(cites[0].section).toBe("447")

--- a/tests/extract/issue587CommaBeforeSection.test.ts
+++ b/tests/extract/issue587CommaBeforeSection.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest"
 import { extractCitations } from "@/extract"
-import type { Citation, StatuteCitation } from "@/types/citation"
+import type { Citation, RegulationCitation, StatuteCitation } from "@/types/citation"
 
 const statutes = (cites: Citation[]): StatuteCitation[] =>
   cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+const regulations = (cites: Citation[]): RegulationCitation[] =>
+  cites.filter((c): c is RegulationCitation => c.type === "regulation")
 
 /**
  * #587 — Federal code citations sometimes appear with a comma between
@@ -43,7 +46,8 @@ describe("issue #587 — comma between code and section", () => {
   })
 
   it("extracts `12 C.F.R., § 226`", () => {
-    const cites = statutes(extractCitations("12 C.F.R., § 226"))
+    // CFR is type=regulation since #637.
+    const cites = regulations(extractCitations("12 C.F.R., § 226"))
     expect(cites).toHaveLength(1)
     const c = cites[0]
     expect(c.title).toBe(12)
@@ -95,7 +99,8 @@ describe("issue #587 — comma between code and section", () => {
   })
 
   it("still extracts canonical `12 C.F.R. § 226.1` — regression for #428", () => {
-    const cites = statutes(extractCitations("12 C.F.R. § 226.1"))
+    // CFR is type=regulation since #637.
+    const cites = regulations(extractCitations("12 C.F.R. § 226.1"))
     expect(cites).toHaveLength(1)
     expect(cites[0].code).toBe("C.F.R.")
     expect(cites[0].section).toBe("226.1")

--- a/tests/extract/issue588YearGluedSubsection.test.ts
+++ b/tests/extract/issue588YearGluedSubsection.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest"
 import { extractCitations } from "@/extract"
-import type { Citation, StatuteCitation } from "@/types/citation"
+import type { Citation, RegulationCitation, StatuteCitation } from "@/types/citation"
 
 const statutes = (cites: Citation[]): StatuteCitation[] =>
   cites.filter((c): c is StatuteCitation => c.type === "statute")
+
+const regulations = (cites: Citation[]): RegulationCitation[] =>
+  cites.filter((c): c is RegulationCitation => c.type === "regulation")
 
 /**
  * #588 — A year-of-edition parenthetical glued directly to a subsection
@@ -80,7 +83,8 @@ describe("issue #588 — year glued to subsection chain", () => {
   })
 
   it("CFR equivalent: `12 C.F.R. § 226.5(a)(2018)`", () => {
-    const cites = statutes(extractCitations("12 C.F.R. § 226.5(a)(2018)"))
+    // CFR is type=regulation since #637.
+    const cites = regulations(extractCitations("12 C.F.R. § 226.5(a)(2018)"))
     expect(cites).toHaveLength(1)
     const c = cites[0]
     expect(c.code).toBe("C.F.R.")

--- a/tests/extract/issue637CfrRegulationType.test.ts
+++ b/tests/extract/issue637CfrRegulationType.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { RegulationCitation, StatuteCitation } from "@/types/citation"
+
+const cfrCites = (text: string): RegulationCitation[] =>
+  extractCitations(text).filter((c): c is RegulationCitation => c.type === "regulation")
+
+const statuteCites = (text: string): StatuteCitation[] =>
+  extractCitations(text).filter((c): c is StatuteCitation => c.type === "statute")
+
+describe("#637 CFR citations have type=regulation, not type=statute", () => {
+  describe("Bare CFR forms", () => {
+    it("42 C.F.R. § 100.3", () => {
+      const cs = cfrCites("42 C.F.R. § 100.3")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(42)
+      expect(cs[0].code).toBe("C.F.R.")
+      expect(cs[0].section).toBe("100.3")
+    })
+
+    it("29 C.F.R. § 779.238", () => {
+      const cs = cfrCites("29 C.F.R. § 779.238")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(29)
+      expect(cs[0].section).toBe("779.238")
+    })
+
+    it("19 C.F.R. § 351.412(e) — with subsection", () => {
+      const cs = cfrCites("19 C.F.R. § 351.412(e)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(19)
+      expect(cs[0].subsection).toBe("(e)")
+    })
+
+    it("19 C.F.R. § 351.403", () => {
+      const cs = cfrCites("19 C.F.R. § 351.403")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(19)
+    })
+
+    it("42 CFR 447 — no §, no periods", () => {
+      const cs = cfrCites("42 CFR 447")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(42)
+      expect(cs[0].section).toBe("447")
+    })
+
+    it("12 C.F.R., § 226 — comma form (#587 carry-forward)", () => {
+      const cs = cfrCites("12 C.F.R., § 226")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(12)
+      expect(cs[0].section).toBe("226")
+    })
+  })
+
+  describe("CFR with Part / Section connectors", () => {
+    it("42 C.F.R. Part 100", () => {
+      const cs = cfrCites("42 C.F.R. Part 100")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(42)
+      expect(cs[0].section).toBe("100")
+    })
+
+    it("42 C.F.R. Section 100.3", () => {
+      const cs = cfrCites("42 C.F.R. Section 100.3")
+      expect(cs).toHaveLength(1)
+    })
+  })
+
+  describe("USC remains type=statute (regression guard)", () => {
+    it("42 U.S.C. § 1983 is statute, not regulation", () => {
+      const stats = statuteCites("42 U.S.C. § 1983")
+      const regs = cfrCites("42 U.S.C. § 1983")
+      expect(stats).toHaveLength(1)
+      expect(regs).toHaveLength(0)
+      expect(stats[0].code).toBe("U.S.C.")
+    })
+
+    it("11 U.S.C. § 547 (bankruptcy) is statute", () => {
+      const stats = statuteCites("11 U.S.C. § 547")
+      expect(stats).toHaveLength(1)
+    })
+  })
+
+  describe("RegulationCitation shape preserves StatuteCitation fields", () => {
+    it("carries title, code, section, subsection, jurisdiction", () => {
+      const cs = cfrCites("42 C.F.R. § 100.3(c)(2)")
+      expect(cs).toHaveLength(1)
+      const c = cs[0]
+      expect(c.type).toBe("regulation")
+      expect(c.title).toBe(42)
+      expect(c.code).toBe("C.F.R.")
+      expect(c.section).toBe("100.3")
+      expect(c.subsection).toBe("(c)(2)")
+      expect(c.jurisdiction).toBe("US")
+      expect(c.pincite).toBe("(c)(2)")
+    })
+
+    it("preserves spans field for granular positions", () => {
+      const cs = cfrCites("42 C.F.R. § 100.3")
+      expect(cs[0].spans?.section).toBeDefined()
+    })
+
+    it("preserves year/publisher binding (`19 C.F.R. § 351.403 (2018)`)", () => {
+      const cs = cfrCites("19 C.F.R. § 351.403 (2018)")
+      expect(cs[0].year).toBe(2018)
+    })
+  })
+
+  describe("Mixed citation lists", () => {
+    it("USC + CFR in the same sentence produce statute + regulation", () => {
+      const text = "See 42 U.S.C. § 1983 and 42 C.F.R. § 100.3."
+      const stats = statuteCites(text)
+      const regs = cfrCites(text)
+      expect(stats).toHaveLength(1)
+      expect(regs).toHaveLength(1)
+      expect(stats[0].code).toBe("U.S.C.")
+      expect(regs[0].code).toBe("C.F.R.")
+    })
+  })
+})

--- a/tests/fixtures/expanded-corpus.json
+++ b/tests/fixtures/expanded-corpus.json
@@ -870,7 +870,7 @@
       "text": "40 C.F.R. § 122",
       "expected": [
         {
-          "type": "statute",
+          "type": "regulation",
           "title": 40,
           "section": "122"
         }
@@ -2006,7 +2006,7 @@
           "section": "1251"
         },
         {
-          "type": "statute",
+          "type": "regulation",
           "title": 40,
           "section": "122"
         },

--- a/tests/fixtures/statute-corpus.json
+++ b/tests/fixtures/statute-corpus.json
@@ -58,7 +58,7 @@
     "text": "40 C.F.R. § 122.26(b)(14)",
     "expected": [
       {
-        "type": "statute",
+        "type": "regulation",
         "title": 40,
         "section": "122.26",
         "subsection": "(b)(14)",
@@ -69,7 +69,7 @@
   {
     "text": "12 C.F.R. § 226.1",
     "expected": [
-      { "type": "statute", "title": 12, "code": "C.F.R.", "section": "226.1", "jurisdiction": "US" }
+      { "type": "regulation", "title": 12, "code": "C.F.R.", "section": "226.1", "jurisdiction": "US" }
     ],
     "note": "CFR § form; 'Part' form is ambiguous with case-reporter pattern and tracked separately"
   },


### PR DESCRIPTION
Closes #637

## Summary

Adds a `RegulationCitation` interface to the discriminated `Citation` union and routes C.F.R. citations to it. USC continues to emit `type: "statute"`; CFR now emits `type: "regulation"`. Pre-existing CFR tests / fixtures updated.

**Migration**: consumers that previously did
\`citations.filter(c => c.type === \"statute\" && c.code === \"C.F.R.\")\` can simplify to
\`citations.filter(c => c.type === \"regulation\")\`. Code that unconditionally branches on `type === \"statute\"` for CFR needs a `regulation` branch.

## Test plan
- [x] 14 new tests in `tests/extract/issue637CfrRegulationType.test.ts` (bare forms, Part/Section connectors, subsections, year-paren binding, #587 comma, #588 year-glued, USC regression guards)
- [x] Updated pre-existing CFR assertions in `extractStatute.test.ts`, `issue587CommaBeforeSection.test.ts`, `issue588YearGluedSubsection.test.ts` + `expanded-corpus.json` / `statute-corpus.json`
- [x] `pnpm exec vitest run` — 3652 passed (3638 → +14)
- [x] `pnpm typecheck` clean (after adding `regulation` case to `toBluebook` exhaustive switch)
- [x] `pnpm build` clean