### PR TITLE
fix(clean): soft-wrapped pincite ranges (`5-\n7`) preserve hyphen (#681)

### DIFF
--- a/.changeset/fix-softwrap-pincite-range.md
+++ b/.changeset/fix-softwrap-pincite-range.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(clean): soft-wrapped pincite ranges (`5-\n7`) preserve hyphen (#681)
+
+Resolves #681. `rejoinHyphenatedWords` stripped every `<word>-\n<word>`
+shape on the assumption it was a wrapped word (`Dil-\nlinger` →
+`Dillinger`). A wrapped pincite range — `5-\n7` — got the same
+treatment and fused into a fabricated `57` pincite that didn't exist
+in the source.
+
+| input | before | after |
+|---|---|---|
+| `5-\n7` | `57` | `5-7` ✓ |
+| `100 F.2d 1, 5-\n7 (1990)` | pincite=`57` | pincite=`5`, range `5-7` ✓ |
+| `Dil-\nlinger` (word wrap) | `Dillinger` | unchanged ✓ |
+| `F. Sup-\np. 3d` (word wrap) | `F. Supp. 3d` | unchanged ✓ |
+
+Fix: `rejoinHyphenatedWords` now preserves the hyphen when both sides
+of the wrap are digits (range form). Letter on either side keeps the
+existing word-rejoin behavior.
+
+5 regression tests in `tests/clean/issueSoftWrapPinciteRange.test.ts`.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -105,6 +105,12 @@ export function stripHtmlTags(text: string): string {
  * with a hyphen at the line break: "Dil-\nlinger" or "F. Sup-\np. 3d".
  * This cleaner removes the hyphen + line break to restore the original word.
  *
+ * Issue #681: Digit-hyphen-newline-digit shapes are NOT word-wraps — they
+ * are pincite ranges (`5-\n7` = `5-7`). When both sides of the hyphen are
+ * digits, preserve the hyphen so the pincite parser sees the range
+ * correctly. Without this guard the hyphen got stripped and the two
+ * digits fused (`57`), fabricating a pincite that wasn't in the source.
+ *
  * Must run before normalizeWhitespace (which converts \n to spaces, leaving
  * "Dil- linger" instead of "Dillinger").
  *
@@ -115,9 +121,19 @@ export function stripHtmlTags(text: string): string {
  * @example
  * rejoinHyphenatedWords("F. Sup-\np. 3d 100")
  * // => "F. Supp. 3d 100"
+ *
+ * @example
+ * rejoinHyphenatedWords("100 F.2d 1, 5-\n7 (1990)")
+ * // => "100 F.2d 1, 5-7 (1990)"  // hyphen preserved (pincite range)
  */
 export function rejoinHyphenatedWords(text: string): string {
-  return text.replace(/(\w)-\s*[\n\r]+\s*(\w)/g, "$1$2")
+  return text.replace(/(\w)-\s*[\n\r]+\s*(\w)/g, (_match, before: string, after: string) => {
+    // Digit-on-both-sides → range, preserve hyphen and collapse the wrap
+    if (/\d/.test(before) && /\d/.test(after)) {
+      return `${before}-${after}`
+    }
+    return `${before}${after}`
+  })
 }
 
 /**

--- a/tests/clean/issueSoftWrapPinciteRange.test.ts
+++ b/tests/clean/issueSoftWrapPinciteRange.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { rejoinHyphenatedWords } from "@/clean/cleaners"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #681 — Soft-wrapped pincite ranges (`5-\n7`) lost the hyphen,
+ * fusing the two digits into a fabricated `57` pincite. `rejoinHyphenatedWords`
+ * now preserves the hyphen when both sides are digits, so the pincite
+ * parser sees the range correctly.
+ */
+describe("Issue #681 - soft-wrapped pincite range preserved", () => {
+  it("preserves hyphen when both sides of wrap are digits", () => {
+    expect(rejoinHyphenatedWords(`5-\n7`)).toBe(`5-7`)
+    expect(rejoinHyphenatedWords(`123-\n456`)).toBe(`123-456`)
+  })
+
+  it("strips hyphen when at least one side is a letter (word wrap)", () => {
+    expect(rejoinHyphenatedWords(`Dil-\nlinger`)).toBe(`Dillinger`)
+    expect(rejoinHyphenatedWords(`F. Sup-\np. 3d`)).toBe(`F. Supp. 3d`)
+  })
+
+  it("preserves digit-hyphen-letter mix as character collapse (rare)", () => {
+    // Digit + letter rejoin — treat as word wrap (no hyphen)
+    expect(rejoinHyphenatedWords(`A5-\nb`)).toBe(`A5b`)
+  })
+
+  it("end-to-end: pincite range survives soft wrap", () => {
+    const text = `The defendant cited Smith v. Jones,
+100 F.2d 1, 5-
+7 (9th Cir. 1990).`
+    const cs = extractCitations(text).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as {
+      pincite?: number
+      pinciteInfo?: { page?: number; endPage?: number; isRange?: boolean; raw?: string }
+    }
+    expect(c.pincite).toBe(5)
+    expect(c.pinciteInfo?.endPage).toBe(7)
+    expect(c.pinciteInfo?.isRange).toBe(true)
+    expect(c.pinciteInfo?.raw).toBe("5-7")
+  })
+
+  it("end-to-end: word-wrap in party name still rejoins", () => {
+    const text = `In Dil-
+linger Foundation v. Smith, 500 F.2d 100`
+    const cs = extractCitations(text).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toContain("Dillinger")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #681. \`rejoinHyphenatedWords\` stripped every \`<word>-\\n<word>\` shape as a wrapped word. A wrapped pincite range \`5-\\n7\` got the same treatment and fused into a fabricated \`57\` that didn't exist in the source.
- Fix: when both sides of the wrap are digits, preserve the hyphen (range form). Letter on either side keeps the existing word-rejoin.
- 5 regression tests in \`tests/clean/issueSoftWrapPinciteRange.test.ts\`.

## Test plan
- [x] \`pnpm exec vitest run tests/clean/issueSoftWrapPinciteRange.test.ts\` — 5/5
- [x] Full suite: 4167 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)