### PR TITLE
fix(extract): editorial + judge-attribution parentheticals no longer pollute court field

### DIFF
--- a/.changeset/fix-non-court-parentheticals.md
+++ b/.changeset/fix-non-court-parentheticals.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): editorial and judge-attribution parentheticals no longer pollute `court` field
+
+Following the disposition-token fix, several other non-court tokens
+still leaked into the `court` field when they appeared in the
+year/court parenthetical position:
+
+- **Editorial status**: `(n.d.)`, `(no date)`, `(year omitted)`,
+  `(unpub.)`, `(unpublished)`, `(slip op.)`, `(table)`, `(mem.)`
+- **Judge attribution with role**: `(Smith, J., dissenting)`,
+  `(Jones, J., concurring)`, `(Doe, JJ., joining)` — the existing
+  trailing-only `, J.` guard missed these because the role word
+  (`dissenting`/`concurring`/`joining`) followed the `J.` marker.
+
+Added two new guards inside `stripDateFromCourt`:
+1. A mid-string `, J.,` / `, JJ.,` followed by a role keyword
+2. A whole-content regex for editorial status tokens
+
+Real court abbreviations (`9th Cir.`, `D. Mass.`, `S.D.N.Y.`) continue
+to pass through unchanged.
+
+11 regression tests in `tests/extract/issueNonCourtParentheticals.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -929,12 +929,32 @@ function stripDateFromCourt(content: string): string | undefined {
   if (/,\s+J\.?J?\.?\s*$|,\s+JJ\.?\s*$/.test(court)) {
     return undefined
   }
+  // Judge-attribution parenthetical with mid-string `, J.,` / `, JJ.,`
+  // (e.g. `Smith, J., dissenting`, `Smith, J., concurring in part`).
+  // The trailing-only check above misses these because `dissenting` /
+  // `concurring` follows the `J.` marker.
+  if (/,\s+J\.?J?\.?,\s+(?:dissenting|concurring|joining)/i.test(court)) {
+    return undefined
+  }
   // Disposition tokens (Bluebook Rule 10.7) sometimes appear inside the
   // court parenthetical: `(rev'd 1990)`, `(per curiam 1990)`, `(en banc)`,
   // `(cert. denied 1990)`. After year-stripping, the bare disposition is
   // not a court — reject it so we don't surface `court="rev'd"`.
   if (
     /^(?:rev'd|aff'd|aff'g|rev'g|mod'd|cert\.?\s+(?:denied|granted|dismissed)|appeal\s+(?:denied|dismissed|docketed)|dismissed|reversed|vacated|vacating|overruled(?:\s+by)?|overruling|en\s+banc|per\s+curiam)(?:\s+(?:in\s+part|on\s+other\s+grounds?|sub\s+nom\.?))?\s*$/i.test(
+      court,
+    )
+  ) {
+    return undefined
+  }
+  // Editorial/status tokens that appear in date parenthetical position but
+  // are not courts: `n.d.` (no date), `unpub.`, `unpublished`,
+  // `slip op.`, `slip opinion`, `table`, `mem.`, `no date`,
+  // `year omitted`. These either contain periods (escaping the no-period
+  // gate) or are single short lowercase words that wouldn't trigger the
+  // multi-word-prose rule.
+  if (
+    /^(?:n\.?\s*d\.?|no\s+date|year\s+omitted|unpub\.?|unpublished|slip\s+op(?:\.|inion)?|table|mem\.?)\s*$/i.test(
       court,
     )
   ) {

--- a/tests/extract/issueNonCourtParentheticals.test.ts
+++ b/tests/extract/issueNonCourtParentheticals.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("non-court parentheticals must not pollute the court field", () => {
+  it.each([
+    ["(n.d.)", "Smith, 100 F.2d 1 (n.d.)"],
+    ["(no date)", "Smith, 100 F.2d 1 (no date)"],
+    ["(year omitted)", "Smith, 100 F.2d 1 (year omitted)"],
+    ["(unpub.)", "Smith, 100 F.2d 1 (unpub.)"],
+    ["(unpublished)", "Smith, 100 F.2d 1 (unpublished)"],
+    ["(slip op.)", "Smith, 100 F.2d 1 (slip op.)"],
+    ["(table)", "Smith, 100 F.2d 1 (table)"],
+    ["(Smith, J., dissenting)", "Smith, 100 F.2d 1 (Smith, J., dissenting)"],
+    ["(Jones, J., concurring)", "Smith, 100 F.2d 1 (Jones, J., concurring)"],
+  ])("`%s` does not pollute court", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBeUndefined()
+  })
+
+  it("real court parenthetical still extracts court", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+  })
+
+  it("known signal words remain rejected", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (citations omitted)")
+    expect(c.court).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Builds on PR #678 (disposition-token guard) by catching several other
non-court tokens that leaked into `court`:

**Editorial / status tokens** (have periods, so escaped the no-period
gate; or short single lowercase words):

| input | before | after |
|---|---|---|
| `(n.d.)` | `court=\"n.d.\"` | `court=undefined` |
| `(no date)` | `court=\"no date\"` | `court=undefined` |
| `(year omitted)` | `court=\"year omitted\"` | `court=undefined` |
| `(unpub.)` | `court=\"unpub.\"` | `court=undefined` |
| `(unpublished)` | `court=\"unpublished\"` | `court=undefined` |
| `(slip op.)` | `court=\"slip op.\"` | `court=undefined` |
| `(table)` | `court=\"table\"` | `court=undefined` |

**Judge-attribution with role keyword** (the trailing-only `, J.` check
missed these because the role word follows the `J.` marker):

| input | before | after |
|---|---|---|
| `(Smith, J., dissenting)` | `court=\"Smith, J., dissenting\"` | `court=undefined` |
| `(Jones, J., concurring)` | `court=\"Jones, J., concurring\"` | `court=undefined` |

Real court abbreviations (`9th Cir.`, `D. Mass.`, `S.D.N.Y.`) and the
already-handled signal words continue to pass through unchanged. Note:
the structured-disposition fields populated by the justice-attribution
extractor are unaffected — this PR only stops the wrong value from
appearing as `court`.

Found via adversarial probing for citation parsing failure modes.

## Test plan

- [x] 11 regression tests in \`tests/extract/issueNonCourtParentheticals.test.ts\`
- [x] Full suite still passes (3935 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)