### PR TITLE
fix(extract): Federal Register year extracts from trailing parens beyond the matched token

### DIFF
--- a/.changeset/fix-fed-reg-year-trailing.md
+++ b/.changeset/fix-fed-reg-year-trailing.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): Federal Register year extracts from trailing parens beyond the matched token
+
+The Federal Register extractor's year regex only scanned the matched
+token text. Since the token only covers `<vol> Fed. Reg. <page>` (not
+the trailing date parenthetical), the year was never extracted:
+
+| input | before | after |
+|---|---|---|
+| `85 Fed. Reg. 12,345 (2020)` | year=undefined | year=2020 ✓ |
+| `85 Fed. Reg. 12,345 (Mar. 1, 2020)` | year=undefined | year=2020 ✓ |
+| `85 Fed. Reg. 12345 (2020)` | year=undefined | year=2020 ✓ |
+
+Mirrored the `cleanedText`-based year scan from `extractStatutesAtLarge`:
+extend the scan window 64 characters beyond `span.cleanEnd` to catch
+the trailing date paren. Plausibility filter (`isPlausibleYear`) still
+rejects page-like numbers.
+
+5 regression tests in `tests/extract/issueFedRegYear.test.ts`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -424,7 +424,7 @@ export function extractCitations(
         citation = extractPublicLaw(token, transformationMap)
         break
       case "federalRegister":
-        citation = extractFederalRegister(token, transformationMap)
+        citation = extractFederalRegister(token, transformationMap, cleaned)
         break
       case "statutesAtLarge":
         citation = extractStatutesAtLarge(token, transformationMap, cleaned)

--- a/src/extract/extractFederalRegister.ts
+++ b/src/extract/extractFederalRegister.ts
@@ -49,6 +49,7 @@ import { isPlausibleYear } from "./dates"
 export function extractFederalRegister(
   token: Token,
   transformationMap: TransformationMap,
+  cleanedText?: string,
 ): FederalRegisterCitation {
   const { text, span } = token
 
@@ -79,8 +80,15 @@ export function extractFederalRegister(
   // Extract optional year in parentheses
   // Pattern: "(year)" or "(month day, year)"
   // Plausibility filter (#523): drop OCR-mangled or page-number years.
+  // Scan the cleaned text starting from the token to catch trailing
+  // year parens that aren't part of the matched token itself
+  // (`85 Fed. Reg. 12,345 (Mar. 1, 2020)` — the `(Mar. 1, 2020)` sits
+  // outside the cite proper but is the publication date).
   const yearRegex = /\((?:.*?\s)?(\d{4})\)/
-  const yearMatch = yearRegex.exec(text)
+  const yearScanText = cleanedText
+    ? cleanedText.substring(span.cleanStart, span.cleanEnd + 64)
+    : text
+  const yearMatch = yearRegex.exec(yearScanText)
   const rawYear = yearMatch ? Number.parseInt(yearMatch[1], 10) : undefined
   const year = rawYear !== undefined && isPlausibleYear(rawYear) ? rawYear : undefined
 

--- a/tests/extract/issueFedRegYear.test.ts
+++ b/tests/extract/issueFedRegYear.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FederalRegisterCitation } from "@/types/citation"
+
+const fedReg = (text: string): FederalRegisterCitation[] =>
+  extractCitations(text).filter((c) => c.type === "federalRegister") as FederalRegisterCitation[]
+
+describe("Federal Register year extracts from trailing parens beyond the token", () => {
+  it("`85 Fed. Reg. 12,345 (2020)` extracts year=2020", () => {
+    const [c] = fedReg("85 Fed. Reg. 12,345 (2020)")
+    expect(c?.year).toBe(2020)
+  })
+
+  it("`85 Fed. Reg. 12,345 (Mar. 1, 2020)` extracts year=2020", () => {
+    const [c] = fedReg("85 Fed. Reg. 12,345 (Mar. 1, 2020)")
+    expect(c?.year).toBe(2020)
+  })
+
+  it("`85 Fed. Reg. 12345 (2020)` (no comma in page) extracts year", () => {
+    const [c] = fedReg("85 Fed. Reg. 12345 (2020)")
+    expect(c?.year).toBe(2020)
+  })
+
+  it("regression: no trailing year paren → year undefined", () => {
+    const [c] = fedReg("85 Fed. Reg. 12,345")
+    expect(c?.year).toBeUndefined()
+  })
+
+  it("regression: implausible year (page-like number) → undefined", () => {
+    const [c] = fedReg("85 Fed. Reg. 12,345 (9999)")
+    expect(c?.year).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

The Fed Reg extractors year regex only scanned the matched token text, so trailing date parens were ignored:

| input | before | after |
|---|---|---|
| `85 Fed. Reg. 12,345 (2020)` | year=undefined | year=2020 ✓ |
| `85 Fed. Reg. 12,345 (Mar. 1, 2020)` | year=undefined | year=2020 ✓ |
| `85 Fed. Reg. 12345 (2020)` | year=undefined | year=2020 ✓ |

Mirrored the `cleanedText`-based year scan already used by `extractStatutesAtLarge`: extend the scan window 64 chars past `span.cleanEnd`. Plausibility filter (`isPlausibleYear`) still rejects page-like numbers.

Found via adversarial probing — likely a long-standing oversight introduced when the Fed. Reg. extractor was first written without a cleanedText param.

## Test plan

- [x] 5 regression tests in `tests/extract/issueFedRegYear.test.ts`
- [x] Full suite passes (4001 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)