### PR TITLE
fix(extract): Statutes at Large pincite accepts thousands-grouping commas

### DIFF
--- a/.changeset/fix-stat-pincite-comma.md
+++ b/.changeset/fix-stat-pincite-comma.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): Statutes at Large pincite accepts thousands-grouping commas
+
+Extends PR #695 (which fixed comma-grouped pages on Fed. Reg. and
+Statutes at Large) to also handle comma-grouped pincites. Previously,
+`134 Stat. 1,234, 1,236` parsed `pincite=1` instead of `1236` because
+the pincite regex `^,\s*(\d+)` stopped at the first comma in the
+pincite token.
+
+| input | before | after |
+|---|---|---|
+| `134 Stat. 1,234, 1,236` | page=1234, pincite=1 | page=1234, pincite=1236 ✓ |
+| `134 Stat. 1,234, 1,236-1,240` | range broken | pincite=1236, end=1240 ✓ |
+
+Extended `SAL_PINCITE_REGEX` to accept `\d{1,3}(?:,\d{3})+|\d+` on both
+endpoints. Integer parse strips commas. Abbreviated-end-page detection
+uses post-strip digit length so `285-99` still expands to `299`.
+
+5 regression tests in `tests/extract/issueStatPinciteComma.test.ts`.

--- a/src/extract/extractStatutesAtLarge.ts
+++ b/src/extract/extractStatutesAtLarge.ts
@@ -28,7 +28,11 @@ import { isPlausibleYear } from "./dates"
  * end-of-string, sentence punctuation, brackets/parens, or whitespace not
  * followed by a capital letter.
  */
-const SAL_PINCITE_REGEX = /^,\s*(\d+)(?:[-–—](\d+))?(?=$|[.,:;)([\]»"'“”‘’]|\s(?![A-Z]))/
+// Pincite accepts comma-grouped digits (`1,234` and `1,234,567`) on
+// both endpoints. Stat. pages routinely exceed 10,000 so commas in the
+// pincite are common.
+const SAL_PINCITE_REGEX =
+  /^,\s*(\d{1,3}(?:,\d{3})+|\d+)(?:[-–—](\d{1,3}(?:,\d{3})+|\d+))?(?=$|[.,:;)([\]»"'“”‘’]|\s(?![A-Z]))/
 
 export function extractStatutesAtLarge(
   token: Token,
@@ -67,16 +71,21 @@ export function extractStatutesAtLarge(
     const after = cleanedText.substring(span.cleanEnd)
     const pinciteMatch = SAL_PINCITE_REGEX.exec(after)
     if (pinciteMatch) {
-      pincite = Number.parseInt(pinciteMatch[1], 10)
+      // Strip thousands-grouping commas before integer parse.
+      const rawStart = pinciteMatch[1]
+      const rawStartDigits = rawStart.replace(/,/g, "")
+      pincite = Number.parseInt(rawStartDigits, 10)
       pinciteConsumed = pinciteMatch[0].length
       if (pinciteMatch[2]) {
         const rawEnd = pinciteMatch[2]
-        // Abbreviated end pages: "3755-58" means 3758.
-        if (rawEnd.length < pinciteMatch[1].length) {
-          const prefix = pinciteMatch[1].slice(0, pinciteMatch[1].length - rawEnd.length)
-          pinciteEndPage = Number.parseInt(prefix + rawEnd, 10)
+        const rawEndDigits = rawEnd.replace(/,/g, "")
+        // Abbreviated end pages: "3755-58" means 3758. Use digit-string
+        // lengths (post-comma-strip) to detect abbreviation.
+        if (rawEndDigits.length < rawStartDigits.length) {
+          const prefix = rawStartDigits.slice(0, rawStartDigits.length - rawEndDigits.length)
+          pinciteEndPage = Number.parseInt(prefix + rawEndDigits, 10)
         } else {
-          pinciteEndPage = Number.parseInt(rawEnd, 10)
+          pinciteEndPage = Number.parseInt(rawEndDigits, 10)
         }
         pinciteIsRange = true
       }

--- a/tests/extract/issueStatPinciteComma.test.ts
+++ b/tests/extract/issueStatPinciteComma.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { StatutesAtLargeCitation } from "@/types/citation"
+
+const sal = (text: string): StatutesAtLargeCitation[] =>
+  extractCitations(text).filter((c) => c.type === "statutesAtLarge") as StatutesAtLargeCitation[]
+
+describe("Statutes at Large pincite accepts thousands-grouping commas", () => {
+  it("`134 Stat. 1,234, 1,236` parses pincite as 1236, not 1", () => {
+    const [c] = sal("134 Stat. 1,234, 1,236")
+    expect(c?.page).toBe(1234)
+    expect(c?.pincite).toBe(1236)
+  })
+
+  it("`134 Stat. 1,234, 1,236-1,240` parses pincite range", () => {
+    const [c] = sal("134 Stat. 1,234, 1,236-1,240")
+    expect(c?.page).toBe(1234)
+    expect(c?.pincite).toBe(1236)
+    expect(c?.pinciteEndPage).toBe(1240)
+  })
+
+  it("regression: bare pincite without comma still works", () => {
+    const [c] = sal("134 Stat. 281, 285")
+    expect(c?.page).toBe(281)
+    expect(c?.pincite).toBe(285)
+  })
+
+  it("regression: abbreviated pincite end (`285-99`) still expands to 299", () => {
+    const [c] = sal("134 Stat. 281, 285-99")
+    expect(c?.pincite).toBe(285)
+    expect(c?.pinciteEndPage).toBe(299)
+  })
+
+  it("regression: full numeric pincite range still works", () => {
+    const [c] = sal("134 Stat. 281, 285-300")
+    expect(c?.pincite).toBe(285)
+    expect(c?.pinciteEndPage).toBe(300)
+  })
+})


### PR DESCRIPTION
## Summary

Extends PR #695. The pincite regex `^,\s*(\d+)` stopped at the first comma inside a thousands-grouped pincite, so `134 Stat. 1,234, 1,236` parsed `pincite=1` instead of `1236`.

| input | before | after |
|---|---|---|
| `134 Stat. 1,234, 1,236` | page=1234, **pincite=1** | page=1234, pincite=1236 ✓ |
| `134 Stat. 1,234, 1,236-1,240` | range broken | pincite=1236, end=1240 ✓ |

Extended endpoints to accept `\d{1,3}(?:,\d{3})+|\d+`; strip commas before `parseInt`; abbreviated-end-page detection (`285-99` -> `299`) uses post-strip digit length.

Found via adversarial probing.

## Test plan

- [x] 5 regression tests in `tests/extract/issueStatPinciteComma.test.ts`
- [x] Full suite passes (4001 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)