### PR TITLE
fix(extract): pincite parser accepts typography terminator (†, ‡, §, ¶, ©, °)

### DIFF
--- a/.changeset/fix-pincite-typography-terminator.md
+++ b/.changeset/fix-pincite-typography-terminator.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): pincite parser accepts typography terminator (†, ‡, §, ¶, ©, °)
+
+Extends PR #724 (page terminator) to the pincite parsers. When a
+pincite digit was immediately followed by a typographic reference
+mark (`Smith, 100 F.2d 1, 5†`), the LOOKAHEAD_PINCITE_REGEX and
+ADDITIONAL_PINCITE_REGEX terminator classes did not include these
+chars, so the pincite was silently dropped:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1, 5†` | pincite=undefined | pincite=5 ✓ |
+| `Smith, 100 F.2d 1, 5‡` | undefined | 5 ✓ |
+| `Smith, 100 F.2d 1, 5§` | undefined | 5 ✓ |
+| `Smith, 100 F.2d 1, 5¶` | undefined | 5 ✓ |
+| `Smith, 100 F.2d 1, 5©` | undefined | 5 ✓ |
+| `Smith, 100 F.2d 1, 5°` | undefined | 5 ✓ |
+
+Added the six typography markers to both pincite-regex terminator
+character classes.
+
+8 regression tests in `tests/extract/issuePinciteTypographyTerminator.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -493,7 +493,7 @@ const LOOKAHEAD_PAREN_REGEX =
 // `pinciteInfo.footnote` with `page=undefined`. The leading `at` prefix is
 // allowed for symmetry with the page-bearing forms.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)([\]»"'“”‘’]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)([\]»"'“”‘’†‡§¶©°]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g
@@ -517,7 +517,7 @@ const PAREN_SKIP_REGEX = /[\s,]/
 //
 // Range separators include tilde (#516).
 const ADDITIONAL_PINCITE_REGEX =
-  /^,\s*(\*?\d+(?:[-–—~]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?)(?=$|[.,:;)([\]»"'“”‘’]|\s(?![A-Z]))/
+  /^,\s*(\*?\d+(?:[-–—~]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?)(?=$|[.,:;)([\]»"'“”‘’†‡§¶©°]|\s(?![A-Z]))/
 
 /** Pincite text that appears between core citation and parentheticals.
  *  Matches: comma-separated page numbers/ranges and optional note refs.

--- a/tests/extract/issuePinciteTypographyTerminator.test.ts
+++ b/tests/extract/issuePinciteTypographyTerminator.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("pincite parser accepts typography terminator (†, ‡, §, ¶, ©, °)", () => {
+  it.each([
+    ["dagger", "Smith, 100 F.2d 1, 5†"],
+    ["double dagger", "Smith, 100 F.2d 1, 5‡"],
+    ["section", "Smith, 100 F.2d 1, 5§"],
+    ["pilcrow", "Smith, 100 F.2d 1, 5¶"],
+    ["copyright", "Smith, 100 F.2d 1, 5©"],
+    ["degree", "Smith, 100 F.2d 1, 5°"],
+  ])("`%s` after pincite digit still captures pincite", (_, input) => {
+    const [c] = cases(input)
+    expect(c?.pincite).toBe(5)
+  })
+
+  it("regression: bare pincite without trailing marker still works", () => {
+    const [c] = cases("Smith, 100 F.2d 1, 5")
+    expect(c?.pincite).toBe(5)
+  })
+
+  it("regression: pincite followed by period still works", () => {
+    const [c] = cases("Smith, 100 F.2d 1, 5.")
+    expect(c?.pincite).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary

Extends PR #724. The page terminator was fixed but the pincite parser terminators (LOOKAHEAD_PINCITE_REGEX and ADDITIONAL_PINCITE_REGEX) still rejected the same typography markers:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1, 5†` | pincite=undefined | pincite=5 ✓ |
| `Smith, 100 F.2d 1, 5‡` | undefined | 5 ✓ |
| `Smith, 100 F.2d 1, 5§` | undefined | 5 ✓ |
| `Smith, 100 F.2d 1, 5¶` | undefined | 5 ✓ |
| `Smith, 100 F.2d 1, 5©` | undefined | 5 ✓ |
| `Smith, 100 F.2d 1, 5°` | undefined | 5 ✓ |

Added the six typography markers to both pincite-regex terminator character classes.

Found via adversarial probing.

## Test plan

- [x] 8 regression tests in `tests/extract/issuePinciteTypographyTerminator.test.ts`
- [x] Full suite passes (4072 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)