### PR TITLE
fix(extract): accept abbreviated `Health & Saf. Code` form — #655 (partial)

### DIFF
--- a/.changeset/fix-655-ca-health-saf-code.md
+++ b/.changeset/fix-655-ca-health-saf-code.md
@@ -1,0 +1,31 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): accept abbreviated `Health & Saf. Code` form — #655 (partial)
+
+CA appellate practice uses `Health & Saf. Code` (with `Saf.` abbreviated)
+as the dominant style; the parser only accepted `Health & Safety Code`
+(unabbreviated `Safety`). Added the abbreviated regex fragment alongside
+the unabbreviated one; both canonicalize to `Health & Saf. Code`.
+
+Documented examples:
+- `Health & Saf. Code, § 1375.4` → `code: "Health & Saf. Code"`, `section: "1375.4"`
+- `Health & Saf. Code, § 1375.4, subd. (b)(4)` → with subdivision
+- `Cal. Health & Saf. Code § 1375.4` → with explicit `Cal.` prefix
+
+The dominant bare-section follow-on pattern (`Pen. Code § 148. Then § 149.`)
+already works via existing inheritance — multiple bare-section cites in
+CA opinions correctly inherit the upstream `Pen. Code` (or other bare-code
+canonical).
+
+**Scope note**: #655 also identified bare `§ 1347.15, subd. (a)` cites
+(CA-shape section numbers `digits.digits`) that no tokenizer currently
+captures. Tracked as a separate follow-up — requires either extending the
+`nm-bare-section` shape to admit CA-shape numbers, or adding a new
+`ca-bare-section` pattern. Deferred from this PR to keep the surface area
+small.
+
+Also updates one pre-existing extractStatute test and the caBareCodes
+self-match invariant test to handle the new "multiple input fragments →
+one canonical" mapping.

--- a/src/data/caBareCodes.ts
+++ b/src/data/caBareCodes.ts
@@ -36,7 +36,12 @@ export const caBareCodeEntries: CaBareCodeEntry[] = [
   // Two-word "<Subject> & <Subject> Code" / "<Subject> Code" forms
   { canonical: "Bus. & Prof. Code", regexFragment: "Bus\\.?\\s*&\\s*Prof\\.?\\s+Code" },
   { canonical: "Welf. & Inst. Code", regexFragment: "Welf\\.?\\s*&\\s*Inst\\.?\\s+Code" },
-  { canonical: "Health & Safety Code", regexFragment: "Health\\s*&\\s*Safety\\s+Code" },
+  // Accept the abbreviated `Saf.` form as well as the unabbreviated
+  // `Safety` (CA opinions use both); both forms canonicalize to the
+  // abbreviated `Health & Saf. Code` which is the dominant style in
+  // CA appellate practice. #655
+  { canonical: "Health & Saf. Code", regexFragment: "Health\\s*&\\s*Saf\\.?\\s+Code" },
+  { canonical: "Health & Saf. Code", regexFragment: "Health\\s*&\\s*Safety\\s+Code" },
   { canonical: "Fish & Game Code", regexFragment: "Fish\\s*&\\s*Game\\s+Code" },
   { canonical: "Food & Agric. Code", regexFragment: "Food\\s*&\\s*Agric\\.?\\s+Code" },
   { canonical: "Harb. & Nav. Code", regexFragment: "Harb\\.?\\s*&\\s*Nav\\.?\\s+Code" },

--- a/tests/data/caBareCodes.test.ts
+++ b/tests/data/caBareCodes.test.ts
@@ -37,10 +37,21 @@ describe("caBareCodes data module", () => {
       expect(m).not.toBeNull()
     })
 
-    it("matches every canonical entry's regexFragment against its canonical form", () => {
+    it("matches every canonical entry's regexFragment against its canonical form (or another entry's)", () => {
+      // Some canonical names have multiple regexFragments mapping to them
+      // (e.g., `Health & Saf. Code` accepts both `Saf.` and `Safety` input
+      // forms but canonicalizes to the abbreviated form — #655). For those,
+      // the test passes when ANY entry sharing the canonical name has a
+      // fragment that matches the canonical.
       for (const entry of caBareCodeEntries) {
         const re = new RegExp(`^${entry.regexFragment}$`, "i")
-        expect(re.test(entry.canonical)).toBe(true)
+        if (re.test(entry.canonical)) continue
+        // Try fragments from other entries with the same canonical.
+        const siblings = caBareCodeEntries.filter((e) => e.canonical === entry.canonical)
+        const anyMatches = siblings.some((sib) =>
+          new RegExp(`^${sib.regexFragment}$`, "i").test(entry.canonical),
+        )
+        expect(anyMatches).toBe(true)
       }
     })
   })

--- a/tests/extract/extractStatute.test.ts
+++ b/tests/extract/extractStatute.test.ts
@@ -359,11 +359,11 @@ describe("extractStatute", () => {
       }
     })
 
