### PR TITLE
fix(extract): case-name backscan preserves ordinal-prefix party names

### DIFF
--- a/.changeset/fix-case-name-ordinal-prefix.md
+++ b/.changeset/fix-case-name-ordinal-prefix.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): case-name backscan preserves ordinal-prefix party names
+
+The numeric prefix in `V_CASE_NAME_REGEX` was `(?:\d[\d-]*\s+)?` — bare
+digits only, with no ordinal-suffix support. When a real party name
+began with an ordinal (`21st Century Fox`, `1st National Bank`,
+`100th Anniversary`), the regex skipped the ordinal prefix entirely
+because the digit-prefix branch couldn't consume `21st` and the
+plaintiff branch started at the next uppercase letter.
+
+| input | before | after |
+|---|---|---|
+| `21st Century Fox v. Smith, 100 F.2d 1` | `Century Fox v. Smith` | `21st Century Fox v. Smith` ✓ |
+| `1st National Bank v. Smith, 100 F.2d 1` | `National Bank v. Smith` | `1st National Bank v. Smith` ✓ |
+| `100th Anniversary v. Smith, 100 F.2d 1` | `Anniversary v. Smith` | `100th Anniversary v. Smith` ✓ |
+
+Extended the numeric prefix to `(?:\d[\d-]*(?:st|nd|rd|th)?\s+)?` so
+ordinal suffixes are absorbed. Bare-number prefixes (`12 Lincoln
+Square`) and no-prefix names (`Smith v. Jones`) continue to work.
+
+7 regression tests in `tests/extract/issueCaseNameOrdinalPrefix.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -743,8 +743,13 @@ function isNonMetadataParenContent(content: string): boolean {
 // accepts both ASCII A-Z and uppercase Latin-1 (À-Þ), so
 // plaintiffs whose name begins with `Ç`, `Ö`, `É` etc. still anchor the
 // backscan.
+//
+// Numeric prefix accepts both bare numbers (`12 Lincoln Square`) and
+// ordinal forms (`21st Century Fox`, `1st National Bank`, `100th
+// Anniversary`). Without the `(?:st|nd|rd|th)?` suffix the regex
+// stripped the ordinal prefix entirely.
 const V_CASE_NAME_REGEX =
-  /((?:\d[\d-]*\s+)?[A-ZÀ-Þ][A-Za-z0-9À-ſ\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9À-ſ\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
+  /((?:\d[\d-]*(?:st|nd|rd|th)?\s+)?[A-ZÀ-Þ][A-Za-z0-9À-ſ\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9À-ſ\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
 
 /** Procedural prefix case name format.
  *  Longer prefixes listed first so the alternation prefers the longer match

--- a/tests/extract/issueCaseNameOrdinalPrefix.test.ts
+++ b/tests/extract/issueCaseNameOrdinalPrefix.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("case-name backscan preserves ordinal-prefix party names", () => {
+  it.each([
+    ["21st Century Fox v. Smith", "21st Century Fox v. Smith"],
+    ["1st National Bank v. Smith", "1st National Bank v. Smith"],
+    ["100th Anniversary v. Smith", "100th Anniversary v. Smith"],
+    ["23rd Street Realty v. Smith", "23rd Street Realty v. Smith"],
+    ["2nd Circuit Partners v. Smith", "2nd Circuit Partners v. Smith"],
+  ])("`%s` preserves the ordinal prefix", (_, plaintiff) => {
+    const [c] = cases(`${plaintiff}, 100 F.2d 1 (1990)`)
+    expect(c?.caseName).toBe(plaintiff)
+  })
+
+  it("regression: bare-number prefix (`12 Lincoln Square`) still preserved", () => {
+    const [c] = cases("12 Lincoln Square v. Smith, 100 F.2d 1")
+    expect(c.caseName).toBe("12 Lincoln Square v. Smith")
+  })
+
+  it("regression: no-prefix case names still work", () => {
+    const [c] = cases("Smith v. Jones, 100 F.2d 1")
+    expect(c.caseName).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
## Summary

The numeric prefix in `V_CASE_NAME_REGEX` was `(?:\d[\d-]*\s+)?` — bare digits only, no ordinal-suffix support. Real party names starting with an ordinal were silently stripped:

| input | before | after |
|---|---|---|
| `21st Century Fox v. Smith, 100 F.2d 1` | `Century Fox v. Smith` | `21st Century Fox v. Smith` ✓ |
| `1st National Bank v. Smith, 100 F.2d 1` | `National Bank v. Smith` | `1st National Bank v. Smith` ✓ |
| `100th Anniversary v. Smith, 100 F.2d 1` | `Anniversary v. Smith` | `100th Anniversary v. Smith` ✓ |

Extended the numeric prefix to `(?:\d[\d-]*(?:st|nd|rd|th)?\s+)?` so ordinal suffixes are absorbed. Bare-number prefixes (`12 Lincoln Square`) and no-prefix names (`Smith v. Jones`) continue to work.

Found via adversarial probing.

## Test plan

- [x] 7 regression tests in `tests/extract/issueCaseNameOrdinalPrefix.test.ts`
- [x] Full suite passes (4026 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)