### PR TITLE
fix(resolve): shortFormCase partyName uses token-sequence match (no prefix collisions)

### DIFF
--- a/.changeset/fix-shortform-partyname-substring-collision.md
+++ b/.changeset/fix-shortform-partyname-substring-collision.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): shortFormCase partyName uses token-sequence match (no prefix collisions)
+
+PR #677's party-name disambiguation block used plain substring containment
+(`name.includes(targetParty) || targetParty.includes(name)`), which
+caused prefix collisions:
+
+- `Smith v. Jones, 100 F.2d 1. Smithers v. Brown, 100 F.2d 50. Smith, 100 F.2d at 7.`
+  → resolvedTo=1 (Smithers, wrong) — `"Smithers".includes("Smith")` ✗
+  → now resolvedTo=0 (Smith, correct) ✓
+- `Doe v. Acme, 100 F.2d 1. Doering v. Beta, 100 F.2d 50. Doe, 100 F.2d at 7.`
+  → similarly fixed
+
+Switched to the existing `containsTokenSequence` helper (whole-word,
+sequential containment) so `Smith` matches `Smith Industries` but not
+`Smithers`.
+
+Additionally, renormalized the short-form's `partyName` through the
+resolver's own `normalizePartyName` (instead of using the raw
+`partyNameNormalized` from extraction). Corporate suffixes (`Inc.`,
+`LLC`, `Corp.`) and connectors (`et al.`) are now stripped on both
+sides of the comparison so `Smith, Inc., 100 F.2d at 7` matches a
+`Smith v. Jones` antecedent.
+
+5 regression tests in
+`tests/resolve/issueShortformPartyNameSubstringCollision.test.ts`.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -840,7 +840,15 @@ export class DocumentResolver {
   private resolveShortFormCase(citation: ShortFormCaseCitation): ResolutionResult | undefined {
     const currentIndex = this.context.citationIndex
     const targetReporter = this.normalizeReporter(citation.reporter)
-    const targetParty = citation.partyNameNormalized
+    // Renormalize the short-form's partyName through the resolver's own
+    // `normalizePartyName` so corporate suffixes (`Inc.`, `LLC`, `Corp.`)
+    // and connector words (`et al.`) are stripped to match the
+    // already-normalized plaintiff/defendant on case citations. Without
+    // this, `Smith, Inc., 100 F.2d at 7` carries `partyNameNormalized =
+    // "smith, inc."` and fails to match a plaintiff of `"smith"`.
+    const targetParty = citation.partyName
+      ? this.normalizePartyName(citation.partyName)
+      : undefined
 
     // Collect all backward candidates (most recent first) that match
     // vol+reporter AND are in-scope.
@@ -887,9 +895,15 @@ export class DocumentResolver {
         if (c.type !== "case") return false
         const plaintiff = c.plaintiffNormalized
         const defendant = c.defendantNormalized
+        // Token-sequence match (whole-word, sequential): `Smith` matches
+        // `Smith, Inc.` (whole-word containment) but does NOT match
+        // `Smithers` (no whole-word boundary). The previous substring
+        // match (`name.includes(targetParty)`) caused prefix collisions.
         const hit = (name: string | undefined) =>
           name !== undefined &&
-          (name === targetParty || name.includes(targetParty) || targetParty.includes(name))
+          (name === targetParty ||
+            this.containsTokenSequence(name, targetParty) ||
+            this.containsTokenSequence(targetParty, name))
         if (hit(plaintiff) || hit(defendant)) return true
         // Antecedent without a `v.` separator carries the single party as
         // `caseName` only — `plaintiff`/`defendant` are undefined. Fall

--- a/tests/resolve/issueShortformPartyNameSubstringCollision.test.ts
+++ b/tests/resolve/issueShortformPartyNameSubstringCollision.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { ResolvedCitation } from "@/resolve/types"
+import type { ShortFormCaseCitation } from "@/types/citation"
+
+const resolved = (text: string): ResolvedCitation[] =>
+  extractCitations(text, { resolve: true })
+
+describe("shortFormCase partyName must word-boundary match (no prefix collisions)", () => {
+  it("`Smith` does not match `Smithers` (prefix collision)", () => {
+    const cs = resolved(
+      "Smith v. Jones, 100 F.2d 1. Smithers v. Brown, 100 F.2d 50. Smith, 100 F.2d at 7.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+
+  it("`Doe` does not match `Doering`", () => {
+    const cs = resolved(
+      "Doe v. Acme, 100 F.2d 1. Doering v. Beta, 100 F.2d 50. Doe, 100 F.2d at 7.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+
+  it("regression: `Smith` still matches `Smith, Inc.` (whole-word containment)", () => {
+    const cs = resolved(
+      "Smith, Inc. v. Jones, 100 F.2d 1. Doe v. Roe, 100 F.2d 50. Smith, 100 F.2d at 7.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+
+  it("regression: `Smith, Inc.` still matches `Smith` (reverse direction)", () => {
+    const cs = resolved(
+      "Smith v. Jones, 100 F.2d 1. Doe v. Roe, 100 F.2d 50. Smith, Inc., 100 F.2d at 7.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+
+  it("regression: exact-match still works", () => {
+    const cs = resolved(
+      "Smith v. Jones, 100 F.2d 1. Doe v. Roe, 100 F.2d 50. Smith, 100 F.2d at 7.",
+    )
+    const sf = cs.find((c) => c.type === "shortFormCase") as
+      | (ShortFormCaseCitation & { resolution?: { resolvedTo?: number } })
+      | undefined
+    expect(sf?.resolution?.resolvedTo).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

PR #677 introduced a partyName disambiguation block using plain substring containment, which caused prefix collisions:

| input | before | after |
|---|---|---|
| `Smith v. Jones, 100 F.2d 1. Smithers v. Brown, 100 F.2d 50. Smith, 100 F.2d at 7.` | resolvedTo=1 (Smithers) ✗ | resolvedTo=0 (Smith) ✓ |
| `Doe v. Acme. Doering v. Beta. Doe, at 7.` | wrong | correct |

Fix: switched to the existing `containsTokenSequence` helper (whole-word, sequential containment). `Smith` matches `Smith Industries` but no longer matches `Smithers`.

Also renormalized the short-forms `partyName` through the resolvers own `normalizePartyName` (instead of using the extractors `partyNameNormalized` which only lowercased and trimmed). Corporate suffixes (`Inc.`, `LLC`, `Corp.`) and connectors (`et al.`) are now stripped on both sides so `Smith, Inc., 100 F.2d at 7` correctly matches `Smith v. Jones`.

Found via adversarial probing on PR #677.

## Test plan

- [x] 5 regression tests in `tests/resolve/issueShortformPartyNameSubstringCollision.test.ts`
- [x] Full suite passes (3964 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)