### PR TITLE
fix(extract): federal rule acronym forms (FRCP, F.R.C.P., FRE, etc.) recognized (#696)

### DIFF
--- a/.changeset/fix-fed-rule-acronym-forms.md
+++ b/.changeset/fix-fed-rule-acronym-forms.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): federal rule acronym forms recognized (`FRCP`, `F.R.C.P.`, `FRE`, etc.) (#696)
+
+Resolves #696. The federal-rule extractor recognized only the canonical
+`Fed. R. Civ. P. 12` and spelled-out `Federal Rule of Civil Procedure 12`
+forms. Common acronym shorthand used in casual writing, court orders,
+and briefs was silently dropped:
+
+| input | before | after |
+|---|---|---|
+| `FRCP 12(b)(6)` | 0 cites | ruleSet=civil ✓ |
+| `FRE 401` | 0 cites | ruleSet=evidence ✓ |
+| `FRAP 4(a)` | 0 cites | ruleSet=appellate ✓ |
+| `FRCrP 11` | 0 cites | ruleSet=criminal ✓ |
+| `FRBP 7001` | 0 cites | ruleSet=bankruptcy ✓ |
+| `F.R.C.P. 12` | 0 cites | ruleSet=civil ✓ |
+| `F.R.E. 401` | 0 cites | ruleSet=evidence ✓ |
+| `F.R.A.P. 4(a)` | 0 cites | ruleSet=appellate ✓ |
+
+Added a third pattern (`fed-rule-acronym`) for bare acronyms and dotted
+forms, plus matching entries in `RULE_SET_MAP`. The dotted forms
+(`F.R.C.P.`) normalize via the period-and-space strip to the same key
+as the bare form (`FRCP`).
+
+10 regression tests in `tests/extract/issueFedRuleAcronym.test.ts`.

--- a/src/extract/extractFederalRule.ts
+++ b/src/extract/extractFederalRule.ts
@@ -33,6 +33,13 @@ const RULE_SET_MAP: ReadonlyMap<string, FederalRuleCitation["ruleSet"]> = new Ma
   ["appellateprocedure", "appellate"],
   ["bankrp", "bankruptcy"],
   ["bankruptcyprocedure", "bankruptcy"],
+  // Acronym forms (#696). Both bare (`FRCP`) and dotted (`F.R.C.P.`)
+  // normalize via the period-and-space strip to the same lowercase key.
+  ["frcp", "civil"],
+  ["frcrp", "criminal"],
+  ["fre", "evidence"],
+  ["frap", "appellate"],
+  ["frbp", "bankruptcy"],
 ])
 
 /**
@@ -80,13 +87,17 @@ export function extractFederalRule(
 ): FederalRuleCitation {
   const { text, span } = token
 
-  // Try the abbreviated form first (more common), then the spelled-out form.
+  // Try the abbreviated form first (more common), then spelled-out,
+  // then acronym (#696).
   const abbreviatedRegex =
     /\bFed\.\s?R\.\s?(Civ\.\s?P\.|Crim\.\s?P\.|Evid\.|App\.\s?P\.|Bankr\.\s?P\.)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/d
   const spelledRegex =
     /\bFederal\s+Rules?\s+of\s+(?:the\s+)?(Civil\s+Procedure|Criminal\s+Procedure|Evidence|Appellate\s+Procedure|Bankruptcy\s+Procedure)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/di
+  const acronymRegex =
+    /\b(FRCP|FRE|FRAP|FRCrP|FRBP|F\.\s?R\.\s?C\.\s?P\.|F\.\s?R\.\s?E\.|F\.\s?R\.\s?A\.\s?P\.|F\.\s?R\.\s?Cr\.\s?P\.|F\.\s?R\.\s?B\.\s?P\.)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/d
 
-  const match = abbreviatedRegex.exec(text) ?? spelledRegex.exec(text)
+  const match =
+    abbreviatedRegex.exec(text) ?? spelledRegex.exec(text) ?? acronymRegex.exec(text)
   if (!match) {
     throw new Error(`Failed to parse federal rule citation: ${text}`)
   }

--- a/src/patterns/federalRulePatterns.ts
+++ b/src/patterns/federalRulePatterns.ts
@@ -53,4 +53,15 @@ export const federalRulePatterns: Pattern[] = [
       'Spelled-out federal rules: "Federal Rule of Civil Procedure 56", "Federal Rules of Evidence 401" — #576',
     type: "federalRule",
   },
+  {
+    // Acronym form: `FRCP 12(b)(6)`, `FRE 401`, `FRAP 4(a)`, `FRCrP 11`,
+    // `FRBP 7001`, plus dotted variants `F.R.C.P.`, `F.R.E.`, etc.
+    // Common in casual writing, court orders, and briefs. #696.
+    id: "fed-rule-acronym",
+    regex:
+      /\b(FRCP|FRE|FRAP|FRCrP|FRBP|F\.\s?R\.\s?C\.\s?P\.|F\.\s?R\.\s?E\.|F\.\s?R\.\s?A\.\s?P\.|F\.\s?R\.\s?Cr\.\s?P\.|F\.\s?R\.\s?B\.\s?P\.)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    description:
+      'Acronym federal rules: "FRCP 12(b)(6)", "FRE 401", "F.R.C.P. 12" — #696',
+    type: "federalRule",
+  },
 ]

--- a/tests/extract/issueFedRuleAcronym.test.ts
+++ b/tests/extract/issueFedRuleAcronym.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FederalRuleCitation } from "@/types/citation"
+
+const rules = (text: string): FederalRuleCitation[] =>
+  extractCitations(text).filter((c) => c.type === "federalRule") as FederalRuleCitation[]
+
+describe("federal rule acronym forms recognized (#696)", () => {
+  it.each([
+    ["FRCP 12(b)(6)", "FRCP 12(b)(6)", "civil"],
+    ["FRE 401", "FRE 401", "evidence"],
+    ["FRAP 4(a)", "FRAP 4(a)", "appellate"],
+    ["FRCrP 11", "FRCrP 11", "criminal"],
+    ["FRBP 7001", "FRBP 7001", "bankruptcy"],
+    ["F.R.C.P. 12", "F.R.C.P. 12", "civil"],
+    ["F.R.E. 401", "F.R.E. 401", "evidence"],
+    ["F.R.A.P. 4(a)", "F.R.A.P. 4(a)", "appellate"],
+  ])("`%s` extracts ruleSet=%s", (_, input, expectedRuleSet) => {
+    const [c] = rules(input)
+    expect(c).toBeDefined()
+    expect(c.ruleSet).toBe(expectedRuleSet)
+  })
+
+  it("regression: canonical `Fed. R. Civ. P. 12` still works", () => {
+    const [c] = rules("Fed. R. Civ. P. 12(b)(6)")
+    expect(c.ruleSet).toBe("civil")
+  })
+
+  it("regression: spelled-out `Federal Rule of Civil Procedure 12` still works", () => {
+    const [c] = rules("Federal Rule of Civil Procedure 12(b)(6)")
+    expect(c.ruleSet).toBe("civil")
+  })
+})


### PR DESCRIPTION
Resolves #696. Federal-rule extractor recognized only canonical `Fed. R. Civ. P. 12` and spelled-out forms. Common acronym shorthand was silently dropped.

| input | before | after |
|---|---|---|
| `FRCP 12(b)(6)` | 0 cites | ruleSet=civil |
| `FRE 401` | 0 cites | ruleSet=evidence |
| `FRAP 4(a)` | 0 cites | ruleSet=appellate |
| `FRCrP 11` | 0 cites | ruleSet=criminal |
| `FRBP 7001` | 0 cites | ruleSet=bankruptcy |
| `F.R.C.P. 12` | 0 cites | ruleSet=civil |
| `F.R.E. 401` | 0 cites | ruleSet=evidence |
| `F.R.A.P. 4(a)` | 0 cites | ruleSet=appellate |

Added fed-rule-acronym pattern + matching RULE_SET_MAP entries. Bare and dotted forms normalize to the same key.

10 regression tests. Resolves #696.