### PR TITLE
fix(extract): year + trailing disposition modifier no longer leaks into court field

### DIFF
--- a/.changeset/fix-court-trailing-modifier.md
+++ b/.changeset/fix-court-trailing-modifier.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): year + trailing disposition modifier no longer leaks into court field
+
+When a court parenthetical had `<court> <year> <modifier>` shape — e.g.,
+`(9th Cir. 1990 mem.)`, `(2d Cir. 1990 unpublished)`,
+`(D. Mass. 1990 per curiam)` — the year sat in the middle and the bare
+trailing-`\d{4}` strip could not reach it. The full `<year> <modifier>`
+chunk leaked into the `court` field:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1 (9th Cir. 1990 mem.)` | `court="9th Cir. 1990 mem."` | `court="9th Cir."` ✓ |
+| `Smith, 100 F.2d 1 (9th Cir. 1990 unpublished)` | `court="9th Cir. 1990 unpublished"` | `court="9th Cir."` ✓ |
+| `Smith, 100 F.2d 1 (9th Cir. 1990 per curiam)` | leaks | `court="9th Cir."` ✓ |
+| `Smith, 100 F.2d 1 (9th Cir. 1990 en banc)` | leaks | `court="9th Cir."` ✓ |
+
+Added an early-pass `\s*\d{4}\s+(?:mem\.?|unpub\.?|unpublished|per\s+curiam|en\s+banc|slip\s+op\.?|table|supp\.?)\s*$`
+regex in `stripDateFromCourt` that lifts the year+modifier suffix before
+the existing date-component strips run.
+
+7 regression tests in `tests/extract/issueCourtWithTrailingModifier.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -889,6 +889,17 @@ const SENTENCE_INITIAL_WORDS = new Set([
 function stripDateFromCourt(content: string): string | undefined {
   // Strip trailing numeric date format first (1/15/2020)
   let court = content.replace(/\s*\d{1,2}\/\d{1,2}\/\d{4}\s*$/, "").trim()
+  // Strip trailing year-plus-disposition-modifier (`1990 mem.`,
+  // `1990 unpublished`, `1990 per curiam`, `1990 en banc`). The year
+  // sits in the middle of `(<court> <year> <modifier>)` so the bare
+  // `\d{4}$` strip below can't reach it; lift the year+modifier suffix
+  // first.
+  court = court
+    .replace(
+      /\s*\d{4}\s+(?:mem\.?|unpub\.?|unpublished|per\s+curiam|en\s+banc|slip\s+op\.?|table|supp\.?)\s*$/i,
+      "",
+    )
+    .trim()
   // Strip trailing year
   court = court.replace(/\s*\d{4}\s*$/, "").trim()
   // Strip trailing date components: optional day+comma, month abbreviation or full name

--- a/tests/extract/issueCourtWithTrailingModifier.test.ts
+++ b/tests/extract/issueCourtWithTrailingModifier.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("court parenthetical with year + trailing modifier strips correctly", () => {
+  it.each([
+    ["mem.", "Smith, 100 F.2d 1 (9th Cir. 1990 mem.)"],
+    ["unpublished", "Smith, 100 F.2d 1 (9th Cir. 1990 unpublished)"],
+    ["unpub.", "Smith, 100 F.2d 1 (9th Cir. 1990 unpub.)"],
+    ["per curiam", "Smith, 100 F.2d 1 (9th Cir. 1990 per curiam)"],
+    ["en banc", "Smith, 100 F.2d 1 (9th Cir. 1990 en banc)"],
+  ])("`%s` after year does not leak into court field", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+
+  it("regression: standard `(9th Cir. 1990)` still works", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+
+  it("regression: month + day + year + trailing word", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. Jan. 15, 1990 per curiam)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+})


### PR DESCRIPTION
## Summary

When a court parenthetical had `<court> <year> <modifier>` shape, the year sat in the middle and the bare trailing-`\d{4}` strip could not reach it. The full `<year> <modifier>` chunk leaked into `court`:

| input | before | after |
|---|---|---|
| `(9th Cir. 1990 mem.)` | court=`9th Cir. 1990 mem.` | court=`9th Cir.` ✓ |
| `(9th Cir. 1990 unpublished)` | court=`9th Cir. 1990 unpublished` | court=`9th Cir.` ✓ |
| `(9th Cir. 1990 per curiam)` | leaks | court=`9th Cir.` ✓ |
| `(9th Cir. 1990 en banc)` | leaks | court=`9th Cir.` ✓ |

Added an early-pass regex in `stripDateFromCourt` that lifts the year+modifier suffix (mem./unpub./unpublished/per curiam/en banc/slip op./table/supp.) before the existing date-component strips run.

Found via adversarial probing.

## Test plan

- [x] 7 regression tests in `tests/extract/issueCourtWithTrailingModifier.test.ts`
- [x] Full suite passes (3996 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)