### PR TITLE
fix(extract): supra partyName strips additional sentence-initial connectors (But, However, Contra, etc.)

### DIFF
--- a/.changeset/fix-supra-but-prefix.md
+++ b/.changeset/fix-supra-but-prefix.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): supra `partyName` strips additional sentence-initial connectors
+
+`SUPRA_PARTY_PREFIX_REGEX` stripped `See`, `Cf.`, `Compare`, `Accord`,
+`But see`, `But cf.`, `E.g.`, `Also`, `In` (non-`In re`), and `Then`.
+It did not strip bare `But`, `However`, `Moreover`, `Therefore`,
+`Indeed`, or `Contra` (Bluebook contrastive signal). Result: when a
+supra followed a contrastive connector in prose, `partyName` absorbed
+the connector:
+
+| input | before | after |
+|---|---|---|
+| `But Smith, supra, at 7` | `partyName="But Smith"` | `"Smith"` ✓ |
+| `However Smith, supra, at 7` | `partyName="However Smith"` | `"Smith"` ✓ |
+| `Moreover Smith, supra, at 7` | leaks | `"Smith"` ✓ |
+| `Therefore Smith, supra, at 7` | leaks | `"Smith"` ✓ |
+| `Indeed Smith, supra, at 7` | leaks | `"Smith"` ✓ |
+| `Contra Smith, supra, at 7` | leaks | `"Smith"` ✓ |
+
+Added `But`, `Contra`, `However`, `Moreover`, `Therefore`, `Indeed` to
+the alternation. Existing `In(?!\s+re\b)` negative lookahead is
+unchanged.
+
+9 regression tests in `tests/extract/issueSupraButPrefix.test.ts`.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -34,7 +34,7 @@ import { parsePincite, type PinciteInfo } from "./pincite"
  * out the party name).
  */
 const SUPRA_PARTY_PREFIX_REGEX =
-  /^(?:But\s+(?:see|cf\.?)|See(?:\s+also)?(?:\s*,\s*e\.\s*g\.?)?|Compare|Cf\.?|Accord|E\.\s*g\.?|Also|In(?!\s+re\b)|Then)\s+/i
+  /^(?:But\s+(?:see|cf\.?)|But|See(?:\s+also)?(?:\s*,\s*e\.\s*g\.?)?|Compare|Cf\.?|Accord|Contra|E\.\s*g\.?|Also|In(?!\s+re\b)|Then|However|Moreover|Therefore|Indeed)\s+/i
 
 function stripSupraPartyPrefix(raw: string): string {
   const stripped = raw.replace(SUPRA_PARTY_PREFIX_REGEX, "").trim()

--- a/tests/extract/issueSupraButPrefix.test.ts
+++ b/tests/extract/issueSupraButPrefix.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { SupraCitation } from "@/types/citation"
+
+const supras = (text: string): SupraCitation[] =>
+  extractCitations(text).filter((c) => c.type === "supra") as SupraCitation[]
+
+describe("supra partyName strips leading sentence-initial connectors", () => {
+  it.each([
+    ["But", "But Smith, supra, at 7", "Smith"],
+    ["However", "However Smith, supra, at 7", "Smith"],
+    ["Moreover", "Moreover Smith, supra, at 7", "Smith"],
+    ["Therefore", "Therefore Smith, supra, at 7", "Smith"],
+    ["Indeed", "Indeed Smith, supra, at 7", "Smith"],
+    ["Contra", "Contra Smith, supra, at 7", "Smith"],
+  ])("`%s` is stripped", (_, input, expected) => {
+    const [c] = supras(input)
+    expect(c?.partyName).toBe(expected)
+  })
+
+  it("regression: `Smith, supra` preserves partyName=`Smith`", () => {
+    const [c] = supras("Smith, supra, at 7")
+    expect(c.partyName).toBe("Smith")
+  })
+
+  it("note: `In re Smith, supra` captures only `Smith` as partyName (tokenizer drops `In re`)", () => {
+    // The SUPRA_PATTERN tokenizer doesn't recognize procedural prefixes
+    // like `In re`, so the partyName is just `Smith`. Documenting current
+    // behavior here to catch any future regression.
+    const [c] = supras("In re Smith, supra, at 7")
+    expect(c.partyName).toBe("Smith")
+  })
+
+  it("regression: `See Smith, supra` strips See", () => {
+    const [c] = supras("See Smith, supra, at 7")
+    expect(c.partyName).toBe("Smith")
+  })
+})


### PR DESCRIPTION
## Summary

`SUPRA_PARTY_PREFIX_REGEX` stripped `See/Cf./Compare/Accord/But see/But cf./E.g./Also/In/Then` but missed bare `But`, `However`, `Moreover`, `Therefore`, `Indeed`, and `Contra` (Bluebook contrastive signal). Result: when a supra followed a contrastive connector in prose, the connector was absorbed into `partyName`:

| input | before | after |
|---|---|---|
| `But Smith, supra, at 7` | `partyName="But Smith"` | `"Smith"` ✓ |
| `However Smith, supra, at 7` | leaks | `"Smith"` ✓ |
| `Moreover Smith, supra, at 7` | leaks | `"Smith"` ✓ |
| `Therefore Smith, supra, at 7` | leaks | `"Smith"` ✓ |
| `Indeed Smith, supra, at 7` | leaks | `"Smith"` ✓ |
| `Contra Smith, supra, at 7` | leaks | `"Smith"` ✓ |

Added these tokens to the alternation. Existing `In(?!\s+re\b)` negative lookahead preserved so `In re Smith` still anchors correctly.

Found via adversarial probing.

## Test plan

- [x] 9 regression tests in `tests/extract/issueSupraButPrefix.test.ts`
- [x] Full suite passes (4053 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)