### PR TITLE
fix(extract): state statute subsection ranges populate subsectionRange (#694 pt 2)

### DIFF
--- a/.changeset/fix-state-subsection-range.md
+++ b/.changeset/fix-state-subsection-range.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): state statute subsection ranges populate subsectionRange (#694)
+
+Resolves part 2 of #694. State statute extractors (`named-code` for
+`Cal. Civ. Code §...`, `extractCaBareCode` for `Civ. Code §...`)
+dropped the `-(c)` subsection-range trailer entirely. Federal USC
+already populated `subsectionRange: {start, end}` for the same shape.
+
+| input | before | after |
+|---|---|---|
+| `Cal. Civ. Code §§ 1714.5(a)-(c)` | subsection=`(a)`, no range | `(a)` + range `(a)→(c)` ✓ |
+| `Cal. Penal Code § 148(b)-(d)` | subsection=`(b)`, no range | `(b)` + range `(b)→(d)` ✓ |
+| `42 U.S.C. § 1983(a)-(c)` (federal control) | unchanged | unchanged ✓ |
+| `Cal. Civ. Code § 1714.5(a)` (single) | unchanged | unchanged ✓ |
+
+Four parallel sites updated:
+1. `named-code` tokenizer pattern in `statutePatterns.ts`
+2. `buildCaBareCodeRegex` tokenizer in `caBareCodes.ts`
+3. `extractNamedCode` extractor regex + parseBody destructure + return
+4. `extractCaBareCode` extractor regex + parseBody destructure + return
+
+4 regression tests in `tests/extract/issueStateSubsectionRange.test.ts`.
+
+Parts 1 and 3 of #694 (`to` connector — fixed earlier in PR #742;
+partial-range `.55` semantics) closed elsewhere.

--- a/src/data/caBareCodes.ts
+++ b/src/data/caBareCodes.ts
@@ -95,8 +95,12 @@ export function buildCaBareCodeRegex(): RegExp {
     .sort((a, b) => b.regexFragment.length - a.regexFragment.length)
     .map((e) => e.regexFragment)
   const alternation = fragments.join("|")
+  // Subsection-range trailer `(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?` (#694)
+  // captures the closing paren of a paren-range like `(a)-(c)` so
+  // parseBody can surface the structured `subsectionRange` field —
+  // symmetric to the abbreviated-code and USC patterns.
   return new RegExp(
-    `\\b(${alternation})\\s*,?\\s*§§?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:,?\\s+(?:subd\\.|subdivision|paragraph|par\\.)\\s+(?:\\([^)]*\\)|\\[[^\\]]*\\])(?:\\s*(?:\\([^)]*\\)|\\[[^\\]]*\\]))*)?(?:\\s*et\\s+seq\\.?)?)`,
+    `\\b(${alternation})\\s*,?\\s*§§?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:,?\\s+(?:subd\\.|subdivision|paragraph|par\\.)\\s+(?:\\([^)]*\\)|\\[[^\\]]*\\])(?:\\s*(?:\\([^)]*\\)|\\[[^\\]]*\\]))*)?(?:\\s*[-–—]+\\s*\\([A-Za-z0-9]+\\))?(?:\\s*et\\s+seq\\.?)?)`,
     "g",
   )
 }

--- a/src/extract/statutes/extractCaBareCode.ts
+++ b/src/extract/statutes/extractCaBareCode.ts
@@ -27,8 +27,12 @@ import { parseBody } from "./parseBody"
  * keyword tail introduced in #589). The actual normalization of
  * `1238, subd. (a)(8)` → `(a)(8)` happens inside `parseBody`.
  */
+// Trailing `(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?` captures the closing
+// paren of a paren-range like `(a)-(c)` so parseBody can surface the
+// structured `subsectionRange` field. Mirrors the tokenizer body
+// grammar in buildCaBareCodeRegex (#694).
 const CA_BARE_CODE_RE =
