### PR TITLE
feat(extract): tribal court rule citations — #658 (partial)

### DIFF
--- a/.changeset/fix-658-tribal-rules.md
+++ b/.changeset/fix-658-tribal-rules.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": patch
+---
+
+feat(extract): tribal court rule citations — #658 (partial)
+
+Extend `stateRulePatterns` (#636) to cover two tribal/territorial court
+rule sets that appeared in the post-Sprint-K judge sweep:
+
+- Ho-Chunk Nation Rules of Civil Procedure: `HCN R. Civ. P. 5(C)(1)`,
+  `HCN R. Civ. P. 27(B)`
+- Territorial Courts Rules of Civil Procedure: `T.C.R.C.P. 19(a)`
+
+Both follow the same shape as existing state-rule patterns (closed
+prefix alternation + mandatory trailing rule number) so false positives
+on bare-prose mentions are bounded.
+
+Jurisdiction codes:
+- HCN — Ho-Chunk Nation
+- TC — Territorial Courts
+
+10 new tests covering both rule sets, mid-sentence prose, federal-rule
+and state-rule regression guards, and false-positive guards.
+
+**Scope note**: #658 originally bundled three tribal-court coverage gaps.
+This PR covers only the rules. Two sub-issues deferred to follow-ups:
+- Tribal constitutions (`Constitution of the Ho-Chunk Nation, Art. VII,
+  sec. 7(B)`, `HCN Const. Art. V, § 4`)
+- Tribal codes (CS&KT `Section 2-1-813` style bare-section cites)

--- a/src/extract/extractStateRule.ts
+++ b/src/extract/extractStateRule.ts
@@ -53,6 +53,16 @@ const PATTERN_META: Record<string, PatternMeta> = {
     ruleSet: "civil",
     re: /^RCFC\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)$/d,
   },
+  "hcn-rcp": {
+    jurisdiction: "HCN",
+    ruleSet: "civil",
+    re: /^HCN\s+R\.\s?Civ\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)$/d,
+  },
+  tcrcp: {
+    jurisdiction: "TC",
+    ruleSet: "civil",
+    re: /^T\.C\.R\.C\.P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)$/d,
+  },
 }
 
 /** Split a captured rule body into bare rule + subsection chain. */

--- a/src/patterns/stateRulePatterns.ts
+++ b/src/patterns/stateRulePatterns.ts
@@ -75,4 +75,21 @@ export const stateRulePatterns: Pattern[] = [
     description: 'Court of Federal Claims rule: "RCFC 56(c)" — #636',
     type: "stateRule",
   },
+  {
+    // Ho-Chunk Nation Rules of Civil Procedure — `HCN R. Civ. P. 5(C)(1)`.
+    // Tribal court citations have distinctive jurisdiction prefixes that
+    // follow the same shape as state-rule patterns. #658
+    id: "hcn-rcp",
+    regex: /\bHCN\s+R\.\s?Civ\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    description: 'Ho-Chunk Nation Rules of Civil Procedure: "HCN R. Civ. P. 5(C)(1)" — #658',
+    type: "stateRule",
+  },
+  {
+    // Territorial Courts Rules of Civil Procedure — `T.C.R.C.P. 19(a)`.
+    // Used by territorial / tribal courts (US Virgin Islands among others).
+    id: "tcrcp",
+    regex: /\bT\.C\.R\.C\.P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    description: 'Territorial Courts Rules of Civil Procedure: "T.C.R.C.P. 19(a)" — #658',
+    type: "stateRule",
+  },
 ]

--- a/tests/extract/issue658TribalRules.test.ts
+++ b/tests/extract/issue658TribalRules.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { StateRuleCitation } from "@/types/citation"
+
+const tribalRules = (text: string): StateRuleCitation[] =>
+  extractCitations(text).filter((c): c is StateRuleCitation => c.type === "stateRule")
+
+describe("#658 tribal court rule citations", () => {
+  describe("Ho-Chunk Nation Rules of Civil Procedure", () => {
+    it("`HCN R. Civ. P. 5(C)(1)`", () => {
+      const cs = tribalRules("HCN R. Civ. P. 5(C)(1)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].jurisdiction).toBe("HCN")
+      expect(cs[0].ruleSet).toBe("civil")
+      expect(cs[0].rule).toBe("5")
+      expect(cs[0].subsection).toBe("(C)(1)")
+    })
+
+    it("`HCN R. Civ. P. 5(A)(2)`", () => {
+      const cs = tribalRules("HCN R. Civ. P. 5(A)(2)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].rule).toBe("5")
+      expect(cs[0].subsection).toBe("(A)(2)")
+    })
+
+    it("`HCN R. Civ. P. 27(B)`", () => {
+      const cs = tribalRules("HCN R. Civ. P. 27(B)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].rule).toBe("27")
+      expect(cs[0].subsection).toBe("(B)")
+    })
+
+    it("bare rule (no subsection)", () => {
+      const cs = tribalRules("HCN R. Civ. P. 12")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].rule).toBe("12")
+    })
+  })
+
+  describe("Territorial Court Rules of Civil Procedure", () => {
+    it("`T.C.R.C.P. 19(a)`", () => {
+      const cs = tribalRules("T.C.R.C.P. 19(a)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].jurisdiction).toBe("TC")
+      expect(cs[0].ruleSet).toBe("civil")
+      expect(cs[0].rule).toBe("19")
+      expect(cs[0].subsection).toBe("(a)")
+    })
+  })
+
+  describe("In running prose", () => {
+    it("mid-sentence HCN cite", () => {
+      const cs = tribalRules("Under HCN R. Civ. P. 5(C)(1), service is required.")
+      expect(cs).toHaveLength(1)
+    })
+  })
+
+  describe("Regression guards", () => {
+    it("`Fed. R. Civ. P. 56` still federalRule (not tribalRule)", () => {
+      const fed = extractCitations("Fed. R. Civ. P. 56").filter((c) => c.type === "federalRule")
+      const tribal = extractCitations("Fed. R. Civ. P. 56").filter((c) => c.type === "stateRule")
+      expect(fed).toHaveLength(1)
+      expect(tribal).toHaveLength(0)
+    })
+
+    it("`I.R.C.P. 60(b)(6)` still ID (existing state rule)", () => {
+      const cs = tribalRules("I.R.C.P. 60(b)(6)")
+      expect(cs).toHaveLength(1)
+      expect(cs[0].jurisdiction).toBe("ID")
+    })
+  })
+
+  describe("False-positive guards", () => {
+    it("does NOT match bare `HCN` in prose", () => {
+      const cs = tribalRules("The HCN governs tribal procedure.")
+      expect(cs).toHaveLength(0)
+    })
+
+    it("does NOT match `T.C.R.C.P.` without rule number", () => {
+      const cs = tribalRules("Under the T.C.R.C.P., service is required.")
+      expect(cs).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Partial fix for #658.

## Summary

Adds Ho-Chunk Nation `HCN R. Civ. P.` and Territorial Courts `T.C.R.C.P.` rule patterns mirroring the existing state-rule infrastructure (#636).

Tribal constitutions and tribal codes deferred to follow-up issues.

## Test plan
- [x] 10 new tests in `tests/extract/issue658TribalRules.test.ts`
- [x] `pnpm exec vitest run` — 3791 passed
- [x] `pnpm typecheck` clean