### PR TITLE
fix(extract): year+comma+modifier form (1990, en banc) no longer leaks into court

### DIFF
--- a/.changeset/fix-year-comma-modifier.md
+++ b/.changeset/fix-year-comma-modifier.md
@@ -1,0 +1,19 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): year+comma+modifier form (`1990, en banc`) no longer leaks into court
+
+Extends PR #704. The strip-pass for trailing year+modifier accepted only
+whitespace between year and modifier (`1990 mem.`). Bluebook also allows
+a comma form (`1990, en banc`, `1990, per curiam`):
+
+| input | before | after |
+|---|---|---|
+| `(9th Cir. 1990, en banc)` | `court="9th Cir. 1990, en banc"` | `court="9th Cir."` ✓ |
+| `(9th Cir. 1990, per curiam)` | leaks | `court="9th Cir."` ✓ |
+| `(1990, mem.)` | `court="1990, mem."` | `court=undefined` ✓ |
+
+The regex now accepts `\d{4}(?:\s+|,\s+)<modifier>` so both forms work.
+
+6 regression tests in `tests/extract/issueYearCommaModifier.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -895,13 +895,15 @@ function stripDateFromCourt(content: string): string | undefined {
   // Strip trailing numeric date format first (1/15/2020)
   let court = content.replace(/\s*\d{1,2}\/\d{1,2}\/\d{4}\s*$/, "").trim()
   // Strip trailing year-plus-disposition-modifier (`1990 mem.`,
-  // `1990 unpublished`, `1990 per curiam`, `1990 en banc`). The year
+  // `1990 unpublished`, `1990 per curiam`, `1990 en banc`, also the
+  // year-first/comma-then-modifier form `1990, en banc`). The year
   // sits in the middle of `(<court> <year> <modifier>)` so the bare
   // `\d{4}$` strip below can't reach it; lift the year+modifier suffix
-  // first.
+  // first. Whitespace OR comma+whitespace is accepted between year
+  // and modifier.
   court = court
     .replace(
-      /\s*\d{4}\s+(?:mem\.?|unpub\.?|unpublished|per\s+curiam|en\s+banc|slip\s+op\.?|table|supp\.?)\s*$/i,
+      /\s*\d{4}(?:\s+|,\s+)(?:mem\.?|unpub\.?|unpublished|per\s+curiam|en\s+banc|slip\s+op\.?|table|supp\.?)\s*$/i,
       "",
     )
     .trim()

--- a/tests/extract/issueYearCommaModifier.test.ts
+++ b/tests/extract/issueYearCommaModifier.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("court parenthetical with year+comma+modifier strips correctly", () => {
+  it.each([
+    ["en banc", "Smith, 100 F.2d 1 (9th Cir. 1990, en banc)"],
+    ["per curiam", "Smith, 100 F.2d 1 (9th Cir. 1990, per curiam)"],
+    ["mem.", "Smith, 100 F.2d 1 (1990, mem.)"],
+    ["unpub.", "Smith, 100 F.2d 1 (1990, unpub.)"],
+  ])("`%s` after `1990,` does not leak", (_, input) => {
+    const [c] = cases(input)
+    // Either undefined (no court) or doesn't contain "1990"
+    if (c.court !== undefined) {
+      expect(c.court).not.toContain("1990")
+    }
+    expect(c.year).toBe(1990)
+  })
+
+  it("`(9th Cir. 1990, en banc)` extracts court=`9th Cir.`", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990, en banc)")
+    expect(c.court).toBe("9th Cir.")
+  })
+
+  it("regression: PR #704 space-form `(9th Cir. 1990 mem.)` still works", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990 mem.)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+})


### PR DESCRIPTION
## Summary

Extends PR #704. The strip-pass for year+modifier accepted only whitespace between year and modifier (`1990 mem.`). Bluebook also allows a comma form (`1990, en banc`, `1990, per curiam`) — these still leaked:

| input | before | after |
|---|---|---|
| `(9th Cir. 1990, en banc)` | court=`9th Cir. 1990, en banc` | court=`9th Cir.` ✓ |
| `(9th Cir. 1990, per curiam)` | leaks | court=`9th Cir.` ✓ |
| `(1990, mem.)` | court=`1990, mem.` | court=undefined ✓ |

The regex now accepts `\d{4}(?:\s+|,\s+)<modifier>` so both forms work.

Found via adversarial probing.

## Test plan

- [x] 6 regression tests in `tests/extract/issueYearCommaModifier.test.ts`
- [x] Full suite passes (4032 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)