### PR TITLE
fix(extract): page-range with hyphen and no comma now extracts (#705)

### DIFF
--- a/.changeset/fix-page-range-hyphen.md
+++ b/.changeset/fix-page-range-hyphen.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): page-range with hyphen and no comma now extracts (#705)
+
+Resolves #705. `100 F.2d 1-5` (page range without comma) produced
+zero citations. The federal-reporter tokenizer's page-capture
+trailing lookahead (`-\D`) required hyphen + non-digit, which
+rejected the digit-hyphen-digit shape.
+
+| input | before | after |
+|---|---|---|
+| `100 F.2d 1-5` | 0 cites | page=1 ✓ |
+| `See 100 F.2d 1-5.` | 0 cites | page=1 ✓ |
+| `100 F.2d 1-5 (1990)` | 0 cites | page=1, year=1990 ✓ |
+| `100 F.2d 1` | unchanged | unchanged ✓ |
+| `100 F.2d 1, 5` | unchanged | unchanged ✓ |
+
+Fix: extend the page capture in both the federal-reporter tokenizer
+pattern and the `VOLUME_REPORTER_PAGE_REGEX` extractor to accept
+`\d+-\d+` (range form) alongside `\d+` (single page).
+
+The `page` field reports the start of the range (1). End-of-range
+capture as a structured field is not part of this fix.
+
+5 regression tests in `tests/extract/issuePageRangeHyphen.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -501,7 +501,7 @@ export function computeCaseConfidence(opts: {
  *  comma-form input and the caller falls through to
  *  `VOLUME_REPORTER_PAGE_REGEX_COMMA` instead — see #570. */
 const VOLUME_REPORTER_PAGE_REGEX =
-  /^(\d+(?:-\d+)?)\s+([A-Za-z0-9.\s'&]+)\s+(?:\((\d+)\s+([A-Z][A-Za-z.]+)\)\s+)?(\d+|_{3,}|-{3,})(?=$|[\s.;,)\]])/d
+  /^(\d+(?:-\d+)?)\s+([A-Za-z0-9.\s'&]+)\s+(?:\((\d+)\s+([A-Z][A-Za-z.]+)\)\s+)?(\d+-\d+|\d+|_{3,}|-{3,})(?=$|[\s.;,)\]])/d
 
 /** Comma-form variant of VOLUME_REPORTER_PAGE_REGEX (#570) for the old
  *  typesetting shape `<vol> <Reporter>, <page>` (`3 Den., 594`,

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -69,8 +69,12 @@ export const casePatterns: Pattern[] = [
     //
     // Terminator accepts `)` for citations wrapped in a sentence-internal
     // parenthetical — e.g., `(Smith v. Jones, 500 F.2d 123)` (#509).
+    // Page capture accepts `N` (single) or `N-M` (range, #705). The
+    // range form has tighter terminator: must be followed by end-of-input,
+    // whitespace, or a clause-ending punctuation. This prevents `1-5-7`
+    // from matching as `page=1-5` with stray `-7`.
     regex: new RegExp(
-      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>†‡§¶©°]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
+      String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+-\d+|\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>†‡§¶©°])|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
       "g",
     ),
     description:

--- a/tests/extract/issuePageRangeHyphen.test.ts
+++ b/tests/extract/issuePageRangeHyphen.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #705 — Page-range with hyphen and no comma (`100 F.2d 1-5`) was
+ * silently dropped. The tokenizer's page-capture lookahead (`-\D`)
+ * rejected the digit-hyphen-digit shape, so the citation never tokenized.
+ * Fixed by extending the page capture to accept `\d+-\d+` (range form)
+ * alongside `\d+` (single page) in both the federal-reporter tokenizer
+ * pattern and the VOLUME_REPORTER_PAGE_REGEX extractor.
+ */
+describe("Issue #705 - page range with hyphen", () => {
+  it("`100 F.2d 1-5` now extracts as a citation", () => {
+    const cs = extractCitations(`100 F.2d 1-5`).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { page?: number }).page).toBe(1)
+  })
+
+  it("`See 100 F.2d 1-5.` extracts in prose context", () => {
+    const cs = extractCitations(`See 100 F.2d 1-5.`).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { page?: number }).page).toBe(1)
+  })
+
+  it("`100 F.2d 1-5 (1990)` extracts with year", () => {
+    const cs = extractCitations(`100 F.2d 1-5 (1990)`).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { page?: number; year?: number }
+    expect(c.page).toBe(1)
+    expect(c.year).toBe(1990)
+  })
+
+  it("single page `100 F.2d 1` unaffected", () => {
+    const cs = extractCitations(`100 F.2d 1`).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { page?: number }).page).toBe(1)
+  })
+
+  it("page + comma pincite `100 F.2d 1, 5` unaffected", () => {
+    const cs = extractCitations(`100 F.2d 1, 5`).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { page?: number }).page).toBe(1)
+    expect((cs[0] as { pincite?: number }).pincite).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #705. \`100 F.2d 1-5\` (page range without comma) produced zero citations. The federal-reporter tokenizer's page-capture trailing lookahead (\`-\\D\`) required hyphen + non-digit, which rejected the digit-hyphen-digit shape.
- Extend the page capture in both the federal-reporter tokenizer pattern and \`VOLUME_REPORTER_PAGE_REGEX\` to accept \`\\d+-\\d+\` (range) alongside \`\\d+\` (single).
- 5 regression tests in \`tests/extract/issuePageRangeHyphen.test.ts\`.

## Test plan
- [x] \`pnpm exec vitest run tests/extract/issuePageRangeHyphen.test.ts\` — 5/5
- [x] Full suite: 4173 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)