### PR TITLE
fix(extract): page terminators accept trailing quote, asterisk, angle brackets

### DIFF
--- a/.changeset/fix-page-terminator-quote-asterisk.md
+++ b/.changeset/fix-page-terminator-quote-asterisk.md
@@ -1,0 +1,23 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): page terminators accept trailing quote, asterisk, angle brackets
+
+Extends PR #684's terminator fix. Citations followed by trailing quote
+or markdown asterisk were silently dropped:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1"` | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1”` (curly) | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1*` (markdown) | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1>` | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1<` | 0 cites | 1 cite ✓ |
+
+Added `"`, `“`, `”`, `*`, `<`, `>` to the page-terminator character class
+across all three case-citation patterns. Real reporters never end with
+these characters, so this is safe and recovers common quoted/markdown
+trailing forms.
+
+8 regression tests in `tests/extract/issuePageTerminatorQuoteAsterisk.test.ts`.

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -46,12 +46,16 @@ export interface Pattern {
 //   - standard sentence punctuation: `.`, `;`, `,`, `)`, `]`
 //   - trailing-prose punctuation that follows the page directly without
 //     a space: `!`, `?`, em dash (—), en dash (–), apostrophe
-//     (possessive `1's holding`)
+//     (possessive `1's holding`), straight quote (`"`), curly quotes
+//     (`“` `”`), markdown asterisk (`*`), angle brackets (`<` `>`).
+//     Real reporters never end with these characters, so accepting them
+//     as terminators is safe and recovers common quoted/markdown
+//     trailing forms.
 //   - `-` followed by a non-digit. The cleaner normalizes in-word em/en
 //     dashes to ASCII `-`, so `1—a` arrives at the tokenizer as `1-a`.
 //     The `\D` lookahead keeps page-range syntax intact (`44-501` does
 //     not terminate at `44`, because `-5` is digit). #681-class.
-const COMMA_PAGE_TERMINATOR = String.raw`(?=$|[.;,)\]!?–—']|-\D)`
+const COMMA_PAGE_TERMINATOR = String.raw`(?=$|[.;,)\]!?–—'"“”*<>]|-\D)`
 
 export const casePatterns: Pattern[] = [
   {
@@ -64,7 +68,7 @@ export const casePatterns: Pattern[] = [
     // Terminator accepts `)` for citations wrapped in a sentence-internal
     // parenthetical — e.g., `(Smith v. Jones, 500 F.2d 123)` (#509).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—']|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:
@@ -79,7 +83,7 @@ export const casePatterns: Pattern[] = [
     // Terminator accepts `)` for sentence-internal parenthetical citations
     // (#509).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)(?:\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—']|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)(?:\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:
@@ -141,7 +145,7 @@ export const casePatterns: Pattern[] = [
     // space to handle Illinois `R. <ruleNum>` and the `L.J./L.Q./L.R.`
     // journal-abbreviation guards (#332, #549).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)(?!(?:AND|OR)\s+\d)([A-Z][A-Za-z.\d&']*(?:(?! L\.[JQR\s])(?! R\.\s+\d)\s+[A-Z\d&][A-Za-z.\d&']*)*?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?\[\]–—']|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)(?!(?:AND|OR)\s+\d)([A-Z][A-Za-z.\d&']*(?:(?! L\.[JQR\s])(?! R\.\s+\d)\s+[A-Z\d&][A-Za-z.\d&']*)*?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?\[\]–—'"“”*<>]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:

--- a/tests/extract/issuePageTerminatorQuoteAsterisk.test.ts
+++ b/tests/extract/issuePageTerminatorQuoteAsterisk.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+
+describe("page terminator accepts trailing quote, asterisk, angle brackets", () => {
+  it.each([
+    ['straight quote `"`', 'Smith, 100 F.2d 1"'],
+    ["curly closing quote", "Smith, 100 F.2d 1”"],
+    ["curly opening quote", "Smith, 100 F.2d 1“"],
+    ["markdown asterisk", "Smith, 100 F.2d 1*"],
+    ["angle bracket >", "Smith, 100 F.2d 1>"],
+    ["angle bracket <", "Smith, 100 F.2d 1<"],
+  ])("`%s` still extracts the citation", (_, input) => {
+    const cs = extractCitations(input)
+    expect(cs.length).toBeGreaterThan(0)
+    expect(cs[0].type).toBe("case")
+    expect(cs[0].matchedText).toBe("100 F.2d 1")
+  })
+
+  it("regression: bare digit page still requires space terminator (not greedy)", () => {
+    const cs = extractCitations("Smith, 100 F.2d 1234")
+    expect(cs[0].matchedText).toBe("100 F.2d 1234")
+  })
+
+  it("regression: U.S. reporter with quote trailing extracts", () => {
+    const cs = extractCitations('Smith, 100 U.S. 5"')
+    expect(cs[0]?.matchedText).toBe("100 U.S. 5")
+  })
+})


### PR DESCRIPTION
## Summary

Extends PR #684. Citations followed by trailing quote (straight or curly), markdown asterisk, or angle brackets were silently dropped:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1"` | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1”` (curly close) | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1*` (markdown) | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1>` | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1<` | 0 cites | 1 cite ✓ |

Added `"`, `“`, `”`, `*`, `<`, `>` to the page-terminator character class. Real reporters never end with these chars, so accepting them as terminators is safe and recovers common quoted / markdown trailing forms.

Found via adversarial probing.

## Test plan

- [x] 8 regression tests in `tests/extract/issuePageTerminatorQuoteAsterisk.test.ts`
- [x] Full suite passes (3967 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)