### PR TITLE
fix(extract): date-strip handles dashed and ISO-format dates

### DIFF
--- a/.changeset/fix-court-date-format-leaks.md
+++ b/.changeset/fix-court-date-format-leaks.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): date-strip handles dashed and ISO-format dates
+
+The numeric-date strip in `stripDateFromCourt` only handled `M/D/YYYY`
+(slash separator). Other common formats leaked partial date content
+into the `court` field:
+
+| input | before | after |
+|---|---|---|
+| `(9th Cir. 02-15-2020)` | `court="9th Cir. 02-15-"` | `court="9th Cir."` ✓ |
+| `(9th Cir. 2020-02-15)` | `court="9th Cir. 2020-02-"` | `court="9th Cir."` ✓ |
+| `(9th Cir. 2020/02/15)` | `court="9th Cir. 2020/02/"` | `court="9th Cir."` ✓ |
+
+Extended to two regex alternatives:
+- `\d{1,2}[/-]\d{1,2}[/-]\d{4}` — day-first or M/D forms
+- `\d{4}[/-]\d{1,2}[/-]\d{1,2}` — ISO year-first forms
+
+6 regression tests in `tests/extract/issueCourtDateFormatLeaks.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -892,8 +892,19 @@ const SENTENCE_INITIAL_WORDS = new Set([
  *        "D. Mass. 1/15/2020" → "D. Mass."
  */
 function stripDateFromCourt(content: string): string | undefined {
-  // Strip trailing numeric date format first (1/15/2020)
-  let court = content.replace(/\s*\d{1,2}\/\d{1,2}\/\d{4}\s*$/, "").trim()
+  // Strip trailing numeric date formats. Accepts:
+  //   - M/D/YYYY  (`1/15/2020`)
+  //   - MM-DD-YYYY (`02-15-2020`)
+  //   - YYYY/MM/DD (`2020/02/15`)
+  //   - YYYY-MM-DD (`2020-02-15`)
+  // The strip uses `[/-]` for the separator so any of these forms is
+  // caught. Each direction (year-first vs day-first) is handled by a
+  // separate alternative so the regex doesn't accidentally absorb
+  // unrelated text.
+  let court = content
+    .replace(/\s*\d{1,2}[/-]\d{1,2}[/-]\d{4}\s*$/, "")
+    .replace(/\s*\d{4}[/-]\d{1,2}[/-]\d{1,2}\s*$/, "")
+    .trim()
   // Strip trailing year-plus-disposition-modifier (`1990 mem.`,
   // `1990 unpublished`, `1990 per curiam`, `1990 en banc`, also the
   // year-first/comma-then-modifier form `1990, en banc`). The year

--- a/tests/extract/issueCourtDateFormatLeaks.test.ts
+++ b/tests/extract/issueCourtDateFormatLeaks.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("date-strip handles multiple numeric formats", () => {
+  it.each([
+    ["MM-DD-YYYY", "Smith, 100 F.2d 1 (9th Cir. 02-15-2020)"],
+    ["MM/DD/YYYY", "Smith, 100 F.2d 1 (9th Cir. 2/15/2020)"],
+    ["YYYY/MM/DD", "Smith, 100 F.2d 1 (9th Cir. 2020/02/15)"],
+    ["YYYY-MM-DD", "Smith, 100 F.2d 1 (9th Cir. 2020-02-15)"],
+  ])("`%s` date does not leak into court", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(2020)
+  })
+
+  it("regression: standard `(Mar. 15, 1990)` still strips", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. Mar. 15, 1990)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+
+  it("regression: bare year `(9th Cir. 1990)` still strips", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+})


### PR DESCRIPTION
## Summary

The numeric-date strip in `stripDateFromCourt` only handled `M/D/YYYY` (slash separator). Common alternates leaked partial date content into `court`:

| input | before | after |
|---|---|---|
| `(9th Cir. 02-15-2020)` | court=`9th Cir. 02-15-` | court=`9th Cir.` ✓ |
| `(9th Cir. 2020-02-15)` | court=`9th Cir. 2020-02-` | court=`9th Cir.` ✓ |
| `(9th Cir. 2020/02/15)` | court=`9th Cir. 2020/02/` | court=`9th Cir.` ✓ |

Extended to two regex alternatives covering both day-first and ISO year-first numeric date forms (`\d{1,2}[/-]\d{1,2}[/-]\d{4}` and `\d{4}[/-]\d{1,2}[/-]\d{1,2}`).

Found via adversarial probing.

## Test plan

- [x] 6 regression tests in `tests/extract/issueCourtDateFormatLeaks.test.ts`
- [x] Full suite passes (4038 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)