### PR TITLE
fix(filter): hard-reject phantoms whose reporter contains a month name (#669)

### DIFF
--- a/.changeset/fix-month-in-prose-reporter-hard-reject.md
+++ b/.changeset/fix-month-in-prose-reporter-hard-reject.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix(filter): hard-reject phantoms whose reporter contains a month name (#669)
+
+Resolves #669. Multi-word "reporter" captures containing a month-name
+token (`On July`, `From January`, `By December`) are always prose, never
+real citations — real reporter abbreviations never contain month names.
+Previously these survived as confidence=0.1 + warning under the
+penalize path; now they are hard-rejected so consumers never see them.
+
+| input | before | after |
+|---|---|---|
+| `¶ 8 On July 11` | 1 cite (conf 0.1) | 0 cites ✓ |
+| `¶ 2 On March 18, 2003` | 1 cite (conf 0.1) | 0 cites ✓ |
+| `1-602 Applications\nOn October 19, 2015` | 1 cite (conf 0.1) | 0 cites ✓ |
+| `Smith v. Jones, 100 F.2d 1` (real cite) | unchanged | unchanged ✓ |
+
+Added `isMonthInProseReporter` to `applyFalsePositiveFilters`' hard-
+reject pass alongside the existing `isMonthNameDateMisparse`. The new
+check fires when the reporter has ≥2 words and any word is a month
+name (case-insensitive).
+
+Two previously-skipped tests in `issuePhantomCaseRejection.test.ts`
+are now enabled. The penalize-mode test in `issue547FullspanOvershoot.test.ts`
+was updated to assert hard-rejection (the cleaner outcome the issue
+asked for).

--- a/src/extract/filterFalsePositives.ts
+++ b/src/extract/filterFalsePositives.ts
@@ -184,6 +184,23 @@ function isMonthNameDateMisparse(citation: Citation): boolean {
   return page >= MIN_PLAUSIBLE_REPORT_YEAR && page <= MAX_PLAUSIBLE_REPORT_YEAR
 }
 
+/**
+ * Issue #669: Multi-word "reporter" containing a month-name token is
+ * always prose, never a real citation. Real reporters never contain
+ * month names. Catches phantoms like `On July`, `From January` that
+ * the existing isMonthNameDateMisparse misses because the reporter
+ * isn't EXACTLY a month name. Hard-reject so consumers don't see them
+ * even at confidence=0.1.
+ */
+function isMonthInProseReporter(citation: Citation): boolean {
+  if (citation.type !== "case" && citation.type !== "shortFormCase") return false
+  const c = citation as FullCaseCitation | ShortFormCaseCitation
+  if (!c.reporter) return false
+  const words = c.reporter.toLowerCase().split(/\s+/)
+  if (words.length < 2) return false
+  return words.some((w) => MONTH_NAMES.has(w))
+}
+
 /** Maximum length for a reporter string without periods.
  *  Real period-less reporters (e.g., "Cal", "Wis", "Mass") are short.
  *  Prose false positives ("Court dismissed the complaint...") are long.
@@ -552,7 +569,9 @@ export function applyFalsePositiveFilters(
   // `<day> <Month> <year>` date misparses (#302). These are never legitimate
   // citations under any policy, so they should not survive even when the
   // caller asked for soft-flag mode.
-  const hardFiltered = citations.filter((c) => !isMonthNameDateMisparse(c))
+  const hardFiltered = citations.filter(
+    (c) => !isMonthNameDateMisparse(c) && !isMonthInProseReporter(c),
+  )
 
   if (remove) {
     return hardFiltered.filter((c) => !isFalsePositive(c, originalText))

--- a/tests/extract/issue547FullspanOvershoot.test.ts
+++ b/tests/extract/issue547FullspanOvershoot.test.ts
@@ -196,18 +196,15 @@ describe("issue #547: fullSpan overshoots on line-crossing false positives", () 
       "2. Denials of 1-⅕85 and 1-602 Applications\n" +
       "On October 19, 2015, USCIS issued Notices of Intent."
 
-    it("flags the line-crossing cite to confidence ≤ 0.1", () => {
+    // Updated for #669: the phantom's reporter `On October` contains a
+    // month-name token, which is now hard-rejected by isMonthInProseReporter
+    // (real reporters never contain month-name tokens). Previously this
+    // phantom was penalized to confidence 0.1 + fullSpan stripped; the
+    // hard-reject is unambiguously better — consumers never see them.
+    it("hard-rejects the month-in-reporter phantom (#669)", () => {
       const cits = extractCitations(text)
       const phantom = cits.find((c) => c.matchedText.includes("1-602 Applications"))
-      expect(phantom, "phantom cite should be extracted under broad regex").toBeDefined()
-      expect(phantom!.confidence).toBeLessThanOrEqual(0.1)
-    })
-
-    it("strips fullSpan from the flagged phantom (no preceding prose leaks)", () => {
-      const cits = extractCitations(text)
-      const phantom = cits.find((c) => c.matchedText.includes("1-602 Applications"))
-      expect(phantom).toBeDefined()
-      expect((phantom as FullCaseCitation).fullSpan).toBeUndefined()
+      expect(phantom).toBeUndefined()
     })
 
     it("removes the phantom entirely when filterFalsePositives is true", () => {

--- a/tests/extract/issuePhantomCaseRejection.test.ts
+++ b/tests/extract/issuePhantomCaseRejection.test.ts
@@ -27,11 +27,11 @@ describe("phantom case-citation rejection (broad state-reporter regex)", () => {
     // require extending the FP filter's hard-reject pass, which broke
     // pre-existing tests that asserted penalize-mode behavior. Deferred
     // to a follow-up that re-baselines those expectations.
-    it.skip("`¶ 8 On July 11` — needs FP filter hard-reject extension", () => {
+    it("`¶ 8 On July 11` — month-in-prose-reporter hard-reject (#669)", () => {
       expect(caseCitesOf("¶ 8 On July 11")).toHaveLength(0)
     })
 
-    it.skip("`¶ 2 On March 18, 2003` — needs FP filter hard-reject extension", () => {
+    it("`¶ 2 On March 18, 2003` — month-in-prose-reporter hard-reject (#669)", () => {
       expect(caseCitesOf("¶ 2 On March 18, 2003")).toHaveLength(0)
     })
   })


### PR DESCRIPTION
## Summary
- Resolves #669. Multi-word reporter captures containing a month-name token (\`On July\`, \`From January\`) are always prose, never real citations — real reporter abbreviations never contain month names.
- Added \`isMonthInProseReporter\` to the hard-reject pass in \`applyFalsePositiveFilters\` alongside the existing \`isMonthNameDateMisparse\`. Previously these survived as confidence=0.1 + warning under the penalize path; now they are hard-rejected.
- Two previously-skipped tests in \`issuePhantomCaseRejection.test.ts\` are enabled. One test in \`issue547FullspanOvershoot.test.ts\` was updated to assert hard-rejection (the cleaner outcome the issue explicitly asked for).

## Test plan
- [x] Full suite: 4174 pass, 0 regressions
- [x] Previously-skipped \`¶ 8 On July 11\` and \`¶ 2 On March 18, 2003\` tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)