### PR TITLE
fix(extract): parseDate handles `Mon., DD, YYYY` (comma after period) (#554)

### DIFF
--- a/.changeset/fix-parse-date-comma-after-period.md
+++ b/.changeset/fix-parse-date-comma-after-period.md
@@ -1,0 +1,24 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): parseDate handles `Mon., DD, YYYY` (comma after period) (#554)
+
+Resolves the remaining sub-issue of #554. `parseDate` dropped month/day
+for the `Mon., DD, YYYY` form (comma immediately after the period).
+The other non-canonical forms (ISO, European, slash, missing-space-
+after-period) had already been fixed by prior PRs.
+
+| input | before | after |
+|---|---|---|
+| `Jan., 15, 2020` | year=2020, month/day dropped | full date ✓ |
+| `Feb., 9, 2015` | year=2015, month/day dropped | full date ✓ |
+| `Jan. 15, 1990` (canonical) | full date | unchanged ✓ |
+| `Jan.15, 1990` (no space) | full date | unchanged ✓ |
+| `Jan 15, 1990` (no period) | full date | unchanged ✓ |
+
+Fix: extended the abbreviated-month regex separator alternation from
+`(?:\.?\s+|\.\s*)` to `(?:\.?,?\s+|\.,?\s*)` to accept an optional
+comma between the period and the day.
+
+5 regression tests in `tests/extract/issueParseDateCommaAfterPeriod.test.ts`.

--- a/src/extract/dates.ts
+++ b/src/extract/dates.ts
@@ -212,14 +212,15 @@ export function toIsoDate(parsed: ParsedDate): string {
  * ```
  */
 export function parseDate(dateStr: string): StructuredDate | undefined {
-  // Try abbreviated month, US order: "Jan. 15, 2020", "Feb 9, 2015", or
-  // "Jan.15, 1990" (missing space after period — common OCR artifact, #554).
-  // The `(?:\.?\s+|\.\s*)` alternation accepts either an explicit space or a
-  // period-with-no-trailing-space ("Jan.15"). We do NOT accept bare
-  // "Jan15" (no period, no space) because that would match arbitrary text
-  // like `Jan15Foo`.
+  // Try abbreviated month, US order: "Jan. 15, 2020", "Feb 9, 2015",
+  // "Jan.15, 1990" (missing space after period — common OCR artifact, #554),
+  // or "Jan., 15, 2020" (comma immediately after period — #554).
+  // The `(?:\.?,?\s+|\.,?\s*)` alternation accepts an explicit space or a
+  // period (with optional comma) followed by zero or more whitespace. We
+  // do NOT accept bare "Jan15" (no period, no space) because that would
+  // match arbitrary text like `Jan15Foo`.
   const abbrMatch = dateStr.match(
-    /\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)(?:\.?\s+|\.\s*)(\d{1,2}),?\s+(\d{4})\b/i,
+    /\b(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)(?:\.?,?\s+|\.,?\s*)(\d{1,2}),?\s+(\d{4})\b/i,
   )
   if (abbrMatch) {
     const month = parseMonth(abbrMatch[1])

--- a/tests/extract/issueParseDateCommaAfterPeriod.test.ts
+++ b/tests/extract/issueParseDateCommaAfterPeriod.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { parseDate } from "@/extract/dates"
+
+/**
+ * Issue #554 (remaining sub-issue) — `parseDate` dropped month/day for
+ * the `Mon., DD, YYYY` form (comma immediately after the period). Other
+ * non-canonical forms (ISO, European, slash, missing-space-after-period)
+ * had already been fixed.
+ *
+ * Fix: extended the abbreviated-month regex separator alternation from
+ * `(?:\.?\s+|\.\s*)` to `(?:\.?,?\s+|\.,?\s*)` to accept an optional
+ * comma between the period and the day.
+ */
+describe("Issue #554 - parseDate comma after period", () => {
+  it("`Jan., 15, 2020` extracts month + day", () => {
+    expect(parseDate("Jan., 15, 2020")).toEqual({
+      iso: "2020-01-15",
+      parsed: { year: 2020, month: 1, day: 15 },
+    })
+  })
+
+  it("`Feb., 9, 2015` extracts month + day", () => {
+    expect(parseDate("Feb., 9, 2015")).toEqual({
+      iso: "2015-02-09",
+      parsed: { year: 2015, month: 2, day: 9 },
+    })
+  })
+
+  it("`Jan. 15, 1990` (canonical) still works", () => {
+    expect(parseDate("Jan. 15, 1990")).toEqual({
+      iso: "1990-01-15",
+      parsed: { year: 1990, month: 1, day: 15 },
+    })
+  })
+
+  it("`Jan.15, 1990` (no space after period) still works (#554 prior fix)", () => {
+    expect(parseDate("Jan.15, 1990")).toEqual({
+      iso: "1990-01-15",
+      parsed: { year: 1990, month: 1, day: 15 },
+    })
+  })
+
+  it("`Jan 15, 1990` (no period) still works", () => {
+    expect(parseDate("Jan 15, 1990")).toEqual({
+      iso: "1990-01-15",
+      parsed: { year: 1990, month: 1, day: 15 },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the remaining sub-issue of #554. \`parseDate("Jan., 15, 2020")\` dropped month/day and returned year-only.
- Extended the abbreviated-month regex separator alternation from \`(?:\\.?\\s+|\\.\\s*)\` to \`(?:\\.?,?\\s+|\\.,?\\s*)\` to accept an optional comma between the period and the day.
- 5 regression tests including 3 regression controls.

## Test plan
- [x] Full suite: 4253 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)