### PR TITLE
fix(extract): approximate-year prefixes (c., circa, about, cir.) no longer pollute court

### DIFF
--- a/.changeset/fix-more-non-court-prefixes.md
+++ b/.changeset/fix-more-non-court-prefixes.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): approximate-year prefixes (`c.`, `circa`, `about`, `cir.`) no longer pollute court
+
+Extends PR #685 (date-modifier verbs) by catching additional non-court
+prefixes that leak after year-stripping:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1 (c. 1990)` | `court="c."` | `court=undefined` |
+| `Smith, 100 F.2d 1 (circa 1990)` | `court="circa"` | `court=undefined` |
+| `Smith, 100 F.2d 1 (about 1990)` | `court="about"` | `court=undefined` |
+| `Smith, 100 F.2d 1 (approx. 1990)` | `court="approx."` | `court=undefined` |
+| `Smith, 100 F.2d 1 (cir. 1990)` | `court="cir."` (typo) | `court=undefined` |
+
+These are approximate-year prefixes that historians, academic writing,
+and OCR artifacts use when the exact decision date is unknown. The
+lowercase `cir.` is a common typo for `Cir.`. Added a leading-word
+check for `c.|circa|about|approx.|approximately|cir.` after year/date
+stripping.
+
+8 regression tests in `tests/extract/issueMoreNonCourtPrefixes.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -980,6 +980,12 @@ function stripDateFromCourt(content: string): string | undefined {
   ) {
     return undefined
   }
+  // Approximate-year prefixes (`c.`, `circa`, `about`, `approx.`) and
+  // typo court abbreviations (`cir.` lowercase, no number). After year-
+  // stripping these leak as the bare prefix word.
+  if (/^(?:c\.|circa|about|approx\.?|approximately|cir\.)\s*$/i.test(court)) {
+    return undefined
+  }
   if (!court.includes(".")) {
     const firstWord = court.match(/^[a-z]+/i)?.[0].toLowerCase()
     if (firstWord && (SIGNAL_WORDS.has(firstWord) ||

--- a/tests/extract/issueMoreNonCourtPrefixes.test.ts
+++ b/tests/extract/issueMoreNonCourtPrefixes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("approximate-year + typo prefixes do not pollute court field", () => {
+  it.each([
+    ["circa abbreviated", "Smith, 100 F.2d 1 (c. 1990)"],
+    ["circa spelled out", "Smith, 100 F.2d 1 (circa 1990)"],
+    ["approximate `about`", "Smith, 100 F.2d 1 (about 1990)"],
+    ["approximate `approx.`", "Smith, 100 F.2d 1 (approx. 1990)"],
+    ["typo `cir.`", "Smith, 100 F.2d 1 (cir. 1990)"],
+    ["tilde", "Smith, 100 F.2d 1 (~1990)"],
+  ])("`%s` does not pollute court", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("regression: real court still extracts", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+  })
+
+  it("regression: existing date-modifier (filed) still rejected", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (filed Jan. 15, 1990)")
+    expect(c.court).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Extends PR #685. Approximate-year prefixes used in academic / historical writing and lowercase `cir.` typos leaked into `court` after year-stripping:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1 (c. 1990)` | court=`c.` | undefined |
| `Smith, 100 F.2d 1 (circa 1990)` | court=`circa` | undefined |
| `Smith, 100 F.2d 1 (about 1990)` | court=`about` | undefined |
| `Smith, 100 F.2d 1 (approx. 1990)` | court=`approx.` | undefined |
| `Smith, 100 F.2d 1 (cir. 1990)` | court=`cir.` (typo) | undefined |

Added leading-word rejection for those tokens in `stripDateFromCourt`. Real courts (`9th Cir.`) continue to extract.

Found via adversarial probing.

## Test plan

- [x] 8 regression tests in `tests/extract/issueMoreNonCourtPrefixes.test.ts`
- [x] Full suite passes (3984 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)