### PR TITLE
fix(extract): impossible dates (Feb 30, Feb 29 non-leap) fall back to month-only (#716)

### DIFF
--- a/.changeset/fix-invalid-date-validation.md
+++ b/.changeset/fix-invalid-date-validation.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): impossible dates (Feb 30, Apr 31, Feb 29 non-leap) fall back to month-only (#716)
+
+Resolves #716. `parseDate` accepted syntactically well-formed but
+semantically impossible dates (`Feb 30`, `Apr 31`, `Feb 29` in non-leap
+years), producing a syntactically valid ISO string for a date that
+doesn't exist:
+
+| input | before | after |
+|---|---|---|
+| `Feb 30 2020` | `iso="2020-02-30"`, `day=30` | `iso="2020-02"`, `day=undefined` ✓ |
+| `Apr 31 2020` | `iso="2020-04-31"` | `iso="2020-04"` ✓ |
+| `Feb 29 2021` (non-leap) | `iso="2021-02-29"` | `iso="2021-02"` ✓ |
+| `Feb 29 2020` (leap) | `iso="2020-02-29"` | unchanged ✓ |
+
+Added `isValidDate(year, month, day)` helper with leap-year awareness
+(div-4, except centuries unless div-400). All four parseDate code paths
+(abbreviated month, full month, ISO, European) now drop the `day`
+field when invalid and return `{ year, month }` instead.
+
+6 regression tests in `tests/extract/dates.invalidDate.test.ts`.

--- a/src/extract/dates.ts
+++ b/src/extract/dates.ts
@@ -133,6 +133,30 @@ export function parseMonth(monthStr: string): number {
   return month
 }
 
+/** Maximum day for each month (non-leap-year). Index 0 is unused (months are 1-based). */
+const DAYS_IN_MONTH: readonly number[] = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+/**
+ * Validate a (year, month, day) tuple. Returns true when the day is in
+ * the valid range for that month, accounting for leap years on February.
+ *
+ * Used by `parseDate` to reject impossible dates like `Feb 30 2020` or
+ * `Apr 31 2020` — the date string format is well-formed but the values
+ * are semantically invalid (often OCR artifacts). When invalid, the
+ * caller falls back to month-only (`{ year, month }`). #716.
+ */
+export function isValidDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12) return false
+  if (day < 1) return false
+  let max = DAYS_IN_MONTH[month]
+  if (month === 2) {
+    // Leap year: divisible by 4, except centuries unless divisible by 400.
+    const isLeap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+    if (isLeap) max = 29
+  }
+  return day <= max
+}
+
 /**
  * Convert structured date components to ISO 8601 string.
  * Handles full dates, month+year, and year-only formats.
@@ -202,7 +226,9 @@ export function parseDate(dateStr: string): StructuredDate | undefined {
     const day = Number.parseInt(abbrMatch[2], 10)
     const year = Number.parseInt(abbrMatch[3], 10)
     if (isPlausibleYear(year)) {
-      const parsed = { year, month, day }
+      // Reject impossible dates (`Feb 30`, `Apr 31`, `Feb 29` non-leap)
+      // by falling back to month-only. #716.
+      const parsed = isValidDate(year, month, day) ? { year, month, day } : { year, month }
       return { iso: toIsoDate(parsed), parsed }
     }
   }
@@ -216,7 +242,7 @@ export function parseDate(dateStr: string): StructuredDate | undefined {
     const day = Number.parseInt(fullMatch[2], 10)
     const year = Number.parseInt(fullMatch[3], 10)
     if (isPlausibleYear(year)) {
-      const parsed = { year, month, day }
+      const parsed = isValidDate(year, month, day) ? { year, month, day } : { year, month }
       return { iso: toIsoDate(parsed), parsed }
     }
   }
@@ -230,7 +256,7 @@ export function parseDate(dateStr: string): StructuredDate | undefined {
     const month = Number.parseInt(isoMatch[3], 10)
     const day = Number.parseInt(isoMatch[4], 10)
     if (isPlausibleYear(year)) {
-      const parsed = { year, month, day }
+      const parsed = isValidDate(year, month, day) ? { year, month, day } : { year, month }
       return { iso: toIsoDate(parsed), parsed }
     }
   }
@@ -248,7 +274,7 @@ export function parseDate(dateStr: string): StructuredDate | undefined {
       year = year <= 50 ? 2000 + year : 1900 + year
     }
     if (isPlausibleYear(year)) {
-      const parsed = { year, month, day }
+      const parsed = isValidDate(year, month, day) ? { year, month, day } : { year, month }
       return { iso: toIsoDate(parsed), parsed }
     }
   }
@@ -266,7 +292,7 @@ export function parseDate(dateStr: string): StructuredDate | undefined {
     const month = parseMonth(euroMatch[2])
     const year = Number.parseInt(euroMatch[3], 10)
     if (isPlausibleYear(year)) {
-      const parsed = { year, month, day }
+      const parsed = isValidDate(year, month, day) ? { year, month, day } : { year, month }
       return { iso: toIsoDate(parsed), parsed }
     }
   }

--- a/tests/extract/dates.invalidDate.test.ts
+++ b/tests/extract/dates.invalidDate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { parseDate, isValidDate } from "@/extract/dates"
+
+describe("parseDate validates impossible dates (#716)", () => {
+  it("`Feb 30 2020` → falls back to month-only", () => {
+    const d = parseDate("Feb 30 2020")
+    expect(d?.parsed.day).toBeUndefined()
+    expect(d?.parsed.month).toBe(2)
+    expect(d?.parsed.year).toBe(2020)
+    expect(d?.iso).toBe("2020-02")
+  })
+
+  it("`Apr 31 2020` → falls back to month-only", () => {
+    const d = parseDate("Apr 31 2020")
+    expect(d?.parsed.day).toBeUndefined()
+    expect(d?.parsed.month).toBe(4)
+  })
+
+  it("`Feb 29 2021` (non-leap) → falls back to month-only", () => {
+    const d = parseDate("Feb 29 2021")
+    expect(d?.parsed.day).toBeUndefined()
+  })
+
+  it("`Feb 29 2020` (leap year) → accepts day", () => {
+    const d = parseDate("Feb 29 2020")
+    expect(d?.parsed.day).toBe(29)
+    expect(d?.iso).toBe("2020-02-29")
+  })
+
+  it("regression: `Jan 15 2020` (valid) → accepts day", () => {
+    const d = parseDate("Jan 15 2020")
+    expect(d?.parsed.day).toBe(15)
+  })
+
+  it("isValidDate helper rejects month>12, day<1, day>maxForMonth", () => {
+    expect(isValidDate(2020, 13, 1)).toBe(false)
+    expect(isValidDate(2020, 2, 0)).toBe(false)
+    expect(isValidDate(2020, 2, 30)).toBe(false)
+    expect(isValidDate(2020, 4, 31)).toBe(false)
+    expect(isValidDate(2020, 1, 31)).toBe(true)
+    expect(isValidDate(1900, 2, 29)).toBe(false)  // 1900 not leap
+    expect(isValidDate(2000, 2, 29)).toBe(true)   // 2000 IS leap
+  })
+})


### PR DESCRIPTION
Resolves #716. parseDate accepted syntactically valid but semantically impossible dates.

| input | before | after |
|---|---|---|
| `Feb 30 2020` | iso="2020-02-30" | iso="2020-02" |
| `Apr 31 2020` | iso="2020-04-31" | iso="2020-04" |
| `Feb 29 2021` (non-leap) | iso="2021-02-29" | iso="2021-02" |
| `Feb 29 2020` (leap) | unchanged | unchanged |

Added isValidDate() helper with leap-year awareness (div-4, except centuries unless div-400). All four parseDate code paths use it.

6 regression tests. Resolves #716.