### PR TITLE
fix(extract): pincite range accepts asymmetric spacing around hyphen (#722)

### DIFF
--- a/.changeset/fix-pincite-asymmetric-spacing.md
+++ b/.changeset/fix-pincite-asymmetric-spacing.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): pincite range accepts asymmetric spacing around hyphen (#722)
+
+Resolves #722. The pincite range regex required either no spaces or
+symmetric spaces around the hyphen. The asymmetric form (`5- 7`,
+`5 -7`) silently dropped the pincite:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1, 5 - 7` | pincite=5 | pincite=5 ✓ |
+| `Smith, 100 F.2d 1, 5- 7` | pincite=undefined | pincite=5 ✓ |
+| `Smith, 100 F.2d 1, 5 -7` | pincite=5 | pincite=5 ✓ |
+| `Smith, 100 F.2d 1, 5-7` | pincite=5 | pincite=5 ✓ |
+
+Changed `[-–—~]` to `\s*[-–—~]\s*` in three regexes:
+- `PINCITE_REGEX` (extractCase.ts inner)
+- `LOOKAHEAD_PINCITE_REGEX` (extractCase.ts trailing pincite scan)
+- `PINCITE_PARSE_REGEX` (pincite.ts numeric parser)
+
+All asymmetric and symmetric spacing forms now parse correctly.
+
+5 regression tests in `tests/extract/issuePinciteAsymmetricSpacing.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -428,7 +428,7 @@ const BLANK_PAGE_REGEX = /^[_-]{3,}$/
  *  Lexis, and other slip-opinion citations; see #191), and an optional
  *  trailing footnote suffix " n.14" / " nn.14-15" (see #202). */
 const PINCITE_REGEX =
-  /,\s*(?:at\s+)?(\*?\d+(?:-\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)/d
+  /,\s*(?:at\s+)?(\*?\d+(?:\s*-\s*\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:\s*[-–—]\s*\d+)?)?)/d
 
 /** Matches parenthetical content */
 const PAREN_REGEX = /\(([^)]+)\)/
@@ -493,7 +493,7 @@ const LOOKAHEAD_PAREN_REGEX =
 // `pinciteInfo.footnote` with `page=undefined`. The leading `at` prefix is
 // allowed for symmetry with the page-bearing forms.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:[-–—~]\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)?|¶¶?\s*\d+(?:[-–—~]\d+)?|paras?\.?\s*\d+(?:[-–—~]\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:[-–—~]\d+)?)(?=$|[.,:;)([\]»"'“”‘’†‡§¶©°]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:\s*[-–—~]\s*\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:\s*[-–—~]\s*\d+)?)?|¶¶?\s*\d+(?:\s*[-–—~]\s*\d+)?|paras?\.?\s*\d+(?:\s*[-–—~]\s*\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:\s*[-–—~]\s*\d+)?)(?=$|[.,:;)([\]»"'“”‘’†‡§¶©°]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g

--- a/src/extract/pincite.ts
+++ b/src/extract/pincite.ts
@@ -56,7 +56,7 @@ const PARA_NUM_REGEX = /^(\d+)(?:\s*[-–—~]\s*(\d+))?\s*$/
  *  Tilde (`~`) is accepted as a range separator alongside hyphen and dashes
  *  for OCR-artifact tolerance (#516). */
 const PINCITE_PARSE_REGEX =
-  /^(?:at\s+)?(\*?)(\d+)(?:[-–—~]\*?(\d+))?(?:\s*,)?\s*(?:(?:nn?|fns?|note)\s*\.?\s*(\d+)(?:[-–—~](\d+))?)?$/i
+  /^(?:at\s+)?(\*?)(\d+)(?:\s*[-–—~]\s*\*?(\d+))?(?:\s*,)?\s*(?:(?:nn?|fns?|note)\s*\.?\s*(\d+)(?:\s*[-–—~]\s*(\d+))?)?$/i
 
 /** Footnote-only pincite — no page digits, just `n. 7`, `note 7`, `nn. 3-5`,
  *  `fn. 4` (#515). Surfaces when the cited material is on the citation's

--- a/tests/extract/issuePinciteAsymmetricSpacing.test.ts
+++ b/tests/extract/issuePinciteAsymmetricSpacing.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("pincite range accepts asymmetric spacing around hyphen (#722)", () => {
+  it.each([
+    ["5- 7 (space after only)", "Smith, 100 F.2d 1, 5- 7"],
+    ["5 -7 (space before only)", "Smith, 100 F.2d 1, 5 -7"],
+    ["5 - 7 (both spaces)", "Smith, 100 F.2d 1, 5 - 7"],
+    ["5-7 (no spaces)", "Smith, 100 F.2d 1, 5-7"],
+  ])("`%s` captures pincite=5", (_, input) => {
+    const [c] = cases(input)
+    expect(c?.pincite).toBe(5)
+  })
+
+  it("regression: comma + page-only (no range) still works", () => {
+    const [c] = cases("Smith, 100 F.2d 1, 5")
+    expect(c?.pincite).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary

Resolves #722. The pincite range regex required no spaces or symmetric spaces around the hyphen. Asymmetric forms (`5- 7`, `5 -7`) silently dropped the pincite:

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1, 5- 7` | pincite=undefined | pincite=5 ✓ |
| `Smith, 100 F.2d 1, 5 -7` | pincite=5 | pincite=5 ✓ |
| `Smith, 100 F.2d 1, 5 - 7` | pincite=5 | pincite=5 ✓ |
| `Smith, 100 F.2d 1, 5-7` | pincite=5 | pincite=5 ✓ |

Changed `[-–—~]` to `\s*[-–—~]\s*` in three regexes:
- `PINCITE_REGEX` (extractCase.ts inner)
- `LOOKAHEAD_PINCITE_REGEX` (extractCase.ts trailing scan)
- `PINCITE_PARSE_REGEX` (pincite.ts numeric parser)

Found via adversarial probing. Resolves #722.

## Test plan

- [x] 5 regression tests in `tests/extract/issuePinciteAsymmetricSpacing.test.ts`
- [x] Full suite passes (4091 passed, 12 skipped, 12 todo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)