-  /^(.+?)\s*,?\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:,?\s+(?:subd\.|subdivision|paragraphs?|pars?\.)\s+(?:\([^)]*\)|\[[^\]]*\])(?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)?(?:\s*et\s+seq\.?)?)$/d
+  /^(.+?)\s*,?\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:,?\s+(?:subd\.|subdivision|paragraphs?|pars?\.)\s+(?:\([^)]*\)|\[[^\]]*\])(?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)?(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)$/d
 
 export function extractCaBareCode(
   token: Token,
@@ -47,7 +51,7 @@ export function extractCaBareCode(
   // tokens whose code text matched one of the canonical alternations.
   const code = findCaBareCode(rawCodeText)!
 
-  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+  const { section, subsection, subsectionRangeEnd, hasEtSeq } = parseBody(rawBody)
 
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
@@ -93,6 +97,8 @@ export function extractCaBareCode(
     code,
     section,
     subsection,
+    subsectionRange:
+      subsection && subsectionRangeEnd ? { start: subsection, end: subsectionRangeEnd } : undefined,
     pincite: subsection,
     jurisdiction: "CA",
     hasEtSeq: hasEtSeq || undefined,

--- a/src/extract/statutes/extractNamedCode.ts
+++ b/src/extract/statutes/extractNamedCode.ts
@@ -189,7 +189,7 @@ export function extractNamedCode(
     }
   }
 
-  const { section, subsection, hasEtSeq } = parseBody(rawBody)
+  const { section, subsection, subsectionRangeEnd, hasEtSeq } = parseBody(rawBody)
 
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
@@ -261,6 +261,8 @@ export function extractNamedCode(
     chapter,
     section: sectionOut,
     subsection,
+    subsectionRange:
+      subsection && subsectionRangeEnd ? { start: subsection, end: subsectionRangeEnd } : undefined,
     pincite: subsection,
     jurisdiction,
     hasEtSeq: hasEtSeq || undefined,

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -274,8 +274,13 @@ export const statutePatterns: Pattern[] = [
     // `paragraph (a)` / `par. (a)` follows the section number. Captured
     // inside the section group so parseBody can normalize to a canonical
     // paren chain.
+    // Subsection-range trailer `(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?` (#694)
+    // captures the closing paren of a paren-range like `(a)-(c)` so the
+    // extractor + parseBody can surface the structured `subsectionRange`
+    // field — symmetric to the federal USC pattern and the bare
+    // abbreviated-code patterns.
     regex:
-      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s?)Va\.?|Ala(?:bama)?\.?)\s+([A-Z][A-Za-z.&']*(?:(?:\s+|,\s+)(?:&|[A-Z][A-Za-z.&']*))*)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:,?\s+(?:subd\.|subdivision|paragraphs?|pars?\.)\s+(?:\([^)]*\)|\[[^\]]*\])(?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)?(?:\s*et\s+seq\.?)?)/g,
+      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s?)Va\.?|Ala(?:bama)?\.?)\s+([A-Z][A-Za-z.&']*(?:(?:\s+|,\s+)(?:&|[A-Z][A-Za-z.&']*))*)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:,?\s+(?:subd\.|subdivision|paragraphs?|pars?\.)\s+(?:\([^)]*\)|\[[^\]]*\])(?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)?(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/g,
     description:
       "Named-code state citations (NY, CA, TX, MD, VA, AL) with jurisdiction prefix + code name + §",
     type: "statute",

--- a/tests/extract/issueStateSubsectionRange.test.ts
+++ b/tests/extract/issueStateSubsectionRange.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #694 (#2) — state statute extractors (`named-code` for
+ * `Cal. Civ. Code ...` / `Cal. Penal Code ...`, and `caBareCode` for
+ * `Civ. Code ...`) dropped the subsection-range trailer `-(c)` because:
+ *   1. The tokenizer regex didn't capture the `-(c)` (no trailer alt)
+ *   2. The extractor regex didn't capture it either
+ *   3. The extractor destructured `{section, subsection, hasEtSeq}` from
+ *      parseBody — it ignored the already-supported `subsectionRangeEnd`
+ *   4. The returned StatuteCitation didn't include `subsectionRange`
+ *
+ * Fixed all four sites symmetric with the federal USC pattern.
+ */
+describe("Issue #694 - state statute subsection range", () => {
+  it("`Cal. Civ. Code §§ 1714.5(a)-(c)` populates subsectionRange", () => {
+    const cs = extractCitations(`Cal. Civ. Code §§ 1714.5(a)-(c)`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as {
+      subsection?: string
+      subsectionRange?: { start: string; end: string }
+    }
+    expect(c.subsection).toBe("(a)")
+    expect(c.subsectionRange).toEqual({ start: "(a)", end: "(c)" })
+  })
+
+  it("`Cal. Penal Code § 148(b)-(d)` populates subsectionRange", () => {
+    const cs = extractCitations(`Cal. Penal Code § 148(b)-(d)`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    expect(
+      (cs[0] as { subsectionRange?: { start: string; end: string } }).subsectionRange,
+    ).toEqual({ start: "(b)", end: "(d)" })
+  })
+
+  it("`42 U.S.C. § 1983(a)-(c)` (federal control) unchanged", () => {
+    const cs = extractCitations(`42 U.S.C. § 1983(a)-(c)`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    expect(
+      (cs[0] as { subsectionRange?: { start: string; end: string } }).subsectionRange,
+    ).toEqual({ start: "(a)", end: "(c)" })
+  })
+
+  it("single subsection `Cal. Civ. Code § 1714.5(a)` unaffected", () => {
+    const cs = extractCitations(`Cal. Civ. Code § 1714.5(a)`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { subsection?: string }).subsection).toBe("(a)")
+    expect(
+      (cs[0] as { subsectionRange?: unknown }).subsectionRange,
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves part 2 of #694. State statute extractors (\`named-code\` for \`Cal. Civ. Code §...\`, \`extractCaBareCode\` for \`Civ. Code §...\`) dropped the \`-(c)\` subsection-range trailer entirely. Federal USC already worked for the same shape.
- Updated 4 parallel sites symmetric with the federal USC pattern:
  1. \`named-code\` tokenizer pattern (statutePatterns.ts)
  2. \`buildCaBareCodeRegex\` tokenizer (caBareCodes.ts)
  3. \`extractNamedCode\` extractor regex + parseBody destructure + return
  4. \`extractCaBareCode\` extractor regex + parseBody destructure + return
- 4 regression tests in \`tests/extract/issueStateSubsectionRange.test.ts\`.

## Test plan
- [x] Full suite: 4200 pass, 0 regressions
- [x] \`Cal. Civ. Code §§ 1714.5(a)-(c)\` → \`subsectionRange: {start: "(a)", end: "(c)"}\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)