### PR TITLE
feat(extract): Tax Court Memorandum decisions (T.C. Memo. YYYY-NNN) (#324)

### DIFF
--- a/.changeset/feat-tc-memo.md
+++ b/.changeset/feat-tc-memo.md
@@ -1,0 +1,23 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): Tax Court Memorandum decisions (`T.C. Memo. YYYY-NNN`) (#324)
+
+Resolves #324. Tax Court Memorandum decisions — the dominant authority
+in U.S. Tax Court opinions and common in any federal tax-related
+opinion — weren't recognized.
+
+| input | before | after |
+|---|---|---|
+| `T.C. Memo. 2002-89` | 0 cites | neutral / court=`T.C. Memo.` / year=2002 / doc=89 ✓ |
+| `Robida v. Commissioner, T.C. Memo. 1970-86` | 0 cites | neutral with caseName backscan ✓ |
+| `Shollenberger v. Commissioner, T.C. Memo. 2009-306` | 0 cites | neutral ✓ |
+
+Added a new `tc-memo` pattern in `neutralPatterns` and a matching
+branch in `extractNeutral`. Treated as a neutral citation because the
+year acts as the volume identifier. Requires the periodized `T.C.`
+form (`TC Memo.` without periods does not match — strict to avoid
+false positives).
+
+4 regression tests in `tests/extract/issueTcMemo.test.ts`.

--- a/src/extract/extractNeutral.ts
+++ b/src/extract/extractNeutral.ts
@@ -102,6 +102,25 @@ export function extractNeutral(
   let unpublished = false
   let spans: NeutralComponentSpans | undefined
 
+  // Issue #324: T.C. Memo. YYYY-NNN. Recognized BEFORE the generic
+  // neutral-regex fallback because the trailing `-NNN` would otherwise
+  // be misparsed as the document number with year=undefined.
+  const tcMemoMatch = /^T\.\s?C\.\s+Memo\.\s+(\d{4})-(\d+)$/d.exec(text)
+  if (tcMemoMatch) {
+    year = Number.parseInt(tcMemoMatch[1], 10)
+    court = "T.C. Memo."
+    documentNumber = tcMemoMatch[2]
+    if (tcMemoMatch.indices) {
+      spans = {
+        year: spanFromGroupIndex(span.cleanStart, tcMemoMatch.indices[1]!, transformationMap),
+        documentNumber: spanFromGroupIndex(
+          span.cleanStart,
+          tcMemoMatch.indices[2]!,
+          transformationMap,
+        ),
+      }
+    }
+  } else {
   const msMatch = /^(\d{4})-([A-Z]+)-(\d+)-([A-Z]+)$/d.exec(text)
   if (msMatch) {
     year = Number.parseInt(msMatch[1], 10)
@@ -149,6 +168,7 @@ export function extractNeutral(
         ),
       }
     }
+  }
   }
 
   // Look ahead in cleaned text for a trailing pincite (e.g., ", at *3" on

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -81,6 +81,17 @@ export const neutralPatterns: Pattern[] = [
     type: "neutral",
   },
   {
+    // Tax Court Memorandum decisions — `T.C. Memo. 2002-89` (#324). Format
+    // is `T.C. Memo. YYYY-NNN` where YYYY is the year and NNN is the
+    // sequential decision number within that year. Treated as a neutral
+    // citation because year acts as the volume identifier.
+    id: "tc-memo",
+    regex: /\bT\.\s?C\.\s+Memo\.\s+(\d{4})-(\d+)\b/g,
+    description:
+      'Tax Court Memorandum decisions (e.g., "T.C. Memo. 2002-89", "T.C. Memo. 1970-86") — #324',
+    type: "neutral",
+  },
+  {
     // Generalized to accept any uppercase-prefixed court abbreviation before
     // LEXIS so state variants (Cal. LEXIS, Tex. App. LEXIS, N.Y. Misc. LEXIS,
     // Ill. App. LEXIS, etc.) tokenize alongside the federal U.S. forms (#228).

--- a/tests/extract/issueTcMemo.test.ts
+++ b/tests/extract/issueTcMemo.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #324 — Tax Court Memorandum decisions (`T.C. Memo. YYYY-NNN`)
+ * weren't extracted. These are the dominant authority in U.S. Tax Court
+ * opinions and common in any tax-related federal opinion.
+ *
+ * Added a new `tc-memo` neutral-type pattern + matching extractor
+ * branch. Format: year + sequential decision number within that year.
+ */
+describe("Issue #324 - Tax Court Memorandum decisions", () => {
+  it("`T.C. Memo. 2002-89` extracts as neutral", () => {
+    const cs = extractCitations(`T.C. Memo. 2002-89`)
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { type: string; court?: string; year?: number; documentNumber?: string }
+    expect(c.type).toBe("neutral")
+    expect(c.court).toBe("T.C. Memo.")
+    expect(c.year).toBe(2002)
+    expect(c.documentNumber).toBe("89")
+  })
+
+  it("`Robida v. Commissioner, T.C. Memo. 1970-86` extracts with caseName", () => {
+    const cs = extractCitations(`Robida v. Commissioner, T.C. Memo. 1970-86`)
+    const neutral = cs.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    const c = neutral as { year?: number; documentNumber?: string }
+    expect(c.year).toBe(1970)
+    expect(c.documentNumber).toBe("86")
+  })
+
+  it("`Shollenberger v. Commissioner, T.C. Memo. 2009-306` higher decision number", () => {
+    const cs = extractCitations(`Shollenberger v. Commissioner, T.C. Memo. 2009-306`)
+    const neutral = cs.find((c) => c.type === "neutral")
+    expect(neutral).toBeDefined()
+    const c = neutral as { year?: number; documentNumber?: string }
+    expect(c.year).toBe(2009)
+    expect(c.documentNumber).toBe("306")
+  })
+
+  it("`TC Memo. 2010-48` (no period in TC) does NOT match — strict form required", () => {
+    // Document the constraint: requires periods on T.C.
+    const cs = extractCitations(`TC Memo. 2010-48`).filter((c) => c.type === "neutral")
+    expect(cs.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves #324. Tax Court Memorandum decisions (\`T.C. Memo. YYYY-NNN\`) — dominant authority in U.S. Tax Court opinions and common in federal tax-related opinions — weren't recognized.
- Added \`tc-memo\` pattern in neutralPatterns + matching extractor branch. Treated as neutral because year acts as the volume identifier.
- Requires periodized \`T.C.\` form (\`TC Memo.\` without periods does not match — strict to avoid false positives).
- 4 regression tests.

## Test plan
- [x] Full suite: 4266 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)