### PR TITLE
fix(extract): page terminator accepts typography / footnote markers (†, ‡, §, ¶, ©, °)

### DIFF
--- a/.changeset/fix-typography-terminator.md
+++ b/.changeset/fix-typography-terminator.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): page terminator accepts typography / footnote markers (†, ‡, §, ¶, ©, °)
+
+When a citation was immediately followed by a typographic reference
+mark (`100 F.2d 1†`, `100 F.2d 1‡`, `100 F.2d 1§`), the terminator
+character class did not include these characters and the whole citation
+was silently dropped:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1†` | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1‡` | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1§` | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1¶` | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1©` | 0 cites | 1 cite ✓ |
+| `Smith, 100 F.2d 1°` | 0 cites | 1 cite ✓ |
+
+Added `†`, `‡`, `§`, `¶`, `©`, `°` to the page-terminator character
+class across all three case patterns. Real reporters never end with
+these characters.
+
+7 regression tests in `tests/extract/issueTypographyTerminator.test.ts`.

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -48,14 +48,16 @@ export interface Pattern {
 //     a space: `!`, `?`, em dash (—), en dash (–), apostrophe
 //     (possessive `1's holding`), straight quote (`"`), curly quotes
 //     (`“` `”`), markdown asterisk (`*`), angle brackets (`<` `>`).
-//     Real reporters never end with these characters, so accepting them
-//     as terminators is safe and recovers common quoted/markdown
-//     trailing forms.
+//   - typographic footnote / reference markers: dagger (`†`), double
+//     dagger (`‡`), section sign (`§`), pilcrow (`¶`), copyright (`©`),
+//     degree sign (`°`). These follow the page when the citation is
+//     immediately tagged with a footnote reference or attribution mark.
+//     Real reporters never end with these characters.
 //   - `-` followed by a non-digit. The cleaner normalizes in-word em/en
 //     dashes to ASCII `-`, so `1—a` arrives at the tokenizer as `1-a`.
 //     The `\D` lookahead keeps page-range syntax intact (`44-501` does
 //     not terminate at `44`, because `-5` is digit). #681-class.
-const COMMA_PAGE_TERMINATOR = String.raw`(?=$|[.;,)\]!?–—'"“”*<>]|-\D)`
+const COMMA_PAGE_TERMINATOR = String.raw`(?=$|[.;,)\]!?–—'"“”*<>†‡§¶©°]|-\D)`
 
 export const casePatterns: Pattern[] = [
   {
@@ -68,7 +70,7 @@ export const casePatterns: Pattern[] = [
     // Terminator accepts `)` for citations wrapped in a sentence-internal
     // parenthetical — e.g., `(Smith v. Jones, 500 F.2d 123)` (#509).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>†‡§¶©°]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:
@@ -83,7 +85,7 @@ export const casePatterns: Pattern[] = [
     // Terminator accepts `)` for sentence-internal parenthetical citations
     // (#509).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)(?:\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)(?:\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>†‡§¶©°]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:
@@ -145,7 +147,7 @@ export const casePatterns: Pattern[] = [
     // space to handle Illinois `R. <ruleNum>` and the `L.J./L.Q./L.R.`
     // journal-abbreviation guards (#332, #549).
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)(?!(?:AND|OR)\s+\d)([A-Z][A-Za-z.\d&']*(?:(?! L\.[JQR\s])(?! R\.\s+\d)\s+[A-Z\d&][A-Za-z.\d&']*)*?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?\[\]–—'"“”*<>]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)(?!(?:AND|OR)\s+\d)([A-Z][A-Za-z.\d&']*(?:(?! L\.[JQR\s])(?! R\.\s+\d)\s+[A-Z\d&][A-Za-z.\d&']*)*?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?\[\]–—'"“”*<>†‡§¶©°]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:

--- a/tests/extract/issueTypographyTerminator.test.ts
+++ b/tests/extract/issueTypographyTerminator.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+
+describe("page terminator accepts typography / footnote-marker characters", () => {
+  it.each([
+    ["dagger †", "Smith, 100 F.2d 1†"],
+    ["double dagger ‡", "Smith, 100 F.2d 1‡"],
+    ["section §", "Smith, 100 F.2d 1§"],
+    ["pilcrow ¶", "Smith, 100 F.2d 1¶"],
+    ["copyright ©", "Smith, 100 F.2d 1©"],
+    ["degree °", "Smith, 100 F.2d 1°"],
+  ])("`%s` still extracts the citation", (_, input) => {
+    const cs = extractCitations(input)
+    expect(cs.length).toBeGreaterThan(0)
+    expect(cs[0].matchedText).toBe("100 F.2d 1")
+  })
+
+  it("regression: bare digit page still requires terminator", () => {
+    const cs = extractCitations("Smith, 100 F.2d 1234")
+    expect(cs[0].matchedText).toBe("100 F.2d 1234")
+  })
+})


### PR DESCRIPTION
## Summary

When a citation was immediately followed by a typographic reference mark, the terminator class did not include these characters and the whole citation was silently dropped:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1†` (dagger) | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1‡` (double dagger) | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1§` (section) | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1¶` (pilcrow) | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1©` (copyright) | 0 cites | 1 cite ✓ |
| `Smith, 100 F.2d 1°` (degree) | 0 cites | 1 cite ✓ |

Added these six markers to the page-terminator character class across all three case patterns. Real reporters never end with these chars.

Found via adversarial probing.

## Test plan

- [x] 7 regression tests in `tests/extract/issueTypographyTerminator.test.ts`
- [x] Full suite passes (4064 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)