### PR TITLE
fix(extract): OCR-typo ordinal reporters normalize to canonical (#687)

### DIFF
--- a/.changeset/fix-ocr-typo-reporters.md
+++ b/.changeset/fix-ocr-typo-reporters.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): OCR-typo ordinal reporters normalize to canonical form (#687)
+
+Resolves #687. Common OCR misreadings and spelled-ordinal variants of
+the `2d`/`3d` reporter suffix left `normalizedReporter` undefined,
+breaking parallel-citation grouping and `reporterKey`-based resolution:
+
+| input | before | after |
+|---|---|---|
+| `100 F.2nd 1` (spelled ordinal) | normalized=undefined | `F.2d` ✓ |
+| `100 F.2ds 1` (spurious `s`) | normalized=undefined | `F.2d` ✓ |
+| `100 F.2cl 1` (OCR `d`→`cl`) | normalized=undefined | `F.2d` ✓ |
+| `100 F.3rd 1` (spelled) | normalized=undefined | `F.3d` ✓ |
+| `100 F.3cl 1` (OCR) | normalized=undefined | `F.3d` ✓ |
+| `100 Cal.2nd 1` | normalized=undefined | `Cal.2d` ✓ |
+| `100 F.4th 1` (canonical) | unchanged | unchanged ✓ |
+
+`resolveNormalizedReporter` now applies an OCR-typo fallback when the
+literal reporter is not in reporters-db. The literal `reporter` field
+on the citation is preserved verbatim — only `normalizedReporter`
+switches to the canonical key. This lets downstream consumers
+(`reporterKey`, parallel-group matching) link the typo'd variant to
+its real reporter without needing to re-clean the source text.
+
+8 regression tests in `tests/extract/issueOcrTypoReporters.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -379,19 +379,21 @@ export function resolveNormalizedReporter(
   if (!reportersDb) return undefined
 
   let matches = reportersDb.byAbbreviation.get(reporter.toLowerCase())
+  let effectiveReporter = reporter
   if (!matches || matches.length === 0) {
     // Issue #687: try OCR-typo fallback (`F.2nd` → `F.2d`).
     const fixed = applyOcrTypoFix(reporter)
     if (fixed) {
-      matches = reportersDb.byAbbreviation.get(fixed.toLowerCase())
-      if (matches && matches.length > 0) {
-        reporter = fixed
+      const fixedMatches = reportersDb.byAbbreviation.get(fixed.toLowerCase())
+      if (fixedMatches && fixedMatches.length > 0) {
+        matches = fixedMatches
+        effectiveReporter = fixed
       }
     }
     if (!matches || matches.length === 0) return undefined
   }
 
-  const lower = reporter.toLowerCase()
+  const lower = effectiveReporter.toLowerCase()
 
   // Year-based era disambiguation for `Black.` (#572): the literal
   // `Black.` only maps to Blackford (Indiana) in reporters-db, but when

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -353,6 +353,24 @@ const SCOTUS_BLACK_REPORTER_END_YEAR = 1862
  * resolution stands. The literal `reporter` field on the citation is
  * preserved verbatim; only `normalizedReporter` shifts.
  */
+/**
+ * Issue #687: OCR/typo substitutions for ordinal-suffix reporters.
+ * Common misreadings: `2d`→`2nd`/`2ds`/`2cl`, `3d`→`3rd`/`3ds`/`3cl`.
+ * The substitution is applied as a fallback when the literal reporter
+ * is not in reporters-db; we then look up the corrected form. The
+ * literal `reporter` field on the citation is preserved verbatim — only
+ * `normalizedReporter` switches to the canonical key. This lets parallel
+ * resolution and downstream `reporterKey` consumers link the typo'd
+ * variant to its real reporter.
+ */
+const OCR_TYPO_ORDINAL_REGEX = /(2|3)(nd|ds|cl|rd)$/i
+function applyOcrTypoFix(reporter: string): string | undefined {
+  const m = OCR_TYPO_ORDINAL_REGEX.exec(reporter)
+  if (!m) return undefined
+  const digit = m[1]
+  return `${reporter.slice(0, m.index)}${digit}d`
+}
+
 export function resolveNormalizedReporter(
   reporter: string,
   year?: number,
@@ -360,8 +378,18 @@ export function resolveNormalizedReporter(
   const reportersDb = getReportersSync()
   if (!reportersDb) return undefined
 
-  const matches = reportersDb.byAbbreviation.get(reporter.toLowerCase())
-  if (!matches || matches.length === 0) return undefined
+  let matches = reportersDb.byAbbreviation.get(reporter.toLowerCase())
+  if (!matches || matches.length === 0) {
+    // Issue #687: try OCR-typo fallback (`F.2nd` → `F.2d`).
+    const fixed = applyOcrTypoFix(reporter)
+    if (fixed) {
+      matches = reportersDb.byAbbreviation.get(fixed.toLowerCase())
+      if (matches && matches.length > 0) {
+        reporter = fixed
+      }
+    }
+    if (!matches || matches.length === 0) return undefined
+  }
 
   const lower = reporter.toLowerCase()
 

--- a/tests/extract/issueOcrTypoReporters.test.ts
+++ b/tests/extract/issueOcrTypoReporters.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import { loadReporters } from "@/data"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #687 — OCR/typo ordinal suffixes on reporters never normalized.
+ * `F.2nd`, `F.2ds`, `F.2cl` (the last two are OCR misreadings of `2d`)
+ * left `normalizedReporter` undefined, so the resolver couldn't link
+ * the typo'd variant to its canonical reporter for parallel grouping.
+ * Fixed by applying a typo-correction fallback before the reporters-db
+ * lookup. The literal `reporter` field is preserved; only
+ * `normalizedReporter` switches to the canonical form.
+ */
+describe("Issue #687 - OCR typo reporter normalization", () => {
+  beforeAll(async () => {
+    await loadReporters()
+  })
+
+  it("preserves canonical F.2d unchanged", () => {
+    const cs = extractCitations(`100 F.2d 1 (1990)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("F.2d")
+    expect(c.normalizedReporter).toBe("F.2d")
+  })
+
+  it("normalizes F.2nd → F.2d (spelled ordinal)", () => {
+    const cs = extractCitations(`100 F.2nd 1 (1990)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("F.2nd")
+    expect(c.normalizedReporter).toBe("F.2d")
+  })
+
+  it("normalizes F.2ds → F.2d (spurious trailing s)", () => {
+    const cs = extractCitations(`100 F.2ds 1 (1990)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("F.2ds")
+    expect(c.normalizedReporter).toBe("F.2d")
+  })
+
+  it("normalizes F.2cl → F.2d (OCR misread of d as cl)", () => {
+    const cs = extractCitations(`100 F.2cl 1 (1990)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("F.2cl")
+    expect(c.normalizedReporter).toBe("F.2d")
+  })
+
+  it("normalizes F.3rd → F.3d", () => {
+    const cs = extractCitations(`100 F.3rd 1 (1995)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("F.3rd")
+    expect(c.normalizedReporter).toBe("F.3d")
+  })
+
+  it("normalizes F.3cl → F.3d", () => {
+    const cs = extractCitations(`100 F.3cl 1 (1995)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("F.3cl")
+    expect(c.normalizedReporter).toBe("F.3d")
+  })
+
+  it("normalizes typos for non-F reporters too (Cal.2nd → Cal.2d)", () => {
+    const cs = extractCitations(`100 Cal.2nd 1 (1990)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("Cal.2nd")
+    expect(c.normalizedReporter).toBeDefined()
+  })
+
+  it("does not corrupt F.4th (correct higher ordinal)", () => {
+    const cs = extractCitations(`100 F.4th 1 (2022)`)
+    const c = cs[0] as { reporter?: string; normalizedReporter?: string }
+    expect(c.reporter).toBe("F.4th")
+    expect(c.normalizedReporter).toBe("F.4th")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #687. OCR misreadings (`F.2cl`, `F.2ds`) and spelled-ordinal variants (`F.2nd`, `F.3rd`) of the `2d`/`3d` suffix left `normalizedReporter` undefined, breaking parallel-citation grouping and reporter-key resolution.
- Added an OCR-typo fallback in \`resolveNormalizedReporter\`: when the literal reporter misses in reporters-db, try common ordinal typos (\`2(nd|ds|cl|rd)\` → \`2d\`, \`3(nd|ds|cl|rd)\` → \`3d\`) and look up the corrected form.
- Literal \`reporter\` field is preserved verbatim — only \`normalizedReporter\` switches to the canonical key.
- 8 regression tests in \`tests/extract/issueOcrTypoReporters.test.ts\` covering F-series and Cal-series variants plus a canonical \`F.4th\` regression control.

## Test plan
- [x] \`pnpm exec vitest run tests/extract/issueOcrTypoReporters.test.ts\` — 8/8
- [x] Full suite: 4143 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)