### PR TITLE
fix(extract): cert. denied[,] (bracketed comma) detects subsequent history (#526)

### DIFF
--- a/.changeset/fix-cert-denied-bracketed-comma.md
+++ b/.changeset/fix-cert-denied-bracketed-comma.md
@@ -1,0 +1,22 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): `cert. denied[,]` (bracketed comma) detects subsequent history (#526)
+
+Resolves #526. The `cert. denied` history-signal regex required the
+next char to be whitespace / comma / semicolon / paren / EOF — `[`
+was not admitted. The `cert. denied[,]` form (bracketed comma — an
+editorial-insertion convention used by some reporters) silently
+dropped the subsequent-history clause. Both the parent's
+`subsequentHistoryEntries` and the child's `subsequentHistoryOf`
+back-pointer were lost.
+
+| input | before | after |
+|---|---|---|
+| `cert. denied[,] 479 U.S. 1059` | no history | parent=`[cert_denied]`, child back-points ✓ |
+| `cert. denied, 479 U.S. 1059` (canonical) | unchanged | unchanged ✓ |
+
+Fix: extended the lookahead character class to include `[`.
+
+2 regression tests in `tests/extract/issueCertDeniedBracketedComma.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -648,9 +648,11 @@ const SIGNAL_TABLE: ReadonlyArray<readonly [RegExp, HistorySignal]> = [
   [/^reversed\s+and\s+remanded\b/i, "reversed"],
   [/^rev'?d\b/i, "reversed"],
   [/^reversed\b/i, "reversed"],
-  // cert denied
+  // cert denied — `[` admitted in the trailing lookahead so the
+  // `cert. denied[,]` form (bracketed comma — editorial insertion
+  // convention used by some reporters) tokenizes. #526
   [/^certiorari\s+denied\b/i, "cert_denied"],
-  [/^cert\.\s*den(ied|\.)(?=[\s,;(]|$)/i, "cert_denied"],
+  [/^cert\.\s*den(ied|\.)(?=[\s,;(\[]|$)/i, "cert_denied"],
   // cert granted
   [/^certiorari\s+granted\b/i, "cert_granted"],
   [/^cert\.\s*granted\b/i, "cert_granted"],

--- a/tests/extract/issueCertDeniedBracketedComma.test.ts
+++ b/tests/extract/issueCertDeniedBracketedComma.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #526 — `cert. denied[,]` (bracketed comma, an editorial-insertion
+ * convention used by some reporters) silently broke subsequent-history
+ * detection. The history-signal regex required the next char to be
+ * whitespace / comma / semicolon / paren / EOF — `[` was not admitted.
+ * Both the parent's `subsequentHistoryEntries` and the child's
+ * `subsequentHistoryOf` back-pointer were lost.
+ *
+ * Fix: extended the lookahead character class to include `[`.
+ */
+describe("Issue #526 - cert. denied[,] bracketed comma", () => {
+  it("`cert. denied[,] N U.S. M` populates subsequentHistory + back-pointer", () => {
+    const text =
+      "Smith v. Jones, 796 F.2d 657 (3d Cir. 1986), cert. denied[,] 479 U.S. 1059 (1987)"
+    const cs = extractCitations(text).filter((c) => c.type === "case")
+    expect(cs.length).toBeGreaterThanOrEqual(2)
+    const parent = cs.find((c) => c.text === "796 F.2d 657") as Record<string, unknown>
+    const child = cs.find((c) => c.text === "479 U.S. 1059") as Record<string, unknown>
+    expect(parent).toBeDefined()
+    expect(child).toBeDefined()
+    expect(parent.subsequentHistoryEntries).toBeDefined()
+    expect((parent.subsequentHistoryEntries as Array<{ signal: string }>)[0].signal).toBe(
+      "cert_denied",
+    )
+    expect(child.subsequentHistoryOf).toBeDefined()
+    expect((child.subsequentHistoryOf as { signal: string }).signal).toBe("cert_denied")
+  })
+
+  it("canonical `cert. denied, N U.S. M` still works (regression)", () => {
+    const text =
+      "Smith v. Jones, 796 F.2d 657 (3d Cir. 1986), cert. denied, 479 U.S. 1059 (1987)"
+    const cs = extractCitations(text).filter((c) => c.type === "case")
+    const parent = cs.find((c) => c.text === "796 F.2d 657") as Record<string, unknown>
+    expect(parent.subsequentHistoryEntries).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #526. The \`cert. denied\` history-signal regex required the next char to be whitespace/comma/semicolon/paren/EOF — \`[\` was not admitted.
- \`cert. denied[,] 479 U.S. 1059\` (bracketed comma — editorial-insertion convention used by some reporters) silently dropped the subsequent-history clause.
- Fix: extended the lookahead char class to include \`[\`.
- 2 regression tests.

## Test plan
- [x] Full suite: 4258 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)