### PR TITLE
fix(constitutional): invalid Roman numerals (IIII, IIIIIII) get low confidence

### DIFF
--- a/.changeset/fix-const-invalid-numeral.md
+++ b/.changeset/fix-const-invalid-numeral.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(constitutional): invalid Roman numerals downgraded to low confidence
+
+The constitutional body regex matches `[IVX]+` permissively (to support
+real Roman numerals up to `XXVII`), but `parseNumeral` rejects
+non-canonical Roman forms like `IIII`, `IIIIIII`, and out-of-range
+numerals like `XXVIII`. The extractor previously surfaced these as
+constitutional citations with confidence 0.9 but with `amendment=undefined`
+AND `article=undefined` — a structurally useless citation passed through
+at the same confidence as a valid one.
+
+| input | before | after |
+|---|---|---|
+| `U.S. Const. amend. IIII` | type=constitutional, amend=undefined, conf=0.9 | conf=0.1 ✓ |
+| `U.S. Const. amend. IIIIIII` | type=constitutional, amend=undefined, conf=0.9 | conf=0.1 ✓ |
+| `U.S. Const. art. XXVIII` | type=constitutional, art=undefined, conf=0.9 | conf=0.1 ✓ |
+
+When both `amendment` and `article` fail to parse, confidence is now
+downgraded to 0.1 so downstream consumers can filter it out.
+
+5 regression tests in `tests/extract/issueConstInvalidNumeral.test.ts`.

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -394,6 +394,17 @@ export function extractConstitutional(
     confidence = 0.9
   }
 
+  // Downgrade confidence when the numeral failed to parse (invalid
+  // Roman numerals like `IIII`, `IIIIIII`, or non-canonical word forms).
+  // The body regex matches `[IVX]+` permissively but `parseNumeral`
+  // returns undefined for non-canonical Roman numerals. A constitutional
+  // citation with neither amendment nor article populated is structurally
+  // useless and should be flagged as low-confidence rather than passed
+  // through at 0.9.
+  if (amendment === undefined && article === undefined) {
+    confidence = 0.1
+  }
+
   // The section regex may greedily consume a sentence-terminating period ("§ 1.")
   const matchedText = text.endsWith(".") ? text.slice(0, -1) : text
 

--- a/tests/extract/issueConstInvalidNumeral.test.ts
+++ b/tests/extract/issueConstInvalidNumeral.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { ConstitutionalCitation } from "@/types/citation"
+
+const cons = (text: string): ConstitutionalCitation[] =>
+  extractCitations(text).filter((c) => c.type === "constitutional") as ConstitutionalCitation[]
+
+describe("invalid Roman numerals in constitutional citations get low confidence", () => {
+  it.each([
+    ["IIII (non-standard 4)", "U.S. Const. amend. IIII"],
+    ["IIIIIII (invalid)", "U.S. Const. amend. IIIIIII"],
+  ])("`%s` confidence drops to 0.1 when no numeral parses", (_, input) => {
+    const [c] = cons(input)
+    expect(c).toBeDefined()
+    expect(c.amendment).toBeUndefined()
+    expect(c.article).toBeUndefined()
+    expect(c.confidence).toBe(0.1)
+  })
+
+  it("regression: valid Roman numeral keeps high confidence", () => {
+    const [c] = cons("U.S. Const. amend. XIV")
+    expect(c.amendment).toBe(14)
+    expect(c.confidence).toBeGreaterThan(0.8)
+  })
+
+  it("regression: valid article numeral keeps high confidence", () => {
+    const [c] = cons("U.S. Const. art. III")
+    expect(c.article).toBe(3)
+    expect(c.confidence).toBeGreaterThan(0.8)
+  })
+
+  it("regression: too-high article number (XXVIII / 28) gets low confidence", () => {
+    const [c] = cons("U.S. Const. art. XXVIII")
+    // XXVIII doesn't parse as a valid roman numeral by current rules
+    expect(c.confidence).toBe(0.1)
+  })
+})


### PR DESCRIPTION
## Summary

The constitutional body regex matches `[IVX]+` permissively (to support real Roman numerals up to `XXVII`), but `parseNumeral` rejects non-canonical Roman forms and out-of-range numerals. Such citations previously surfaced at confidence 0.9 with `amendment=undefined` AND `article=undefined` — structurally useless citations passed through at the same confidence as valid ones.

| input | before | after |
|---|---|---|
| `U.S. Const. amend. IIII` | type=constitutional, amend=undefined, conf=**0.9** | conf=**0.1** ✓ |
| `U.S. Const. amend. IIIIIII` | conf=0.9 | conf=0.1 ✓ |
| `U.S. Const. art. XXVIII` | conf=0.9 | conf=0.1 ✓ |

Fix: when both `amendment` and `article` fail to parse, confidence drops to 0.1 so downstream consumers can filter the citation. Valid numerals continue to extract at their previous confidence levels.

Found via adversarial probing.

## Test plan

- [x] 5 regression tests in `tests/extract/issueConstInvalidNumeral.test.ts`
- [x] Full suite passes (3981 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)