### PR TITLE
fix(clean): preserve space in <X>. <N>th Cir. court parentheticals

### DIFF
--- a/.changeset/fix-cleaner-bap-spacing.md
+++ b/.changeset/fix-cleaner-bap-spacing.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix(clean): preserve space in `<X>. <N>th Cir.` court parentheticals
+
+The reporter-spacing cleaner's general ordinal-suffix rule
+(`([A-Za-z])\.\s+(\d+[a-z]+)` → collapse) blindly stripped the space
+before any ordinal token, even when the ordinal was a circuit number
+rather than a reporter edition:
+
+| input | before | after |
+|---|---|---|
+| `B.A.P. 9th Cir.` | `B.A.P.9th Cir.` | `B.A.P. 9th Cir.` ✓ |
+| `Bankr. 9th Cir.` | `Bankr.9th Cir.` | `Bankr. 9th Cir.` ✓ |
+| `La. App. 3d Cir.` | `La. App.3d Cir.` | `La. App. 3d Cir.` ✓ |
+
+Fix: anchor the ordinal with `\b` to defeat greedy backtracking, then
+add a negative lookahead `(?!\s+Cir\.)` so the collapse skips circuit
+numbers. Reporter editions (`Wis. 2d`, `F. Supp. 2d`, `So. 2d`, `Cal.
+Rptr. 2d`) continue to collapse correctly.
+
+Pre-existing Louisiana date-in-number tests (#232) that pinned the
+buggy `La. App.3d Cir.` form are updated to expect the canonical
+Bluebook T7 form `La. App. 3d Cir.`.
+
+6 regression tests in `tests/extract/issueCleanerBAPSpacing.test.ts`.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -352,7 +352,13 @@ export function normalizeReporterSpacing(text: string): string {
 
   // General ordinal-suffix collapse: "Supp. 2d" → "Supp.2d", "Ed. 2d" → "Ed.2d",
   // "St. 3d" → "St.3d", "So. 2d" → "So.2d", "Wis. 2d" → "Wis.2d"
-  result = result.replace(/([A-Za-z])\.\s+(\d+[a-z]+)/g, "$1.$2")
+  //
+  // The `\b` after `[a-z]+` anchors the ordinal at a word boundary so the
+  // greedy capture doesn't backtrack (otherwise `9th` could shrink to
+  // `9t` to dodge the lookahead). The negative lookahead `(?!\s+Cir\.)`
+  // then prevents collapsing when the ordinal is a circuit number
+  // (`B.A.P. 9th Cir.`) rather than a reporter edition.
+  result = result.replace(/([A-Za-z])\.\s+(\d+[a-z]+)\b(?!\s+Cir\.)/g, "$1.$2")
 
   // Illinois Appellate Reports — restore the space `App.` strips out by the
   // general rule above. Bluebook T1 canonical form is `Ill. App. 2d` /

--- a/tests/extract/extractCase.test.ts
+++ b/tests/extract/extractCase.test.ts
@@ -5587,10 +5587,10 @@ describe("Louisiana date-in-number citations (#232)", () => {
     if (primary?.type === "case") {
       expect(primary.caseName).toBe("Herff Jones, Inc. v. Girouard")
       expect(primary.year).toBe(2007)
-      // The default cleaner collapses the reporter-style space after "App."
-      // so the canonical court string is `La. App.3d Cir.` (matches the
-      // reporters-db normalization applied elsewhere in the parser).
-      expect(primary.court).toBe("La. App.3d Cir.")
+      // The cleaner preserves the space before `<N>th Cir.` (the ordinal
+      // is a circuit number, not a reporter edition) — Bluebook T7
+      // canonical form is `La. App. 3d Cir.`.
+      expect(primary.court).toBe("La. App. 3d Cir.")
       expect(primary.date?.iso).toBe("2007-10-03")
     }
   })
@@ -5606,7 +5606,7 @@ describe("Louisiana date-in-number citations (#232)", () => {
     if (primary?.type === "case") {
       expect(primary.caseName).toBe("Boudreaux v. Doe")
       expect(primary.year).toBe(2010)
-      expect(primary.court).toBe("La. App.1st Cir.")
+      expect(primary.court).toBe("La. App. 1st Cir.")
       expect(primary.date?.iso).toBe("2010-02-15")
     }
   })

--- a/tests/extract/issueCleanerBAPSpacing.test.ts
+++ b/tests/extract/issueCleanerBAPSpacing.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+import { normalizeReporterSpacing } from "@/clean/cleaners"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("cleaner preserves space in `<X>. <N>th Cir.` court parentheticals", () => {
+  it("`B.A.P. 9th Cir.` keeps the space", () => {
+    expect(normalizeReporterSpacing("B.A.P. 9th Cir.")).toBe("B.A.P. 9th Cir.")
+  })
+
+  it("`Bankr. 9th Cir.` keeps the space (hypothetical)", () => {
+    expect(normalizeReporterSpacing("Bankr. 9th Cir.")).toBe("Bankr. 9th Cir.")
+  })
+
+  it("`Smith, 100 F.2d 1 (B.A.P. 9th Cir. 1990)` court=`B.A.P. 9th Cir.`", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (B.A.P. 9th Cir. 1990)")
+    expect(c.court).toBe("B.A.P. 9th Cir.")
+  })
+
+  it("regression: reporter editions still collapse (`Wis. 2d` → `Wis.2d`)", () => {
+    expect(normalizeReporterSpacing("Wis. 2d")).toBe("Wis.2d")
+  })
+
+  it("regression: `F. Supp. 2d 100` cleaned correctly", () => {
+    expect(normalizeReporterSpacing("100 F. Supp. 2d 100")).toBe("100 F.Supp.2d 100")
+  })
+
+  it("regression: `9th Cir.` standalone still extracts as court", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+  })
+})


### PR DESCRIPTION
## Summary

The reporter-spacing cleaners general ordinal-suffix rule (`([A-Za-z])\.\s+(\d+[a-z]+)` -> collapse) blindly stripped the space before any ordinal, even when the ordinal was a circuit number rather than a reporter edition:

| input | before | after |
|---|---|---|
| `B.A.P. 9th Cir.` | `B.A.P.9th Cir.` | `B.A.P. 9th Cir.` ✓ |
| `Bankr. 9th Cir.` | `Bankr.9th Cir.` | `Bankr. 9th Cir.` ✓ |
| `La. App. 3d Cir.` | `La. App.3d Cir.` | `La. App. 3d Cir.` ✓ |

Fix: anchor the ordinal with `\b` to defeat greedy backtracking (otherwise `9th` was shrinking to `9t` to dodge the lookahead), then add a negative lookahead `(?!\s+Cir\.)` so the collapse skips circuit numbers. Reporter editions (`Wis. 2d`, `F. Supp. 2d`, `So. 2d`, `Cal. Rptr. 2d`) continue to collapse correctly.

Pre-existing Louisiana date-in-number tests (#232) that pinned the buggy `La. App.3d Cir.` form are updated to expect the canonical Bluebook T7 form.

Found via adversarial probing.

## Test plan

- [x] 6 regression tests in `tests/extract/issueCleanerBAPSpacing.test.ts`
- [x] Updated 2 pre-existing assertions in `extractCase.test.ts` (Louisiana courts)
- [x] Full suite passes (4012 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)