### PR TITLE
fix(extract): adverb-prefixed disposition tokens don't pollute court (#719)

### DIFF
--- a/.changeset/fix-now-reversed-disposition.md
+++ b/.changeset/fix-now-reversed-disposition.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): adverb-prefixed disposition tokens don't pollute court (#719)
+
+Resolves #719. PR #678's disposition-token rejection required the
+disposition to start the content (`^(?:rev'd|aff'd|...|reversed|...)`).
+When the disposition is prefixed with `now`, `previously`, `formerly`,
+or `since`, the regex didn't match and the prefix+disposition leaked
+into court:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1 (now reversed, 1990)` | court=`now reversed` | undefined ✓ |
+| `Smith, 100 F.2d 1 (previously vacated, 1990)` | leaks | undefined ✓ |
+| `Smith, 100 F.2d 1 (formerly aff'd, 1990)` | leaks | undefined ✓ |
+| `Smith, 100 F.2d 1 (since overruled, 1990)` | leaks | undefined ✓ |
+
+Added an optional leading adverb (`(?:(?:now|previously|formerly|since)\s+)?`)
+before the disposition token. Existing bare-disposition forms continue
+to be rejected.
+
+8 regression tests in `tests/extract/issueNowReversedDisposition.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -992,8 +992,12 @@ function stripDateFromCourt(content: string): string | undefined {
   // court parenthetical: `(rev'd 1990)`, `(per curiam 1990)`, `(en banc)`,
   // `(cert. denied 1990)`. After year-stripping, the bare disposition is
   // not a court — reject it so we don't surface `court="rev'd"`.
+  //
+  // Optional leading adverb (`now`, `previously`, `formerly`, `since`)
+  // is allowed so `(now reversed, 1990)` / `(previously vacated)` are
+  // also rejected. #719.
   if (
-    /^(?:rev'd|aff'd|aff'g|rev'g|mod'd|cert\.?\s+(?:denied|granted|dismissed)|appeal\s+(?:denied|dismissed|docketed)|dismissed|reversed|vacated|vacating|overruled(?:\s+by)?|overruling|en\s+banc|per\s+curiam)(?:\s+(?:in\s+part|on\s+other\s+grounds?|sub\s+nom\.?))?\s*$/i.test(
+    /^(?:(?:now|previously|formerly|since)\s+)?(?:rev'd|aff'd|aff'g|rev'g|mod'd|cert\.?\s+(?:denied|granted|dismissed)|appeal\s+(?:denied|dismissed|docketed)|dismissed|reversed|vacated|vacating|overruled(?:\s+by)?|overruling|en\s+banc|per\s+curiam)(?:\s+(?:in\s+part|on\s+other\s+grounds?|sub\s+nom\.?))?\s*$/i.test(
       court,
     )
   ) {

--- a/tests/extract/issueNowReversedDisposition.test.ts
+++ b/tests/extract/issueNowReversedDisposition.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("adverb-prefixed disposition tokens don't pollute court (#719)", () => {
+  it.each([
+    ["now reversed", "Smith, 100 F.2d 1 (now reversed, 1990)"],
+    ["now vacated", "Smith, 100 F.2d 1 (now vacated, 1990)"],
+    ["previously reversed", "Smith, 100 F.2d 1 (previously reversed, 1990)"],
+    ["formerly aff'd", "Smith, 100 F.2d 1 (formerly aff'd, 1990)"],
+    ["since overruled", "Smith, 100 F.2d 1 (since overruled, 1990)"],
+    ["since overruled by", "Smith, 100 F.2d 1 (since overruled by, 1990)"],
+  ])("`%s` does not pollute court", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("regression: bare `rev'd` still rejected", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (rev'd 1990)")
+    expect(c.court).toBeUndefined()
+  })
+
+  it("regression: real court still extracts", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+  })
+})


### PR DESCRIPTION
Resolves #719. PR #678 disposition-token rejection required disposition to start content. When prefixed with now/previously/formerly/since, the regex didn't match.

| input | before | after |
|---|---|---|
| `(now reversed, 1990)` | court="now reversed" | undefined |
| `(previously vacated, 1990)` | leaks | undefined |
| `(formerly affd, 1990)` | leaks | undefined |
| `(since overruled, 1990)` | leaks | undefined |

Added optional leading adverb in the disposition regex.

8 regression tests in tests/extract/issueNowReversedDisposition.test.ts. Resolves #719.