### PR TITLE
fix(extract): date-modifier verbs (filed, decided, argued, etc.) no longer pollute court field

### DIFF
--- a/.changeset/fix-date-modifier-as-court.md
+++ b/.changeset/fix-date-modifier-as-court.md
@@ -1,0 +1,23 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): date-modifier verbs (`filed`, `decided`, `argued`, etc.) no longer pollute `court` field
+
+Following the disposition + editorial + judge-attribution fixes,
+Bluebook Rule 10.5 date-modifier verbs that prefix a date inside the
+court parenthetical still leaked into the `court` field:
+
+- `(filed Jan. 15, 1990)` → `court="filed"` ⇒ now `undefined`
+- `(decided Mar. 15, 1990)` → `court="decided"` ⇒ now `undefined`
+- `(argued Apr. 1, 1990)` → `court="argued"` ⇒ now `undefined`
+- `(submitted Jan. 1, 1990)` → `court="submitted"` ⇒ now `undefined`
+- `(effective Jan. 1, 1990)` → `court="effective"` ⇒ now `undefined`
+- `(entered Jan. 1, 1990)` → `court="entered"` ⇒ now `undefined`
+- `(heard Jan. 1, 1990)` → `court="heard"` ⇒ now `undefined`
+- `(argued ..., decided ...)` → `court="argued Apr. 1, 1990, decided"` ⇒ now `undefined`
+
+Detection: after year+date-stripping, content starting with one of
+these verb prefixes is rejected.
+
+10 regression tests in `tests/extract/issueDateModifierAsCourt.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -960,6 +960,20 @@ function stripDateFromCourt(content: string): string | undefined {
   ) {
     return undefined
   }
+  // Date-modifier verbs (Bluebook Rule 10.5) that prefix the date inside
+  // the court parenthetical: `(filed Jan. 15, 1990)`, `(decided
+  // Mar. 15, 1990)`, `(argued Apr. 1, 1990)`, `(effective Jan. 1, 1990)`,
+  // `(entered Jan. 1, 1990)`, `(submitted Jan. 1, 1990)`, `(heard ...)`.
+  // After year + date stripping the residue is the bare verb (or messy
+  // mid-string commas for `argued ..., decided ...`). Detect by leading
+  // verb word and reject — these are not courts.
+  if (
+    /^(?:filed|decided|argued|submitted|heard|effective|entered)\b/i.test(
+      court,
+    )
+  ) {
+    return undefined
+  }
   if (!court.includes(".")) {
     const firstWord = court.match(/^[a-z]+/i)?.[0].toLowerCase()
     if (firstWord && (SIGNAL_WORDS.has(firstWord) ||

--- a/tests/extract/issueDateModifierAsCourt.test.ts
+++ b/tests/extract/issueDateModifierAsCourt.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("date-modifier verbs in court parenthetical do not pollute court field", () => {
+  it.each([
+    ["filed", "Smith, 100 F.2d 1 (filed Jan. 15, 1990)"],
+    ["decided", "Smith, 100 F.2d 1 (decided Mar. 15, 1990)"],
+    ["argued", "Smith, 100 F.2d 1 (argued Apr. 1, 1990)"],
+    ["argued+decided", "Smith, 100 F.2d 1 (argued Apr. 1, 1990, decided Jun. 15, 1990)"],
+    ["effective", "Smith, 100 F.2d 1 (effective Jan. 1, 1990)"],
+    ["entered", "Smith, 100 F.2d 1 (entered Jan. 1, 1990)"],
+    ["submitted", "Smith, 100 F.2d 1 (submitted Jan. 1, 1990)"],
+    ["heard", "Smith, 100 F.2d 1 (heard Jan. 1, 1990)"],
+    ["filed-in", "Smith, 100 F.2d 1 (filed in Jan. 1990)"],
+  ])("`%s` does not pollute court", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("real court + date modifier still extracts the court (court before verb)", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990) (filed Jan. 15, 1990)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+})


### PR DESCRIPTION
## Summary

Bluebook Rule 10.5 date-modifier verbs that prefix a date inside the court parenthetical leaked into `court` after year-stripping as the bare verb:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1 (filed Jan. 15, 1990)` | `court="filed"` | `undefined` |
| `Smith, 100 F.2d 1 (decided Mar. 15, 1990)` | `court="decided"` | `undefined` |
| `Smith, 100 F.2d 1 (argued Apr. 1, 1990)` | `court="argued"` | `undefined` |
| `Smith, 100 F.2d 1 (submitted Jan. 1, 1990)` | `court="submitted"` | `undefined` |
| `Smith, 100 F.2d 1 (effective Jan. 1, 1990)` | `court="effective"` | `undefined` |
| `Smith, 100 F.2d 1 (entered Jan. 1, 1990)` | `court="entered"` | `undefined` |
| `Smith, 100 F.2d 1 (heard Jan. 1, 1990)` | `court="heard"` | `undefined` |
| `Smith, 100 F.2d 1 (argued Apr. 1, 1990, decided Jun. 15, 1990)` | `court="argued Apr. 1, 1990, decided"` | `undefined` |

Added a leading-verb check in `stripDateFromCourt` to reject these. Real court parentheticals (e.g. `(9th Cir. 1990)`) continue to work.

Found via adversarial probing. Companion to #678/#680.

## Test plan

- [x] 10 regression tests in `tests/extract/issueDateModifierAsCourt.test.ts`
- [x] Full suite passes (3945 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)