### PR TITLE
fix(resolve): shortFormCase partyName disambiguation works when antecedent has no `v.`

### DIFF
--- a/.changeset/fix-shortform-partyname-disambig-without-v.md
+++ b/.changeset/fix-shortform-partyname-disambig-without-v.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): shortFormCase partyName disambiguation works when antecedent has no `v.`
+
+When two full case citations shared the same volume + reporter and the
+antecedents were one-party references (`Smith, 100 F.2d 1.`,
+`Doe, 100 F.2d 5.`), the shortFormCase resolver fell back to recency
+because the antecedents had `plaintiffNormalized`/`defendantNormalized`
+both undefined (the `v.` separator is what splits caseName into
+plaintiff + defendant). The disambiguation block at
+`DocumentResolver.ts:884` only checked those two fields, so
+`Smith, 100 F.2d at 3` resolved to **Doe** (most recent same-vol+reporter)
+instead of **Smith** (correct party-name match).
+
+Fix: in the party-name fallback, also check the antecedent's normalized
+`caseName` when neither plaintiff nor defendant is populated. Single-
+party shortform anchors now resolve correctly:
+
+- `Smith, 100 F.2d 1. Doe, 100 F.2d 5. Smith, 100 F.2d at 3.` → resolvedTo=0 (Smith) ✓
+- `Smith, 100 F.2d 1. Doe, 100 F.2d 5. Roe, 100 F.2d 9. Smith, 100 F.2d at 3.` → resolvedTo=0 ✓
+
+Full `v.` antecedents continue to resolve via the existing plaintiff/
+defendant check unchanged.
+
+6 new tests in `tests/resolve/issueShortformPartynameDisambig.test.ts`
+cover single-party + multi-party scenarios with same vol+reporter.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -890,7 +890,17 @@ export class DocumentResolver {
         const hit = (name: string | undefined) =>
           name !== undefined &&
           (name === targetParty || name.includes(targetParty) || targetParty.includes(name))
-        return hit(plaintiff) || hit(defendant)
+        if (hit(plaintiff) || hit(defendant)) return true
+        // Antecedent without a `v.` separator carries the single party as
+        // `caseName` only — `plaintiff`/`defendant` are undefined. Fall
+        // back to matching `caseName` normalized so single-party
+        // shortform anchors (`Smith, 100 F.2d 1. Doe, 100 F.2d 5.
+        // Smith, 100 F.2d at 3.`) still pick the right antecedent.
+        if (c.caseName) {
+          const caseNameNorm = this.normalizePartyName(c.caseName)
+          if (hit(caseNameNorm)) return true
+        }
+        return false
       })
       if (namedMatch !== undefined) {
         return {

--- a/tests/resolve/issueShortformPartynameDisambig.test.ts
+++ b/tests/resolve/issueShortformPartynameDisambig.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { ResolvedCitation } from "@/resolve/types"
+import type { ShortFormCaseCitation } from "@/types/citation"
+
+const resolved = (text: string): ResolvedCitation[] =>
+  extractCitations(text, { resolve: true })
+
+describe("shortFormCase partyName disambiguation (no `v.` in antecedent)", () => {
+  it("`Smith, 100 F.2d 1. Doe, 100 F.2d 5. Smith, 100 F.2d at 3.` resolves to Smith (index 0), not Doe", () => {
+    const cs = resolved("Smith, 100 F.2d 1. Doe, 100 F.2d 5. Smith, 100 F.2d at 3.")
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf).toBeDefined()
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+
+  it("`Smith, 100 F.2d 1. Doe, 100 F.2d 5. Doe, 100 F.2d at 7.` resolves to Doe (index 1)", () => {
+    const cs = resolved("Smith, 100 F.2d 1. Doe, 100 F.2d 5. Doe, 100 F.2d at 7.")
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf).toBeDefined()
+    expect(sf?.resolution?.resolvedTo).toBe(1)
+  })
+
+  it("three same-vol+reporter cases — Smith shortform picks Smith (index 0), not most recent", () => {
+    const cs = resolved(
+      "Smith, 100 F.2d 1. Doe, 100 F.2d 5. Roe, 100 F.2d 9. Smith, 100 F.2d at 3.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf).toBeDefined()
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+
+  it("three same-vol+reporter cases — Roe shortform picks Roe (index 2)", () => {
+    const cs = resolved(
+      "Smith, 100 F.2d 1. Doe, 100 F.2d 5. Roe, 100 F.2d 9. Roe, 100 F.2d at 12.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(2)
+  })
+
+  it("regression: full `v.` antecedent still works", () => {
+    const cs = resolved(
+      "Smith v. Jones, 100 F.2d 1. Doe v. Roe, 100 F.2d 5. Smith, 100 F.2d at 3.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+
+  it("regression: only one candidate falls through to recency", () => {
+    const cs = resolved("Smith, 100 F.2d 1. Smith, 100 F.2d at 3.")
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+})


### PR DESCRIPTION
## Before

```
Smith, 100 F.2d 1. Doe, 100 F.2d 5. Smith, 100 F.2d at 3.
```

→ resolves shortform `Smith, 100 F.2d at 3` to **Doe** (most recent same-vol+reporter, wrong) instead of **Smith** (correct partyName match).

## Now

Same input → resolves to **Smith** (index 0) ✓.

## Why this matters

Single-party citation anchors (`Smith, 100 F.2d 1.` with no `v.`) are common in mid-text references where authors use the short party name to introduce a case. Without this fix, the resolver silently picks the wrong antecedent whenever two such citations share vol+reporter — which has been the silent failure mode in real opinions for an unknown number of citations.

## Implementation

In `DocumentResolver.resolveShortFormCase`, extend the partyName-match block to also check the antecedent's normalized `caseName` when plaintiff/defendant aren't populated. Full `v.` antecedents continue to resolve via the existing check unchanged.

## Test plan
- [x] 6 new tests in `tests/resolve/issueShortformPartynameDisambig.test.ts`
- [x] `pnpm exec vitest run` — 3909 passed (up from 3886, +6 new + 17 from other recent merges)
- [x] `pnpm typecheck` clean