### PR TITLE
fix(constitutional): capture § section when no comma separates the numeral

### DIFF
--- a/.changeset/fix-const-section-no-comma.md
+++ b/.changeset/fix-const-section-no-comma.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(constitutional): capture `§ N` section without comma separator
+
+`OPTIONAL_SECTION` and `OPTIONAL_CLAUSE` in the constitutional body
+regex required a leading `[,;]` between the article/amendment numeral
+and the `§`/`cl.` token. Real-world Bluebook citations frequently omit
+the separator:
+
+- `U.S. Const. amend. XIV § 1` → section dropped (now: `section="1"`)
+- `U.S. Const. art. III § 2` → section dropped (now: `section="2"`)
+- `Cal. Const. art. I § 7` → section dropped (now: `section="7"`)
+- `U.S. Const. art. III § 2 cl. 1` → section + clause dropped
+
+Made the leading punctuation optional. Existing comma/semicolon forms
+continue to parse as before. The bare-numeral guard
+(`U.S. Const. amend. XIV 1` — no `§`) still rejects, because the regex
+still requires `§ <numeral>` to capture as section.
+
+7 regression tests in `tests/extract/issueConstSectionNoComma.test.ts`.

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -50,8 +50,12 @@ const ARTICLE_OR_AMENDMENT = String.raw`(?:art(?:icle)?\.?|amend(?:ment)?\.?|amd
 // never written with an ordinal-prefix form (`5th Art.` is not legal).
 const ORDINAL_PREFIX_AMENDMENT = `(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+(?:amend(?:ment)?\\.?|amdt\\.?|Amendment)`
 
-const OPTIONAL_SECTION = String.raw`(?:[,;]\s*§\s*([\w-]+))?`
-const OPTIONAL_CLAUSE = String.raw`(?:[,;]\s*cl\.?\s*(\d+))?`
+// Comma/semicolon between the numeral and the section/clause is optional
+// (#680). `U.S. Const. amend. XIV § 1` and `U.S. Const. art. III § 2`
+// are valid Bluebook forms — separator-free spacing should not lose
+// the structured section/clause field.
+const OPTIONAL_SECTION = String.raw`(?:[,;]?\s*§\s*([\w-]+))?`
+const OPTIONAL_CLAUSE = String.raw`(?:[,;]?\s*cl\.?\s*(\d+))?`
 const BODY_TAIL = `(?:${ARTICLE_OR_AMENDMENT}|${ORDINAL_PREFIX_AMENDMENT})${OPTIONAL_SECTION}${OPTIONAL_CLAUSE}`
 
 /** Compiled body regex shared with the extractor to avoid duplicate definitions. */

--- a/tests/extract/issueConstSectionNoComma.test.ts
+++ b/tests/extract/issueConstSectionNoComma.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { ConstitutionalCitation } from "@/types/citation"
+
+const cons = (text: string): ConstitutionalCitation[] =>
+  extractCitations(text).filter((c) => c.type === "constitutional") as ConstitutionalCitation[]
+
+describe("constitutional § section without comma separator", () => {
+  it("`U.S. Const. amend. XIV § 1` extracts section=1 (no comma)", () => {
+    const [c] = cons("U.S. Const. amend. XIV § 1")
+    expect(c?.amendment).toBe(14)
+    expect(c?.section).toBe("1")
+  })
+
+  it("`U.S. Const. art. III § 2` extracts section=2 (no comma)", () => {
+    const [c] = cons("U.S. Const. art. III § 2")
+    expect(c?.article).toBe(3)
+    expect(c?.section).toBe("2")
+  })
+
+  it("`U.S. Const. amend. XIV, § 1` still works (comma form)", () => {
+    const [c] = cons("U.S. Const. amend. XIV, § 1")
+    expect(c?.amendment).toBe(14)
+    expect(c?.section).toBe("1")
+  })
+
+  it("`U.S. Const. amend. XIV; § 1` works (semicolon form)", () => {
+    const [c] = cons("U.S. Const. amend. XIV; § 1")
+    expect(c?.amendment).toBe(14)
+    expect(c?.section).toBe("1")
+  })
+
+  it("`U.S. Const. art. III § 2 cl. 1` extracts section + clause without commas", () => {
+    const [c] = cons("U.S. Const. art. III § 2 cl. 1")
+    expect(c?.article).toBe(3)
+    expect(c?.section).toBe("2")
+    expect(c?.clause).toBe(1)
+  })
+
+  it("`Cal. Const. art. I § 7` extracts state section without comma", () => {
+    const [c] = cons("Cal. Const. art. I § 7")
+    expect(c?.article).toBe(1)
+    expect(c?.section).toBe("7")
+  })
+
+  it("regression: bare numeral after amendment does NOT match as section", () => {
+    // `U.S. Const. amend. XIV 1` (no §) should not produce section="1"
+    const [c] = cons("U.S. Const. amend. XIV 1")
+    expect(c?.amendment).toBe(14)
+    expect(c?.section).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

`OPTIONAL_SECTION`/`OPTIONAL_CLAUSE` in the constitutional body regex
required a leading `[,;]` between the article/amendment numeral and the
`§`/`cl.` token. Real Bluebook citations frequently omit the separator:

| input | before | after |
|---|---|---|
| `U.S. Const. amend. XIV § 1` | `section=undefined` | `section="1"` |
| `U.S. Const. art. III § 2` | `section=undefined` | `section="2"` |
| `Cal. Const. art. I § 7` | `section=undefined` | `section="7"` |
| `U.S. Const. art. III § 2 cl. 1` | both dropped | `section="2"` + `clause=1` |

Made the leading punctuation optional. Existing comma/semicolon forms
still parse identically. The bare-numeral guard
(`U.S. Const. amend. XIV 1` — no `§`) still rejects because the regex
still requires `§ <numeral>` to capture as section.

Found via adversarial probing for citation parsing failure modes.

## Test plan

- [x] 7 regression tests in `tests/extract/issueConstSectionNoComma.test.ts`
- [x] Full suite still passes (3916 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)