### PR TITLE
fix(extract): constitutional citations chained with `;` now expand (#707)

### DIFF
--- a/.changeset/fix-const-semicolon-chain.md
+++ b/.changeset/fix-const-semicolon-chain.md
@@ -1,0 +1,26 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): constitutional citations chained with `;` now expand (#707)
+
+Resolves #707. String-cited constitutional references separated by `;`
+(`U.S. Const. art. III, § 2, cl. 1; amend. XIV, § 1`) only produced
+a citation for the head — the trailing `;\s*art./amend. ...` had no
+`Const.` anchor for the tokenizer pattern to match. Common in
+scholarly footnotes and brief arguments.
+
+| input | before | after |
+|---|---|---|
+| `U.S. Const. art. III, § 2, cl. 1; amend. XIV, § 1` | 1 cite | 2 cites ✓ |
+| `U.S. Const. art. I, § 8; art. II, § 1` | 1 cite | 2 cites ✓ |
+| `U.S. Const. art. I, § 1; amend. V; amend. XIV` | 1 cite | 3 cites ✓ |
+| `Cal. Const. art. I, § 7; art. II, § 2` | 1 cite | 2 cites (both CA) ✓ |
+
+Added a post-extraction pass `expandChainedConstitutional` that scans
+forward from each constitutional cite's cleanEnd across `;` separators
+for additional body-tail matches (`art./amend. <numeral> [§ N] [cl. M]`)
+and emits a synthetic citation per element inheriting the head's
+jurisdiction (US / state code).
+
+6 regression tests in `tests/extract/issueConstSemicolonChain.test.ts`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -496,6 +496,10 @@ export function extractCitations(
     citations.push(citation)
   }
 
+  // Step 4.3: Expand constitutional citations chained with `;` that
+  // share an implied jurisdiction with the preceding cite. (#707)
+  expandChainedConstitutional(citations, cleaned, transformationMap)
+
   // Step 4.35: Detect bare-prefix `§§ N, N` lists that lack any code
   // identifier in front of the §§ marker. These never produce a head cite
   // through normal tokenization, so seed a head before expansion. (#563)
@@ -632,6 +636,92 @@ export async function extractCitationsAsync(
   // Async wrapper for future extensibility (e.g., async reporters-db lookup)
   // For MVP, wraps synchronous extractCitations
   return extractCitations(text, options)
+}
+
+/**
+ * Issue #707 — Expand constitutional citations chained with `;` that
+ * share an implied jurisdiction with the preceding cite. The canonical
+ * `U.S. Const.` prefix is required by the tokenizer pattern, so a chain
+ * like `U.S. Const. art. III, § 2; amend. XIV, § 1` only produces one
+ * citation. This pass scans forward from each constitutional cite's
+ * cleanEnd across `;` separators for additional body-tail matches
+ * (`art./amend. <numeral> [§ N] [cl. M]`) and emits a synthetic
+ * citation per chain element inheriting the head's jurisdiction.
+ */
+function expandChainedConstitutional(
+  citations: Citation[],
+  cleaned: string,
+  transformationMap: TransformationMap,
+): void {
+  const added: Citation[] = []
+  const chainRe =
+    /^\s*;\s*((?:art(?:icle)?\.?|amend(?:ment)?\.?|amdt\.?)\s+([IVX]+|\d+))(?:[,;]?\s*§\s*([\w-]+))?(?:[,;]?\s*cl\.?\s*(\d+))?/i
+
+  for (const c of citations) {
+    if (c.type !== "constitutional") continue
+    const jurisdiction = (c as { jurisdiction?: string }).jurisdiction
+    if (!jurisdiction) continue
+    let cursor = c.span.cleanEnd
+    while (cursor < cleaned.length) {
+      const tail = cleaned.slice(cursor)
+      const m = chainRe.exec(tail)
+      if (!m) break
+      const matchedText = m[0]
+      const article = m[1]
+      const numeralText = m[2]
+      const section = m[3]
+      const clauseText = m[4]
+      const isAmendment = /^amend|^amdt/i.test(article)
+      const numeral = parseChainNumeral(numeralText)
+      if (numeral === undefined) break
+      const matchStart = cursor + matchedText.indexOf(article)
+      const matchEnd = cursor + matchedText.length
+      const { originalStart, originalEnd } = resolveOriginalSpan(
+        { cleanStart: matchStart, cleanEnd: matchEnd },
+        transformationMap,
+      )
+      const cite: Citation = {
+        type: "constitutional",
+        text: cleaned.slice(matchStart, matchEnd),
+        span: { cleanStart: matchStart, cleanEnd: matchEnd, originalStart, originalEnd },
+        confidence: c.confidence,
+        matchedText: cleaned.slice(matchStart, matchEnd),
+        processTimeMs: 0,
+        patternsChecked: 1,
+        jurisdiction,
+        ...(isAmendment ? { amendment: numeral } : { article: numeral }),
+        ...(section ? { section } : {}),
+        ...(clauseText ? { clause: Number.parseInt(clauseText, 10) } : {}),
+      } as Citation
+      added.push(cite)
+      cursor = matchEnd
+    }
+  }
+  citations.push(...added)
+}
+
+const CHAIN_WORD_ORDINAL: Record<string, number> = {
+  first: 1, second: 2, third: 3, fourth: 4, fifth: 5,
+  sixth: 6, seventh: 7, eighth: 8, ninth: 9, tenth: 10,
+}
+function parseChainNumeral(raw: string): number | undefined {
+  if (!raw) return undefined
+  if (/^\d+$/.test(raw)) return Number.parseInt(raw, 10)
+  const word = raw.toLowerCase()
+  if (word in CHAIN_WORD_ORDINAL) return CHAIN_WORD_ORDINAL[word]
+  if (/^[IVX]+$/i.test(raw)) {
+    const map: Record<string, number> = { I: 1, V: 5, X: 10 }
+    let total = 0
+    let prev = 0
+    for (const ch of raw.toUpperCase()) {
+      const v = map[ch] ?? 0
+      if (v > prev) total += v - 2 * prev
+      else total += v
+      prev = v
+    }
+    return total > 0 ? total : undefined
+  }
+  return undefined
 }
 
 /**

--- a/tests/extract/issueConstSemicolonChain.test.ts
+++ b/tests/extract/issueConstSemicolonChain.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #707 — Constitutional citations chained with `;` only produced one
+ * citation. The us-/state-constitution tokenizer patterns require the
+ * `Const.` anchor, so trailing `;\s*art./amend. ...` continuations were
+ * silently dropped. Fixed by adding a post-extraction pass that scans
+ * forward from each constitutional cite for chained body-tail matches
+ * and emits a synthetic citation per element with the same jurisdiction.
+ */
+describe("Issue #707 - chained constitutional citations", () => {
+  it("expands `; amend. XIV, § 1` after US article cite", () => {
+    const cs = extractCitations(`U.S. Const. art. III, § 2, cl. 1; amend. XIV, § 1`)
+    const consts = cs.filter((c) => c.type === "constitutional")
+    expect(consts).toHaveLength(2)
+    const head = consts[0] as Record<string, unknown>
+    const tail = consts[1] as Record<string, unknown>
+    expect(head.article).toBe(3)
+    expect(head.section).toBe("2")
+    expect(head.clause).toBe(1)
+    expect(head.jurisdiction).toBe("US")
+    expect(tail.amendment).toBe(14)
+    expect(tail.section).toBe("1")
+    expect(tail.jurisdiction).toBe("US")
+  })
+
+  it("expands `; art. II, § 1` after US article cite", () => {
+    const cs = extractCitations(`U.S. Const. art. I, § 8; art. II, § 1`)
+    const consts = cs.filter((c) => c.type === "constitutional")
+    expect(consts).toHaveLength(2)
+    expect((consts[1] as { article?: number }).article).toBe(2)
+    expect((consts[1] as { section?: string }).section).toBe("1")
+  })
+
+  it("expands multi-element chain with mixed article/amendment", () => {
+    const cs = extractCitations(`U.S. Const. art. I, § 1; amend. V; amend. XIV`)
+    const consts = cs.filter((c) => c.type === "constitutional")
+    expect(consts).toHaveLength(3)
+    expect((consts[0] as { article?: number }).article).toBe(1)
+    expect((consts[1] as { amendment?: number }).amendment).toBe(5)
+    expect((consts[2] as { amendment?: number }).amendment).toBe(14)
+  })
+
+  it("inherits state jurisdiction for chained state-const cites", () => {
+    const cs = extractCitations(`Cal. Const. art. I, § 7; art. II, § 2`)
+    const consts = cs.filter((c) => c.type === "constitutional")
+    expect(consts).toHaveLength(2)
+    expect((consts[0] as { jurisdiction?: string }).jurisdiction).toBe("CA")
+    expect((consts[1] as { jurisdiction?: string }).jurisdiction).toBe("CA")
+    expect((consts[1] as { article?: number }).article).toBe(2)
+  })
+
+  it("unchained constitutional citation remains a single result", () => {
+    const cs = extractCitations(`U.S. Const. art. III, § 2`)
+    const consts = cs.filter((c) => c.type === "constitutional")
+    expect(consts).toHaveLength(1)
+  })
+
+  it("does not chain across unrelated text after `;`", () => {
+    const cs = extractCitations(`U.S. Const. art. I, § 1; the law was passed`)
+    const consts = cs.filter((c) => c.type === "constitutional")
+    expect(consts).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #707. String-cite chains like `U.S. Const. art. III, § 2, cl. 1; amend. XIV, § 1` only produced a citation for the head — the trailing `;\s*art./amend. ...` had no `Const.` anchor for the tokenizer pattern.
- Added a post-extraction pass `expandChainedConstitutional` that scans forward from each constitutional cite's cleanEnd across `;` separators for additional body-tail matches and emits a synthetic citation per element inheriting the head's jurisdiction (US / state code).
- 6 regression tests in `tests/extract/issueConstSemicolonChain.test.ts` covering article+amendment chains, multi-element chains, state-const inheritance, and unchained controls.

## Test plan
- [x] `pnpm exec vitest run tests/extract/issueConstSemicolonChain.test.ts` — 6/6
- [x] Full suite: 4143 pass, 0 regressions
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)