### PR TITLE
feat(extract): bare-abbreviation journals + bare-ALR annotations — #638

### DIFF
--- a/.changeset/fix-638-journal-and-alr-bare.md
+++ b/.changeset/fix-638-journal-and-alr-bare.md
@@ -1,0 +1,40 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): bare-abbreviation journals + bare-ALR annotations — #638
+
+Two coverage gaps the broad state-reporter regex was silently swallowing
+into `type: "case"`:
+
+**1. Bare-abbreviation journals (no periods).** Curated list of well-known
+scientific/medical journals + period-stripped law reviews. New
+`bare-journal` pattern in `secondaryAuthorityPatterns` (positioned
+before casePatterns) wins span dedup against the broad state-reporter
+match.
+
+Documented examples:
+- `53 Neurology 1107` → journal (was case)
+- `285 JAMA 2486` → journal
+- `344 New Eng. J. Med. 678` → journal
+- `70 Brook L Rev 1045` → journal (period-stripped law review)
+- `96 Yale L J 1234` → journal
+
+Curated list (extensible — one-line change to add): Neurology, Nature,
+Science, JAMA, Pediatrics, Lancet, New Eng. J. Med., Am. J. Psychiatry,
+Am. J. Pub. Health + a couple dozen common law-review abbreviations in
+period-stripped form (Brook L Rev, Yale L J, Harv L Rev, Stan L Rev,
+NYU L Rev, etc.).
+
+Bare-acronym mentions in prose (`Neurology specialists agree.`) do NOT
+match — the trailing volume + page digits gate the pattern.
+
+**2. Bare-ALR annotations (no periods).** Extended `alr-annotation`
+tokenizer + `extractAnnotation` parsing regex to accept the
+period-stripped form alongside the canonical `A.L.R.2d`:
+
+Documented examples:
+- `48 ALR 749` → annotation (was case)
+- `100 ALR2d 567` → annotation
+- `23 ALR Fed 3d 456` → annotation
+- `100 A.L.R.2d 1234` continues to work (regression guard)

