### PR TITLE
fix(extract): bare `Code § N` cites in DC opinions route to D.C. Code — #659

### DIFF
--- a/.changeset/fix-659-dc-code-jurisdiction.md
+++ b/.changeset/fix-659-dc-code-jurisdiction.md
@@ -1,0 +1,32 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): bare `Code § N` cites in DC opinions route to D.C. Code — #659
+
+Both DC and VA write statute cites as bare `Code § N` without
+jurisdiction prefix, and both use overlapping section formats (period-
+laden `22-404.01` and no-period `22-404`). The existing
+`extractVaBareCode` and GA pre-1983 extractors silently claimed every
+bare `Code §` for VA or GA based on the section number's punctuation —
+so DC opinions citing their own code came out as `Va. Code` or `Ga.
+Code`, breaking jurisdictional filters.
+
+New post-process pass `reassignDcCodeJurisdiction` walks citations in
+document order, looks back ~400 chars for the most recent
+jurisdiction signal (`D.C. Code`, `D.C. Cir.`, `D.C.`, `District of
+Columbia` vs `Va.`, `Virginia`), and re-routes bare-`Code §` cites
+tagged as VA or GA to DC when DC is the nearest signal.
+
+Documented examples:
+- `D.C. Code § 22-404(a). The court also considered Code § 22-404.01(a)(2).` → both DC
+- `District of Columbia statute at issue is Code § 22-404(a)(2).` → DC (period-less section)
+- `See Smith v. Jones, 500 F.2d 100 (D.C. Cir. 2010). Per Code § 22-404.01(a)(2), ...` → DC
+
+Regression guards:
+- `Code § 18.2-308.2` (no DC context) → still VA
+- `Virginia Code § 8.01-581.17` → still VA
+- VA opinion with subsequent bare cite → still VA
+- Mixed `D.C. Code ... Va. Code ... Code § N` (VA is most recent) → VA
+
+8 new tests in `tests/extract/issue659DcCodeJurisdiction.test.ts`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -541,6 +541,13 @@ export function extractCitations(
   // jurisdiction. (#432)
   inheritBareSectionJurisdiction(citations, cleaned)
 
+  // Step 4.71: Reassign jurisdiction for bare `Code §` cites that the
+  // VA bare-code extractor claimed but actually belong to D.C. Both
+  // jurisdictions write bare `Code § N.N-N` and the period-laden
+  // section format is identical, so the only disambiguator is upstream
+  // context. (#659)
+  reassignDcCodeJurisdiction(citations, cleaned)
+
   // Step 4.72: Detect bare-party shortform back-references (`Smith, at 12`)
   // anchored to earlier full case citations. (#439)
   detectBarePartyBackReferences(citations, cleaned, transformationMap)
@@ -862,6 +869,66 @@ const BARE_SECTION_CONTEXT_OVERRIDES: Record<string, BareSectionContext> = {
   WV: { jurisdiction: "WV", code: "W. Va. Code" },
   CO: { jurisdiction: "CO", code: "C.R.S." },
   MT: { jurisdiction: "MT", code: "MCA" },
+}
+
+/**
+ * Reassign jurisdiction for bare `Code § N` cites that the VA bare-code
+ * extractor (or the GA pre-1983 extractor) claimed but actually belong to
+ * D.C. (#659)
+ *
+ * Both DC and VA write bare `Code §` and the section-number shape is
+ * ambiguous (both jurisdictions use period-laden forms like `22-404.01`
+ * AND no-period forms like `22-404`). The only disambiguator is upstream
+ * context. Walk citations in document order and track the most recent
+ * jurisdiction signal:
+ *
+ *   - DC signals: `D.C. Code` cite, `D.C. Cir.` in prose, `D.C.`
+ *     abbreviation, `District of Columbia` literal.
+ *   - VA signals: explicit `Va. Code §` / `Virginia Code §` cite, or
+ *     `Va.` in prose.
+ *
+ * A bare `Code §` cite tagged as `Va. Code` (or GA pre-1983) is rerouted
+ * to DC iff the most recent signal upstream is DC.
+ */
+const DC_CODE_CONTEXT_WINDOW = 400
+const DC_CONTEXT_RE = /\bD\.\s*C\.|\bDistrict\s+of\s+Columbia\b/
+const VA_CONTEXT_RE = /\bVa\.|\bVirginia\b/
+
+/** Find the most recent jurisdiction signal in upstream window. */
+function nearestUpstreamSignal(cleaned: string, cleanStart: number): "DC" | "VA" | null {
+  const start = Math.max(0, cleanStart - DC_CODE_CONTEXT_WINDOW)
+  const window = cleaned.slice(start, cleanStart)
+  // Find rightmost (most recent) signal of each type.
+  let dcIdx = -1
+  let vaIdx = -1
+  for (const m of window.matchAll(new RegExp(DC_CONTEXT_RE, "g"))) {
+    if (m.index !== undefined && m.index > dcIdx) dcIdx = m.index
+  }
+  for (const m of window.matchAll(new RegExp(VA_CONTEXT_RE, "g"))) {
+    if (m.index !== undefined && m.index > vaIdx) vaIdx = m.index
+  }
+  if (dcIdx < 0 && vaIdx < 0) return null
+  return dcIdx > vaIdx ? "DC" : "VA"
+}
+
+function reassignDcCodeJurisdiction(citations: Citation[], cleaned: string): void {
+  for (const cite of citations) {
+    if (cite.type !== "statute") continue
+
+    // Only re-route bare `Code §` cites (not explicit `Va. Code §` or `Virginia Code §`).
+    if (!/^Code\s+§/.test(cite.matchedText)) continue
+
+    // Only consider cites currently tagged as VA or GA — those are the
+    // two pattern matchers that claim bare `Code §`. DC-tagged cites
+    // (from explicit `D.C. Code §`) already have correct jurisdiction.
+    if (cite.jurisdiction !== "VA" && cite.jurisdiction !== "GA") continue
+
+    const signal = nearestUpstreamSignal(cleaned, cite.span.cleanStart)
+    if (signal === "DC") {
+      cite.code = "D.C. Code"
+      cite.jurisdiction = "DC"
+    }
+  }
 }
 
 /**

--- a/tests/extract/issue659DcCodeJurisdiction.test.ts
+++ b/tests/extract/issue659DcCodeJurisdiction.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { StatuteCitation } from "@/types/citation"
+
+const codeCites = (text: string): StatuteCitation[] =>
+  extractCitations(text).filter((c): c is StatuteCitation => c.type === "statute")
+
+describe("#659 DC Code bare-form jurisdictional disambiguation", () => {
+  describe("With upstream D.C. context", () => {
+    it("`D.C. Code § 22-404.01(a)(2)` (explicit prefix) emits DC", () => {
+      const cs = codeCites("D.C. Code § 22-404.01(a)(2)")
+      const dc = cs.find((c) => c.section === "22-404.01")
+      expect(dc?.jurisdiction).toBe("DC")
+      expect(dc?.code).toBe("D.C. Code")
+    })
+
+    it("`D.C. Code` upstream reroutes bare `Code §` to DC", () => {
+      const text =
+        "Defendant was convicted under D.C. Code § 22-404(a). The court also considered Code § 22-404.01(a)(2)."
+      const cs = codeCites(text)
+      const second = cs.find((c) => c.section === "22-404.01")
+      expect(second?.jurisdiction).toBe("DC")
+      expect(second?.code).toBe("D.C. Code")
+    })
+
+    it("`District of Columbia` upstream reroutes bare `Code §` to DC", () => {
+      const text =
+        "The District of Columbia statute at issue is Code § 22-404(a)(2)."
+      const cs = codeCites(text)
+      expect(cs[0]?.jurisdiction).toBe("DC")
+    })
+
+    it("`D.C. Cir.` upstream reroutes bare `Code §` to DC", () => {
+      const text =
+        "See Smith v. Jones, 500 F.2d 100 (D.C. Cir. 2010). Per Code § 22-404.01(a)(2), ..."
+      const cs = codeCites(text)
+      const dc = cs.find((c) => c.section === "22-404.01")
+      expect(dc?.jurisdiction).toBe("DC")
+    })
+  })
+
+  describe("Without DC context (regression)", () => {
+    it("bare `Code § 18.2-308.2` (VA-shape section) still routes to VA", () => {
+      const cs = codeCites("Code § 18.2-308.2")
+      expect(cs[0]?.jurisdiction).toBe("VA")
+      expect(cs[0]?.code).toBe("Va. Code")
+    })
+
+    it("`Virginia Code § 8.01-581.17` still VA", () => {
+      const cs = codeCites("Virginia Code § 8.01-581.17")
+      expect(cs[0]?.jurisdiction).toBe("VA")
+    })
+
+    it("VA opinion: `Va. Code § 18.2-308.2` upstream → subsequent bare `Code §` stays VA", () => {
+      const text =
+        "The court applied Va. Code § 18.2-308.2. The defendant also violated Code § 18.2-457.1."
+      const cs = codeCites(text)
+      const second = cs.find((c) => c.section === "18.2-457.1")
+      expect(second?.jurisdiction).toBe("VA")
+    })
+  })
+
+  describe("Mixed contexts", () => {
+    it("DC opinion with VA case citation — bare `Code §` after DC context stays DC", () => {
+      const text =
+        "D.C. Code § 22-404.01 was at issue. Compare with the analogous provision in Va. Code § 18.2-308.2. The trial court applied Code § 22-457.1."
+      const cs = codeCites(text)
+      // The last bare `Code §` follows BOTH a DC context AND a VA context,
+      // but DC came first and the VA cite is its own citation, not context
+      // for the bare form. The most recent context wins.
+      const last = cs.find((c) => c.section === "22-457.1")
+      expect(last).toBeDefined()
+      // Most recent context is VA (since the Va. Code cite came after DC), so VA wins
+      expect(last?.jurisdiction).toBe("VA")
+    })
+  })
+})


### PR DESCRIPTION
Closes #659

## Summary

DC opinions citing their own code came out as `Va. Code` or `Ga. Code` because both jurisdictions share the bare `Code §` form and overlapping section number shapes. Added `reassignDcCodeJurisdiction` post-process that tracks the most recent upstream jurisdiction signal and re-routes when DC is closest.

## Test plan
- [x] 8 new tests in `tests/extract/issue659DcCodeJurisdiction.test.ts`
- [x] `pnpm exec vitest run` — 3789 passed
- [x] `pnpm typecheck` clean