### PR TITLE
fix(score): inheritSubsequentHistoryCaseName recomputes child confidence (#613)

### DIFF
--- a/.changeset/fix-subsequent-history-confidence.md
+++ b/.changeset/fix-subsequent-history-confidence.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(score): `inheritSubsequentHistoryCaseName` recomputes child confidence (#613)
+
+Resolves #613. `inheritSubsequentHistoryCaseName` mutated `caseName` /
+`plaintiff` / `defendant` onto subsequent-history child citations
+AFTER `buildCaseCitation` had already locked in their confidence
+score. The +0.15 caseName bonus never fired for the child.
+
+This is the same bug pattern as #556 (parallel-cite secondaries),
+fixed there in PR #611. Mechanical port: call `computeCaseConfidence`
+on each child after the caption mutation.
+
+| input | before | after |
+|---|---|---|
+| `Smith v. Jones, 100 F.2d 1 (9th Cir. 1990), aff'd, 200 U.S. 5` | child confidence missed caseName bonus | child confidence ≥ 0.9 ✓ |
+| `Smith v. Jones, 100 F.2d 1, rev'd, 200 U.S. 5` | child confidence missed caseName bonus | child confidence ≥ 0.9 ✓ |
+| `Smith v. Jones, 100 F.2d 1` (standalone) | unchanged | unchanged ✓ |
+
+3 regression tests in `tests/extract/issueSubsequentHistoryConfidence.test.ts`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -855,6 +855,21 @@ function inheritSubsequentHistoryCaseName(citations: Citation[]): void {
         originalEnd: child.fullSpan.originalEnd,
       }
     }
+
+    // The confidence score on `child` was computed by buildCaseCitation()
+    // when caseName was still undefined, so it missed the +0.15 caseName
+    // signal it now qualifies for. Re-derive with the same formula so the
+    // inherited caption registers in the score (#613, mirrors #556 fix in
+    // inheritParallelCaseName). Reporter / year / court are unchanged by
+    // this pass, so this only swings score for children that had their
+    // caseName mutated above.
+    child.confidence = computeCaseConfidence({
+      reporter: child.reporter,
+      year: child.year,
+      caseName: child.caseName,
+      court: child.court,
+      hasBlankPage: child.hasBlankPage ?? false,
+    })
   }
 }
 

--- a/tests/extract/issueSubsequentHistoryConfidence.test.ts
+++ b/tests/extract/issueSubsequentHistoryConfidence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #613 — `inheritSubsequentHistoryCaseName` mutated caseName onto
+ * subsequent-history child citations after `buildCaseCitation` had
+ * already locked in their confidence score, so the +0.15 caseName
+ * bonus never fired for the child. Mirror of #556's fix on the
+ * parallel-cite path.
+ */
+describe("Issue #613 - subsequent-history child confidence recomputed", () => {
+  it("aff'd child inherits parent caseName + gets confidence bonus", () => {
+    const text = `Smith v. Jones, 100 F.2d 1 (9th Cir. 1990), aff'd, 200 U.S. 5 (1991).`
+    const cs = extractCitations(text).filter((c) => c.type === "case")
+    expect(cs.length).toBeGreaterThanOrEqual(2)
+    const child = cs.find(
+      (c) =>
+        (c as { subsequentHistoryOf?: unknown }).subsequentHistoryOf !== undefined,
+    ) as { caseName?: string; confidence?: number; reporter?: string } | undefined
+    expect(child).toBeDefined()
+    expect(child?.caseName).toBe("Smith v. Jones")
+    // U.S. + year + court are all present, so the child base score is already
+    // high. The caseName bonus should push it solidly above 0.9.
+    expect(child?.confidence).toBeGreaterThan(0.9)
+  })
+
+  it("rev'd child also inherits caseName and re-scores", () => {
+    const text = `Smith v. Jones, 100 F.2d 1 (9th Cir. 1990), rev'd, 200 U.S. 5 (1991).`
+    const cs = extractCitations(text).filter((c) => c.type === "case")
+    const child = cs.find(
+      (c) =>
+        (c as { subsequentHistoryOf?: unknown }).subsequentHistoryOf !== undefined,
+    ) as { caseName?: string; confidence?: number } | undefined
+    expect(child?.caseName).toBe("Smith v. Jones")
+    expect(child?.confidence).toBeGreaterThan(0.9)
+  })
+
+  it("standalone (non-history) cite unaffected", () => {
+    const text = `Smith v. Jones, 100 F.2d 1`
+    const cs = extractCitations(text).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    // No subsequent-history relationship → confidence comes from
+    // buildCaseCitation directly, unchanged by this fix.
+    expect(cs[0].confidence).toBeGreaterThan(0.6)
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #613. \`inheritSubsequentHistoryCaseName\` mutated caseName onto child citations after \`buildCaseCitation\` had already locked in their confidence — the +0.15 caseName bonus never fired for the child.
- Same bug pattern as #556 (parallel-cite secondaries), fixed there in PR #611. Mechanical port: call \`computeCaseConfidence\` on each child after the caption mutation.
- 3 regression tests in \`tests/extract/issueSubsequentHistoryConfidence.test.ts\`.

## Test plan
- [x] Full suite: 4178 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)