--- a/src/extract/extractAnnotation.ts
+++ b/src/extract/extractAnnotation.ts
@@ -29,8 +29,11 @@ export function extractAnnotation(
 ): AnnotationCitation {
   const { text, span } = token
 
+  // Accepts both periodized (`A.L.R.2d`) and bare (`ALR2d`) forms — the
+  // tokenizer pattern was extended in #638 to admit the bare style for
+  // citations like `48 ALR 749`.
   const annotationRegex =
-    /\b(\d+)\s+(A\.\s?L\.\s?R\.(?:\s?(?:Fed\.(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?)\s+(\d+)\b/d
+    /\b(\d+)\s+(A\.\s?L\.\s?R\.(?:\s?(?:Fed\.(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?|ALR(?:\s?(?:Fed(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?)\s+(\d+)\b/d
   const match = annotationRegex.exec(text)
   if (!match) {
     throw new Error(`Failed to parse A.L.R. annotation citation: ${text}`)

--- a/src/patterns/secondaryAuthorityPatterns.ts
+++ b/src/patterns/secondaryAuthorityPatterns.ts
@@ -64,6 +64,63 @@ const KNOWN_TREATISES: ReadonlyArray<string> = [
 const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 const TREATISE_ALTERNATION = KNOWN_TREATISES.map(escapeRegex).join("|")
 
+/**
+ * Curated list of journal abbreviations that frequently appear in legal
+ * opinions cited in the `<vol> Abbrev <page>` shape WITHOUT periods.
+ * Two flavors:
+ *
+ *  1. Scientific / medical journals cited as authority for empirical
+ *     claims (medical, neuroscience, psychology, public health).
+ *  2. Law-review acronymized forms that some court reporters strip of
+ *     periods (`Brook L Rev` rather than `Brook. L. Rev.`).
+ *
+ * Without this pattern the broad state-reporter regex claims these as
+ * `type: "case"` (the case extractor doesn't validate against
+ * reporters-db at tokenize time, so an unknown reporter name is accepted
+ * verbatim). #638
+ *
+ * Keep this list curated and small — adding a journal is a one-line
+ * change. The mandatory volume + page digits gate the match so
+ * bare-acronym mentions in prose (`Neurology specialists agree.`) do
+ * not match.
+ */
+const KNOWN_BARE_JOURNALS: ReadonlyArray<string> = [
+  // Medical / scientific (frequently cited in tort, products-liability,
+  // criminal-mens-rea cases)
+  "Neurology",
+  "Nature",
+  "Science",
+  "JAMA",
+  "Pediatrics",
+  "Lancet",
+  "New Eng\\. J\\. Med\\.",
+  "Am\\. J\\. Psychiatry",
+  "Am\\. J\\. Pub\\. Health",
+  // Law reviews / journals stripped of periods by some court reporters
+  "Brook L Rev",
+  "Yale L J",
+  "Harv L Rev",
+  "Colum L Rev",
+  "Stan L Rev",
+  "Mich L Rev",
+  "U Chi L Rev",
+  "Geo L J",
+  "Tex L Rev",
+  "Va L Rev",
+  "Cal L Rev",
+  "NYU L Rev",
+  "Cornell L Rev",
+  "Hastings L J",
+  "Hous L Rev",
+  "Fordham L Rev",
+  "Notre Dame L Rev",
+  "U Pa L Rev",
+  "Wash L Rev",
+  "Wis L Rev",
+]
+
+const BARE_JOURNAL_ALTERNATION = KNOWN_BARE_JOURNALS.join("|")
+
 export const secondaryAuthorityPatterns: Pattern[] = [
   {
     // Restatement. Canonical form: `Restatement (Edition) of Subject § Section`.
@@ -86,15 +143,38 @@ export const secondaryAuthorityPatterns: Pattern[] = [
     type: "restatement",
   },
   {
+    // Bare-abbreviation journals (no periods). Closed alternation against
+    // KNOWN_BARE_JOURNALS protects against false-positives on prose. The
+    // pattern enforces `\b` boundaries and trailing volume/page digits;
+    // bare-acronym mentions (`Neurology specialists agree.`) do not match.
+    // Listed BEFORE casePatterns via dispatcher order so the journal
+    // classification wins span dedup against the broad state-reporter
+    // regex that otherwise emits `type: "case"`. #638
+    //
+    // Captures: (1) volume, (2) journal name, (3) page — matches
+    // extractJournal's parsing shape exactly.
+    id: "bare-journal",
+    regex: new RegExp(`\\b(\\d+)\\s+(${BARE_JOURNAL_ALTERNATION})\\s+(\\d+)\\b`, "g"),
+    description:
+      'Bare-abbreviation journals (scientific journals + period-stripped law reviews): "53 Neurology 1107", "70 Brook L Rev 1045" — #638',
+    type: "journal",
+  },
+  {
     // A.L.R. annotation. Captured shape is identical to a state-reporter
     // citation (vol + reporter + page), so this pattern must outrank
     // state-reporter in the dispatcher. The reporter alternation matches
     // the recognized A.L.R. series — A.L.R. (1st), A.L.R.2d/3d/4th/5th/6th/7th,
     // A.L.R. Fed., A.L.R. Fed. 2d/3d.
     id: "alr-annotation",
+    // Periodized + bare forms. The bare form (`ALR`, `ALR2d`, `ALR Fed`,
+    // `ALR Fed 3d`) lacks the dots between letters but still uses the same
+    // series-suffix shape. Without bare support, citations like `48 ALR 749`
+    // fell through to the broad state-reporter regex and emitted as
+    // `type: "case"`. #638
     regex:
-      /\b(\d+)\s+(A\.\s?L\.\s?R\.(?:\s?(?:Fed\.(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?)\s+(\d+)\b/g,
-    description: 'A.L.R. annotation citations: "100 A.L.R.2d 1234", "23 A.L.R. Fed. 3d 456" — #581',
+      /\b(\d+)\s+(A\.\s?L\.\s?R\.(?:\s?(?:Fed\.(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?|ALR(?:\s?(?:Fed(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?)\s+(\d+)\b/g,
+    description:
+      'A.L.R. annotation citations (periodized + bare): "100 A.L.R.2d 1234", "48 ALR 749", "23 A.L.R. Fed. 3d 456" — #581 #638',
     type: "annotation",
   },
   {

--- a/tests/extract/issue638JournalBareAlrAndScientific.test.ts
+++ b/tests/extract/issue638JournalBareAlrAndScientific.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { AnnotationCitation, JournalCitation } from "@/types/citation"
+
+const journals = (text: string): JournalCitation[] =>
+  extractCitations(text).filter((c): c is JournalCitation => c.type === "journal")
+
+const annotations = (text: string): AnnotationCitation[] =>
+  extractCitations(text).filter((c): c is AnnotationCitation => c.type === "annotation")
+
+describe("#638 bare-abbreviation journals + ALR-no-periods + scientific journals", () => {
+  describe("Scientific / medical journals", () => {
+    it("53 Neurology 1107 → journal", () => {
+      const cs = journals("53 Neurology 1107")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].volume).toBe(53)
+      expect(cs[0].abbreviation).toBe("Neurology")
+      expect(cs[0].page).toBe(1107)
+    })
+
+    it("344 New Eng. J. Med. 678 → journal", () => {
+      const cs = journals("344 New Eng. J. Med. 678")
+      expect(cs).toHaveLength(1)
+    })
+
+    it("285 JAMA 2486 → journal", () => {
+      const cs = journals("285 JAMA 2486")
+      expect(cs).toHaveLength(1)
+    })
+
+    it("scientific journal in prose (`...as reported in 53 Neurology 1107 (1999)`)", () => {
+      const cs = journals("...as reported in 53 Neurology 1107 (1999) by the authors.")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].abbreviation).toBe("Neurology")
+      expect(cs[0].year).toBe(1999)
+    })
+  })
+
+  describe("Law reviews without periods", () => {
+    it("70 Brook L Rev 1045 → journal", () => {
+      const cs = journals("70 Brook L Rev 1045")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].volume).toBe(70)
+      expect(cs[0].abbreviation).toBe("Brook L Rev")
+      expect(cs[0].page).toBe(1045)
+    })
+
+    it("96 Yale L J 1234 → journal", () => {
+      const cs = journals("96 Yale L J 1234")
+      expect(cs).toHaveLength(1)
+    })
+
+    it("with-periods canonical form still works (regression)", () => {
+      const cs = journals("100 Harv. L. Rev. 500")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].abbreviation).toBe("Harv. L. Rev.")
+    })
+  })
+
+  describe("ALR bare-acronym (no periods)", () => {
+    it("48 ALR 749 → annotation (not case)", () => {
+      const cs = annotations("48 ALR 749")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].volume).toBe(48)
+      expect(cs[0].page).toBe(749)
+    })
+
+    it("100 ALR2d 567 → annotation", () => {
+      const cs = annotations("100 ALR2d 567")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].volume).toBe(100)
+    })
+
+    it("23 ALR Fed 3d 456 → annotation", () => {
+      const cs = annotations("23 ALR Fed 3d 456")
+      expect(cs).toHaveLength(1)
+    })
+
+    it("canonical `100 A.L.R.2d 1234` still works (regression)", () => {
+      const cs = annotations("100 A.L.R.2d 1234")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].volume).toBe(100)
+    })
+  })
+
+  describe("Case-citation regression guards", () => {
+    it("`500 F.2d 123` still extracts as case", () => {
+      const cs = extractCitations("500 F.2d 123").filter((c) => c.type === "case")
+      expect(cs).toHaveLength(1)
+    })
+
+    it("`347 U.S. 483` (Brown v. Board) still case, not journal", () => {
+      const cs = extractCitations("Brown v. Board of Education, 347 U.S. 483 (1954)")
+      const cases = cs.filter((c) => c.type === "case")
+      const journ = cs.filter((c) => c.type === "journal")
+      expect(cases.length).toBeGreaterThanOrEqual(1)
+      expect(journ.length).toBe(0)
+    })
+  })
+
+  describe("False-positive guards", () => {
+    it("does NOT match `Neurology` in prose without volume/page", () => {
+      const cs = journals("Neurology specialists agree on the diagnosis.")
+      expect(cs).toHaveLength(0)
+    })
+
+    it("does NOT match `ALR` as standalone abbreviation in prose", () => {
+      const cs = annotations("The ALR specifications were updated.")
+      expect(cs).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Closes #638

## Summary

Two coverage gaps the broad state-reporter regex was silently swallowing into \`type: \"case\"\`:

**1. Bare-abbreviation journals.** New \`bare-journal\` pattern in secondaryAuthorityPatterns (ordered before casePatterns) with curated list of scientific/medical journals + period-stripped law reviews.

**2. Bare-ALR annotations.** Extended \`alr-annotation\` tokenizer + \`extractAnnotation\` parser to accept \`ALR\`, \`ALR2d\`, \`ALR Fed 3d\` alongside canonical \`A.L.R.2d\`.

## Test plan
- [x] 15 new tests in \`tests/extract/issue638JournalBareAlrAndScientific.test.ts\`
- [x] \`pnpm exec vitest run\` — 3675 passed (+15)
- [x] \`pnpm typecheck\` clean