### PR TITLE
docs: update subsequentHistoryEntries JSDoc for post-#527 contract (#619)

### DIFF
--- a/.changeset/docs-subsequent-history-entries-jsdoc.md
+++ b/.changeset/docs-subsequent-history-entries-jsdoc.md
@@ -1,0 +1,18 @@
+---
+"eyecite-ts": patch
+---
+
+docs: update `subsequentHistoryEntries` JSDoc for post-#527 contract (#619)
+
+Resolves #619. The JSDoc still said "Only populated on the parent
+(original) citation" — that was true before PR #617's #527 rewrite,
+which changed the field to populate on every chain link that received
+a history clause from the scanner. The minor version bump (0.22.0)
+flagged the contract change but the JSDoc was not updated.
+
+Replaced with text documenting the new contract:
+> Populated on every chain link that received a history clause from
+> the scanner — not just the chain's root. For `Smith, aff'd, X,
+> cert. denied, Y`, both Smith and X populate this field.
+
+No code changes. Doc-only patch.

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -305,9 +305,16 @@ export interface FullCaseCitation extends CitationBase {
   parentheticals?: Parenthetical[]
 
   /**
-   * Subsequent history entries for this citation.
+   * Subsequent history entries attached to this citation.
+   *
+   * Populated on every chain link that received a history clause from the
+   * scanner — not just the chain's root (#619, post-#527 contract change).
+   * For `Smith, aff'd, X, cert. denied, Y`, both `Smith` (carrying
+   * `[affirmed]` linking to `X`) and `X` (carrying `[cert_denied]`
+   * linking to `Y`) populate this field. Walk `subsequentHistoryOf`
+   * back-pointers from child→parent to traverse the chain in reverse.
+   *
    * Each entry describes a procedural event (affirmed, reversed, etc.).
-   * Only populated on the parent (original) citation.
    * @example [{ signal: "affirmed", rawSignal: "aff'd", signalSpan: {...}, order: 0 }]
    */
   subsequentHistoryEntries?: SubsequentHistoryEntry[]


### PR DESCRIPTION
## Summary
- Resolves #619. JSDoc on \`subsequentHistoryEntries\` said "Only populated on the parent" but PR #617's #527 rewrite changed the field to populate on every chain link.
- Doc-only patch. No code changes.

## Test plan
- [x] Full suite: 4178 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)