### PR TITLE
fix(resolve): bare Id. attaches to immediately preceding cite of any type (#721)

### DIFF
--- a/.changeset/fix-id-cross-type.md
+++ b/.changeset/fix-id-cross-type.md
@@ -1,0 +1,31 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): bare `Id.` attaches to immediately preceding cite of any type (#721)
+
+Resolves #721. Per Bluebook Rule 4.1, bare `Id.` (no pincite)
+attaches to the immediately preceding cited authority of any type.
+The resolver's case-family-preference filter overrode positional
+priority — `42 U.S.C. § 1983. Id.` resolved to an earlier case if
+one was in scope.
+
+| input | before | after |
+|---|---|---|
+| `Smith, 100 F.2d 1. 42 U.S.C. § 1983. Id.` | Smith (case) | statute ✓ |
+| `42 U.S.C. § 1983. Id.` (statute only) | statute | unchanged ✓ |
+| `Smith, 100 F.2d 1. 42 U.S.C. § 1983. Id. at 5.` (page pincite, case family) | Smith | unchanged ✓ |
+| `Smith, 100 F.2d 1. 42 U.S.C. § 1983. Id. § 7.` (section pincite, statute family) | statute | unchanged ✓ |
+| `42 U.S.C. § 1983. Smith, 100 F.2d 1. Id.` (case is most recent) | Smith | unchanged ✓ |
+
+`resolveId` now skips family preference when Id. has NO pincite AND
+NO trailing `§ N` section marker — the bare form is unambiguously
+positional. Id. WITH an explicit pincite still uses family
+preference (the pincite shape disambiguates: `Id. § 5` → statute
+family; `Id. at 27` → case family).
+
+Two existing tests (issue480_idAntecedent.test.ts:217, integration/
+resolution.test.ts:239) asserted the old behavior — both updated to
+match the corrected positional rule.
+
+5 regression tests in `tests/extract/issueIdCrossType.test.ts`.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -361,7 +361,22 @@ export class DocumentResolver {
    */
   private resolveId(citation: IdCitation): ResolutionResult | undefined {
     const currentIndex = this.context.citationIndex
-    const preferredFamily = this.getIdPreferredFamily(citation)
+    // Issue #721: bare `Id.` (no pincite/section marker) should attach to
+    // the immediately preceding cite of ANY type per Bluebook Rule 4.1.
+    // When the user wrote `42 U.S.C. § 1983. Id.`, they meant the statute,
+    // not the case three sentences earlier. The family preference still
+    // applies when Id. has a pincite shape that disambiguates (`Id. § 5`
+    // → statute; `Id. at 27` → case).
+    const hasPincite =
+      citation.pincite !== undefined || citation.pinciteInfo !== undefined
+    const tailHasSection = /^\s*[,]?\s*§§?\s*\d/.test(
+      this.text.substring(
+        citation.span.cleanEnd,
+        Math.min(this.text.length, citation.span.cleanEnd + 20),
+      ),
+    )
+    const preferredFamily =
+      hasPincite || tailHasSection ? this.getIdPreferredFamily(citation) : null
     const idQuoteZone = isInZone(citation.span.originalStart, this.quoteZones)
 
     interface Candidate {
@@ -449,7 +464,13 @@ export class DocumentResolver {
     // mention. Per Bluebook Rule 4.1, signal phrase does NOT affect
     // antecedent selection: `Id.` anchors to the immediately preceding
     // cited authority regardless of `See`, `Cf.`, etc. (#498).
-    const preferred = candidates.find((c) => c.family === preferredFamily)
+    // When preferredFamily is null (bare Id. with no pincite — #721),
+    // pick the most recent candidate regardless of family. Otherwise,
+    // prefer family-match first, then fall back to recency.
+    const preferred =
+      preferredFamily === null
+        ? undefined
+        : candidates.find((c) => c.family === preferredFamily)
     const best = preferred ?? candidates[0]
 
     // Case-name window check: if the prose immediately before Id. names a

--- a/tests/extract/issueIdCrossType.test.ts
+++ b/tests/extract/issueIdCrossType.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { ResolvedCitation } from "@/resolve/types"
+
+/**
+ * Issue #721 — Id. cross-type resolution. Per Bluebook Rule 4.1, bare
+ * `Id.` (no pincite) attaches to the immediately preceding cited
+ * authority of any type. The resolver's family-preference filter
+ * overrode positional priority — `42 U.S.C. § 1983. Id.` resolved
+ * to an earlier case if one was in scope.
+ *
+ * Fix: when Id. has NO pincite and NO trailing `§ N` section marker,
+ * skip family preference and take the most recent candidate.
+ *
+ * Id. WITH a pincite still uses family preference (the pincite shape
+ * disambiguates: `Id. § 5` → statute family; `Id. at 27` → case).
+ */
+describe("Issue #721 - Id. cross-type resolution", () => {
+  it("bare `Id.` resolves to immediately preceding statute (was case)", () => {
+    const text = "Smith, 100 F.2d 1. 42 U.S.C. § 1983. Id."
+    const cs = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = cs.find((c) => c.type === "statute") as ResolvedCitation
+    const id = cs.find((c) => c.type === "id") as ResolvedCitation
+    expect(id.resolution?.resolvedTo).toBe(cs.indexOf(statute))
+  })
+
+  it("`Id. at 5` (page pincite, case family) resolves to case", () => {
+    const text = "Smith, 100 F.2d 1. 42 U.S.C. § 1983. Id. at 5."
+    const cs = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = cs.find((c) => c.type === "case") as ResolvedCitation
+    const id = cs.find((c) => c.type === "id") as ResolvedCitation
+    expect(id.resolution?.resolvedTo).toBe(cs.indexOf(smith))
+  })
+
+  it("`Id. § 7` (section pincite, statute family) resolves to statute", () => {
+    const text = "Smith, 100 F.2d 1. 42 U.S.C. § 1983. Id. § 7."
+    const cs = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = cs.find((c) => c.type === "statute") as ResolvedCitation
+    const id = cs.find((c) => c.type === "id") as ResolvedCitation
+    expect(id.resolution?.resolvedTo).toBe(cs.indexOf(statute))
+  })
+
+  it("reversed order: `statute. case. Id.` resolves to case (most recent)", () => {
+    const text = "42 U.S.C. § 1983. Smith, 100 F.2d 1. Id."
+    const cs = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = cs.find((c) => c.type === "case") as ResolvedCitation
+    const id = cs.find((c) => c.type === "id") as ResolvedCitation
+    expect(id.resolution?.resolvedTo).toBe(cs.indexOf(smith))
+  })
+
+  it("statute-only context: bare `Id.` resolves to statute", () => {
+    const text = "42 U.S.C. § 1983. Id."
+    const cs = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = cs.find((c) => c.type === "statute") as ResolvedCitation
+    const id = cs.find((c) => c.type === "id") as ResolvedCitation
+    expect(id.resolution?.resolvedTo).toBe(cs.indexOf(statute))
+  })
+})

--- a/tests/integration/resolution.test.ts
+++ b/tests/integration/resolution.test.ts
@@ -236,22 +236,25 @@ describe("Resolution Integration Tests", () => {
       expect(id!.resolution?.warnings).toBeDefined()
     })
 
-    it("Id. with no pincite after case → statute skips the statute (#480)", () => {
-      // Bluebook-aware behavior: `Id.` with a page-style (or absent) pincite
-      // refers to the most recent *case-family* authority. A statute in the
-      // gap is deprioritized when an earlier case is in scope.
+    it("Id. with no pincite after case → statute resolves to statute (#721, Bluebook 4.1)", () => {
+      // Updated for #721. Per Bluebook Rule 4.1, bare `Id.` (no pincite)
+      // attaches to the IMMEDIATELY preceding cited authority of any type.
+      // The earlier behavior (case-family preference) was changed because
+      // the family filter overrode positional priority for bare Id. Id.
+      // WITH an explicit page-style pincite still uses case-family
+      // preference (that's a meaningful disambiguator).
       const text = "Smith v. Jones, 500 F.2d 123 (2020). " + "42 U.S.C. § 1983. " + "Id."
 
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
 
-      const smith = citations.find((c) => c.type === "case")
+      const statute = citations.find((c) => c.type === "statute")
       const id = citations.find((c) => c.type === "id")
 
-      expect(smith).toBeDefined()
+      expect(statute).toBeDefined()
       expect(id).toBeDefined()
 
-      const smithIndex = citations.indexOf(smith!)
-      expect(id!.resolution?.resolvedTo).toBe(smithIndex)
+      const statuteIndex = citations.indexOf(statute!)
+      expect(id!.resolution?.resolvedTo).toBe(statuteIndex)
     })
 
     it("Id. resolves to a statute when no case is in scope", () => {

--- a/tests/resolve/issue480_idAntecedent.test.ts
+++ b/tests/resolve/issue480_idAntecedent.test.ts
@@ -214,12 +214,18 @@ describe("Issue #480: Id./short-form antecedent resolution", () => {
       expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
     })
 
-    it("case → statute → Id. (no pincite) skips the statute", () => {
+    it("case → statute → Id. (no pincite) resolves to statute (#721, Bluebook Rule 4.1)", () => {
+      // Per Bluebook Rule 4.1, bare `Id.` (no pincite) attaches to the
+      // IMMEDIATELY preceding cited authority of any type — not the most
+      // recent case. The earlier behavior was changed in #721 because the
+      // family-preference filter overrode positional priority for bare Id.
+      // Id. with an explicit pincite (`Id. at 125`) still uses family
+      // preference, as that's a meaningful disambiguator.
       const text = "Smith v. Jones, 500 F.2d 123 (2020). 42 U.S.C. § 1983. Id."
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const smith = citations.find((c) => c.type === "case")!
+      const statute = citations.find((c) => c.type === "statute")!
       const id = citations.find((c) => c.type === "id")!
-      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+      expect(id.resolution?.resolvedTo).toBe(citations.indexOf(statute))
     })
 
     it("statute-only context: Id. still resolves to the statute (only option)", () => {


### PR DESCRIPTION
## Summary
- Resolves #721. Per Bluebook Rule 4.1, bare \`Id.\` (no pincite) attaches to the immediately preceding cited authority of any type.
- Previously the resolver's case-family-preference filter overrode positional priority — \`42 U.S.C. § 1983. Id.\` resolved to an earlier case if one was in scope.
- Fix: \`resolveId\` skips family preference when Id. has NO pincite AND NO trailing \`§ N\` section marker.
- Id. WITH an explicit pincite still uses family preference (the pincite shape disambiguates).
- Two existing tests asserted the old behavior — both updated to match the corrected positional rule with explanatory comments.
- 5 regression tests in \`tests/extract/issueIdCrossType.test.ts\`.

## Test plan
- [x] Full suite: 4249 pass, 0 regressions
- [x] All 5 new regression tests pass
- [x] Updated tests document the change with rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)