### PR TITLE
fix(extract): NYC Admin. Code bare prefix routes to NY (#594)

### DIFF
--- a/.changeset/fix-nyc-admin-code-bare-prefix.md
+++ b/.changeset/fix-nyc-admin-code-bare-prefix.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): `NYC Admin. Code` bare prefix routes to NY (#594)
+
+Resolves the bare-prefix gap of #594. The canonical `N.Y.C. Admin.
+Code` and spelled-out `New York City Administrative Code` forms were
+already correct, but the bare-period form (`NYC Admin. Code § 8-107`)
+was mis-tagged as Georgia by the `ga-pre-1983` fallback because the
+`nyc-admin-code` pattern only matched the period-rich variant.
+
+| input | before | after |
+|---|---|---|
+| `NYC Admin. Code § 8-107` | code=`Code`, GA | `N.Y.C. Admin. Code`, NY ✓ |
+| `NYC Admin Code § 8-107` (no `.`) | code=`Code`, GA | `N.Y.C. Admin. Code`, NY ✓ |
+| `N.Y.C. Admin. Code § 8-107(1)(a)` | unchanged | unchanged ✓ |
+| `New York City Administrative Code § 8-107` | unchanged | unchanged ✓ |
+
+Extended the tokenizer (`nyc-admin-code` pattern) and the matching
+extractor regex to accept the bare `NYC` prefix alongside the
+period-rich `N.Y.C.` form.
+
+4 regression tests in `tests/extract/issueNycAdminCodeBare.test.ts`.

--- a/src/extract/statutes/extractNycAdminCode.ts
+++ b/src/extract/statutes/extractNycAdminCode.ts
@@ -22,8 +22,11 @@ import type { StatuteComponentSpans } from "@/types/componentSpans"
 import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
 import { parseBody } from "./parseBody"
 
+// Mirror of the tokenizer pattern in `nyc-admin-code`. Accepts the
+// canonical `N.Y.C. Admin. Code`, the spelled-out form, and the bare
+// `NYC Admin. Code` (#594).
 const NYC_ADMIN_CODE_RE =
-  /^(?:N\.\s*Y\.\s*C\.\s*Admin\.?\s+Code|New\s+York\s+City\s+Administrative\s+Code)\s+§§?\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?)((?:\([^)]*\))*)$/d
+  /^(?:N\.\s*Y\.\s*C\.\s*Admin\.?\s+Code|NYC\s+Admin\.?\s+Code|New\s+York\s+City\s+Administrative\s+Code)\s+§§?\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?)((?:\([^)]*\))*)$/d
 
 export function extractNycAdminCode(
   token: Token,

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -667,8 +667,14 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body (two-part hyphen), (2) optional
     //   paren subsection chain.
     id: "nyc-admin-code",
+    // Accept the canonical `N.Y.C. Admin. Code`, the spelled-out
+    // `New York City Administrative Code`, and the bare `NYC Admin.
+    // Code` form (common in modern briefs and employment opinions
+    // where the periods are dropped). Bare `NYC` was previously routed
+    // to Georgia by the ga-pre-1983 fallback; this prefix-qualified
+    // shape now wins span dedup. #594
     regex:
-      /\b(?:N\.\s*Y\.\s*C\.\s*Admin\.?\s+Code|New\s+York\s+City\s+Administrative\s+Code)\s+§§?\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?)((?:\([^)]*\))*)/g,
+      /\b(?:N\.\s*Y\.\s*C\.\s*Admin\.?\s+Code|NYC\s+Admin\.?\s+Code|New\s+York\s+City\s+Administrative\s+Code)\s+§§?\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?)((?:\([^)]*\))*)/g,
     description:
       'New York City Administrative Code: "N.Y.C. Admin. Code § 8-107(1)(a)" / "New York City Administrative Code § 8-107(1)(a)" — #594',
     type: "statute",

--- a/tests/extract/issueNycAdminCodeBare.test.ts
+++ b/tests/extract/issueNycAdminCodeBare.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #594 — `NYC Admin. Code § N` (bare prefix without periods) was
+ * mis-tagged as Georgia by the `ga-pre-1983` fallback because the
+ * `nyc-admin-code` pattern required the period-rich `N.Y.C.` form.
+ * Extended the tokenizer and extractor regexes to accept the bare form.
+ *
+ * Canonical and spelled-out forms were already correct from an earlier
+ * patch; this is the bare-prefix follow-up.
+ */
+describe("Issue #594 - NYC Admin Code bare prefix", () => {
+  it("`NYC Admin. Code § 8-107` routes to NY (not GA)", () => {
+    const cs = extractCitations(`NYC Admin. Code § 8-107`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { code?: string; jurisdiction?: string }
+    expect(c.code).toBe("N.Y.C. Admin. Code")
+    expect(c.jurisdiction).toBe("NY")
+  })
+
+  it("`NYC Admin Code § 8-107` (no period after Admin) also routes to NY", () => {
+    const cs = extractCitations(`NYC Admin Code § 8-107`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { code?: string; jurisdiction?: string }
+    expect(c.code).toBe("N.Y.C. Admin. Code")
+    expect(c.jurisdiction).toBe("NY")
+  })
+
+  it("canonical `N.Y.C. Admin. Code § 8-107(1)(a)` unchanged", () => {
+    const cs = extractCitations(`N.Y.C. Admin. Code § 8-107(1)(a)`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { code?: string }).code).toBe("N.Y.C. Admin. Code")
+  })
+
+  it("spelled-out `New York City Administrative Code § 8-107` unchanged", () => {
+    const cs = extractCitations(`New York City Administrative Code § 8-107`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { code?: string }).code).toBe("N.Y.C. Admin. Code")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the bare-prefix gap of #594. \`NYC Admin. Code § 8-107\` (no periods on NYC) was mis-tagged as Georgia by the \`ga-pre-1983\` fallback.
- Extended both the tokenizer pattern (\`nyc-admin-code\`) and the extractor regex to accept the bare \`NYC\` prefix alongside the period-rich variant.
- 4 regression tests in \`tests/extract/issueNycAdminCodeBare.test.ts\`.

## Test plan
- [x] Full suite: 4209 pass, 0 regressions
- [x] All 4 NYC Admin Code variants route to NY

🤖 Generated with [Claude Code](https://claude.com/claude-code)