### PR TITLE
fix(extract): `compare A with B` propagates compare signal to B (#702)

### DIFF
--- a/.changeset/fix-compare-with-signal.md
+++ b/.changeset/fix-compare-with-signal.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): `compare A with B` propagates compare signal to B (#702)
+
+Resolves #702. Bluebook Rule 1.2(b) treats `compare A with B` as a
+paired signal — both citations belong to the same comparison. The
+extractor previously assigned `signal=compare` only to A, leaving B
+with `signal=undefined`.
+
+| input | before | after |
+|---|---|---|
+| `Compare Smith, 100 F.2d 1, with Doe, 200 F.3d 5` | A=compare, B=undefined | A=compare, B=compare ✓ |
+| `Compare Smith, 100 F.2d 1 with Doe, 200 F.3d 5` | A=compare, B=undefined | A=compare, B=compare ✓ |
+| `See Smith, 100 F.2d 1, with Doe, 200 F.3d 5` | A=see, B=undefined | unchanged (no compare) ✓ |
+| `Compare A; see Doe, 200 F.3d 5` | A=compare, B=see | unchanged (explicit signal preserved) ✓ |
+
+Added `propagateCompareWithSignal` post-process pass: when a citation
+carries `signal=compare` and the gap to the next citation contains
+`with`, propagate `compare` to the following citation. Does not
+overwrite an explicit signal on the follow-on.
+
+5 regression tests in `tests/extract/issueCompareWithSignal.test.ts`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -560,6 +560,11 @@ export function extractCitations(
   // only scan backward for citations that still lack a signal.
   detectLeadingSignals(citations, cleaned)
 
+  // Step 4.85: Propagate `compare` signal across `with` connector (#702).
+  // Bluebook Rule 1.2(b) treats `compare A with B` as paired — B inherits
+  // the comparison signal from A.
+  propagateCompareWithSignal(citations, cleaned)
+
   // Step 4.9: Apply false positive filters (blocklist + year heuristic).
   // Passing `text` (the original pre-cleaning input) lets the filter detect
   // citations whose span crosses a hard line break in the source — those are
@@ -632,6 +637,25 @@ export async function extractCitationsAsync(
   // Async wrapper for future extensibility (e.g., async reporters-db lookup)
   // For MVP, wraps synchronous extractCitations
   return extractCitations(text, options)
+}
+
+/**
+ * Issue #702 — Bluebook Rule 1.2(b) paired-comparison signal. When a
+ * citation carries `signal=compare` and the gap to the next citation
+ * contains `with`, propagate the `compare` signal to the following
+ * citation. `compare A with B` is a paired construct; both citations
+ * belong to the same comparison.
+ */
+function propagateCompareWithSignal(citations: Citation[], cleaned: string): void {
+  for (let i = 0; i < citations.length - 1; i++) {
+    const a = citations[i]
+    const b = citations[i + 1]
+    if (a.signal !== "compare") continue
+    if (b.signal) continue
+    const gap = cleaned.slice(a.span.cleanEnd, b.span.cleanStart)
+    if (!/\bwith\b/i.test(gap)) continue
+    ;(b as { signal?: typeof a.signal }).signal = "compare"
+  }
 }
 
 /**

--- a/tests/extract/issueCompareWithSignal.test.ts
+++ b/tests/extract/issueCompareWithSignal.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #702 — Bluebook Rule 1.2(b) `compare A with B` is a paired
+ * comparison signal. Previously only A received `signal=compare`;
+ * the B citation across the `with` connector had `signal=undefined`.
+ * Fixed by a post-process pass that propagates `compare` to the
+ * next citation when the gap contains `with`.
+ */
+describe("Issue #702 - propagate `compare` across `with`", () => {
+  it("propagates compare from A to B in `compare A with B`", () => {
+    const cs = extractCitations(`Compare Smith, 100 F.2d 1, with Doe, 200 F.3d 5`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(2)
+    expect((cases[0] as { signal?: string }).signal).toBe("compare")
+    expect((cases[1] as { signal?: string }).signal).toBe("compare")
+  })
+
+  it("works without intervening comma before `with`", () => {
+    const cs = extractCitations(`Compare Smith, 100 F.2d 1 with Doe, 200 F.3d 5`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect(cases).toHaveLength(2)
+    expect((cases[1] as { signal?: string }).signal).toBe("compare")
+  })
+
+  it("does not propagate when first citation has different signal", () => {
+    const cs = extractCitations(`See Smith, 100 F.2d 1, with Doe, 200 F.3d 5`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect((cases[0] as { signal?: string }).signal).toBe("see")
+    expect((cases[1] as { signal?: string | undefined }).signal).not.toBe("compare")
+  })
+
+  it("does not overwrite explicit signal on following citation", () => {
+    const cs = extractCitations(
+      `Compare Smith, 100 F.2d 1; see Doe, 200 F.3d 5`,
+    )
+    const cases = cs.filter((c) => c.type === "case")
+    expect((cases[1] as { signal?: string }).signal).toBe("see")
+  })
+
+  it("standalone `see` unaffected", () => {
+    const cs = extractCitations(`See Smith, 100 F.2d 1`)
+    const cases = cs.filter((c) => c.type === "case")
+    expect((cases[0] as { signal?: string }).signal).toBe("see")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #702. Bluebook Rule 1.2(b) treats \`compare A with B\` as a paired signal — both citations belong to the same comparison.
- Added \`propagateCompareWithSignal\` post-process pass: when a citation carries \`signal=compare\` and the gap to the next citation contains \`with\`, propagate \`compare\` to the following citation. Does not overwrite an explicit signal on the follow-on.
- 5 regression tests in \`tests/extract/issueCompareWithSignal.test.ts\`.

## Test plan
- [x] \`pnpm exec vitest run tests/extract/issueCompareWithSignal.test.ts\` — 5/5
- [x] Full suite: 4151 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)