### PR TITLE
fix(extract): nested year parenthetical does not leak into court (#682)

### DIFF
--- a/.changeset/fix-nested-year-paren.md
+++ b/.changeset/fix-nested-year-paren.md
@@ -1,0 +1,23 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): nested year parenthetical does not leak into court (#682)
+
+Resolves #682. When a citation's year parenthetical contained a nested
+disposition paren (`(1990 (en banc))`, `(9th Cir. 1990 (per curiam))`),
+the trailing-year strip couldn't reach the year because `(en banc)`
+sat between it and end-of-string. The whole `1990 (en banc)` residue
+leaked into the `court` field:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1 (1990 (en banc))` | court=`1990 (en banc)` | undefined ✓ |
+| `Smith, 100 F.2d 1 (9th Cir. 1990 (en banc))` | court=`9th Cir. 1990 (en banc)` | court=`9th Cir.` ✓ |
+
+Added a leading-pass that strips a trailing nested `\([^()]*\)` before
+the year/date strips run. The year stays in the parent paren and is
+extracted normally; the nested disposition is discarded (could be
+surfaced as structured disposition in a future enhancement).
+
+4 regression tests in `tests/extract/issueNestedYearParen.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -903,6 +903,12 @@ function stripDateFromCourt(content: string): string | undefined {
   if (/^(?:Vol\.?|vol\.?|p\.?|pp\.?|at|n\.?|note)\s+\d/i.test(content)) {
     return undefined
   }
+  // Strip a trailing nested parenthetical (`(en banc)` / `(per curiam)`
+  // inside the outer year paren — `(1990 (en banc))`). Without this
+  // the trailing-year strip can't reach `1990` because `(en banc)`
+  // sits between it and end-of-string, and the entire `1990 (en banc)`
+  // residue leaks into court. #682.
+  content = content.replace(/\s*\([^()]*\)\s*$/, "").trim()
   // Strip trailing numeric date formats. Accepts:
   //   - M/D/YYYY  (`1/15/2020`)
   //   - MM-DD-YYYY (`02-15-2020`)

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -908,7 +908,7 @@ function stripDateFromCourt(content: string): string | undefined {
   // the trailing-year strip can't reach `1990` because `(en banc)`
   // sits between it and end-of-string, and the entire `1990 (en banc)`
   // residue leaks into court. #682.
-  content = content.replace(/\s*\([^()]*\)\s*$/, "").trim()
+  const stripped = content.replace(/\s*\([^()]*\)\s*$/, "").trim()
   // Strip trailing numeric date formats. Accepts:
   //   - M/D/YYYY  (`1/15/2020`)
   //   - MM-DD-YYYY (`02-15-2020`)
@@ -918,7 +918,7 @@ function stripDateFromCourt(content: string): string | undefined {
   // caught. Each direction (year-first vs day-first) is handled by a
   // separate alternative so the regex doesn't accidentally absorb
   // unrelated text.
-  let court = content
+  let court = stripped
     .replace(/\s*\d{1,2}[/-]\d{1,2}[/-]\d{4}\s*$/, "")
     .replace(/\s*\d{4}[/-]\d{1,2}[/-]\d{1,2}\s*$/, "")
     .trim()

--- a/tests/extract/issueNestedYearParen.test.ts
+++ b/tests/extract/issueNestedYearParen.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("nested year parenthetical does not leak into court (#682)", () => {
+  it("`(1990 (en banc))` → court undefined, year=1990", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (1990 (en banc))")
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("`(9th Cir. 1990 (en banc))` → court='9th Cir.', year=1990", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990 (en banc))")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+
+  it("`(1990 (per curiam))` does not leak", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (1990 (per curiam))")
+    expect(c.court).toBeUndefined()
+    expect(c.year).toBe(1990)
+  })
+
+  it("regression: simple `(9th Cir. 1990)` still works", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 1990)")
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(1990)
+  })
+})


### PR DESCRIPTION
Resolves #682. When a year parenthetical contained a nested disposition paren, the trailing-year strip couldnt reach the year and the whole `1990 (en banc)` residue leaked into court.

| input | before | after |
|---|---|---|
| `Smith, 100 F.2d 1 (1990 (en banc))` | court="1990 (en banc)" | undefined |
| `Smith, 100 F.2d 1 (9th Cir. 1990 (en banc))` | court="9th Cir. 1990 (en banc)" | court="9th Cir." |
| `Smith, 100 F.2d 1 (1990 (per curiam))` | leaks | undefined |

Added a leading-pass that strips a trailing nested `\([^()]*\)` before the date strips run.

4 regression tests in tests/extract/issueNestedYearParen.test.ts. Resolves #682.