### PR TITLE
fix(extract): preserve leading numeric prefix in case names — #641 (partial)

### DIFF
--- a/.changeset/fix-641-leading-numeric-casename.md
+++ b/.changeset/fix-641-leading-numeric-casename.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): preserve leading numeric prefix in case-name extraction — #641 (partial)
+
+`V_CASE_NAME_REGEX` required the plaintiff capture to begin with `[A-Z]`,
+so address-derived party names that lead with a digit prefix lost it:
+
+- `2312-2316 Realty Corp. v. Font` → was `Realty Corp. v. Font` (numeric prefix dropped)
+- `235 East 73rd Street, Inc. v. Smith` → was `East 73rd Street, Inc. v. Smith`
+- `125 Broadway Associates v. NYC` → was `Broadway Associates v. NYC`
+
+Common in NY real-property and tax cases where the legal name is the
+street address. Extended the leading character class to admit an optional
+`\d[\d-]*\s+` prefix before the required `[A-Z]` proper-noun head.
+
+5 new tests in `tests/extract/issue641LeadingNumericCaseName.test.ts`
+cover hyphenated address ranges, intermediate digits in addresses, and
+regression guards for the existing citation-boundary detection and
+ordinary alphabetic case names.
+
+Scope note: #641 originally bundled three sub-issues. Only the
+leading-numeric trim is addressed here. Two siblings remain open as
+follow-ups:
+- Parallel-cite caseName propagation without a closing `(YYYY)` paren
+  (`Kauffman v. Griesemer, 26 Pa. 407, 67 Am. Dec. 437.`)
+- Puerto Rico DPR / JTS reporter coverage (the reporters themselves
+  aren't in reporters-db so the case extractor doesn't tokenize them)

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -738,7 +738,7 @@ function isNonMetadataParenContent(content: string): boolean {
  *  The `d` flag enables `match.indices` so the caller can compute a year
  *  span. See #19, #293. */
 const V_CASE_NAME_REGEX =
-  /([A-Z][A-Za-z0-9\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
+  /((?:\d[\d-]*\s+)?[A-Z][A-Za-z0-9\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
 
 /** Procedural prefix case name format.
  *  Longer prefixes listed first so the alternation prefers the longer match

--- a/tests/extract/issue641LeadingNumericCaseName.test.ts
+++ b/tests/extract/issue641LeadingNumericCaseName.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+const cases = (text: string): FullCaseCitation[] =>
+  extractCitations(text).filter((c): c is FullCaseCitation => c.type === "case")
+
+describe("#641 case name with leading numeric prefix preserved", () => {
+  it("`2312-2316 Realty Corp. v. Font, 140 Misc. 2d 901` keeps numeric prefix", () => {
+    const cs = cases("2312-2316 Realty Corp. v. Font, 140 Misc. 2d 901")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].caseName).toBe("2312-2316 Realty Corp. v. Font")
+  })
+
+  it("`235 East 73rd Street, Inc. v. Smith, 100 N.Y.S.2d 1`", () => {
+    const cs = cases("235 East 73rd Street, Inc. v. Smith, 100 N.Y.S.2d 1")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].caseName).toMatch(/235 East 73rd Street/)
+  })
+
+  it("`125 Broadway Associates v. NYC, 100 N.E.2d 200`", () => {
+    const cs = cases("125 Broadway Associates v. NYC, 100 N.E.2d 200")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].caseName).toMatch(/125 Broadway Associates/)
+  })
+
+  it("does NOT incorrectly include leading volume digit from a prior cite", () => {
+    // Make sure the existing boundary detection (digit-period-space) still
+    // works — when a prior citation's page ends in `.`, the next caption
+    // should not include that digit.
+    const cs = cases("See 500 F.2d 100. Smith v. Jones, 600 F.2d 200.")
+    const smith = cs.find((c) => c.volume === 600)
+    expect(smith?.caseName).toBe("Smith v. Jones")
+  })
+
+  it("normal alphabetic case names still work (regression)", () => {
+    const cs = cases("Smith v. Jones, 500 F.2d 100")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].caseName).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
Partial fix for #641.

## Summary

\`V_CASE_NAME_REGEX\` rejected plaintiffs starting with digits, so address-derived NY real-property captions like \`2312-2316 Realty Corp. v. Font\` lost the numeric prefix. Extended the leading character class to admit an optional \`\\d[\\d-]*\\s+\` prefix.

Two sibling sub-issues from #641 deferred to follow-up issues:
- Parallel-cite caseName propagation without \`(YYYY)\` closing paren
- Puerto Rico DPR/JTS reporter coverage

## Test plan
- [x] 5 new tests in \`tests/extract/issue641LeadingNumericCaseName.test.ts\`
- [x] \`pnpm exec vitest run\` — 3725 passed
- [x] \`pnpm typecheck\` clean