### PR TITLE
fix(extract): bare §§ N, M lists (no code prefix) get lower confidence (#726)

### DIFF
--- a/.changeset/fix-bare-section-confidence.md
+++ b/.changeset/fix-bare-section-confidence.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): bare `§§ N, M` lists (no code prefix) get lower confidence (#726)
+
+Resolves #726. `detectBareSectionLists` produced statute citations
+from `§§ 1983, 1985` (bare section-list with no code prefix) at
+confidence 0.5 — same as a real statute. The `code` field defaulted
+to the literal `§` character, which isn't a meaningful code
+identifier.
+
+Lowered confidence to 0.3 when the only code marker is `§` (no
+surrounding `Code`/`Code Ann.` prefix). Downstream consumers can now
+confidently filter these out at the 0.5 threshold unless they
+specifically want unbound section refs.
+
+| input | before | after |
+|---|---|---|
+| `§§ 1983, 1985` | confidence=0.5 | confidence=0.3 ✓ |
+| `Code §§ 19.2-81 and 18.2-266` (with `Code` prefix) | confidence=0.5 | unchanged ✓ |
+| `42 U.S.C. § 1983` (real code) | unchanged | unchanged ✓ |
+
+3 regression tests in `tests/extract/issueBareSectionConfidence.test.ts`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -1123,8 +1123,11 @@ function detectBareSectionLists(
         originalEnd,
       },
       // Bare-prefix lists are inherently low-confidence — no code identifier
-      // means no jurisdiction grounding.
-      confidence: 0.5,
+      // means no jurisdiction grounding. When the only code marker we have
+      // is `§` (no surrounding `Code`/`Code Ann.` prefix), drop further to
+      // 0.3 so downstream consumers can confidently filter these out
+      // unless they specifically want unbound section refs. #726.
+      confidence: code === "§" ? 0.3 : 0.5,
       matchedText: fullMatch,
       processTimeMs: 0,
       patternsChecked: 1,

--- a/tests/extract/issueBareSectionConfidence.test.ts
+++ b/tests/extract/issueBareSectionConfidence.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+
+describe("bare `§§ N, M` lists get lower confidence (#726)", () => {
+  it("`§§ 1983, 1985` (no code prefix) → confidence=0.3, code=`§`", () => {
+    const cs = extractCitations("§§ 1983, 1985")
+    expect(cs.length).toBeGreaterThan(0)
+    for (const c of cs) {
+      expect(c.type).toBe("statute")
+      const o = c as unknown as Record<string, unknown>
+      expect(o.code).toBe("§")
+      expect(c.confidence).toBe(0.3)
+    }
+  })
+
+  it("`Code §§ 19.2-81 and 18.2-266` (with Code prefix) → confidence=0.5", () => {
+    const cs = extractCitations("Code §§ 19.2-81 and 18.2-266")
+    const statutes = cs.filter((c) => c.type === "statute")
+    expect(statutes.length).toBeGreaterThan(0)
+    // First citation (the head with Code prefix) has higher confidence
+    const head = statutes.find((c) => {
+      const o = c as unknown as Record<string, unknown>
+      return o.code === "Code"
+    })
+    if (head) {
+      expect(head.confidence).toBe(0.5)
+    }
+  })
+
+  it("regression: `42 U.S.C. § 1983` (real code) is confidence ≥ 0.5", () => {
+    const [c] = extractCitations("42 U.S.C. § 1983")
+    expect(c.confidence).toBeGreaterThanOrEqual(0.5)
+  })
+})


### PR DESCRIPTION
Resolves #726. detectBareSectionLists produced statute citations from `§§ 1983, 1985` (no code prefix) at confidence 0.5 with code="§". Lowered to 0.3 when code===§ so downstream consumers can filter at the 0.5 threshold.

3 regression tests. Resolves #726.