### PR TITLE
fix(extract): misspelled month names stripped from court (#717)

### DIFF
--- a/.changeset/fix-misspelled-month-strip.md
+++ b/.changeset/fix-misspelled-month-strip.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): misspelled / OCR-mangled month names stripped from court (#717)
+
+Resolves #717. The date-strip pipeline only knew canonical month names
+and abbreviations (`Jan`-`Dec`, `January`-`December`). Misspelled or
+truncated month names (`Jaunary` for January, `Ferbuary` for February,
+`Marc` for March, `Septmber` for September) leaked into the court field:
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1 (9th Cir. Jaunary 15, 2020)` | court=`9th Cir. Jaunary` | court=`9th Cir.` ✓ |
+| `Smith, 100 F.2d 1 (9th Cir. Ferbuary 2020)` | court=`9th Cir. Ferbuary` | court=`9th Cir.` ✓ |
+| `Smith, 100 F.2d 1 (9th Cir. Marc 15, 2020)` | court=`9th Cir. Marc` | court=`9th Cir.` ✓ |
+
+Added a fuzzy-match strip after the canonical month strip: if the
+trailing word is Title-Case, 3-12 chars, starts with the same letter
+as a month name, and has Levenshtein distance ≤ 2 from that month,
+strip it. The first-letter constraint prevents real court abbreviations
+like `Cal.` (distance 2 from `Jan`) from being mis-stripped.
+
+A `NO_STRIP_TRAILING` blocklist (Cir, Ct, App, Sup, Dist, Div, etc.)
+provides an explicit safety net for court abbreviation tokens.
+
+8 regression tests in `tests/extract/issueMisspelledMonthStrip.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -35,6 +35,7 @@ import { getReportersSync } from "@/data/reportersCache"
 import { inferCourtFromReporter } from "./courtInference"
 import { parsePincite, type PinciteInfo } from "./pincite"
 import { normalizeCourt } from "./courtNormalization"
+import { levenshteinDistance } from "@/resolve/levenshtein"
 
 /** Valid CitationSignal values for safe validation after regex capture + normalization. */
 const VALID_SIGNALS = new Set([
@@ -105,6 +106,70 @@ function parseVolume(raw: string): number | string {
 /** Month abbreviations and full names found in legal citation parentheticals */
 const MONTH_PATTERN =
   /(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)\.?/
+
+/** Canonical month names for fuzzy match. Includes both short and full forms. */
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const
+
+/** Court-abbrev tokens that should NEVER be stripped as a misspelled month
+ *  even if a fuzzy comparison happens to land within distance 2. Real court
+ *  T7 abbreviations that overlap with month-name fuzzy space. */
+const NO_STRIP_TRAILING = new Set([
+  "Cir",
+  "Ct",
+  "App",
+  "Sup",
+  "Dist",
+  "Div",
+  "Bankr",
+  "Crim",
+  "Civ",
+  "Mass",
+  "Tex",
+  "Penn",
+  "Wash",
+  "Ind",
+  "Ark",
+])
+
+/** Strip a trailing word if it fuzzy-matches a month name (Levenshtein ≤ 2)
+ *  and isn't a court-abbrev word. Used to clean OCR-mangled or misspelled
+ *  month names that the canonical strip didn't catch (`Jaunary`, `Ferbuary`,
+ *  `Marc`, `Septmber`). #717. */
+function stripMisspelledTrailingMonth(content: string): string {
+  const match = /\s+(\w{3,12})\.?\s*$/.exec(content)
+  if (!match) return content
+  const word = match[1]
+  // Must be Title-Case (starts with capital) to be a plausible month candidate.
+  if (!/^[A-Z]/.test(word)) return content
+  // Skip known court-abbrev tokens even if they're within fuzzy distance.
+  const wordStem = word.replace(/\.$/, "")
+  if (NO_STRIP_TRAILING.has(wordStem)) return content
+  // Fuzzy-match against month names with maxDistance=2 AND require the
+  // first letter to match. Without the first-letter constraint, real
+  // court abbreviations like `Cal.` collide with `Jan` (distance 2) and
+  // get mis-stripped.
+  const firstLetter = word[0]
+  for (const month of MONTH_NAMES) {
+    if (month[0] !== firstLetter) continue
+    if (levenshteinDistance(word, month, 2) <= 2) {
+      return content.slice(0, match.index).trim()
+    }
+  }
+  return content
+}
 
 // ============================================================================
 // Compiled regex patterns for performance (hoisted to module level)
@@ -940,6 +1005,13 @@ function stripDateFromCourt(content: string): string | undefined {
   // Strip trailing date components: optional day+comma, month abbreviation or full name
   court = court.replace(/\s*,?\s*\d{1,2}\s*,?\s*$/, "").trim()
   court = court.replace(new RegExp(`\\s*${MONTH_PATTERN.source}\\s*$`, "i"), "").trim()
+  // Fuzzy strip of misspelled / OCR-mangled month names — `Jaunary`,
+  // `Ferbuary`, `Marc`, etc. After the canonical month strip leaves
+  // a trailing Title-Case word, fuzzy-match it (Levenshtein ≤ 2)
+  // against the known month names; on match, strip. Bounded length
+  // (3-12) and Title-Case constraint keep the heuristic from chewing
+  // real court abbreviations. #717.
+  court = stripMisspelledTrailingMonth(court).trim()
   // Strip any trailing commas left over
   court = court.replace(/,\s*$/, "").trim()
   if (!court || !/[A-Za-z]/.test(court)) return undefined

--- a/tests/extract/issueMisspelledMonthStrip.test.ts
+++ b/tests/extract/issueMisspelledMonthStrip.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CaseCitation } from "@/types/citation"
+
+const cases = (text: string): CaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as CaseCitation[]
+
+describe("misspelled / OCR-mangled month names stripped from court (#717)", () => {
+  it.each([
+    ["Jaunary (typo Jan)", "Smith, 100 F.2d 1 (9th Cir. Jaunary 15, 2020)"],
+    ["Ferbuary (typo Feb)", "Smith, 100 F.2d 1 (9th Cir. Ferbuary 2020)"],
+    ["Marc (truncated March)", "Smith, 100 F.2d 1 (9th Cir. Marc 15, 2020)"],
+    ["Septmber (typo Sept)", "Smith, 100 F.2d 1 (9th Cir. Septmber 15, 2020)"],
+    ["Octber (typo Oct)", "Smith, 100 F.2d 1 (9th Cir. Octber 15, 2020)"],
+  ])("`%s` strips correctly, court=`9th Cir.`", (_, input) => {
+    const [c] = cases(input)
+    expect(c.court).toBe("9th Cir.")
+    expect(c.year).toBe(2020)
+  })
+
+  it("regression: canonical month names still strip", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. January 15, 2020)")
+    expect(c.court).toBe("9th Cir.")
+  })
+
+  it("regression: `9th Cir.` alone (no month) still works", () => {
+    const [c] = cases("Smith, 100 F.2d 1 (9th Cir. 2020)")
+    expect(c.court).toBe("9th Cir.")
+  })
+
+  it("regression: court-abbrev tokens not mistakenly stripped", () => {
+    // `App` is in NO_STRIP_TRAILING — should never be removed
+    const [c] = cases("Smith, 100 F.2d 1 (Ill. App. 2020)")
+    expect(c.court).toContain("App")
+  })
+})


### PR DESCRIPTION
Resolves #717. The date-strip pipeline only knew canonical months. Typos leaked into court.

| input | before | after |
|---|---|---|
| `(9th Cir. Jaunary 15, 2020)` | court="9th Cir. Jaunary" | court="9th Cir." |
| `(9th Cir. Ferbuary 2020)` | leaks | court="9th Cir." |
| `(9th Cir. Marc 15, 2020)` | leaks | court="9th Cir." |

Added fuzzy-match strip with first-letter constraint and NO_STRIP_TRAILING blocklist.

8 regression tests. Resolves #717.