### PR TITLE
fix(extract): strip variable single-letter prefix from plaintiff (#710)

### DIFF
--- a/.changeset/fix-x-var-prefix-strip.md
+++ b/.changeset/fix-x-var-prefix-strip.md
@@ -1,0 +1,32 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): strip variable single-letter prefix from plaintiff (#710)
+
+Resolves part of #710. When `<single-letter>. ` appears immediately
+before what looks like a party name (`held that X. Smith v. Jones`)
+and the trim block fires (because the regex captured surrounding
+prose context), strip the single-letter prefix — it's a sentence-
+internal variable, not an initial.
+
+Disambiguator: the dropped word immediately before the single-letter
+token must be a lowercase ≥4-char word (verb/conjunction like
+`that`/`because`/`unless`/`when`). Signal contexts (`See J. Smith`)
+and procedural-prefix contexts (`In re J. Smith`) are unaffected
+because those drop different prefixes.
+
+| input | before | after |
+|---|---|---|
+| `The Smith case held that X. Smith v. Jones, ...` | plaintiff=`X. Smith` | `Smith` ✓ |
+| `In re J. Smith v. Jones` | plaintiff=`J. Smith` | unchanged ✓ |
+| `See J. Smith v. Jones` | plaintiff=`J. Smith` | unchanged ✓ |
+| `K. Brown was right; M. Jones v. K. Brown` | plaintiff=`M. Jones` | unchanged ✓ |
+| `The court held that K. Brown v. Smith` | plaintiff=`K. Brown` | `Brown` ✓ |
+
+Known limitation (not covered by this fix): standalone shapes where
+the regex doesn't trim at all (e.g., `held because X. Smith v. Y`
+with no longer surrounding prose) still produce `X. Smith`. Those
+need a different anchor and are deferred.
+
+5 regression tests in `tests/extract/issueXVarPrefixStrip.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -2076,6 +2076,22 @@ export function extractCaseName(
                 const prefix = words.slice(0, i).join(" ")
                 trimOffset = prefix.length + 1
                 plaintiff = candidate
+                // Issue #710: when the trimmed plaintiff starts with
+                // `<single-letter>. ` (e.g., `X. Smith`) AND the
+                // immediately preceding context word (the one we just
+                // dropped, or its right neighbor) is a lowercase
+                // conjunction/verb like `that`/`because`, the single-
+                // letter token is a sentence-internal variable, not an
+                // initial. Strip the prefix.
+                const slMatch = /^([A-Z])\.\s+([A-Z][a-zA-Z'-]+)/.exec(plaintiff)
+                if (slMatch) {
+                  const lastDroppedWord = words[i - 1]?.toLowerCase().replace(/[.,]+$/, "")
+                  if (lastDroppedWord && /^[a-z]{4,}$/.test(lastDroppedWord)) {
+                    const slStrip = slMatch[0].length - slMatch[2].length
+                    plaintiff = `${slMatch[2]}${plaintiff.slice(slMatch[0].length)}`
+                    trimOffset += slStrip
+                  }
+                }
                 break
               }
             }

--- a/tests/extract/issueXVarPrefixStrip.test.ts
+++ b/tests/extract/issueXVarPrefixStrip.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #710 — When `<single-letter>. ` (e.g., `X.`) appears immediately
+ * before what looks like a party name, V_CASE_NAME_REGEX treated the
+ * single letter as an initial and absorbed it into the plaintiff field.
+ * In sentence-internal contexts (`held that X. Smith ...`) the X is a
+ * variable, not an initial — strip it.
+ *
+ * This fix only triggers when the extractor's trim block already runs
+ * (i.e., the regex captured prose context like `held that X. Smith`).
+ * Standalone `held because X. Smith v. Y` shapes where the regex doesn't
+ * trim at all are not yet covered.
+ */
+describe("Issue #710 - strip variable single-letter prefix from plaintiff", () => {
+  it("`held that X. Smith v. Jones` → plaintiff `Smith`", () => {
+    const cs = extractCitations(
+      `The Smith case held that X. Smith v. Jones, 100 F.2d 1.`,
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { plaintiff?: string }).plaintiff).toBe("Smith")
+  })
+
+  it("`In re J. Smith v. Jones` keeps `J. Smith` (procedural prefix)", () => {
+    const cs = extractCitations(`In re J. Smith v. Jones, 100 F.2d 1.`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { plaintiff?: string }).plaintiff).toBe("J. Smith")
+  })
+
+  it("`See J. Smith v. Jones` keeps `J. Smith` (signal context)", () => {
+    const cs = extractCitations(`See J. Smith v. Jones, 100 F.2d 1.`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { plaintiff?: string }).plaintiff).toBe("J. Smith")
+  })
+
+  it("`K. Brown was right; M. Jones v. K. Brown` keeps `M. Jones`", () => {
+    const cs = extractCitations(
+      `K. Brown was right; M. Jones v. K. Brown, 100 F.2d 1.`,
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { plaintiff?: string }).plaintiff).toBe("M. Jones")
+  })
+
+  it("`The court held that K. Brown v. Smith` → plaintiff `Brown`", () => {
+    const cs = extractCitations(
+      `The court held that K. Brown v. Smith, 100 F.2d 1.`,
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { plaintiff?: string }).plaintiff).toBe("Brown")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves part of #710. When \`<single-letter>. \` appears immediately before what looks like a party name (\`held that X. Smith v. Jones\`) and the existing trim block fires (regex captured surrounding prose context), strip the single-letter prefix — it's a sentence-internal variable, not an initial.
- Disambiguator: dropped word immediately before the single letter must be a lowercase ≥4-char word (verb/conjunction like \`that\`/\`because\`/\`unless\`/\`when\`). Signal and procedural-prefix contexts unaffected.
- Known limitation: standalone shapes where regex doesn't trim (\`held because X. Smith v. Y\`) not yet covered.
- 5 regression tests in \`tests/extract/issueXVarPrefixStrip.test.ts\`.

## Test plan
- [x] Full suite: 4192 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)