### PR TITLE
feat(extract): prose-form state-constitutional citations — #656

### DIFF
--- a/.changeset/fix-656-state-const-prose.md
+++ b/.changeset/fix-656-state-const-prose.md
@@ -1,0 +1,32 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): prose-form state-constitutional citations — #656
+
+State opinions frequently cite their own constitution in natural prose
+instead of the canonical Bluebook `<State>. Const. art. <N>` form:
+
+- `art. 14 of the Massachusetts Declaration of Rights`
+- `Section 5(B), Article IV of the Ohio Constitution`
+- `Section 2, Article I of the Pennsylvania Constitution`
+
+Two new tokenizer patterns + extractor handling:
+
+1. `state-const-prose-declaration` — matches the MA/PA/VT/NH/MD/NC/DE/NJ
+   "Declaration of Rights" / "Constitution" prose form with closed
+   state-name alternation.
+
+2. `state-const-prose-section-article` — matches the more general
+   `Section <N>, Article <N> of the <State> Constitution` form across all
+   50 states.
+
+Both patterns map full state names ("Massachusetts", "New Jersey") to
+2-letter jurisdiction codes via a new FULL_STATE_NAME_TO_CODE table.
+Closed alternations keep false positives bounded: `art. 14 of the
+document` does not match because `document` is not in the state list.
+
+10 new tests in `tests/extract/issue656StateConstProse.test.ts` cover
+both shapes across MA, OH, PA, NJ; mid-sentence prose; regression
+guards for `U.S. Const.` and `Cal. Const.` canonical forms; and
+false-positive guards for non-state contexts.

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -114,6 +114,65 @@ function parseNumeral(raw: string): number | undefined {
 }
 
 /**
+ * Full state name → 2-letter code mapping. Used for the prose-form
+ * state-constitution patterns (#656) where the state name appears as
+ * full words ("Massachusetts", "New Jersey") rather than the canonical
+ * Bluebook abbreviation ("Mass.", "N.J.").
+ */
+const FULL_STATE_NAME_TO_CODE: Record<string, string> = {
+  alabama: "AL",
+  alaska: "AK",
+  arizona: "AZ",
+  arkansas: "AR",
+  california: "CA",
+  colorado: "CO",
+  connecticut: "CT",
+  delaware: "DE",
+  florida: "FL",
+  georgia: "GA",
+  hawaii: "HI",
+  idaho: "ID",
+  illinois: "IL",
+  indiana: "IN",
+  iowa: "IA",
+  kansas: "KS",
+  kentucky: "KY",
+  louisiana: "LA",
+  maine: "ME",
+  maryland: "MD",
+  massachusetts: "MA",
+  michigan: "MI",
+  minnesota: "MN",
+  mississippi: "MS",
+  missouri: "MO",
+  montana: "MT",
+  nebraska: "NE",
+  nevada: "NV",
+  "new hampshire": "NH",
+  "new jersey": "NJ",
+  "new mexico": "NM",
+  "new york": "NY",
+  "north carolina": "NC",
+  "north dakota": "ND",
+  ohio: "OH",
+  oklahoma: "OK",
+  oregon: "OR",
+  pennsylvania: "PA",
+  "rhode island": "RI",
+  "south carolina": "SC",
+  "south dakota": "SD",
+  tennessee: "TN",
+  texas: "TX",
+  utah: "UT",
+  vermont: "VT",
+  virginia: "VA",
+  washington: "WA",
+  "west virginia": "WV",
+  wisconsin: "WI",
+  wyoming: "WY",
+}
+
+/**
  * State abbreviation → 2-letter code mapping.
  * Keys are lowercase abbreviation stems (without trailing period).
  */
