### PR TITLE
fix(extract): bare-article accepts Arabic numerals (Art. 1, § 10) (#321 partial)

### DIFF
--- a/.changeset/fix-bare-article-arabic.md
+++ b/.changeset/fix-bare-article-arabic.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): `bare-article` accepts Arabic numerals (`Art. 1, § 10`) (#321 partial)
+
+Resolves the bare-article-Arabic sub-issue of #321. The `bare-article`
+pattern previously required Roman numerals only (`Art. I, § 8`),
+missing the common-in-modern-state-codes Arabic form (`Art. 1, § 10`).
+
+| input | before | after |
+|---|---|---|
+| `Art. 1, § 10` | 0 cites | article=1, section=10 ✓ |
+| `Art. 42, §3` | 0 cites | article=42, section=3 ✓ |
+| `Art. I, § 8` (Roman) | unchanged | unchanged ✓ |
+| `Art. 42 of the treaty` (no section) | 0 cites | unchanged ✓ |
+
+Fix: extended the numeral capture from `[IVX]+` to `([IVX]+|\d+)`.
+The mandatory `§ N` requirement keeps false-positive risk low —
+prose like `Art. 1 of the treaty` (no section) still won't match.
+
+One existing test in `constitutionalPatterns.test.ts` asserted the
+old Roman-only behavior — updated to reflect the new acceptance and
+added a regression control for the no-section case.
+
+5 regression tests in `tests/extract/issueBareArticleArabic.test.ts`.
+
+Other #321 sub-issues (plural `amends.`, `pmbl.`, full prose form)
+remain open.

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -102,15 +102,18 @@ export const constitutionalPatterns: Pattern[] = [
   {
     id: "bare-article",
     // Lowest-priority pattern: bare "Art." with no "Const." prefix at all.
-    // Constrained to reduce false positives: Roman numerals only (no Arabic),
-    // must include a § section reference, and lookbehind rejects "Const." prefix
-    // (already handled by higher-priority patterns). Confidence set to 0.5 in extractor.
+    // Constrained to reduce false positives: must include a § section
+    // reference. Roman + Arabic numerals both accepted (#321). The
+    // mandatory `§ N` lookahead keeps FP risk low — prose like
+    // `Art. 1 of the treaty` does not match. Lookbehind rejects
+    // "Const." prefix (handled by higher-priority patterns).
+    // Confidence set to 0.5 in extractor.
     regex: new RegExp(
-      String.raw`(?<!Const\.?,?\s)\bArt\.?\s+[IVX]+[,;]\s*§\s*[\w-]+(?:[,;]\s*cl\.?\s*\d+)?`,
+      String.raw`(?<!Const\.?,?\s)\bArt\.?\s+([IVX]+|\d+)[,;]\s*§\s*[\w-]+(?:[,;]\s*cl\.?\s*\d+)?`,
       "g",
     ),
     description:
-      'Bare article references without "Const." prefix (e.g., "Art. I, §8, cl. 3")',
+      'Bare article references without "Const." prefix (e.g., "Art. I, §8, cl. 3", "Art. 1, § 10")',
     type: "constitutional",
   },
   {

--- a/tests/extract/issueBareArticleArabic.test.ts
+++ b/tests/extract/issueBareArticleArabic.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #321 (part: bare article Arabic numerals) — the `bare-article`
+ * pattern required Roman numerals (`Art. I, § 8`), missing the
+ * common-in-modern-state-codes Arabic form (`Art. 1, § 10`). Fixed by
+ * extending the numeral capture to `([IVX]+|\d+)`. The mandatory `§ N`
+ * requirement keeps false-positive risk low — `Art. 1 of the treaty`
+ * (no section) still won't match.
+ */
+describe("Issue #321 - bare-article Arabic numerals", () => {
+  it("`Art. 1, § 10` extracts as constitutional", () => {
+    const cs = extractCitations(`Art. 1, § 10`).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { article?: number; section?: string }
+    expect(c.article).toBe(1)
+    expect(c.section).toBe("10")
+  })
+
+  it("`Art. I, § 8` (Roman, regression control) unchanged", () => {
+    const cs = extractCitations(`Art. I, § 8`).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { article?: number; section?: string }
+    expect(c.article).toBe(1)
+    expect(c.section).toBe("8")
+  })
+
+  it("`Art. III, § 2, cl. 1` (Roman + clause) unchanged", () => {
+    const cs = extractCitations(`Art. III, § 2, cl. 1`).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { article?: number; section?: string; clause?: number }
+    expect(c.article).toBe(3)
+    expect(c.section).toBe("2")
+    expect(c.clause).toBe(1)
+  })
+
+  it("`Art. 42 of the treaty` (no section) does NOT match", () => {
+    const cs = extractCitations(`Art. 42 of the treaty`).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(0)
+  })
+
+  it("Arabic article in mid-prose context: `see Art. 42, §3 of the treaty`", () => {
+    const cs = extractCitations(`see Art. 42, §3 of the treaty`).filter(
+      (c) => c.type === "constitutional",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { article?: number }).article).toBe(42)
+  })
+})

--- a/tests/patterns/constitutionalPatterns.test.ts
+++ b/tests/patterns/constitutionalPatterns.test.ts
@@ -162,8 +162,16 @@ describe("constitutionalPatterns", () => {
       expect(matches.some((m) => m.patternId === "bare-article")).toBe(false)
     })
 
-    it("does not match Art. with Arabic numeral", () => {
+    // Updated for #321: Arabic numerals are now accepted in bare-article
+    // form (`Art. 1, § 10`). The mandatory `§ N` requirement keeps FP
+    // risk low — `Art. 1 of the treaty` (no section) still won't match.
+    it("matches Art. with Arabic numeral when followed by section (#321)", () => {
       const matches = findMatches("see Art. 42, §3 of the treaty")
+      expect(matches.some((m) => m.patternId === "bare-article")).toBe(true)
+    })
+
+    it("does not match Art. with Arabic numeral but no section", () => {
+      const matches = findMatches("see Art. 42 of the treaty")
       expect(matches.some((m) => m.patternId === "bare-article")).toBe(false)
     })
   })


### PR DESCRIPTION
## Summary
- Resolves the bare-article-Arabic sub-issue of #321. The \`bare-article\` pattern previously required Roman numerals (\`Art. I, § 8\`), missing the common-in-modern-state-codes Arabic form (\`Art. 1, § 10\`).
- Extended the numeral capture from \`[IVX]+\` to \`([IVX]+|\\d+)\`. Mandatory \`§ N\` requirement keeps FP risk low.
- One pre-existing Roman-only test updated; added a regression control for the no-section case.
- 5 regression tests.

Other #321 sub-issues (plural \`amends.\`, \`pmbl.\`, prose form) remain open.

## Test plan
- [x] Full suite: 4266 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)