### PR TITLE
fix(extract): `§§ N to M` statute ranges populate sectionRange (#694)

### DIFF
--- a/.changeset/fix-statute-to-range.md
+++ b/.changeset/fix-statute-to-range.md
@@ -1,0 +1,26 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): `§§ N to M` statute ranges populate sectionRange (#694)
+
+Resolves part 1 of #694. `§§ 1983 to 1985` produced two sibling
+statute citations with no range marker, despite `to` being a
+canonical Bluebook range connector.
+
+| input | before | after |
+|---|---|---|
+| `42 U.S.C. §§ 1983 to 1985` | 2 cites (1983, 1985), no range | 1 cite with `sectionRange: {start: "1983", end: "1985"}` ✓ |
+| `42 U.S.C. §§ 1983 and 1985` | 2 siblings | unchanged ✓ |
+| `42 U.S.C. §§ 1983, 1984` | 2 siblings | unchanged ✓ |
+| `42 U.S.C. § 1983` | 1 cite | unchanged ✓ |
+
+`expandPluralSectionList` now captures the connector substring. When
+the connector matches `^\s+to\s+$` (range form), it populates
+`sectionRange` on the head citation and skips emitting the sibling.
+Comma/and connectors continue to emit siblings (list semantics).
+
+5 regression tests in `tests/extract/issueStatuteRangeTo.test.ts`.
+
+Subsection range gaps and partial-range semantics (parts 2 and 3 of
+#694) remain open.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -1174,7 +1174,10 @@ function expandPluralSectionList(
   // so bare `Code §§ 19.2-81 and 18.2-266` siblings are picked up.
   const sectionPart = "\\d[\\w-]*(?:\\.[\\d\\w-]+)*(?:\\([A-Za-z0-9]+\\))*"
   const connectorPart = "\\s*,\\s*|\\s+and\\s+|\\s+to\\s+"
-  const continuationRe = new RegExp(`^(?:${connectorPart})(${sectionPart})`)
+  // Issue #694: capture the connector so we can distinguish range (`to`)
+  // from list (`,`, `and`). Range-form chains populate `sectionRange` on
+  // the head; list-form chains continue emitting siblings.
+  const continuationRe = new RegExp(`^(${connectorPart})(${sectionPart})`)
   // `et seq.` immediately after a sibling — owner detection. (#566)
   const TRAILING_ET_SEQ_RE = /^\s*et\s+seq\.?/i
 
@@ -1191,9 +1194,42 @@ function expandPluralSectionList(
       if (!m) break
 
       const fullMatchLen = m[0].length
-      const sectionText = m[1]
+      const connectorText = m[1]
+      const sectionText = m[2]
       const sectionStart = cursor + fullMatchLen - sectionText.length
       const sectionEnd = cursor + fullMatchLen
+      const isRangeConnector = /^\s+to\s+$/.test(connectorText)
+
+      // Issue #694: `to` is a range connector, not a list connector.
+      // Populate sectionRange on the head and skip emitting a sibling.
+      if (isRangeConnector) {
+        const headSection =
+          typeof (cite as { section?: string }).section === "string"
+            ? (cite as { section: string }).section
+            : undefined
+        if (headSection) {
+          ;(cite as { sectionRange?: { start: string; end: string } }).sectionRange = {
+            start: headSection,
+            end: sectionText,
+          }
+          ;(cite as { matchedText: string }).matchedText = cleaned.slice(
+            cite.span.cleanStart,
+            sectionEnd,
+          )
+          ;(cite as { text: string }).text = cleaned.slice(cite.span.cleanStart, sectionEnd)
+          ;(cite as { span: { cleanStart: number; cleanEnd: number; originalStart: number; originalEnd: number } }).span = {
+            cleanStart: cite.span.cleanStart,
+            cleanEnd: sectionEnd,
+            originalStart: cite.span.originalStart,
+            originalEnd: resolveOriginalSpan(
+              { cleanStart: cite.span.cleanStart, cleanEnd: sectionEnd },
+              transformationMap,
+            ).originalEnd,
+          }
+        }
+        cursor = sectionEnd
+        continue
+      }
 
       const { originalStart, originalEnd } = resolveOriginalSpan(
         { cleanStart: sectionStart, cleanEnd: sectionEnd },

--- a/tests/extract/issueStatuteRangeTo.test.ts
+++ b/tests/extract/issueStatuteRangeTo.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #694 (#1) — `§§ N to M` range connector. Previously produced two
+ * sibling citations with no range marker; now populates `sectionRange`
+ * on the head and skips the redundant sibling.
+ */
+describe("Issue #694 - statute `to` range connector", () => {
+  it("`§§ 1983 to 1985` populates sectionRange on head", () => {
+    const cs = extractCitations(`42 U.S.C. §§ 1983 to 1985`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { section?: string; sectionRange?: { start: string; end: string } }
+    expect(c.section).toBe("1983")
+    expect(c.sectionRange).toEqual({ start: "1983", end: "1985" })
+  })
+
+  it("`§§ 1983 and 1985` keeps list-form sibling behavior", () => {
+    const cs = extractCitations(`42 U.S.C. §§ 1983 and 1985`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(2)
+    expect((cs[0] as { sectionRange?: unknown }).sectionRange).toBeUndefined()
+    expect((cs[1] as { sectionRange?: unknown }).sectionRange).toBeUndefined()
+  })
+
+  it("`§§ 1983, 1984` keeps list-form sibling behavior", () => {
+    const cs = extractCitations(`42 U.S.C. §§ 1983, 1984`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(2)
+    expect((cs[0] as { sectionRange?: unknown }).sectionRange).toBeUndefined()
+  })
+
+  it("single section without §§ unaffected", () => {
+    const cs = extractCitations(`42 U.S.C. § 1983`).filter((c) => c.type === "statute")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { sectionRange?: unknown }).sectionRange).toBeUndefined()
+  })
+
+  it("range text reaches across `to` in matchedText", () => {
+    const cs = extractCitations(`42 U.S.C. §§ 1983 to 1985`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { matchedText: string }).matchedText).toContain("1985")
+    expect((cs[0] as { matchedText: string }).matchedText).toContain("to")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves part 1 of #694. \`§§ 1983 to 1985\` produced two siblings with no range marker despite \`to\` being a canonical Bluebook range connector.
- \`expandPluralSectionList\` now captures the connector substring; when it matches \`^\\s+to\\s+\$\` (range form), populate \`sectionRange\` on the head and skip the sibling.
- Comma/and connectors keep list semantics.
- 5 regression tests in \`tests/extract/issueStatuteRangeTo.test.ts\`.

Subsection range and partial-range semantics (parts 2 and 3 of #694) remain open.

## Test plan
- [x] \`pnpm exec vitest run tests/extract/issueStatuteRangeTo.test.ts\` — 5/5
- [x] Full suite: 4143 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)