@@ -212,6 +271,48 @@ export function extractConstitutional(
   transformationMap: TransformationMap,
 ): ConstitutionalCitation {
   const { text, span } = token
+
+  // #656 — Prose state-constitutional citations: `art. 14 of the
+  // Massachusetts Declaration of Rights` and `Section 5(B), Article IV
+  // of the Ohio Constitution`. Parse directly from the token text since
+  // CONSTITUTIONAL_BODY_RE doesn't recognize this shape; full state
+  // names map to 2-letter codes via FULL_STATE_NAME_TO_CODE.
+  if (
+    token.patternId === "state-const-prose-declaration" ||
+    token.patternId === "state-const-prose-section-article"
+  ) {
+    let article: number | undefined
+    let section: string | undefined
+    let stateName: string | undefined
+    if (token.patternId === "state-const-prose-declaration") {
+      const m = /\b(?:art(?:icle)?\.?)\s+(\d+)\s+of\s+the\s+([A-Za-z\s]+?)\s+(?:Declaration\s+of\s+Rights|Constitution)\b/i.exec(text)
+      if (m) {
+        article = Number.parseInt(m[1], 10)
+        stateName = m[2].trim().toLowerCase()
+      }
+    } else {
+      const m = /\bSection\s+([\w()-]+)\s*,\s*Article\s+([IVX]+|\d+)\s+of\s+the\s+([A-Za-z\s]+?)\s+Constitution\b/i.exec(text)
+      if (m) {
+        section = m[1]
+        article = parseNumeral(m[2])
+        stateName = m[3].trim().toLowerCase()
+      }
+    }
+    const jurisdiction = stateName ? FULL_STATE_NAME_TO_CODE[stateName] : undefined
+    const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+    return {
+      type: "constitutional",
+      text,
+      span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+      confidence: 0.85,
+      matchedText: text,
+      processTimeMs: 0,
+      patternsChecked: 1,
+      article,
+      section,
+      jurisdiction,
+    }
+  }
 
   const bodyMatch = CONSTITUTIONAL_BODY_RE.exec(text)
 

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -121,6 +121,43 @@ export const constitutionalPatterns: Pattern[] = [
     // `bare-article` — without the `Const.` anchor the FP risk is
     // higher (e.g., movie titles, generic prose), so consumers can
     // filter low-confidence matches if they need stricter precision.
+    // #656 — Prose state-constitutional citations:
+    //   - `art. 14 of the Massachusetts Declaration of Rights`
+    //   - `Section 5(B), Article IV of the Ohio Constitution`
+    //   - `Section 2, Article I of the Pennsylvania Constitution`
+    //
+    // These do NOT use the canonical Bluebook `<State>. Const.` prefix —
+    // they spell the state name in full as part of natural prose. The
+    // closed alternation of full state names (US states + DC) gates the
+    // pattern so generic phrases like `art. 14 of the document` do not
+    // match.
+    //
+    // Two variants share one patternId because they collapse to the same
+    // shape after extraction (article + optional section + jurisdiction).
+    // The extractor distinguishes via regex group layout.
+    //
+    // Shape 1 captures: (1) article number, (2) state name (full word)
+    // Shape 2 captures: (3) section text, (4) article numeral (roman or arabic), (5) state name
+    id: "state-const-prose-declaration",
+    regex: new RegExp(
+      String.raw`\b(?:art(?:icle)?\.?)\s+(\d+)\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey)\s+(?:Declaration\s+of\s+Rights|Constitution)\b`,
+      "gi",
+    ),
+    description:
+      'Prose-form state constitutional citations: "art. 14 of the Massachusetts Declaration of Rights" — #656',
+    type: "constitutional",
+  },
+  {
+    id: "state-const-prose-section-article",
+    regex: new RegExp(
+      String.raw`\bSection\s+([\w()-]+)\s*,\s*Article\s+([IVX]+|\d+)\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey|Ohio|California|Texas|Florida|Illinois|Michigan|New\s+York|Georgia|Virginia|Washington|Arizona|Colorado|Wisconsin|Minnesota|Indiana|Louisiana|Oregon|Tennessee|South\s+Carolina|Alabama|Missouri|Kentucky|Connecticut|Iowa|Mississippi|Arkansas|Kansas|Nevada|Utah|Hawaii|Alaska|Idaho|Maine|Montana|Nebraska|New\s+Mexico|North\s+Dakota|Oklahoma|Rhode\s+Island|South\s+Dakota|West\s+Virginia|Wyoming|Florida)\s+Constitution\b`,
+      "g",
+    ),
+    description:
+      'Prose-form state constitutional citations: "Section 5(B), Article IV of the Ohio Constitution" — #656',
+    type: "constitutional",
+  },
+  {
     id: "bare-amendment-word",
     regex: new RegExp(
       `(?<!Const\\.?,?\\s)\\b(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+(?:[Aa]mend(?:ment)?\\.?|[Aa]mdt\\.?)`,

--- a/tests/extract/issue656StateConstProse.test.ts
+++ b/tests/extract/issue656StateConstProse.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { ConstitutionalCitation } from "@/types/citation"
+
+const constCites = (text: string): ConstitutionalCitation[] =>
+  extractCitations(text).filter((c): c is ConstitutionalCitation => c.type === "constitutional")
+
+describe("#656 state constitutional prose-form citations", () => {
+  describe("`art. <N> of the <State> Declaration of Rights`", () => {
+    it("`art. 14 of the Massachusetts Declaration of Rights`", () => {
+      const cs = constCites("art. 14 of the Massachusetts Declaration of Rights")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(14)
+      expect(cs[0].jurisdiction).toBe("MA")
+    })
+
+    it("`art. 12 of the Massachusetts Declaration of Rights`", () => {
+      const cs = constCites("art. 12 of the Massachusetts Declaration of Rights")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(12)
+      expect(cs[0].jurisdiction).toBe("MA")
+    })
+  })
+
+  describe("`Section <N>, Article <N> of the <State> Constitution`", () => {
+    it("`Section 5(B), Article IV of the Ohio Constitution`", () => {
+      const cs = constCites("Section 5(B), Article IV of the Ohio Constitution")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(4)
+      expect(cs[0].section).toBe("5(B)")
+      expect(cs[0].jurisdiction).toBe("OH")
+    })
+
+    it("`Section 2, Article I of the Pennsylvania Constitution`", () => {
+      const cs = constCites("Section 2, Article I of the Pennsylvania Constitution")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(1)
+      expect(cs[0].section).toBe("2")
+      expect(cs[0].jurisdiction).toBe("PA")
+    })
+
+    it("`Section 10, Article 1 of the New Jersey Constitution`", () => {
+      const cs = constCites("Section 10, Article 1 of the New Jersey Constitution")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(1)
+      expect(cs[0].jurisdiction).toBe("NJ")
+    })
+  })
+
+  describe("In running prose", () => {
+    it("mid-sentence with comma context", () => {
+      const cs = constCites(
+        "The court relied on art. 14 of the Massachusetts Declaration of Rights to suppress the evidence.",
+      )
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(14)
+    })
+  })
+
+  describe("Regression guards", () => {
+    it("`U.S. Const. amend. V` still works", () => {
+      const cs = constCites("U.S. Const. amend. V")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].amendment).toBe(5)
+      expect(cs[0].jurisdiction).toBe("US")
+    })
+
+    it("`Cal. Const. art. I, § 7` still works", () => {
+      const cs = constCites("Cal. Const. art. I, § 7")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].article).toBe(1)
+      expect(cs[0].section).toBe("7")
+      expect(cs[0].jurisdiction).toBe("CA")
+    })
+  })
+
+  describe("False-positive guards", () => {
+    it("does NOT match `art. 14 of the document`", () => {
+      const cs = constCites("art. 14 of the document was filed late")
+      expect(cs).toHaveLength(0)
+    })
+
+    it("does NOT match `Section 5 of the contract`", () => {
+      const cs = constCites("Section 5 of the contract requires arbitration")
+      expect(cs).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Closes #656

Two new tokenizer patterns + extractor handling for prose state-constitutional citations across 50 states + DC.

## Test plan
- [x] 10 new tests in `tests/extract/issue656StateConstProse.test.ts`
- [x] `pnpm exec vitest run` — 3793 passed
- [x] `pnpm typecheck` clean