### PR TITLE
fix(extract): case-name backscan handles non-ASCII letters (umlaut, accents, cedilla)

### DIFF
--- a/.changeset/fix-case-name-unicode.md
+++ b/.changeset/fix-case-name-unicode.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): case-name backscan handles non-ASCII letters (umlaut, accents, cedilla)
+
+The plaintiff/defendant character class in `V_CASE_NAME_REGEX` was
+ASCII-only (`[A-Za-z0-9\s.,'&()/-]+?`), so any case name containing
+non-ASCII letters failed the backscan and surfaced as `caseName=null`:
+
+- `Müller v. Schmidt, 100 F.2d 1 (1990)` → `caseName=null` ⇒ now `Müller v. Schmidt` ✓
+- `Société Générale v. Banque, 100 F.2d 1 (1990)` → null ⇒ `Société Générale v. Banque` ✓
+- `Pérez v. González, 100 F.2d 1 (1990)` → null ⇒ `Pérez v. González` ✓
+- `Çelik v. Banque, 100 F.2d 1 (1990)` → null ⇒ `Çelik v. Banque` ✓
+- `Smith v. Müller, 100 F.2d 1 (1990)` → null ⇒ `Smith v. Müller` ✓
+
+Extended the character class to include Latin-1 Supplement (`À`-`ÿ`) and
+Latin Extended-A (`Ā`-`ſ`), which covers the bulk of accented characters
+in real case names (French, German, Spanish, Polish, etc.). The
+uppercase anchor accepts both ASCII and uppercase Latin-1
+(`À`-`Þ`), so plaintiffs whose name begins with `Ç`, `É`, `Ö` still
+anchor the scan correctly.
+
+6 regression tests in `tests/extract/issueCaseNameUnicode.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -737,8 +737,14 @@ function isNonMetadataParenContent(content: string): boolean {
  *  at least one period). Capture group 3 = court (optional), 4 = year.
  *  The `d` flag enables `match.indices` so the caller can compute a year
  *  span. See #19, #293. */
+// Latin-1 Supplement (À-ÿ) and Latin Extended-A (Ā-ſ)
+// cover the bulk of accented characters that appear in real case names
+// (Müller, Société, Pérez, González, Çelik, etc.). Uppercase initial
+// accepts both ASCII A-Z and uppercase Latin-1 (À-Þ), so
+// plaintiffs whose name begins with `Ç`, `Ö`, `É` etc. still anchor the
+// backscan.
 const V_CASE_NAME_REGEX =
-  /((?:\d[\d-]*\s+)?[A-Z][A-Za-z0-9\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
+  /((?:\d[\d-]*\s+)?[A-ZÀ-Þ][A-Za-z0-9À-ſ\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9À-ſ\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
 
 /** Procedural prefix case name format.
  *  Longer prefixes listed first so the alternation prefers the longer match

--- a/tests/extract/issueCaseNameUnicode.test.ts
+++ b/tests/extract/issueCaseNameUnicode.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("case-name backscan handles Unicode characters", () => {
+  it.each([
+    ["umlaut (German)", "Müller v. Schmidt, 100 F.2d 1 (1990)", "Müller v. Schmidt"],
+    ["accents (French)", "Société Générale v. Banque, 100 F.2d 1 (1990)", "Société Générale v. Banque"],
+    ["acute accent (Spanish)", "Pérez v. González, 100 F.2d 1 (1990)", "Pérez v. González"],
+    ["cedilla", "Çelik v. Banque, 100 F.2d 1 (1990)", "Çelik v. Banque"],
+    ["mixed ASCII + accent", "Smith v. Müller, 100 F.2d 1 (1990)", "Smith v. Müller"],
+  ])("`%s` extracts case name with non-ASCII letters", (_, input, expected) => {
+    const [c] = cases(input)
+    expect(c?.caseName).toBe(expected)
+  })
+
+  it("regression: plain ASCII case name still works", () => {
+    const [c] = cases("Smith v. Jones, 100 F.2d 1 (1990)")
+    expect(c.caseName).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
## Summary

The plaintiff/defendant character class in V_CASE_NAME_REGEX was ASCII-only, so any case name containing non-ASCII letters silently failed the backscan and surfaced as caseName=null:

| input | before | after |
|---|---|---|
| `Müller v. Schmidt, 100 F.2d 1 (1990)` | null | `Müller v. Schmidt` ✓ |
| `Société Générale v. Banque, 100 F.2d 1 (1990)` | null | `Société Générale v. Banque` ✓ |
| `Pérez v. González, 100 F.2d 1 (1990)` | null | `Pérez v. González` ✓ |
| `Çelik v. Banque, 100 F.2d 1 (1990)` | null | `Çelik v. Banque` ✓ |
| `Smith v. Müller, 100 F.2d 1 (1990)` | null | `Smith v. Müller` ✓ |

Extended the char class to include Latin-1 Supplement (À-ÿ) and Latin Extended-A (Ā-ſ), which covers French, German, Spanish, Polish, etc. The uppercase anchor accepts both ASCII A-Z and uppercase Latin-1 (À-Þ).

Found via adversarial probing — international case names are silently dropped.

## Test plan

- [x] 6 regression tests in `tests/extract/issueCaseNameUnicode.test.ts`
- [x] Full suite passes (3941 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)