### PR TITLE
fix(extract): case-name backscan accepts colon in subtitles

### DIFF
--- a/.changeset/fix-case-name-colon.md
+++ b/.changeset/fix-case-name-colon.md
@@ -1,0 +1,18 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): case-name backscan accepts colon in subtitles
+
+V_CASE_NAME_REGEX's plaintiff/defendant char class lacked `:`, so case
+names with subtitle separators returned `caseName=null`:
+
+| input | before | after |
+|---|---|---|
+| `Smith v. Jones: Continued, 100 F.2d 1` | null | `Smith v. Jones: Continued` ✓ |
+| `Smith v. Jones: A Sequel, 100 F.2d 1` | null | `Smith v. Jones: A Sequel` ✓ |
+
+Added `:` to both plaintiff and defendant char classes. Case names
+without colons (most cases) are unaffected.
+
+4 regression tests in `tests/extract/issueCaseNameColon.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -748,8 +748,12 @@ function isNonMetadataParenContent(content: string): boolean {
 // ordinal forms (`21st Century Fox`, `1st National Bank`, `100th
 // Anniversary`). Without the `(?:st|nd|rd|th)?` suffix the regex
 // stripped the ordinal prefix entirely.
+//
+// Defendant char class includes `:` so case-name subtitles like
+// `Smith v. Jones: A Sequel` extract correctly. Plaintiff also accepts
+// `:` for the same reason.
 const V_CASE_NAME_REGEX =
-  /((?:\d[\d-]*(?:st|nd|rd|th)?\s+)?[A-ZÀ-Þ][A-Za-z0-9À-ſ\s.,'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9À-ſ\s.,'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
+  /((?:\d[\d-]*(?:st|nd|rd|th)?\s+)?[A-ZÀ-Þ][A-Za-z0-9À-ſ\s.,:'&()/-]+?)\s+v(?:s)?\.?\s+([A-Za-z0-9À-ſ\s.,:'&()/-]+?)\s*(?:,|\((?:([^)]*?\.[^)]*?)\s+)?(\d{4})\))\s*$/d
 
 /** Procedural prefix case name format.
  *  Longer prefixes listed first so the alternation prefers the longer match

--- a/tests/extract/issueCaseNameColon.test.ts
+++ b/tests/extract/issueCaseNameColon.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("case-name backscan accepts colon in case name (subtitles)", () => {
+  it("`Smith v. Jones: Continued` extracts case name with colon", () => {
+    const [c] = cases("Smith v. Jones: Continued, 100 F.2d 1")
+    expect(c?.caseName).toBe("Smith v. Jones: Continued")
+  })
+
+  it("`Smith v. Jones: A Sequel` extracts", () => {
+    const [c] = cases("Smith v. Jones: A Sequel, 100 F.2d 1")
+    expect(c?.caseName).toBe("Smith v. Jones: A Sequel")
+  })
+
+  it("regression: case names without colon still work", () => {
+    const [c] = cases("Smith v. Jones, 100 F.2d 1")
+    expect(c.caseName).toBe("Smith v. Jones")
+  })
+
+  it("regression: case names with hyphen still work", () => {
+    const [c] = cases("Smith v. Jones - Continued, 100 F.2d 1")
+    expect(c.caseName).toBe("Smith v. Jones - Continued")
+  })
+})


### PR DESCRIPTION
## Summary

V_CASE_NAME_REGEXs plaintiff/defendant char class lacked `:`, so case names with subtitle separators returned `caseName=null`:

| input | before | after |
|---|---|---|
| `Smith v. Jones: Continued, 100 F.2d 1` | null | `Smith v. Jones: Continued` ✓ |
| `Smith v. Jones: A Sequel, 100 F.2d 1` | null | `Smith v. Jones: A Sequel` ✓ |

Added `:` to both plaintiff and defendant char classes.

Found via adversarial probing.

## Test plan

- [x] 4 regression tests in `tests/extract/issueCaseNameColon.test.ts`
- [x] Full suite passes (4057 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)