### PR TITLE
feat(extract): emit each amendment in coordinated lists — #657

### DIFF
--- a/.changeset/fix-657-multi-amendment-list.md
+++ b/.changeset/fix-657-multi-amendment-list.md
@@ -1,0 +1,40 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): emit each amendment in coordinated lists — #657
+
+`the Fifth and Sixth Amendment`, `Fourth, Fifth, and Fourteenth
+Amendments`, `his Fifth and Sixth Amendment rights` previously only
+emitted a citation for the LAST amendment in the chain — the
+`bare-amendment-word` pattern (#534) requires `<ordinal>\s+Amendment`
+adjacently, and leading ordinals (Fifth, Fourth) have no trailing
+`Amendment` word.
+
+New `bare-amendment-coord` tokenizer pattern matches each leading
+ordinal in a coordinated list using a lookahead that requires the
+chain to terminate in `<ordinal>\s+Amendments?`. Each match emits a
+separate amendment citation; the trailing `<ordinal> Amendment`
+continues to be captured by `bare-amendment-word`.
+
+Documented examples (each emits an amendment citation per number):
+- `the Fifth and Sixth Amendment` → 5, 6
+- `the Fifth and Sixth Amendments` → 5, 6
+- `his Fifth and Sixth Amendment rights` → 5, 6
+- `Fourth and Fourteenth Amendments` → 4, 14
+- `the Fifth, Sixth, and Fourteenth Amendments` → 5, 6, 14
+- `First, Fourth, Fifth, and Fourteenth Amendments` → 1, 4, 5, 14
+- `5th and 6th Amendments` → 5, 6
+
+Confidence matches `bare-amendment-word` (0.5) since both are
+bare-prose matches without a `Const.` anchor. Single-amendment forms
+(`the Fifth Amendment`, `U.S. Const. amend. V`) are unchanged.
+
+11 new tests in `tests/extract/issue657MultiAmendmentList.test.ts`
+cover two/three/four-amendment lists, ordinal-abbreviation forms,
+regression guards for singular forms, and a false-positive guard for
+prose that mentions ordinals without the `Amendment` word.
+
+One pre-existing thorny-corpus fixture entry (death-penalty brief with
+`the Eighth and Fourteenth Amendments`) was updated to expect the
+additional Eighth Amendment citation that now emits.

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -213,6 +213,28 @@ export function extractConstitutional(
 ): ConstitutionalCitation {
   const { text, span } = token
 
+  // #657 — Coordinated amendment list leading-ordinal pattern. The token
+  // text is just the ordinal (`Fifth`, `5th`, ...) with no `Amendment`
+  // suffix because the lookahead matched the trailing context without
+  // consuming it. Parse the numeral directly and emit an amendment.
+  if (token.patternId === "bare-amendment-coord") {
+    const amendment = parseNumeral(text)
+    const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+    return {
+      type: "constitutional",
+      text,
+      span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+      confidence: 0.5,
+      matchedText: text,
+      processTimeMs: 0,
+      patternsChecked: 1,
+      amendment,
+      spans: {
+        amendment: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+      },
+    }
+  }
+
   const bodyMatch = CONSTITUTIONAL_BODY_RE.exec(text)
 
   let article: number | undefined

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -130,4 +130,34 @@ export const constitutionalPatterns: Pattern[] = [
       'Bare word-form amendment references without "Const." prefix (e.g., "the Fifth Amendment", "the Fourteenth Amendment") — #534',
     type: "constitutional",
   },
+  {
+    // #657 — Coordinated amendment lists: `the Fifth and Sixth Amendment`,
+    // `Fourth, Fifth, and Fourteenth Amendments`. The `bare-amendment-word`
+    // pattern only matches the trailing `<ordinal> Amendment` portion;
+    // leading ordinals in the list (Fifth, Fourth) are silently dropped
+    // because no `Amendment` word follows them directly.
+    //
+    // This pattern matches each leading ordinal using a lookahead that
+    // requires the chain to terminate in `<ordinal>\s+Amendments?`. Two
+    // alternatives in the lookahead:
+    //   1. Comma form: `Fifth, Sixth, and Fourteenth Amendments`
+    //   2. Bare-and form: `Fourth and Fourteenth Amendments`
+    //
+    // Each match captures just the ordinal text (e.g., `Fifth`). The
+    // extractor parses the numeral via `parseNumeral` and emits a
+    // separate amendment citation. The trailing `<ordinal> Amendment`
+    // continues to be captured by `bare-amendment-word`.
+    //
+    // Confidence is set to 0.5 in the extractor (same as
+    // `bare-amendment-word`) since this is also a bare-prose match
+    // without the `Const.` anchor.
+    id: "bare-amendment-coord",
+    regex: new RegExp(
+      `(?<!Const\\.?,?\\s)\\b(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})(?=,\\s+(?:(?:${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS}),?\\s+)*(?:and\\s+)?(?:${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+[Aa]mendments?|\\s+and\\s+(?:${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+[Aa]mendments?)`,
+      "g",
+    ),
+    description:
+      'Leading ordinals in coordinated amendment lists ("Fifth and Sixth Amendment" → Fifth + Sixth) — #657',
+    type: "constitutional",
+  },
 ]

--- a/tests/extract/issue657MultiAmendmentList.test.ts
+++ b/tests/extract/issue657MultiAmendmentList.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { ConstitutionalCitation } from "@/types/citation"
+
+const constCites = (text: string): ConstitutionalCitation[] =>
+  extractCitations(text).filter((c): c is ConstitutionalCitation => c.type === "constitutional")
+
+const amendments = (text: string): number[] =>
+  constCites(text)
+    .map((c) => c.amendment)
+    .filter((a): a is number => a !== undefined)
+    .sort((a, b) => a - b)
+
+describe("#657 multi-amendment list extraction", () => {
+  describe("Two-amendment lists", () => {
+    it("`the Fifth and Sixth Amendment` extracts both", () => {
+      expect(amendments("the Fifth and Sixth Amendment")).toEqual([5, 6])
+    })
+
+    it("`the Fifth and Sixth Amendments` (plural)", () => {
+      expect(amendments("the Fifth and Sixth Amendments")).toEqual([5, 6])
+    })
+
+    it("`his Fifth and Sixth Amendment rights` (with trailing context)", () => {
+      expect(amendments("his Fifth and Sixth Amendment rights")).toEqual([5, 6])
+    })
+
+    it("`Fourth and Fourteenth Amendments`", () => {
+      expect(amendments("Fourth and Fourteenth Amendments")).toEqual([4, 14])
+    })
+  })
+
+  describe("Three-amendment lists", () => {
+    it("`the Fifth, Sixth, and Fourteenth Amendments`", () => {
+      expect(amendments("the Fifth, Sixth, and Fourteenth Amendments")).toEqual([5, 6, 14])
+    })
+
+    it("`Fourth, Fifth, and Fourteenth Amendments`", () => {
+      expect(amendments("Fourth, Fifth, and Fourteenth Amendments")).toEqual([4, 5, 14])
+    })
+  })
+
+  describe("Four-amendment list", () => {
+    it("`First, Fourth, Fifth, and Fourteenth Amendments`", () => {
+      expect(amendments("First, Fourth, Fifth, and Fourteenth Amendments")).toEqual([1, 4, 5, 14])
+    })
+  })
+
+  describe("Regression guards", () => {
+    it("single `the Fifth Amendment` still works", () => {
+      expect(amendments("the Fifth Amendment")).toEqual([5])
+    })
+
+    it("`U.S. Const. amend. V` still single", () => {
+      expect(amendments("U.S. Const. amend. V")).toEqual([5])
+    })
+
+    it("does NOT match prose without `Amendment`", () => {
+      expect(amendments("the fifth section and the sixth chapter")).toEqual([])
+    })
+  })
+
+  describe("Ordinal abbreviations", () => {
+    it("`5th and 6th Amendments`", () => {
+      expect(amendments("5th and 6th Amendments")).toEqual([5, 6])
+    })
+  })
+})

--- a/tests/fixtures/thorny-corpus.json
+++ b/tests/fixtures/thorny-corpus.json
@@ -1220,6 +1220,10 @@
         },
         {
           "type": "constitutional",
+          "amendment": 8
+        },
+        {
+          "type": "constitutional",
           "amendment": 14
         },
         {


### PR DESCRIPTION
Closes #657

## Summary

Adds `bare-amendment-coord` pattern that catches the LEADING ordinals in coordinated amendment lists. Previously `Fifth and Sixth Amendment` produced only one citation (Sixth); now produces two.

## Test plan
- [x] 11 new tests in `tests/extract/issue657MultiAmendmentList.test.ts`
- [x] `pnpm exec vitest run` — 3793 passed
- [x] `pnpm typecheck` clean
- [x] Updated 1 fixture entry (thorny-corpus death-penalty brief)