### PR TITLE
feat(extract): Puerto Rico LPRA / L.P.R.A. statute citations — #635

### DIFF
--- a/.changeset/fix-635-lpra-puerto-rico.md
+++ b/.changeset/fix-635-lpra-puerto-rico.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): Puerto Rico LPRA / L.P.R.A. statute citations — #635
+
+Add `lpra` tokenizer pattern + `extractLpra` extractor for citations to
+*Leyes de Puerto Rico Anotadas* — previously the entire Puerto Rico
+statutory corpus was invisible to the parser.
+
+Supported forms:
+- `23 LPRA § 72` — bare acronym, § connector
+- `23 LPRA §72` — glued §
+- `23 LPRA §72(a)` — with subsection chain
+- `23 LPRA § 72` — with space
+- `21 L.P.R.A. § 4615` — periodized
+- `21 L.P.R.A. § 4615(a)(1)` — periodized with chained subsections
+- `32 LPRA § 3651-c` — hyphenated section
+
+Each match emits `code: "L.P.R.A."` (canonical Bluebook form) and
+`jurisdiction: "PR"`. Closed `(L\.P\.R\.A\.|LPRA)` alternation +
+mandatory § connector + trailing digits keep false positives bounded
+— bare-acronym mentions in prose (`The LPRA includes...`) do not
+match.
+
+The appendix-rule form (`4 LPRA Ap. XXII-A, R. 40`) is not yet
+covered and deferred to a follow-up; the dominant bare-section form
+covers the majority of LPRA citations in the wild.

--- a/src/extract/extractStatute.ts
+++ b/src/extract/extractStatute.ts
@@ -36,6 +36,7 @@ import { extractMdArticleLetter } from "./statutes/extractMdArticleLetter"
 import { extractMinnStYearEdition } from "./statutes/extractMinnStYearEdition"
 import { extractNamedCode } from "./statutes/extractNamedCode"
 import { extractNmBareSection } from "./statutes/extractNmBareSection"
+import { extractLpra } from "./statutes/extractLpra"
 import { extractNyBareLaw } from "./statutes/extractNyBareLaw"
 import { extractNyAcronymBare } from "./statutes/extractNyAcronymBare"
 import { extractNyCplrBare } from "./statutes/extractNyCplrBare"
