### PR TITLE
fix(extract): volume/page reference parentheticals not parsed as court (#700)

### DIFF
--- a/.changeset/fix-vol-paren-not-court.md
+++ b/.changeset/fix-vol-paren-not-court.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): volume/page reference parentheticals not parsed as court (#700)
+
+Resolves #700. Parentheticals starting with volume/page reference
+tokens (`Vol. 100`, `p. 5`, `at 7`, `note 7`) leaked into the `court`
+field. Worse, the trailing-day-strip regex chewed 1-2 digits off
+`Vol. 100` producing the malformed `court="Vol. 1"`.
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1 (Vol. 100)` | court=`Vol. 1` | undefined ✓ |
+| `Smith, 100 F.2d 1 (p. 5)` | court=`p.` | undefined ✓ |
+| `Smith, 100 F.2d 1 (at 7)` | court=`at` | undefined ✓ |
+| `Smith, 100 F.2d 1 (note 7)` | court=`note` | undefined ✓ |
+
+Added an early-exit check at the top of `stripDateFromCourt` that
+rejects parentheticals starting with `Vol.|vol.|p.|pp.|at|n.|note`
+followed by a digit. This runs BEFORE the date-strip pipeline so the
+digits don't get chewed away.
+
+9 regression tests in `tests/extract/issueVolParenNotCourt.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -896,6 +896,13 @@ const SENTENCE_INITIAL_WORDS = new Set([
  *        "D. Mass. 1/15/2020" → "D. Mass."
  */
 function stripDateFromCourt(content: string): string | undefined {
+  // Reject volume/page-reference parentheticals BEFORE any date-stripping
+  // runs (`(Vol. 100)`, `(p. 5)`, `(at 7)`). The day-strip regex below
+  // would otherwise eat 1-2 trailing digits from `Vol. 100`, producing
+  // a garbage `court="Vol. 1"`. #700.
+  if (/^(?:Vol\.?|vol\.?|p\.?|pp\.?|at|n\.?|note)\s+\d/i.test(content)) {
+    return undefined
+  }
   // Strip trailing numeric date formats. Accepts:
   //   - M/D/YYYY  (`1/15/2020`)
   //   - MM-DD-YYYY (`02-15-2020`)

--- a/tests/extract/issueVolParenNotCourt.test.ts
+++ b/tests/extract/issueVolParenNotCourt.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("volume / page reference parens not parsed as court (#700)", () => {
+  it.each([
+    ["Vol. 100", "Smith, 100 F.2d 1 (Vol. 100)"],
+    ["vol. 100", "Smith, 100 F.2d 1 (vol. 100)"],
+    ["Vol 100", "Smith, 100 F.2d 1 (Vol 100)"],
+    ["p. 5", "Smith, 100 F.2d 1 (p. 5)"],
+    ["pp. 5-10", "Smith, 100 F.2d 1 (pp. 5-10)"],
+    ["at 7", "Smith, 100 F.2d 1 (at 7)"],
+    ["n. 7", "Smith, 100 F.2d 1 (n. 7)"],
+    ["note 7", "Smith, 100 F.2d 1 (note 7)"],
+  ])("`%s` does not pollute court", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBeUndefined()
+  })
+
+  it("regression: real court still extracts", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+  })
+})


### PR DESCRIPTION
## Summary

Resolves #700. Parentheticals starting with volume/page reference tokens leaked into `court`, sometimes with mangled digits:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1 (Vol. 100)` | court=`Vol. 1` (digits eaten) | undefined ✓ |
| `Smith, 100 F.2d 1 (p. 5)` | court=`p.` | undefined ✓ |
| `Smith, 100 F.2d 1 (at 7)` | court=`at` | undefined ✓ |
| `Smith, 100 F.2d 1 (note 7)` | court=`note` | undefined ✓ |

Added an early-exit check in `stripDateFromCourt` that rejects parens starting with `Vol.|vol.|p.|pp.|at|n.|note` followed by a digit. Runs BEFORE the date-strip pipeline so digits dont get chewed.

Found via adversarial probing.

## Test plan

- [x] 9 regression tests in `tests/extract/issueVolParenNotCourt.test.ts`
- [x] Full suite passes (4086 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)