### PR TITLE
fix(extract): Fed. Reg. + Stat. pages accept thousands-grouping commas

### DIFF
--- a/.changeset/fix-fed-reg-comma-page.md
+++ b/.changeset/fix-fed-reg-comma-page.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): Federal Register and Statutes at Large pages accept thousands-grouping commas
+
+The Federal Register and Statutes at Large patterns + extractors used
+bare `\d+` for the page, so a comma-grouped page (`12,345`,
+`1,234,567`) truncated to just the digits before the first comma:
+
+| input | before | after |
+|---|---|---|
+| `85 Fed. Reg. 12,345` | `matchedText="85 Fed. Reg. 12"`, `page=12` | `matchedText="85 Fed. Reg. 12,345"`, `page=12345` ✓ |
+| `134 Stat. 1,234` | `matchedText="134 Stat. 1"`, `page=1` | `matchedText="134 Stat. 1,234"`, `page=1234` ✓ |
+
+Federal Register pages routinely exceed 10,000 so the comma form is
+common in practice. Both pattern and extractor regex now accept
+`\d{1,3}(?:,\d{3})+|\d+`; the integer `page` field strips commas
+before `parseInt`.
+
+4 regression tests in `tests/extract/issueFedRegCommaPage.test.ts`.

--- a/src/extract/extractFederalRegister.ts
+++ b/src/extract/extractFederalRegister.ts
@@ -53,8 +53,10 @@ export function extractFederalRegister(
   const { text, span } = token
 
   // Parse volume-page using regex
-  // Pattern: volume (digits) + "Fed. Reg." + page (digits)
-  const federalRegisterRegex = /^(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d+)/d
+  // Pattern: volume (digits) + "Fed. Reg." + page (digits, optionally
+  // comma-grouped like `12,345`). Federal Register pages routinely
+  // exceed 10,000 so commas are common.
+  const federalRegisterRegex = /^(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d{1,3}(?:,\d{3})+|\d+)/d
   const match = federalRegisterRegex.exec(text)
 
   if (!match) {
@@ -63,7 +65,8 @@ export function extractFederalRegister(
 
   const rawVolume = match[1]
   const volume = /^\d+$/.test(rawVolume) ? Number.parseInt(rawVolume, 10) : rawVolume
-  const page = Number.parseInt(match[2], 10)
+  // Strip thousands-grouping commas before integer parse.
+  const page = Number.parseInt(match[2].replace(/,/g, ""), 10)
 
   let spans: FederalRegisterComponentSpans | undefined
   if (match.indices) {

--- a/src/extract/extractStatutesAtLarge.ts
+++ b/src/extract/extractStatutesAtLarge.ts
@@ -37,8 +37,8 @@ export function extractStatutesAtLarge(
 ): StatutesAtLargeCitation {
   const { text, span } = token
 
-  // Parse volume-Stat.-page
-  const statRegex = /^(\d+(?:-\d+)?)\s+Stat\.\s+(\d+)/d
+  // Parse volume-Stat.-page. Page accepts thousands-grouping commas.
+  const statRegex = /^(\d+(?:-\d+)?)\s+Stat\.\s+(\d{1,3}(?:,\d{3})+|\d+)/d
   const match = statRegex.exec(text)
 
   if (!match) {
@@ -47,7 +47,8 @@ export function extractStatutesAtLarge(
 
   const rawVolume = match[1]
   const volume = /^\d+$/.test(rawVolume) ? Number.parseInt(rawVolume, 10) : rawVolume
-  const page = Number.parseInt(match[2], 10)
+  // Strip thousands-grouping commas before integer parse.
+  const page = Number.parseInt(match[2].replace(/,/g, ""), 10)
 
   let spans: StatutesAtLargeComponentSpans | undefined
   if (match.indices) {

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -104,14 +104,18 @@ export const neutralPatterns: Pattern[] = [
   },
   {
     id: "federal-register",
-    regex: /\b(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d+)\b/g,
-    description: 'Federal Register citations (e.g., "86 Fed. Reg. 12345")',
+    // Page accepts comma-grouped digits (`12,345` and `1,234,567`). The
+    // Federal Register routinely surfaces pages above 10,000 so the
+    // comma-grouped form is common. Bare-digit form remains supported.
+    regex: /\b(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d{1,3}(?:,\d{3})+|\d+)\b/g,
+    description: 'Federal Register citations (e.g., "86 Fed. Reg. 12,345" or "86 Fed. Reg. 12345")',
     type: "federalRegister",
   },
   {
     id: "statutes-at-large",
-    regex: /\b(\d+(?:-\d+)?)\s+Stat\.\s+(\d+)\b/g,
-    description: 'Statutes at Large citations (e.g., "124 Stat. 119")',
+    // Page accepts comma-grouped digits to match the federal-register fix.
+    regex: /\b(\d+(?:-\d+)?)\s+Stat\.\s+(\d{1,3}(?:,\d{3})+|\d+)\b/g,
+    description: 'Statutes at Large citations (e.g., "124 Stat. 1,119" or "124 Stat. 119")',
     type: "statutesAtLarge",
   },
   {

--- a/tests/extract/issueFedRegCommaPage.test.ts
+++ b/tests/extract/issueFedRegCommaPage.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation } from "@/types/citation"
+
+const cites = (text: string): Citation[] => extractCitations(text)
+
+describe("Federal Register page accepts comma-grouped digits", () => {
+  it("`85 Fed. Reg. 12,345` extracts the full page", () => {
+    const [c] = cites("85 Fed. Reg. 12,345 (Mar. 1, 2020)").filter(
+      (c) => c.type === "federalRegister",
+    )
+    expect(c).toBeDefined()
+    expect(c?.matchedText).toBe("85 Fed. Reg. 12,345")
+    const o = c as unknown as Record<string, unknown>
+    // Page strips thousands commas for arithmetic compatibility but
+    // matchedText preserves the original form.
+    expect(o.page).toBe(12345)
+  })
+
+  it("`87 Fed. Reg. 1,234,567` (multi-comma) extracts the full page", () => {
+    const [c] = cites("87 Fed. Reg. 1,234,567").filter((c) => c.type === "federalRegister")
+    expect(c?.matchedText).toBe("87 Fed. Reg. 1,234,567")
+  })
+
+  it("regression: `85 Fed. Reg. 12345` (no comma) still works", () => {
+    const [c] = cites("85 Fed. Reg. 12345").filter((c) => c.type === "federalRegister")
+    expect(c?.matchedText).toBe("85 Fed. Reg. 12345")
+  })
+
+  it("Statutes at Large accepts comma-grouped page", () => {
+    const [c] = cites("134 Stat. 1,234").filter((c) => c.type === "statutesAtLarge")
+    expect(c?.matchedText).toBe("134 Stat. 1,234")
+  })
+})


### PR DESCRIPTION
## Summary

Federal Register and Statutes at Large patterns used bare `\d+` for the page, truncating common comma-grouped pages:

| input | before | after |
|---|---|---|
| `85 Fed. Reg. 12,345` | matchedText=`85 Fed. Reg. 12`, page=12 | matchedText=`85 Fed. Reg. 12,345`, page=12345 ✓ |
| `134 Stat. 1,234` | matchedText=`134 Stat. 1`, page=1 | matchedText=`134 Stat. 1,234`, page=1234 ✓ |

Federal Register pages routinely exceed 10,000 so the comma form is common in practice.

Both the tokenizer pattern and the extractor regex now accept `\d{1,3}(?:,\d{3})+|\d+`. The integer `page` field strips commas before `parseInt` so callers still get a number for arithmetic; matchedText preserves the original form.

Found via adversarial probing.

## Test plan

- [x] 4 regression tests in `tests/extract/issueFedRegCommaPage.test.ts`
- [x] Full suite passes (3976 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)