-    it("extracts `Health & Safety Code § 11350`", () => {
+    it("extracts `Health & Safety Code § 11350` (now canonicalized to `Health & Saf. Code`)", () => {
       const cits = extractCitations("Health & Safety Code § 11350 controls.")
       expect(cits).toHaveLength(1)
       if (cits[0].type === "statute") {
-        expect(cits[0].code).toBe("Health & Safety Code")
+        expect(cits[0].code).toBe("Health & Saf. Code")
         expect(cits[0].section).toBe("11350")
         expect(cits[0].jurisdiction).toBe("CA")
       }

--- a/tests/extract/issue655CaBareSection.test.ts
+++ b/tests/extract/issue655CaBareSection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { StatuteCitation } from "@/types/citation"
+
+const statutes = (text: string): StatuteCitation[] =>
+  extractCitations(text).filter((c): c is StatuteCitation => c.type === "statute")
+
+describe("#655 California bare-section statutes with upstream code context", () => {
+  describe("Abbreviated `Health & Saf. Code`", () => {
+    it("`Health & Saf. Code, § 1375.4`", () => {
+      const cs = statutes("Health & Saf. Code, § 1375.4")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].code).toBe("Health & Saf. Code")
+      expect(cs[0].section).toBe("1375.4")
+      expect(cs[0].jurisdiction).toBe("CA")
+    })
+
+    it("`Health & Saf. Code, § 1375.4, subd. (b)(4)`", () => {
+      const cs = statutes("Health & Saf. Code, § 1375.4, subd. (b)(4)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("1375.4")
+      expect(cs[0].subsection).toBe("(b)(4)")
+    })
+
+    it("with-Cal. prefix: `Cal. Health & Saf. Code § 1375.4`", () => {
+      const cs = statutes("Cal. Health & Saf. Code § 1375.4")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].section).toBe("1375.4")
+    })
+  })
+
+  describe("Bare `§ N` inheriting CA code from upstream", () => {
+    it("`Pen. Code § 148. Then § 149.` — both CA", () => {
+      const cs = statutes("Pen. Code § 148. Then § 149.")
+      expect(cs).toHaveLength(2)
+      expect(cs[0].section).toBe("148")
+      expect(cs[1].section).toBe("149")
+      expect(cs[1].code).toBe("Pen. Code")
+      expect(cs[1].jurisdiction).toBe("CA")
+    })
+
+    // Note: bare `§ 1347.15` (CA-shape section: digits-dot-digits) is not yet
+    // captured by any tokenizer pattern (`nm-bare-section` requires the
+    // hyphenated `N-N-N` shape). Tracked as a follow-up. This PR fixes the
+    // upstream `Health & Saf. Code` abbreviation but the bare-section
+    // inheritance for CA-shape sections is deferred.
+
+    it("multiple bare cites all inherit the most-recent CA code", () => {
+      const text =
+        "Pen. Code § 148. The court also looked at § 149.5 and § 150."
+      const cs = statutes(text)
+      expect(cs.length).toBeGreaterThanOrEqual(3)
+      for (const c of cs) {
+        expect(c.jurisdiction).toBe("CA")
+        expect(c.code).toBe("Pen. Code")
+      }
+    })
+  })
+
+  describe("Regression guards (no CA context)", () => {
+    it("bare `§ 11-2-3` (NM-shape) still NM-tagged without CA context", () => {
+      // Per #565: bare-section without any jurisdictional anchor defaults
+      // to NM. Adding CA tracking should NOT change this for non-CA
+      // section shapes.
+      const cs = statutes("§ 11-2-3")
+      // Either no extraction or tagged NM/null — but not CA.
+      for (const c of cs) {
+        expect(c.jurisdiction).not.toBe("CA")
+      }
+    })
+
+    it("USC followed by bare `§` does NOT inherit CA", () => {
+      const cs = statutes("42 U.S.C. § 1983. The court also cited § 1985.")
+      const second = cs.find((c) => c.section === "1985")
+      // Bare cite after USC should not become CA.
+      if (second) {
+        expect(second.jurisdiction).not.toBe("CA")
+      }
+    })
+  })
+})


### PR DESCRIPTION
Partial fix for #655.

## Summary

CA appellate style uses `Health & Saf. Code` (abbreviated `Saf.`) which the parser previously rejected. Added the abbreviated form; both canonicalize to `Health & Saf. Code`.

Bare `§ 1347.15` (CA-shape `digits.digits` sections) is deferred to a follow-up — no tokenizer pattern currently captures that shape.

## Test plan
- [x] 7 new tests in `tests/extract/issue655CaBareSection.test.ts`
- [x] `pnpm exec vitest run` — 3788 passed
- [x] `pnpm typecheck` clean