### PR TITLE
fix(extract): disposition tokens (rev'd, per curiam, en banc, cert. denied) no longer pollute court field

### DIFF
--- a/.changeset/fix-disposition-as-court.md
+++ b/.changeset/fix-disposition-as-court.md
@@ -1,0 +1,26 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): disposition tokens no longer pollute the court field
+
+When a citation's parenthetical contained a bare disposition signal
+(Bluebook Rule 10.7) without a court abbreviation —
+`Smith, 100 F.2d 1 (rev'd 1990)`, `(per curiam 1990)`, `(en banc)`,
+`(cert. denied 1990)`, `(dismissed 1990)` — the post-year-strip token
+fell through `stripDateFromCourt` and surfaced as a (wrong) court value:
+`court="rev'd"`, `court="per curiam"`, etc.
+
+Fix: after stripping the trailing date, reject content that matches a
+known disposition signal (`rev'd`, `aff'd`, `rev'g`, `aff'g`, `mod'd`,
+`cert. denied|granted|dismissed`, `appeal denied|dismissed|docketed`,
+`dismissed`, `reversed`, `vacated`, `vacating`, `overruled (by)`,
+`overruling`, `en banc`, `per curiam`), optionally followed by
+`in part`, `on other grounds`, or `sub nom.`.
+
+The disposition information itself is not yet surfaced as a structured
+field for bare-parenthetical cases like `(en banc)` — that remains a
+follow-up. This patch only stops the wrong value from leaking into
+`court`.
+
+8 regression tests in `tests/extract/issueDispositionAsCourt.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -929,6 +929,17 @@ function stripDateFromCourt(content: string): string | undefined {
   if (/,\s+J\.?J?\.?\s*$|,\s+JJ\.?\s*$/.test(court)) {
     return undefined
   }
+  // Disposition tokens (Bluebook Rule 10.7) sometimes appear inside the
+  // court parenthetical: `(rev'd 1990)`, `(per curiam 1990)`, `(en banc)`,
+  // `(cert. denied 1990)`. After year-stripping, the bare disposition is
+  // not a court — reject it so we don't surface `court="rev'd"`.
+  if (
+    /^(?:rev'd|aff'd|aff'g|rev'g|mod'd|cert\.?\s+(?:denied|granted|dismissed)|appeal\s+(?:denied|dismissed|docketed)|dismissed|reversed|vacated|vacating|overruled(?:\s+by)?|overruling|en\s+banc|per\s+curiam)(?:\s+(?:in\s+part|on\s+other\s+grounds?|sub\s+nom\.?))?\s*$/i.test(
+      court,
+    )
+  ) {
+    return undefined
+  }
   if (!court.includes(".")) {
     const firstWord = court.match(/^[a-z]+/i)?.[0].toLowerCase()
     if (firstWord && (SIGNAL_WORDS.has(firstWord) ||

--- a/tests/extract/issueDispositionAsCourt.test.ts
+++ b/tests/extract/issueDispositionAsCourt.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("disposition tokens should not pollute the court field", () => {
+  it("`(rev'd 1990)` does not set court='rev'd'", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (rev'd 1990)")
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("`(aff'd 1990)` does not set court='aff'd'", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (aff'd 1990)")
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("`(per curiam 1990)` does not set court='per curiam'", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (per curiam 1990)")
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("`(en banc)` (no year) does not set court='en banc'", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (en banc)")
+    expect(c.court).toBeUndefined()
+  })
+
+  it("`(cert. denied 1990)` does not set court='cert. denied'", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (cert. denied 1990)")
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("`(dismissed 1990)` does not set court='dismissed'", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (dismissed 1990)")
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("real court with no disposition leaks through unchanged", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+
+  it("disposition + court still extracts court (en banc trailing)", () => {
+    const cs = cases("Smith, 100 F.2d 1 (9th Cir. 1990) (en banc)")
+    expect(cs[0].court).toBe("9th Cir.")
+  })
+})


### PR DESCRIPTION
## Summary

When a citation's court parenthetical contained only a bare disposition
signal (Bluebook Rule 10.7) — no actual court abbreviation — the
post-year-strip token leaked into `court`:

| input | wrong | correct |
|---|---|---|
| `Smith, 100 F.2d 1 (rev'd 1990)` | `court="rev'd"` | `court=undefined`, `year=1990` |
| `Smith, 100 F.2d 1 (per curiam 1990)` | `court="per curiam"` | `court=undefined` |
| `Smith, 100 F.2d 1 (en banc)` | `court="en banc"` | `court=undefined` |
| `Smith, 100 F.2d 1 (cert. denied 1990)` | `court="cert. denied"` | `court=undefined` |
| `Smith, 100 F.2d 1 (dismissed 1990)` | `court="dismissed"` | `court=undefined` |

Root cause: `stripDateFromCourt` strips the trailing date and runs a
no-period gate against case-name nicknames and signal words, but it
never knew about disposition tokens. `rev'd` (single word, contains an
apostrophe but no period) and `per curiam` (two lowercase words) and
`cert. denied` (has periods so skipped the no-period gate entirely)
all fell through.

Fix: after year-stripping, reject any content matching a known
disposition signal — `rev'd`, `aff'd`, `rev'g`, `aff'g`, `mod'd`,
`cert. denied|granted|dismissed`, `appeal denied|dismissed|docketed`,
`dismissed`, `reversed`, `vacated`, `vacating`, `overruled (by)`,
`overruling`, `en banc`, `per curiam` — optionally followed by
`in part`, `on other grounds`, or `sub nom.`.

This patch only stops the wrong value from leaking into `court`. Surfacing the
disposition as a structured field for bare-parenthetical cases like
`(en banc)` remains a follow-up.

Found via adversarial probing for citation parsing failure modes.

## Test plan

- [x] 8 regression tests in `tests/extract/issueDispositionAsCourt.test.ts`
- [x] Full suite still passes (3917 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)