### PR TITLE
fix(extract): URL/filepath in court parenthetical does not pollute court

### DIFF
--- a/.changeset/fix-url-in-parens-court.md
+++ b/.changeset/fix-url-in-parens-court.md
@@ -1,0 +1,20 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): URL/filepath in court parenthetical no longer polluting court field
+
+When a citation's court parenthetical contained a URL (web link or
+filepath), the URL leaked into the `court` field. Real court
+abbreviations never contain `://` or `file:///`:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1 (file:///opinions/100-f2d-1.pdf)` | `court="file:///opinions/..."` | `court=undefined` ✓ |
+| `Smith, 100 F.2d 1 (https://example.com/100-f2d-1)` | leaks | `court=undefined` ✓ |
+| `Smith, 100 F.2d 1 (avail. at https://courts.gov/...)` | leaks | `court=undefined` ✓ |
+
+Added a URL-detection check in `stripDateFromCourt` — `://` (any URI
+scheme) or `file:///` triggers rejection.
+
+6 regression tests in `tests/extract/issueUrlInParensCourt.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -952,6 +952,12 @@ function stripDateFromCourt(content: string): string | undefined {
   if (/^["'“”‘’]/.test(court)) {
     return undefined
   }
+  // URL or filepath in parens: `(https://...)`, `(file:///...)`,
+  // `(avail. at https://...)`. Reject — URLs are never court
+  // abbreviations. Detect a `://` scheme separator or `file:///`.
+  if (/(?:[a-z][a-z\d+.-]*:\/\/|file:\/\/\/)/i.test(court)) {
+    return undefined
+  }
   // Dissent / concurring opinion attribution (`dis. opn. of Shenk, J.`,
   // `conc. opn. of Werdegar, J.`) contains periods so it passes the
   // period gate. Detect the `dis.|conc. opn.` head OR the trailing

--- a/tests/extract/issueUrlInParensCourt.test.ts
+++ b/tests/extract/issueUrlInParensCourt.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("URL/filepath in parens does not pollute court field", () => {
+  it.each([
+    ["https URL", "Smith, 100 F.2d 1 (https://example.com/100-f2d-1)"],
+    ["http URL", "Smith, 100 F.2d 1 (http://example.com/100-f2d-1)"],
+    ["file URL", "Smith, 100 F.2d 1 (file:///opinions/100-f2d-1.pdf)"],
+    ["URL with prefix", "Smith, 100 F.2d 1 (avail. at https://courts.gov/100/f2d/1)"],
+    ["ftp URL", "Smith, 100 F.2d 1 (ftp://example.com/100-f2d-1)"],
+  ])("`%s` does not pollute court", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBeUndefined()
+  })
+
+  it("regression: real court (9th Cir.) still extracts", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+  })
+})


### PR DESCRIPTION
## Summary

Citation parentheticals containing URLs (web links, file:// paths, ftp://, etc.) leaked the URL into the `court` field. Real court abbreviations never contain URI schemes:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1 (file:///opinions/100-f2d-1.pdf)` | court=`file:///opinions/...` | undefined ✓ |
| `Smith, 100 F.2d 1 (https://example.com/100-f2d-1)` | leaks | undefined ✓ |
| `Smith, 100 F.2d 1 (avail. at https://courts.gov/...)` | leaks | undefined ✓ |

Added a URL-scheme detection (`://` or `file:///`) in `stripDateFromCourt` — these contents are rejected.

Found via adversarial probing.

## Test plan

- [x] 6 regression tests in `tests/extract/issueUrlInParensCourt.test.ts`
- [x] Full suite passes (4044 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)