### PR TITLE
fix(extract): Id.at (no space before 'at') captures pincite (#683)

### DIFF
--- a/.changeset/fix-id-at-no-space.md
+++ b/.changeset/fix-id-at-no-space.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): `Id.at 5` (no space before `at`) captures pincite
+
+Resolves #683. The Id./Ibid. pincite-capture regexes required at least
+one whitespace character between the closing period/comma and the `at`
+keyword. OCR / compressed text frequently omits this space, producing
+`Id.at 5` which silently dropped the pincite:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1. Id.at 5.` | matchedText=`Id.`, pincite=undefined | matchedText=`Id.at 5`, pincite=5 ✓ |
+| `Smith, 100 F.2d 1. Ibid.at 5.` | similar | pincite=5 ✓ |
+
+Changed `\s+at` to `\s*at` in three regexes: `ID_PATTERN` and
+`IBID_PATTERN` (tokenizer) and the inline `idRegex` in `extractId`
+(extractor). Canonical `Id. at 5` and bare `Id.` continue to work.
+
+5 regression tests in `tests/extract/issueIdAtNoSpace.test.ts`.

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -182,7 +182,7 @@ export function extractId(
   // truncates the token before reaching this point), but keeps the
   // regexes in lock-step to prevent future drift.
   const idRegex =
-    /([Ii])(?:d|bid)\s*([.,])(?:(,\s+(?!\d+\s+[A-Z])|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
+    /([Ii])(?:d|bid)\s*([.,])(?:(,\s+(?!\d+\s+[A-Z])|,?\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?))?/d
   const match = idRegex.exec(text)
 
   if (!match) {

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -36,13 +36,13 @@ import type { Pattern } from "./casePatterns"
  *  (`Id., 6.`) keeps working because its digits are not followed by a
  *  capital-letter reporter shape. */
 export const ID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d(?:\s*\.|\s*,(?=\s+at\s))(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d(?:\s*\.|\s*,(?=\s+at\s))(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /** Ibid. with optional pincite (less common variant). Paragraph forms (#204)
  *  follow the same convention as Id. Optional space before the period (#305).
  *  Comma-pincite guard (#549) mirrors ID_PATTERN — see comment there. */
 export const IBID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\s*\.(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\s*\.(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
 
 /**
  * Supra with party name and optional pincite.

--- a/tests/extract/issueIdAtNoSpace.test.ts
+++ b/tests/extract/issueIdAtNoSpace.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { IdCitation } from "@/types/citation"
+
+const ids = (text: string): IdCitation[] =>
+  extractCitations(text).filter((c) => c.type === "id") as IdCitation[]
+
+describe("Id. without space before `at` still captures pincite (#683)", () => {
+  it("`Id.at 5` extracts pincite=5", () => {
+    const [c] = ids("Smith, 100 F.2d 1. Id.at 5.")
+    expect(c?.matchedText).toBe("Id.at 5")
+    expect(c?.pincite).toBe(5)
+  })
+
+  it("`Id.at 5-7` extracts pincite range", () => {
+    const [c] = ids("Smith, 100 F.2d 1. Id.at 5-7.")
+    expect(c?.matchedText).toBe("Id.at 5-7")
+  })
+
+  it("`Ibid.at 5` extracts (Ibid variant)", () => {
+    const [c] = ids("Smith, 100 F.2d 1. Ibid.at 5.")
+    expect(c?.matchedText).toBe("Ibid.at 5")
+    expect(c?.pincite).toBe(5)
+  })
+
+  it("regression: `Id. at 5` (canonical form) still works", () => {
+    const [c] = ids("Smith, 100 F.2d 1. Id. at 5.")
+    expect(c?.pincite).toBe(5)
+  })
+
+  it("regression: bare `Id.` (no pincite) still works", () => {
+    const [c] = ids("Smith, 100 F.2d 1. Id.")
+    expect(c?.matchedText).toBe("Id.")
+    expect(c?.pincite).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Resolves #683. The Id./Ibid. pincite-capture regexes required `\s+at` (at least one space before `at`). OCR / compressed text often omits this space:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1. Id.at 5.` | matchedText=`Id.`, pincite=undefined | matchedText=`Id.at 5`, pincite=5 ✓ |
| `Smith, 100 F.2d 1. Ibid.at 5.` | similar | pincite=5 ✓ |

Changed `\s+at` to `\s*at` in three regexes: ID_PATTERN, IBID_PATTERN (tokenizer), and the inline idRegex in extractId (extractor). Canonical `Id. at 5` and bare `Id.` continue to work.

Found via adversarial probing. Resolves #683.

## Test plan

- [x] 5 regression tests in `tests/extract/issueIdAtNoSpace.test.ts`
- [x] Full suite passes (4077 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)