### PR TITLE
fix(clean): strip ™ ® ℠ © before NFKC normalization (#693)

### DIFF
--- a/.changeset/fix-trademark-symbols-strip.md
+++ b/.changeset/fix-trademark-symbols-strip.md
@@ -1,0 +1,26 @@
+---
+"eyecite-ts": patch
+---
+
+fix(clean): strip ™ ® ℠ © before NFKC normalization (#693)
+
+Resolves part 1 of #693. NFKC normalization decomposed `™` → "TM",
+`®` → "(R)", `℠` → "SM" inline, which corrupted party names
+(`Smith™ v. Jones®` produced caseName=`SmithTM v. Jones`) and broke
+case-name backscan.
+
+| input | before | after |
+|---|---|---|
+| `Smith™ v. Jones, 100 F.2d 1` | caseName=`SmithTM v. Jones` | `Smith v. Jones` ✓ |
+| `Smith v. Jones®, 100 F.2d 1` | caseName=`Smith v. Jones(R)` | `Smith v. Jones` ✓ |
+| `Acme℠ v. Beta, 100 F.2d 1` | caseName=`AcmeSM v. Beta` | `Acme v. Beta` ✓ |
+| `Smith v. Jones, 100 F.2d 1` | unchanged | unchanged ✓ |
+
+Fix: in `normalizeUnicode`, strip the four mark symbols (`™ ® ℠ ©`)
+BEFORE applying NFKC. They are decorative and never affect canonical
+citation text.
+
+Em-dash separators, ellipses, and zero-width-space-as-separator
+(other parts of #693) have different root causes and remain open.
+
+6 regression tests in `tests/extract/issueTrademarkSymbols.test.ts`.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -165,7 +165,14 @@ export function normalizeWhitespace(text: string): string {
  * // => "Smith v. Doe, 500 F.2d 123" // normalized
  */
 export function normalizeUnicode(text: string): string {
-  return text.normalize("NFKC")
+  // Issue #693: Strip trademark / registered / service-mark / copyright
+  // symbols BEFORE NFKC. NFKC decomposes ™ → "TM", ® → "(R)", ℠ → "SM",
+  // which then corrupt party names (`Smith™` becomes `SmithTM`, breaking
+  // case-name backscan and producing wrong captions). These symbols are
+  // decorative — they don't affect canonical citation text — so removing
+  // them entirely is preferable to letting NFKC expand them inline.
+  const stripped = text.replace(/[™®℠©]/g, "")
+  return stripped.normalize("NFKC")
 }
 
 /**

--- a/tests/extract/issueTrademarkSymbols.test.ts
+++ b/tests/extract/issueTrademarkSymbols.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #693 (part 1) — Trademark / registered / service-mark / copyright
+ * symbols appended to party names broke case-name backscan. NFKC
+ * normalization decomposed `™` → "TM", `®` → "(R)", which then corrupted
+ * party names (`Smith™` → `SmithTM`). Fixed by stripping these symbols
+ * BEFORE NFKC normalization in `normalizeUnicode`.
+ *
+ * Em dashes, ellipses, zero-width-space-as-separator are tracked as
+ * separate sub-problems (different root causes) and remain open.
+ */
+describe("Issue #693 - trademark/registered symbol stripping", () => {
+  it("strips ™ from plaintiff", () => {
+    const cs = extractCitations(`Smith™ v. Jones, 100 F.2d 1`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("strips ® from defendant", () => {
+    const cs = extractCitations(`Smith v. Jones®, 100 F.2d 1`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("strips ™ + ® on both parties", () => {
+    const cs = extractCitations(`Smith™ v. Jones®, 100 F.2d 1`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("strips ℠ (service mark)", () => {
+    const cs = extractCitations(`Acme℠ v. Beta, 100 F.2d 1`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Acme v. Beta")
+  })
+
+  it("strips © (copyright)", () => {
+    const cs = extractCitations(`Alpha v. Beta©, 100 F.2d 1`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Alpha v. Beta")
+  })
+
+  it("plain case name unaffected", () => {
+    const cs = extractCitations(`Smith v. Jones, 100 F.2d 1`).filter(
+      (c) => c.type === "case",
+    )
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves part 1 of #693. NFKC normalization decomposed \`™\` → "TM", \`®\` → "(R)", \`℠\` → "SM" inline, corrupting party names (\`Smith™ v. Jones®\` produced \`caseName=SmithTM v. Jones\`) and breaking case-name backscan.
- Fix: in \`normalizeUnicode\`, strip the four mark symbols (\`™ ® ℠ ©\`) BEFORE applying NFKC. They are decorative and never affect canonical citation text.
- 6 regression tests in \`tests/extract/issueTrademarkSymbols.test.ts\`.

Em-dash separators, ellipses, and zero-width-space-as-separator (other parts of #693) have different root causes and remain open.

## Test plan
- [x] \`pnpm exec vitest run tests/extract/issueTrademarkSymbols.test.ts\` — 6/6
- [x] Full suite: 4157 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)