### PR TITLE
docs: document supra party-name case-sensitivity constraint (#688)

### DIFF
--- a/.changeset/docs-supra-case-sensitivity.md
+++ b/.changeset/docs-supra-case-sensitivity.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": patch
+---
+
+docs: document supra party-name case-sensitivity constraint (#688)
+
+Resolves #688 via the "document as explicit constraint" path the
+issue author offered as an acceptable resolution. SUPRA_PATTERN
+requires an uppercase initial on the party-name capture — `Smith,
+supra` matches; `smith, supra` does not.
+
+Adds a prominent **CASE SENSITIVITY (#688)** block to SUPRA_PATTERN's
+JSDoc explaining why: a lowercase-permissive regex generates 18+
+regressions in resolver tests because words like `Later`, `However`,
+and `In re` would be absorbed as multi-word party names.
+
+Lowercase party-name supras (informal/OCR-extracted text) must
+either be hand-corrected upstream or handled by a future
+resolver-side fuzzy match.
+
+No code change. Doc-only patch.

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -49,6 +49,15 @@ export const IBID_PATTERN: RegExp =
  * Pattern: word(s), supra [note N] [, at page]
  * Captures: (1) party name, (2) note number (if any), (3) pincite
  *
+ * **CASE SENSITIVITY (#688):** The party-name capture requires an
+ * uppercase initial — `Smith, supra` matches, `smith, supra` does
+ * NOT. This is intentional: the lowercase-permissive variant generates
+ * 18+ regressions in resolver tests because words like `Later`,
+ * `However`, and `In re` get absorbed as multi-word party names.
+ * Lowercase party-name supras (informal/OCR-extracted text) must
+ * either be hand-corrected upstream or handled by a future
+ * resolver-side fuzzy match.
+ *
  * Party-name capture (#301): continuation accepts `\s+v\.?\s+` (v.),
  * `\s+&\s+` (ampersand-joined parties — `Walker & Horwich, supra`),
  * `,\s+` (corporate-suffix continuation — `Thorn Americas, Inc., supra`),


### PR DESCRIPTION
## Summary
- Resolves #688 via the "document as explicit constraint" path the issue author offered as acceptable.
- Adds prominent CASE SENSITIVITY block to SUPRA_PATTERN JSDoc explaining the uppercase-initial requirement and why a permissive variant breaks 18+ resolver tests.
- Doc-only patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)