### PR TITLE
fix(extract): leading-zero volumes consistently parse as integers (#703)

### DIFF
--- a/.changeset/fix-leading-zero-volume.md
+++ b/.changeset/fix-leading-zero-volume.md
@@ -1,0 +1,23 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): leading-zero volumes consistently parse as integers (#703)
+
+Resolves #703. The case-extractor's `parseVolume` used `String(num) === raw`
+to decide whether a volume was purely numeric. Leading-zero forms
+(`"01"`, `"001"`) failed that equality check (`String(1) !== "01"`) and
+fell through to the string branch, producing inconsistent typing:
+
+| input | before | after |
+|---|---|---|
+| `0 F.2d 1` | volume=`0` (number) | volume=`0` (number) ✓ |
+| `01 F.2d 1` | volume=`"01"` (string) | volume=`1` (number) ✓ |
+| `001 F.2d 1` | volume=`"001"` (string) | volume=`1` (number) ✓ |
+| `1984-1 F.2d 1` | volume=`"1984-1"` (string) | unchanged ✓ |
+
+Fix: parse purely-digit volumes via `Number.parseInt` unconditionally
+(detected by `/^\d+$/`). Hyphenated forms (`1984-1`) still return as
+strings.
+
+7 regression tests in `tests/extract/issueLeadingZeroVolume.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -97,10 +97,17 @@ const SIGNAL_STRIP_REGEX = (() => {
   return new RegExp(`^(${alternatives.join("|")}),?\\s+${proseConnector}`, "i")
 })()
 
-/** Parse a volume string as number when purely numeric, string when hyphenated */
+/** Parse a volume string as number when purely numeric, string when hyphenated.
+ *
+ * Leading zeros are stripped so `"01"` parses to `1` (not `"01"` as a string)
+ * for consistency with the no-leading-zero `"1"` form. Hyphenated forms
+ * like `"1984-1"` stay as strings. #703.
+ */
 function parseVolume(raw: string): number | string {
-  const num = Number.parseInt(raw, 10)
-  return String(num) === raw ? num : raw
+  if (/^\d+$/.test(raw)) {
+    return Number.parseInt(raw, 10)
+  }
+  return raw
 }
 
 /** Month abbreviations and full names found in legal citation parentheticals */

--- a/tests/extract/issueLeadingZeroVolume.test.ts
+++ b/tests/extract/issueLeadingZeroVolume.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { FullCaseCitation } from "@/types/citation"
+
+const cases = (text: string): FullCaseCitation[] =>
+  extractCitations(text).filter((c) => c.type === "case") as FullCaseCitation[]
+
+describe("leading-zero volumes consistently parse as integers (#703)", () => {
+  it.each([
+    ["0", "0 F.2d 1", 0],
+    ["01", "01 F.2d 1", 1],
+    ["001", "001 F.2d 1", 1],
+    ["00100", "00100 F.2d 1", 100],
+    ["01 U.S.", "01 U.S. 1", 1],
+  ])("`%s` parses to number, not string", (_, input, expected) => {
+    const [c] = cases(input)
+    expect(typeof c.volume).toBe("number")
+    expect(c.volume).toBe(expected)
+  })
+
+  it("regression: hyphenated volume `1984-1` stays as string", () => {
+    const [c] = cases("1984-1 F.2d 1")
+    expect(typeof c.volume).toBe("string")
+    expect(c.volume).toBe("1984-1")
+  })
+
+  it("regression: bare number `100` still parses as number", () => {
+    const [c] = cases("100 F.2d 1")
+    expect(typeof c.volume).toBe("number")
+    expect(c.volume).toBe(100)
+  })
+})


### PR DESCRIPTION
Resolves #703. parseVolume used `String(num) === raw` which failed for leading-zero forms (`String(1) !== "01"`).

| input | before | after |
|---|---|---|
| `01 F.2d 1` | volume="01" (string) | volume=1 (number) |
| `001 F.2d 1` | volume="001" (string) | volume=1 (number) |
| `1984-1 F.2d 1` | string | string (unchanged) |

7 regression tests. Resolves #703.