### PR TITLE
fix(statute): publisher/supplement markers no longer parsed as subsection

### DIFF
--- a/.changeset/fix-statute-supplement-subsection.md
+++ b/.changeset/fix-statute-supplement-subsection.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix(statute): publisher/supplement markers no longer mis-parsed as subsection
+
+The statute body parser's `SUBSECTION_RE` accepted any paren content as
+a subsection chain. Bluebook publisher/supplement markers and
+parenthetical context phrases were silently captured as `subsection`:
+
+| input | before | after |
+|---|---|---|
+| `42 U.S.C. § 1983 (Supp. III)` | subsection=`(Supp. III)` | undefined ✓ |
+| `42 U.S.C. § 1983 (West)` | subsection=`(West)` | undefined ✓ |
+| `42 U.S.C. § 1983 (Cum. Supp. 2020)` | subsection=`(Cum. Supp. 2020)` | undefined ✓ |
+| `28 U.S.C. § 1331 (federal question)` | subsection=`(federal question)` | undefined ✓ |
+
+Reject paren content as a subsection when it contains internal whitespace
+OR matches a known publisher word (`West`, `Lexis`, `Supp.`, `Cum.`,
+`Pamphlet`, `Pocket`). When rejected, also strip the paren content from
+the `section` field so section stays clean (`1331`, not `1331 (federal
+question)`).
+
+Wisconsin's idiosyncratic `48.415(l)(a)3` format (#414) where the
+section legitimately contains parens is unaffected — the reject-and-
+strip path only fires when the rejection criteria match.
+
+7 regression tests in `tests/extract/issueStatuteSupplementSubsection.test.ts`.

--- a/src/extract/statutes/parseBody.ts
+++ b/src/extract/statutes/parseBody.ts
@@ -109,10 +109,40 @@ export function parseBody(rawBody: string): ParsedBody {
 
   // Split section from subsections: "1983(a)(1)" → section="1983", subsection="(a)(1)"
   const trimmed = normalized.trim()
-  const subMatch = SUBSECTION_RE.exec(trimmed)
-  const subGroups = subMatch?.[2]
+  let subMatch = SUBSECTION_RE.exec(trimmed)
+  let subGroups = subMatch?.[2]
 
-  const sectionBody = subMatch !== null && subGroups ? subMatch[1].trim() : trimmed
+  // Reject paren content that isn't a real subsection chain. Real
+  // subsection chains are short tokens like `(a)`, `(1)`, `(B)`,
+  // `(ii)` — never `(Supp. III)`, `(West)`, `(West 2010)`,
+  // `(federal question)`. The latter are Bluebook
+  // publisher/supplement/parenthetical-context markers (#711). When
+  // matched as `subsection`, downstream consumers see meaningless data.
+  //
+  // Reject when ANY paren contains internal whitespace OR a known
+  // publisher word. Strip the rejected content from `section` so the
+  // section field stays clean.
+  let rejectedNonSubsection = false
+  if (
+    subGroups &&
+    (/\s/.test(subGroups) ||
+      /\((?:West|Lexis|Supp\.|Cum\.|Pamphlet|Pocket)\b/i.test(subGroups))
+  ) {
+    subMatch = null
+    subGroups = undefined
+    rejectedNonSubsection = true
+  }
+
+  let sectionBody = subMatch !== null && subGroups ? subMatch[1].trim() : trimmed
+  // When we explicitly rejected a publisher/whitespace paren, also
+  // strip it from the section field so the section doesn't carry
+  // `1331 (federal question)`. Only do this when the rejection fired —
+  // otherwise we'd break formats where the section legitimately
+  // contains `(...)` like Wisconsin's `48.415(l)(a)3` (#414).
+  if (rejectedNonSubsection) {
+    const parenIdx = sectionBody.indexOf("(")
+    if (parenIdx !== -1) sectionBody = sectionBody.slice(0, parenIdx).trim()
+  }
 
   // Detect plain numeric range (e.g. `591-99`, `1330-1332`). Callers may use
   // this to populate `sectionRange` and reset `section` to the start. #564

--- a/tests/extract/issueStatuteSupplementSubsection.test.ts
+++ b/tests/extract/issueStatuteSupplementSubsection.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { StatuteCitation } from "@/types/citation"
+
+const stats = (text: string): StatuteCitation[] =>
+  extractCitations(text).filter((c) => c.type === "statute") as StatuteCitation[]
+
+describe("statute subsection rejects publisher/supplement markers", () => {
+  it.each([
+    ["Supp. III", "42 U.S.C. § 1983 (Supp. III)"],
+    ["West", "42 U.S.C. § 1983 (West)"],
+    ["Cum. Supp. 2020", "42 U.S.C. § 1983 (Cum. Supp. 2020)"],
+    ["West 2010", "42 U.S.C. § 1983 (West 2010)"],
+  ])("`%s` is not parsed as subsection", (_, input) => {
+    const [c] = stats(input)
+    expect(c?.subsection).toBeUndefined()
+  })
+
+  it("regression: canonical subsection `(a)(1)(B)` still parses", () => {
+    const [c] = stats("42 U.S.C. § 1983(a)(1)(B)")
+    expect(c?.subsection).toBe("(a)(1)(B)")
+  })
+
+  it("regression: bare letter subsection `(A)` (uppercase) still parses", () => {
+    const [c] = stats("42 U.S.C. § 1983(A)")
+    expect(c?.subsection).toBe("(A)")
+  })
+
+  it("regression: numeric subsection `(1)(b)` still parses", () => {
+    const [c] = stats("42 U.S.C. § 1983(1)(b)")
+    expect(c?.subsection).toBe("(1)(b)")
+  })
+})


### PR DESCRIPTION
## Summary

The statute body parsers `SUBSECTION_RE` accepted any paren content as a subsection chain, so Bluebook publisher/supplement markers and parenthetical context phrases leaked into `subsection`:

| input | before | after |
|---|---|---|
| `42 U.S.C. § 1983 (Supp. III)` | subsection=`(Supp. III)` | undefined ✓ |
| `42 U.S.C. § 1983 (West)` | subsection=`(West)` | undefined ✓ |
| `42 U.S.C. § 1983 (Cum. Supp. 2020)` | subsection=`(Cum. Supp. 2020)` | undefined ✓ |
| `28 U.S.C. § 1331 (federal question)` | subsection=`(federal question)`, section=`1331 (federal question)` | undefined / `1331` ✓ |

Reject paren content when it contains internal whitespace OR matches a known publisher word (`West`, `Lexis`, `Supp.`, `Cum.`, `Pamphlet`, `Pocket`). When rejected, also strip the paren content from `section` so section stays clean.

Wisconsins idiosyncratic `48.415(l)(a)3` format (#414) where the section legitimately contains parens is preserved — the reject-and-strip path only fires when the rejection criteria match.

Found via adversarial probing.

## Test plan

- [x] 7 regression tests in `tests/extract/issueStatuteSupplementSubsection.test.ts`
- [x] Full suite passes (4019 passed, 12 skipped, 12 todo)
- [x] Pre-existing Wisconsin and U.S.C. tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)