### PR TITLE
fix(extract): case names inside quotation marks now capture caseName (#691)

### DIFF
--- a/.changeset/fix-quoted-case-name.md
+++ b/.changeset/fix-quoted-case-name.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): case names inside quotation marks now capture caseName (#691)
+
+Resolves #691. When a case caption was wrapped in quotation marks
+(`"Smith v. Jones," 100 F.2d 1`), the V_CASE_NAME_REGEX anchored on
+a trailing comma and never matched — the closing quote sat between
+the defendant and the comma, breaking the anchor. Both common
+quote/comma orderings were affected:
+
+| input | before | after |
+|---|---|---|
+| `"Smith v. Jones," 100 F.2d 1` (American) | caseName=undefined | `Smith v. Jones` ✓ |
+| `"Smith v. Jones", 100 F.2d 1` (British) | caseName=undefined | `Smith v. Jones` ✓ |
+| `as held in "Smith v. Jones," 100 F.2d 1` | caseName=undefined | `Smith v. Jones` ✓ |
+| `“Smith v. Jones,” 100 F.2d 1` (curly) | caseName=undefined | `Smith v. Jones` ✓ |
+| `Smith v. Jones, 100 F.2d 1` (no quotes) | unchanged | unchanged ✓ |
+
+Fix: in `extractCaseName`, strip a leading straight/curly quote and a
+trailing straight/curly quote adjacent to the citation-side comma
+before applying V_CASE_NAME_REGEX. Quote chars are not legal-citation
+punctuation; nothing real depends on them surviving at these
+positions.
+
+6 regression tests in `tests/extract/issueQuotedCaseName.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -1995,6 +1995,16 @@ export function extractCaseName(
     adjustedSearchStart += openParenStop
   }
 
+  // Issue #691: Quoted case names — `"Smith v. Jones," 100 F.2d 1` and
+  // `"Smith v. Jones", 100 F.2d 1`. The V_CASE_NAME_REGEX anchors on a
+  // trailing comma and never matches when the closing quote sits between
+  // the defendant and the comma (or the leading quote sits before the
+  // plaintiff). Strip the envelope so the regex sees the bare caption.
+  // The quote chars are not legal-citation punctuation; nothing real
+  // depends on them being preserved at these positions.
+  precedingText = precedingText.replace(/^\s*["“”]/, "")
+  precedingText = precedingText.replace(/["“”](\s*,?\s*)$/, "$1")
+
   // Priority 1: Standard "v." or "vs." format with comma before citation
   // Match party names with letters, numbers (for "Doe No. 2"), periods, apostrophes, ampersands, hyphens, slashes
   const vMatch = V_CASE_NAME_REGEX.exec(precedingText)

--- a/tests/extract/issueQuotedCaseName.test.ts
+++ b/tests/extract/issueQuotedCaseName.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #691 — Quoted case names (`"Smith v. Jones," 100 F.2d 1`) lost their
+ * caption: V_CASE_NAME_REGEX anchors on a trailing comma and a closing
+ * straight-quote between the defendant and the comma broke that anchor.
+ * Stripping the quote envelope in extractCaseName fixes both quote orderings
+ * (American `,"` and British `",`).
+ */
+describe("Issue #691 - quoted case names", () => {
+  it("extracts caseName from American-style quotes (comma inside quotes)", () => {
+    const cs = extractCitations(`"Smith v. Jones," 100 F.2d 1`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect((cases[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("extracts caseName from British-style quotes (comma outside quotes)", () => {
+    const cs = extractCitations(`"Smith v. Jones", 100 F.2d 1`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect((cases[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("works with quotes following prose connector", () => {
+    const cs = extractCitations(`as held in "Smith v. Jones," 100 F.2d 1`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect((cases[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("preserves pincite after quoted caption", () => {
+    const cs = extractCitations(`"Smith v. Jones," 100 F.2d 1, 5`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    const c = cases[0] as { caseName?: string; pincite?: number }
+    expect(c.caseName).toBe("Smith v. Jones")
+    expect(c.pincite).toBe(5)
+  })
+
+  it("handles curly quotes (Unicode left/right double)", () => {
+    const cs = extractCitations(`“Smith v. Jones,” 100 F.2d 1`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect((cases[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("unquoted form remains unaffected", () => {
+    const cs = extractCitations(`Smith v. Jones, 100 F.2d 1`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(1)
+    expect((cases[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #691. Case captions wrapped in quotes (`"Smith v. Jones," 100 F.2d 1` and `"Smith v. Jones", 100 F.2d 1`) lost `caseName`/`plaintiff`/`defendant` because V_CASE_NAME_REGEX anchored on a trailing comma and the closing quote broke that anchor.
- Fix: in `extractCaseName`, strip a leading and trailing straight/curly quote adjacent to the citation-side comma before V_CASE_NAME_REGEX runs.
- 6 regression tests in `tests/extract/issueQuotedCaseName.test.ts` covering American (comma inside) and British (comma outside) orderings plus curly quotes, prose-leading forms, and pincite preservation.

## Test plan
- [x] `pnpm exec vitest run tests/extract/issueQuotedCaseName.test.ts` — 6/6
- [x] Full suite: 4143 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)