@@ -187,6 +188,8 @@ export function extractStatute(
       return extractNyCplrBare(token, transformationMap)
     case "ny-acronym-bare":
       return extractNyAcronymBare(token, transformationMap)
+    case "lpra":
+      return extractLpra(token, transformationMap)
     case "nyc-admin-code":
       return extractNycAdminCode(token, transformationMap)
     case "oh-chapter":

--- a/src/extract/statutes/extractLpra.ts
+++ b/src/extract/statutes/extractLpra.ts
@@ -1,0 +1,76 @@
+/**
+ * Puerto Rico LPRA (Leyes de Puerto Rico Anotadas) extractor — #635
+ *
+ * Parses tokenized Puerto Rico statute citations in the dominant court
+ * styles seen across PR opinions and federal opinions applying PR law:
+ *   - `23 LPRA § 72`           (bare acronym, § connector)
+ *   - `23 LPRA §72`            (bare acronym, glued §)
+ *   - `23 LPRA §72(a)`         (with subsection)
+ *   - `21 L.P.R.A. § 4615`     (periodized)
+ *   - `21 L.P.R.A. § 4615(a)(1)`
+ *
+ * Emits `code` in canonical Bluebook form (`L.P.R.A.` with periods)
+ * and `jurisdiction: "PR"`.
+ *
+ * @module extract/statutes/extractLpra
+ */
+
+import type { Token } from "@/tokenize"
+import type { StatuteCitation } from "@/types/citation"
+import type { StatuteComponentSpans } from "@/types/componentSpans"
+import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { parseBody } from "./parseBody"
+
+/** Anchored mirror of the tokenizer's `lpra` pattern. */
+const LPRA_RE =
+  /^(\d+)\s+(L\.P\.R\.A\.|LPRA)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/d
+
+export function extractLpra(
+  token: Token,
+  transformationMap: TransformationMap,
+): StatuteCitation {
+  const { text, span } = token
+  const match = LPRA_RE.exec(text)!
+  const title = Number.parseInt(match[1], 10)
+  const body = match[3]
+  const { section, subsection, hasEtSeq } = parseBody(body)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  let spans: StatuteComponentSpans | undefined
+  if (match.indices) {
+    spans = {}
+    const sectionIdx = match.indices[3]
+    if (sectionIdx && section) {
+      const sectionSpanLen = section.replace(/[.,;:]\s*$/, "").length
+      spans.section = spanFromGroupIndex(
+        span.cleanStart,
+        [sectionIdx[0], sectionIdx[0] + sectionSpanLen],
+        transformationMap,
+      )
+    }
+  }
+
+  // Confidence: closed LPRA alternation + mandatory trailing § + digits.
+  let confidence = 0.95
+  if (subsection) confidence += 0.05
+  confidence = Math.min(confidence, 1.0)
+
+  return {
+    type: "statute",
+    text,
+    span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+    confidence,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    title,
+    code: "L.P.R.A.",
+    section,
+    subsection,
+    pincite: subsection,
+    jurisdiction: "PR",
+    hasEtSeq: hasEtSeq || undefined,
+    spans,
+  }
+}

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -237,6 +237,22 @@ export const statutePatterns: Pattern[] = [
     type: "statute",
   },
   {
+    // Puerto Rico Leyes de Puerto Rico Anotadas (LPRA / L.P.R.A.).
+    // The dominant form in PR opinions and federal opinions applying PR
+    // law is `<title> LPRA § <section>(<subsection>)?`. The closed
+    // alternation + mandatory § connector + trailing digits keep false
+    // positives bounded — bare-acronym mentions in prose
+    // (`The LPRA includes...`) do not match. #635
+    //
+    // Captures: (1) title, (2) code, (3) section body with subsection chain.
+    id: "lpra",
+    regex:
+      /\b(\d+)\s+(L\.P\.R\.A\.|LPRA)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+    description:
+      'Puerto Rico statutes (Leyes de Puerto Rico Anotadas): "23 LPRA § 72", "21 L.P.R.A. § 4615" — #635',
+    type: "statute",
+  },
+  {
     id: "named-code",
     // Matches: [State abbrev]. [Code/Law Name] § [section]
     // Captures: (1) jurisdiction prefix, (2) code name text, (3) section+subsections+et seq

--- a/tests/extract/issue635LpraPuertoRico.test.ts
+++ b/tests/extract/issue635LpraPuertoRico.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { StatuteCitation } from "@/types/citation"
+
+const lpra = (text: string): StatuteCitation[] =>
+  extractCitations(text).filter((c): c is StatuteCitation => c.type === "statute")
+
+describe("#635 Puerto Rico LPRA / L.P.R.A. statute citations", () => {
+  describe("Bare LPRA (no periods)", () => {
+    it("23 LPRA §72", () => {
+      const cs = lpra("23 LPRA §72")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(23)
+      expect(cs[0].code).toMatch(/L\.?P\.?R\.?A\.?/)
+      expect(cs[0].section).toBe("72")
+    })
+
+    it("23 LPRA §72(a) with subsection", () => {
+      const cs = lpra("23 LPRA §72(a)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("72")
+      expect(cs[0].subsection).toBe("(a)")
+    })
+
+    it("23 LPRA § 72 — space before §", () => {
+      const cs = lpra("23 LPRA § 72")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("72")
+    })
+
+    it("21 LPRA § 4615", () => {
+      const cs = lpra("21 LPRA § 4615")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(21)
+      expect(cs[0].section).toBe("4615")
+    })
+
+    it("multi-digit title", () => {
+      const cs = lpra("31 LPRA § 9651")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(31)
+    })
+
+    it("hyphenated section (`§ 3651-c`)", () => {
+      const cs = lpra("32 LPRA § 3651-c")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("3651-c")
+    })
+  })
+
+  describe("Periodized L.P.R.A.", () => {
+    it("23 L.P.R.A. § 72", () => {
+      const cs = lpra("23 L.P.R.A. § 72")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].title).toBe(23)
+      expect(cs[0].code).toMatch(/L\.P\.R\.A\./)
+      expect(cs[0].section).toBe("72")
+    })
+
+    it("21 L.P.R.A. § 4615(a)(1)", () => {
+      const cs = lpra("21 L.P.R.A. § 4615(a)(1)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("4615")
+      expect(cs[0].subsection).toBe("(a)(1)")
+    })
+  })
+
+  describe("Jurisdiction", () => {
+    it("emits jurisdiction=PR", () => {
+      const cs = lpra("23 LPRA § 72")
+      expect(cs[0].jurisdiction).toBe("PR")
+    })
+  })
+
+  describe("In running prose", () => {
+    it("extracts mid-sentence", () => {
+      const cs = lpra("The court applied 23 LPRA § 72(a) to dismiss.")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("72")
+      expect(cs[0].subsection).toBe("(a)")
+    })
+
+    it("extracts in parallel cite list", () => {
+      const cs = lpra("See 23 LPRA § 72 and 21 LPRA § 4615.")
+      expect(cs).toHaveLength(2)
+    })
+  })
+
+  describe("False-positive guards", () => {
+    it("does NOT match bare `LPRA` in prose (no title/section)", () => {
+      const cs = lpra("The LPRA includes many regulatory provisions.")
+      expect(cs).toHaveLength(0)
+    })
+
+    it("does NOT confuse with CPLR", () => {
+      // CPLR is NY; LPRA is PR. Both end in `R.` but the alternation is closed.
+      const cs = lpra("CPLR 3211")
+      expect(cs.filter((c) => c.code?.match(/LPRA|L\.P\.R\.A\./))).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Closes #635

## Summary

Add Puerto Rico LPRA / L.P.R.A. statute citations to the parser. Bare-acronym and periodized forms, with subsection chains.

## Test plan
- [x] 13 new tests in \`tests/extract/issue635LpraPuertoRico.test.ts\`
- [x] \`pnpm exec vitest run\` — 3674 passed (3661 → +13)
- [x] \`pnpm typecheck\` clean