### PR TITLE
fix(extract): page terminators accept !, ?, em/en dash, possessive 's

### DIFF
--- a/.changeset/fix-page-terminator-trailing-punct.md
+++ b/.changeset/fix-page-terminator-trailing-punct.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): page terminators accept `!`, `?`, em/en dash, possessive `'s`
+
+The page-terminator character classes in all three case-citation
+patterns (federal, supreme, state) accepted only `\s`, `$`, parens,
+comma, semicolon, period, and brackets. Citations followed by
+common trailing punctuation were silently dropped:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1!` | 0 citations | 1 citation ✓ |
+| `Smith, 100 F.2d 1?` | 0 citations | 1 citation ✓ |
+| `Smith, 100 F.2d 1's holding` | 0 citations | 1 citation ✓ |
+| `Smith, 100 F.2d 1—a notable case` | 0 citations | 1 citation ✓ |
+| `Smith, 100 F.2d 1–a notable case` | 0 citations | 1 citation ✓ |
+
+Added `!`, `?`, em dash (`—`), en dash (`–`), and apostrophe (`'`)
+to the terminator class. Also added `-` followed by `\D` (non-digit),
+because `normalizeDashes` rewrites in-word em/en dashes to ASCII `-`
+before tokenization, so `1—a` arrives as `1-a`. The `\D` lookahead
+preserves page-range syntax: `K.S.A. 2009 Supp. 44-501(d)(2)` is still
+parsed as the K.S.A. statute (not as a phantom case with page 44).
+
+8 regression tests in `tests/extract/issueTrailingPunctTerminator.test.ts`.

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -41,7 +41,17 @@ export interface Pattern {
  * canonical `\s+` form keeps the broader trailing lookahead so existing
  * inline-citation shapes continue to work.
  */
-const COMMA_PAGE_TERMINATOR = String.raw`(?=$|[.;,)\]])`
+// Page-terminator character class. Citations end at:
+//   - end of input (`$`)
+//   - standard sentence punctuation: `.`, `;`, `,`, `)`, `]`
+//   - trailing-prose punctuation that follows the page directly without
+//     a space: `!`, `?`, em dash (—), en dash (–), apostrophe
+//     (possessive `1's holding`)
+//   - `-` followed by a non-digit. The cleaner normalizes in-word em/en
+//     dashes to ASCII `-`, so `1—a` arrives at the tokenizer as `1-a`.
+//     The `\D` lookahead keeps page-range syntax intact (`44-501` does
+//     not terminate at `44`, because `-5` is digit). #681-class.
+const COMMA_PAGE_TERMINATOR = String.raw`(?=$|[.;,)\]!?–—']|-\D)`
 
 export const casePatterns: Pattern[] = [
   {
@@ -54,7 +64,7 @@ export const casePatterns: Pattern[] = [
     // Terminator accepts `)` for citations wrapped in a sentence-internal
     // parenthetical — e.g., `(Smith v. Jones, 500 F.2d 123)` (#509).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|\)|,|;|\.)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—']|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:
@@ -69,7 +79,7 @@ export const casePatterns: Pattern[] = [
     // Terminator accepts `)` for sentence-internal parenthetical citations
     // (#509).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)(?:\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|\(|\)|,|;|\.)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)(?:\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—']|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:
@@ -131,7 +141,7 @@ export const casePatterns: Pattern[] = [
     // space to handle Illinois `R. <ruleNum>` and the `L.J./L.Q./L.R.`
     // journal-abbreviation guards (#332, #549).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)(?!(?:AND|OR)\s+\d)([A-Z][A-Za-z.\d&']*(?:(?! L\.[JQR\s])(?! R\.\s+\d)\s+[A-Z\d&][A-Za-z.\d&']*)*?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|\(|\)|,|;|\.|\[|\])|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)(?!(?:AND|OR)\s+\d)([A-Z][A-Za-z.\d&']*(?:(?! L\.[JQR\s])(?! R\.\s+\d)\s+[A-Z\d&][A-Za-z.\d&']*)*?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?\[\]–—']|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:

--- a/tests/extract/issueTrailingPunctTerminator.test.ts
+++ b/tests/extract/issueTrailingPunctTerminator.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation } from "@/types/citation"
+
+const cs = (text: string): Citation[] => extractCitations(text)
+
+describe("page terminators should accept common trailing punctuation", () => {
+  it.each([
+    ["em dash without space", "Smith, 100 F.2d 1—a notable case"],
+    ["en dash without space", "Smith, 100 F.2d 1–a notable case"],
+    ["possessive `'s`", "Smith, 100 F.2d 1's holding"],
+    ["exclamation", "Smith, 100 F.2d 1!"],
+    ["question mark", "Smith, 100 F.2d 1?"],
+    ["em dash + space", "Smith, 100 F.2d 1 — a notable case"],
+  ])("`%s` still extracts the citation", (_, input) => {
+    const found = cs(input)
+    expect(found.length).toBeGreaterThan(0)
+    expect(found[0].type).toBe("case")
+    expect(found[0].matchedText).toBe("100 F.2d 1")
+  })
+
+  it("U.S. reporter with em dash trailing also extracts", () => {
+    const found = cs("Smith v. Jones, 100 U.S. 5—a landmark")
+    expect(found.length).toBeGreaterThan(0)
+    expect(found[0].matchedText).toBe("100 U.S. 5")
+  })
+
+  it("regression: existing terminators still work (space, comma, paren, period, semicolon)", () => {
+    for (const t of [
+      "Smith, 100 F.2d 1 (1990)",
+      "Smith, 100 F.2d 1, 5",
+      "Smith, 100 F.2d 1.",
+      "Smith, 100 F.2d 1;",
+    ]) {
+      const found = cs(t)
+      expect(found.length).toBeGreaterThan(0)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The page-terminator character class in all three case-citation patterns (federal, supreme, state) missed common trailing punctuation. Citations followed by these chars were silently dropped:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1!` | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1?` | 0 cites | 1 cite ✓ |
| ``Smith, 100 F.2d 1's holding`` | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1—a notable case` | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1–a notable case` | 0 cites | 1 cite ✓ |

Added `!`, `?`, em dash (`—`), en dash (`–`), and apostrophe (`'`) to the terminator class.

Also added `-` followed by `\D` (non-digit), because `normalizeDashes` rewrites in-word em/en dashes to ASCII `-` before tokenization, so `1—a` arrives as `1-a`. The `\D` lookahead preserves page-range syntax: `K.S.A. 2009 Supp. 44-501(d)(2)` is still parsed as the K.S.A. statute (because `-5` is a digit, not a terminator).

Found via adversarial probing.

## Test plan

- [x] 8 regression tests in `tests/extract/issueTrailingPunctTerminator.test.ts`
- [x] Full suite passes (3925 passed, 12 skipped, 12 todo) — pre-existing K.S.A. range test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)