### PR TITLE
fix(extract): strip sentence-internal connector prefix from caseName (#670)

### DIFF
--- a/.changeset/fix-backscan-sentence-prefix.md
+++ b/.changeset/fix-backscan-sentence-prefix.md
@@ -1,0 +1,33 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): strip sentence-internal connector prefix from caseName (#670 part)
+
+Resolves the connector-prefix sub-issue of #670. The trim block in
+`extractCaseName` considered words like `Rather,` as plausible
+party-name prefixes (`Rather, State v. Epps` → caseName=`Rather,
+State v. Epps`) because they pass the `firstWordIsProperName` check.
+
+Fix: added common sentence-internal connector adverbs (`rather`,
+`moreover`, `furthermore`, `however`, `nevertheless`, `accordingly`,
+`consequently`, `instead`, `meanwhile`, `indeed`, `thus`, `hence`) to
+`SENTENCE_INITIAL_WORDS`. This routes them to the prefix-strip branch.
+
+| input | before | after |
+|---|---|---|
+| `Rather, State v. Epps, 100 F.2d 1` | `Rather, State v. Epps` | `State v. Epps` ✓ |
+| `However, Smith v. Jones, 100 F.2d 1` | `However, Smith v. Jones` | `Smith v. Jones` ✓ |
+| `Moreover, Doe v. Roe, 100 F.2d 1` | `Moreover, Doe v. Roe` | `Doe v. Roe` ✓ |
+| `Indeed, Brown v. Board, 347 U.S. 483` | `Indeed, Brown v. Board` | `Brown v. Board` ✓ |
+| `Smith v. Jones, 100 F.2d 1` (control) | unchanged | unchanged ✓ |
+
+Real party names that start with these adverbs are vanishingly rare;
+the false-negative risk is dominated by the false-positive cost of
+absorbing prose context.
+
+Known limitations (not in this patch): all-caps preamble absorption
+and the additional `Professional Conduct.` sentence-prefix forms
+remain open.
+
+6 regression tests in `tests/extract/issueBackscanSentencePrefix.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -987,6 +987,24 @@ const SENTENCE_INITIAL_WORDS = new Set([
   "whereas",
   "pursuant",
   "applying",
+  // Sentence-internal connector adverbs (#670). These commonly precede
+  // a citation as `<Connector>, <Party> v. <Party>` and the trailing
+  // comma fools the trim-block check into thinking the connector is
+  // a multi-word party-name prefix. Real party names that start with
+  // these adverbs are vanishingly rare; the false-negative risk is
+  // dominated by the false-positive cost of absorbing prose context.
+  "rather",
+  "moreover",
+  "furthermore",
+  "however",
+  "nevertheless",
+  "accordingly",
+  "consequently",
+  "instead",
+  "meanwhile",
+  "indeed",
+  "thus",
+  "hence",
 ])
 
 /**

--- a/tests/extract/issueBackscanSentencePrefix.test.ts
+++ b/tests/extract/issueBackscanSentencePrefix.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #670 (part: sentence-internal connector prefix) — the trim
+ * block in extractCaseName considered words like `Rather,` as plausible
+ * party-name prefixes because they pass `firstWordIsProperName`
+ * (capital first letter + not in PARTY_NAME_CONNECTORS + not in
+ * SENTENCE_INITIAL_WORDS + INTERNAL_QUALIFIER_REGEX matches). Adding
+ * common connector adverbs (rather, however, moreover, etc.) to
+ * SENTENCE_INITIAL_WORDS routes them to the prefix-strip branch.
+ */
+describe("Issue #670 - sentence-internal connector prefix strip", () => {
+  it("`Rather, State v. Epps` → caseName = `State v. Epps`", () => {
+    const cs = extractCitations(`Rather, State v. Epps, 100 F.2d 1 (1990).`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("State v. Epps")
+  })
+
+  it("`However, Smith v. Jones` → caseName = `Smith v. Jones`", () => {
+    const cs = extractCitations(`However, Smith v. Jones, 100 F.2d 1 (1990).`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("`Moreover, Doe v. Roe` → caseName = `Doe v. Roe`", () => {
+    const cs = extractCitations(`Moreover, Doe v. Roe, 100 F.2d 1 (1990).`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Doe v. Roe")
+  })
+
+  it("`Indeed, Brown v. Board` → caseName = `Brown v. Board`", () => {
+    const cs = extractCitations(`Indeed, Brown v. Board, 347 U.S. 483 (1954).`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Brown v. Board")
+  })
+
+  it("no-prefix control: `Smith v. Jones` unchanged", () => {
+    const cs = extractCitations(`Smith v. Jones, 100 F.2d 1 (1990).`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Smith v. Jones")
+  })
+
+  it("sentence-boundary control: `... case. Heath, 509 F.2d at 19` unchanged", () => {
+    const cs = extractCitations(
+      `Congress did something. Heath, 509 F.2d 1 at 19 (1990).`,
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { caseName?: string }).caseName).toBe("Heath")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the connector-prefix sub-issue of #670. The trim block in extractCaseName considered words like \`Rather,\` as plausible party-name prefixes (\`Rather, State v. Epps\` → caseName=\`Rather, State v. Epps\`).
- Fix: added common sentence-internal connector adverbs (\`rather\`, \`moreover\`, \`furthermore\`, \`however\`, \`nevertheless\`, \`accordingly\`, \`consequently\`, \`instead\`, \`meanwhile\`, \`indeed\`, \`thus\`, \`hence\`) to \`SENTENCE_INITIAL_WORDS\`. This routes them to the prefix-strip branch.
- 6 regression tests covering the most common forms plus a no-prefix control and a sentence-boundary control.

Known limitations (not in this patch): all-caps preamble absorption and the additional \`Professional Conduct.\` sentence-prefix forms remain open.

## Test plan
- [x] Full suite: 4220 pass, 0 regressions
- [x] All 6 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)