### PR TITLE
fix(filter): warn when applyFalsePositiveFilters called without originalText (#606)

### DIFF
--- a/.changeset/fix-fp-filter-missing-original-text-warning.md
+++ b/.changeset/fix-fp-filter-missing-original-text-warning.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(filter): warn when applyFalsePositiveFilters called without originalText (#606)
+
+Resolves #606. `applyFalsePositiveFilters` silently skipped the
+line-crossing check (#547) when the `originalText` parameter was
+omitted, letting line-crossing false positives slip through.
+
+Now emits a one-time `console.warn` (per process, idempotent across
+repeated calls) when called without `originalText` AND the input
+contains at least one case/shortFormCase citation (the only types
+the line-crossing check applies to). Pure statute / journal / neutral
+inputs do not trigger the warning.
+
+The signature is unchanged so this is a non-breaking patch. JSDoc
+updated to mark `originalText` as **strongly recommended**.
+
+Internal export `_resetMissingOriginalTextWarning()` added for test
+fixtures.
+
+5 regression tests in
+`tests/extract/issueFpFilterMissingOriginalTextWarning.test.ts`.

--- a/src/extract/filterFalsePositives.ts
+++ b/src/extract/filterFalsePositives.ts
@@ -549,15 +549,32 @@ function collectFalsePositiveReasons(citation: Citation, originalText?: string):
   return reasons
 }
 
+/** Tracks whether the missing-originalText warning has already fired
+ *  to avoid spamming the console on repeated calls. Reset by tests. */
+let warnedMissingOriginalText = false
+
+/** @internal — exported for test reset only. */
+export function _resetMissingOriginalTextWarning(): void {
+  warnedMissingOriginalText = false
+}
+
 /**
  * Apply false positive filters to extracted citations.
  *
  * @param citations - Extracted citations (may be mutated in penalize mode)
  * @param remove - If true, remove flagged citations. If false, penalize confidence + add warning.
- * @param originalText - Original (pre-cleaning) source text. Required for the
- *   line-crossing check (#547) which inspects the raw bytes of the cite span.
- *   When omitted, the line-crossing check is skipped to preserve backward
- *   compatibility for callers that hold only parsed citations.
+ * @param originalText - Original (pre-cleaning) source text. **Strongly
+ *   recommended** — required for the line-crossing check (#547) which
+ *   inspects the raw bytes of the cite span. Passing `undefined`
+ *   silently skips the line-crossing FP check, allowing line-crossing
+ *   false positives to slip through with default confidence (#606).
+ *
+ *   When this function is invoked WITHOUT `originalText` AND the input
+ *   contains at least one case/shortFormCase citation, a one-time
+ *   `console.warn` fires (per process, idempotent across repeated
+ *   calls) to alert callers to the silently-skipped check. Pass
+ *   `originalText` explicitly to silence the warning, or call
+ *   `_resetMissingOriginalTextWarning()` in tests.
  * @returns Filtered array (same reference if remove=false, new array if remove=true and items removed)
  */
 export function applyFalsePositiveFilters(
@@ -565,6 +582,22 @@ export function applyFalsePositiveFilters(
   remove: boolean,
   originalText?: string,
 ): Citation[] {
+  // Issue #606: warn (once per process) when originalText is omitted
+  // AND the input could plausibly contain line-crossing false positives.
+  // Line-crossing only applies to case/shortFormCase, so a pure
+  // statute/journal/neutral input has nothing to skip.
+  if (originalText === undefined && !warnedMissingOriginalText) {
+    const hasCaseCite = citations.some(
+      (c) => c.type === "case" || c.type === "shortFormCase",
+    )
+    if (hasCaseCite) {
+      warnedMissingOriginalText = true
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[eyecite-ts] applyFalsePositiveFilters: called without `originalText` — line-crossing false-positive check (#547) is silently skipped. Pass the original source text as the 3rd argument to enable it. This warning fires only once per process; see issue #606.",
+      )
+    }
+  }
   // Hard-reject pass: unconditionally drop unambiguous garbage like
   // `<day> <Month> <year>` date misparses (#302). These are never legitimate
   // citations under any policy, so they should not survive even when the

--- a/tests/extract/issueFpFilterMissingOriginalTextWarning.test.ts
+++ b/tests/extract/issueFpFilterMissingOriginalTextWarning.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  _resetMissingOriginalTextWarning,
+  applyFalsePositiveFilters,
+} from "@/extract/filterFalsePositives"
+import type { FullCaseCitation, StatuteCitation } from "@/types/citation"
+
+/**
+ * Issue #606 — `applyFalsePositiveFilters` silently skipped the
+ * line-crossing check (#547) when `originalText` was omitted. Now
+ * emits a one-time console.warn when called without `originalText`
+ * AND the input contains case/shortFormCase citations (the only
+ * types the line-crossing check applies to).
+ */
+describe("Issue #606 - missing-originalText warning", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    _resetMissingOriginalTextWarning()
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  function makeCaseAt(): FullCaseCitation {
+    return {
+      type: "case",
+      text: "100 F.2d 123",
+      span: { cleanStart: 0, cleanEnd: 12, originalStart: 0, originalEnd: 12 },
+      confidence: 0.8,
+      matchedText: "100 F.2d 123",
+      processTimeMs: 0,
+      patternsChecked: 1,
+      volume: 100,
+      reporter: "F.2d",
+      page: 123,
+    }
+  }
+
+  function makeStatuteAt(): StatuteCitation {
+    return {
+      type: "statute",
+      text: "42 U.S.C. § 1983",
+      span: { cleanStart: 0, cleanEnd: 16, originalStart: 0, originalEnd: 16 },
+      confidence: 1.0,
+      matchedText: "42 U.S.C. § 1983",
+      processTimeMs: 0,
+      patternsChecked: 1,
+      title: 42,
+      code: "U.S.C.",
+      section: "1983",
+      jurisdiction: "US",
+    }
+  }
+
+  it("warns on first call without originalText when case cites present", () => {
+    applyFalsePositiveFilters([makeCaseAt()], false)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain("originalText")
+    expect(warnSpy.mock.calls[0][0]).toContain("#606")
+  })
+
+  it("does NOT re-warn on subsequent calls (one-time per process)", () => {
+    applyFalsePositiveFilters([makeCaseAt()], false)
+    applyFalsePositiveFilters([makeCaseAt()], false)
+    applyFalsePositiveFilters([makeCaseAt()], false)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("does NOT warn when originalText is explicitly passed", () => {
+    applyFalsePositiveFilters([makeCaseAt()], false, "100 F.2d 123 some text")
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT warn for pure non-case-cite inputs (nothing to skip)", () => {
+    applyFalsePositiveFilters([makeStatuteAt()], false)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("does NOT warn on empty citation list", () => {
+    applyFalsePositiveFilters([], false)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #606. \`applyFalsePositiveFilters\` silently skipped the line-crossing check (#547) when \`originalText\` was omitted.
- Emits a one-time \`console.warn\` (per process) when called without \`originalText\` AND the input contains case/shortFormCase citations (the only types the line-crossing check applies to).
- Non-breaking — signature unchanged, JSDoc strengthened. Internal \`_resetMissingOriginalTextWarning()\` export for test fixtures.
- 5 regression tests.

## Test plan
- [x] Full suite: 4209 pass, 0 regressions
- [x] Warn fires once on case-cite input without originalText
- [x] Does NOT re-fire on subsequent calls
- [x] Does NOT fire when originalText passed explicitly
- [x] Does NOT fire on pure statute/non-case inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)