### PR TITLE
fix(extract): treatise author-prefixed form recognized (#643)

### DIFF
--- a/.changeset/fix-treatise-author-prefix.md
+++ b/.changeset/fix-treatise-author-prefix.md
@@ -1,0 +1,27 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): treatise author-prefixed form recognized (#643)
+
+Resolves #643. The treatise extractor missed Bluebook R15's canonical
+full-author form (`5A Charles Alan Wright & Arthur R. Miller, Federal
+Practice and Procedure § 1357`) — the dominant style in modern
+federal briefs and law-review footnotes.
+
+| input | before | after |
+|---|---|---|
+| `5A Charles Alan Wright & Arthur R. Miller, Federal Practice and Procedure § 1357` | 0 cites | volume=5, title=`Federal Practice and Procedure` ✓ |
+| `2 Wayne LaFave, Criminal Law § 5.1` | 0 cites | volume=2, title=`Criminal Law` ✓ |
+| `5 Wright & Miller, Federal Practice and Procedure § 1290` (compact form) | unchanged | unchanged ✓ |
+| `1 Witkin, Cal. Procedure (5th ed. 2008) § 234` (compact + edition) | unchanged | unchanged ✓ |
+
+Changes:
+- Volume admits an optional letter suffix (`5A`, `13C`) for sub-volume citations
+- Added a `KNOWN_TREATISE_BARE_TITLES` alternation (just the title, no embedded author)
+- Tokenizer + extractor regexes now accept either the compact form (winning by alternation order to preserve existing tests) OR an author-prefix + bare title
+- Author prefix constrained to capitalized words optionally joined by `&`, so prose can't false-positive
+
+Known limitation (not in this patch): trailing `(3d ed. 2004)` parenthetical AFTER the section is not yet captured as edition/year. The existing pattern only handles edition-paren BEFORE the section.
+
+5 regression tests in `tests/extract/issueTreatiseAuthorPrefix.test.ts`.

--- a/src/extract/extractTreatise.ts
+++ b/src/extract/extractTreatise.ts
@@ -38,11 +38,31 @@ const KNOWN_TREATISES: ReadonlyArray<string> = [
   "Davis & Pierce, Administrative Law Treatise",
 ]
 
+/** Bare-title alternation for author-prefixed form (#643). Mirrors the
+ *  list in src/patterns/secondaryAuthorityPatterns.ts. */
+const KNOWN_TREATISE_BARE_TITLES: ReadonlyArray<string> = [
+  "Federal Practice and Procedure",
+  "Cal. Procedure",
+  "Summary of California Law",
+  "Criminal Procedure",
+  "Criminal Law",
+  "Administrative Law Treatise",
+]
+
 const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 const TREATISE_ALTERNATION = KNOWN_TREATISES.map(escapeRegex).join("|")
+const TREATISE_BARE_TITLE_ALTERNATION = KNOWN_TREATISE_BARE_TITLES.map(escapeRegex).join("|")
 
+// Mirrors the tokenizer regex in secondaryAuthorityPatterns.ts. Two
+// title shapes (group 2 = bare title with prefix-author, group 3 =
+// compact title) and an edition paren (group 4), section (group 5).
+// Group 2 = compact title, group 3 = bare title (author-prefixed).
+// Exactly one is populated per match.
 const TREATISE_REGEX = new RegExp(
-  `\\b(\\d+)\\s+(${TREATISE_ALTERNATION})(?:\\s+\\(([^)]+)\\))?\\s+§§?\\s*(\\d+(?:[.:][A-Za-z0-9]+)*(?:\\[[A-Za-z0-9]+\\])?(?:\\([^)]*\\))*)`,
+  `\\b(\\d+[A-Z]?)\\s+(?:` +
+    `(${TREATISE_ALTERNATION})` +
+    `|(?:[A-Z][A-Za-z.]*(?:\\s+[A-Z][A-Za-z.]*)*(?:\\s*&\\s*[A-Z][A-Za-z.]*(?:\\s+[A-Z][A-Za-z.]*)*)?,\\s+)(${TREATISE_BARE_TITLE_ALTERNATION})` +
+    `)(?:\\s+\\(([^)]+)\\))?\\s+§§?\\s*(\\d+(?:[.:][A-Za-z0-9]+)*(?:\\[[A-Za-z0-9]+\\])?(?:\\([^)]*\\))*)`,
   "d",
 )
 
@@ -70,17 +90,23 @@ export function extractTreatise(
     throw new Error(`Failed to parse treatise citation: ${text}`)
   }
 
-  const volume = Number.parseInt(match[1], 10)
-  const title = match[2]
-  const edition = match[3]
-  const section = match[4]
+  // Volume now admits an optional letter suffix (`5A`). Parse only the
+  // numeric prefix for the structured volume field; the letter suffix is
+  // preserved in the text span. #643
+  const volNumMatch = /^(\d+)/.exec(match[1])
+  const volume = volNumMatch ? Number.parseInt(volNumMatch[1], 10) : 0
+  // Title shape: group 2 = bare title (with author prefix), group 3 =
+  // compact title (no author prefix). Exactly one is populated.
+  const title = match[2] ?? match[3]
+  const edition = match[4]
+  const section = match[5]
   const year = extractYearFromEdition(edition)
 
   let spans: TreatiseComponentSpans | undefined
   if (match.indices) {
     const volumeIdx = match.indices[1]
-    const titleIdx = match.indices[2]
-    const sectionIdx = match.indices[4]
+    const titleIdx = match.indices[2] ?? match.indices[3]
+    const sectionIdx = match.indices[5]
     if (volumeIdx && titleIdx && sectionIdx) {
       spans = {
         volume: spanFromGroupIndex(span.cleanStart, volumeIdx, transformationMap),

--- a/src/patterns/secondaryAuthorityPatterns.ts
+++ b/src/patterns/secondaryAuthorityPatterns.ts
@@ -61,8 +61,31 @@ const KNOWN_TREATISES: ReadonlyArray<string> = [
   "Davis & Pierce, Administrative Law Treatise",
 ]
 
+/**
+ * Bare-title alternation (#643): titles WITHOUT the author shortname
+ * prefix, for the Bluebook R15 canonical form where the citation
+ * spells out the full author names between the volume and the title:
+ * `5A Charles Alan Wright & Arthur R. Miller, Federal Practice and
+ * Procedure § 1357`.
+ *
+ * Only includes titles where the author is plausibly external and
+ * variable (Wright & Miller, LaFave, Witkin, Davis & Pierce). Titles
+ * with the author baked into the work itself (`Williston on Contracts`,
+ * `Nimmer on Copyright`, `Moore's Federal Practice`) are NOT included
+ * here — they always appear with their canonical short title.
+ */
+const KNOWN_TREATISE_BARE_TITLES: ReadonlyArray<string> = [
+  "Federal Practice and Procedure",
+  "Cal. Procedure",
+  "Summary of California Law",
+  "Criminal Procedure",
+  "Criminal Law",
+  "Administrative Law Treatise",
+]
+
 const escapeRegex = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 const TREATISE_ALTERNATION = KNOWN_TREATISES.map(escapeRegex).join("|")
+const TREATISE_BARE_TITLE_ALTERNATION = KNOWN_TREATISE_BARE_TITLES.map(escapeRegex).join("|")
 
 /**
  * Curated list of journal abbreviations that frequently appear in legal
@@ -186,13 +209,36 @@ export const secondaryAuthorityPatterns: Pattern[] = [
     // An optional `(\<edition\>\s+ed\.?\s+\<year\>)` parenthetical can
     // appear between the title and the section sigil; we capture it for
     // the `edition` / `year` fields.
+    // Issue #643: Volume admits an optional letter suffix (`5A`,
+    // `13C`) for sub-volume citations common in Federal Practice and
+    // Procedure and Williston. The pattern accepts two title shapes:
+    //   1. Bare-title with optional author-prefix: `5A Charles Alan
+    //      Wright & Arthur R. Miller, Federal Practice and Procedure`
+    //      — Bluebook R15 prescribes the full-author form as canonical
+    //      and it's the dominant style in modern federal briefs.
+    //   2. Compact title with embedded author shortname: `5 Wright &
+    //      Miller, Federal Practice and Procedure` (existing).
+    //
+    // The bare-title alternative requires the preceding author prefix
+    // (constrained to capitalized words optionally joined by `&`); the
+    // compact alternative requires no prefix. Prose like
+    // `5 because the section is long, Wright & Miller, ...` cannot
+    // match either branch.
     id: "treatise",
     regex: new RegExp(
-      `\\b(\\d+)\\s+(${TREATISE_ALTERNATION})(?:\\s+\\(([^)]+)\\))?\\s+§§?\\s*(\\d+(?:[.:][A-Za-z0-9]+)*(?:\\[[A-Za-z0-9]+\\])?(?:\\([^)]*\\))*)`,
+      `\\b(\\d+[A-Z]?)\\s+(?:` +
+        // Compact form FIRST so existing tests pass (`5 Wright & Miller,
+        // Federal Practice and Procedure`); only fall back to the
+        // bare-title-with-author shape when the compact alternation
+        // misses (e.g., `5A Charles Alan Wright & Arthur R. Miller,
+        // Federal Practice and Procedure`).
+        `(${TREATISE_ALTERNATION})` +
+        `|(?:[A-Z][A-Za-z.]*(?:\\s+[A-Z][A-Za-z.]*)*(?:\\s*&\\s*[A-Z][A-Za-z.]*(?:\\s+[A-Z][A-Za-z.]*)*)?,\\s+)(${TREATISE_BARE_TITLE_ALTERNATION})` +
+        `)(?:\\s+\\(([^)]+)\\))?\\s+§§?\\s*(\\d+(?:[.:][A-Za-z0-9]+)*(?:\\[[A-Za-z0-9]+\\])?(?:\\([^)]*\\))*)`,
       "g",
     ),
     description:
-      'Treatise: "5 Wright & Miller, Federal Practice and Procedure § 1290", "1 Nimmer on Copyright § 5.05[A]" — #579',
+      'Treatise: "5 Wright & Miller, Federal Practice and Procedure § 1290", "5A Charles Alan Wright & Arthur R. Miller, Federal Practice and Procedure § 1357" (#643), "1 Nimmer on Copyright § 5.05[A]" — #579',
     type: "treatise",
   },
 ]

--- a/tests/extract/issueTreatiseAuthorPrefix.test.ts
+++ b/tests/extract/issueTreatiseAuthorPrefix.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #643 — Treatise extractor missed the author-prefixed form
+ * (`5A Charles Alan Wright & Arthur R. Miller, Federal Practice and
+ * Procedure § 1357`) — Bluebook R15's canonical full-author form and
+ * the dominant style in modern federal briefs.
+ *
+ * Fix: the volume admits an optional letter suffix (`5A`); a
+ * bare-title alternation accepts the title without the embedded
+ * author shortname; an optional author-prefix group sits between
+ * the volume and the bare title. Compact form remains the primary
+ * match so existing tests pass.
+ */
+describe("Issue #643 - treatise author-prefixed form", () => {
+  it("`5A Charles Alan Wright & Arthur R. Miller, Federal Practice and Procedure § 1357`", () => {
+    const cs = extractCitations(
+      `5A Charles Alan Wright & Arthur R. Miller, Federal Practice and Procedure § 1357 (3d ed. 2004)`,
+    ).filter((c) => c.type === "treatise")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { volume?: number; title?: string; section?: string }
+    expect(c.volume).toBe(5)
+    expect(c.title).toBe("Federal Practice and Procedure")
+    expect(c.section).toBe("1357")
+    // Note: trailing `(3d ed. 2004)` after section is not yet captured
+    // as edition/year — the existing pattern only handles edition-paren
+    // BEFORE the section (as in `(5th ed. 2008) § 234`).
+  })
+
+  it("single-author prefix: `2 Wayne LaFave, Criminal Law § 5.1`", () => {
+    const cs = extractCitations(`2 Wayne LaFave, Criminal Law § 5.1`).filter(
+      (c) => c.type === "treatise",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { volume?: number; title?: string }
+    expect(c.volume).toBe(2)
+    expect(c.title).toBe("Criminal Law")
+  })
+
+  it("compact form preserved (regression): `5 Wright & Miller, Federal Practice and Procedure § 1290`", () => {
+    const cs = extractCitations(
+      `5 Wright & Miller, Federal Practice and Procedure § 1290`,
+    ).filter((c) => c.type === "treatise")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { title?: string }
+    expect(c.title).toBe("Wright & Miller, Federal Practice and Procedure")
+  })
+
+  it("compact form with edition paren (regression): `1 Witkin, Cal. Procedure (5th ed. 2008) § 234`", () => {
+    const cs = extractCitations(`1 Witkin, Cal. Procedure (5th ed. 2008) § 234`).filter(
+      (c) => c.type === "treatise",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { title?: string; year?: number }
+    expect(c.title).toBe("Witkin, Cal. Procedure")
+    expect(c.year).toBe(2008)
+  })
+
+  it("sub-volume suffix `5A` parses as volume 5", () => {
+    const cs = extractCitations(
+      `5A Charles Alan Wright & Arthur R. Miller, Federal Practice and Procedure § 1357`,
+    ).filter((c) => c.type === "treatise")
+    expect((cs[0] as { volume?: number }).volume).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #643. Match Bluebook R15's canonical full-author form (\`5A Charles Alan Wright & Arthur R. Miller, Federal Practice and Procedure § 1357\`) — the dominant style in modern federal briefs.
- Volume admits optional letter suffix (\`5A\`); added bare-title alternation; tokenizer + extractor accept either compact form (existing) OR author-prefix + bare title.
- Compact-form tests pass unchanged (alternation order preserves backward compat).
- 5 regression tests.

Known limitation: trailing \`(ed. YYYY)\` paren AFTER section not yet captured as edition/year.

## Test plan
- [x] Full suite: 4214 pass, 0 regressions
- [x] All 5 new regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)