### PR TITLE
fix(extract): CFR Title-comma form recognized (#630)

### DIFF
--- a/.changeset/fix-cfr-title-comma.md
+++ b/.changeset/fix-cfr-title-comma.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): CFR `Title 12, C.F.R.` form recognized (#630)
+
+Resolves #630. CFR pattern's title→code separator required pure
+whitespace (`\s+`), missing the comma-tolerant form that USC got in
+Sprint H (#586).
+
+| input | before | after |
+|---|---|---|
+| `Title 12, C.F.R. § 226` | 0 cites | regulation ✓ |
+| `Title 12, C.F.R., § 226` | 0 cites | regulation ✓ |
+| `Title 12 C.F.R. § 226` (no comma) | regulation | unchanged ✓ |
+| `12 C.F.R. § 226` (no Title prefix) | regulation | unchanged ✓ |
+
+Fix: change CFR title→code separator from `\s+` to `\s*,?\s+` —
+mirrors the USC fix for #586. Trailing letter alternation is USC-only,
+so no other changes.
+
+5 regression tests in `tests/extract/issueCfrTitleComma.test.ts`.

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -77,8 +77,11 @@ export const statutePatterns: Pattern[] = [
     // Code→connector separator admits an optional comma (`12 C.F.R.,
     // § 226`) — symmetric to the USC fix for #587. The Sprint F
     // year-paren guard `(?![^)]*\d{4})` is preserved intact.
+    // Title→code separator admits an optional comma (`Title 12, C.F.R.
+    // § 226`) — symmetric to the USC fix for #586. The trailing letter
+    // alternation is USC-only.
     regex:
-      /\b(\d+)\s+C\.?F\.?R\.?\s*,?\s*(?:(?:Part|pt\.)\s+|§§?\s*|[Ss]ections?\s+|[Ss]ec\.?\s+)?(\d+(?:\.\d+)?[A-Za-z0-9-]*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/g,
+      /\b(\d+)\s*,?\s+C\.?F\.?R\.?\s*,?\s*(?:(?:Part|pt\.)\s+|§§?\s*|[Ss]ections?\s+|[Ss]ec\.?\s+)?(\d+(?:\.\d+)?[A-Za-z0-9-]*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/g,
     description:
       'Code of Federal Regulations with optional Part/§/Section connector — #428 #587',
     type: "statute",

--- a/tests/extract/issueCfrTitleComma.test.ts
+++ b/tests/extract/issueCfrTitleComma.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #630 — CFR title-side comma form (`Title 12, C.F.R. § 226`) was
+ * not recognized — asymmetric with the USC pattern, which was fixed in
+ * Sprint H (#586). The CFR title→code separator still required pure
+ * whitespace. Fixed by allowing an optional comma (`\s*,?\s+`).
+ */
+describe("Issue #630 - CFR title-comma form", () => {
+  it("`Title 12, C.F.R. § 226` extracts as regulation", () => {
+    const cs = extractCitations(`Title 12, C.F.R. § 226`)
+    expect(cs).toHaveLength(1)
+    expect(cs[0].type).toBe("regulation")
+  })
+
+  it("`Title 12, C.F.R., § 226` extracts as regulation", () => {
+    const cs = extractCitations(`Title 12, C.F.R., § 226`)
+    expect(cs).toHaveLength(1)
+    expect(cs[0].type).toBe("regulation")
+  })
+
+  it("`Title 12 C.F.R. § 226` (no comma) still works", () => {
+    const cs = extractCitations(`Title 12 C.F.R. § 226`)
+    expect(cs).toHaveLength(1)
+    expect(cs[0].type).toBe("regulation")
+  })
+
+  it("`12 C.F.R. § 226` (no Title prefix) still works", () => {
+    const cs = extractCitations(`12 C.F.R. § 226`)
+    expect(cs).toHaveLength(1)
+    expect(cs[0].type).toBe("regulation")
+  })
+
+  it("`42 C.F.R. § 122.26` (canonical Bluebook) still works", () => {
+    const cs = extractCitations(`42 C.F.R. § 122.26`)
+    expect(cs).toHaveLength(1)
+    expect(cs[0].type).toBe("regulation")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #630. CFR pattern's title→code separator required pure whitespace, missing the comma-tolerant form that USC got in Sprint H (#586).
- Fix: \`\s+\` → \`\s*,?\s+\`. Mirrors USC fix.
- 5 regression tests in \`tests/extract/issueCfrTitleComma.test.ts\`.

## Test plan
- [x] Full suite: 4183 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)