### PR TITLE
fix(extract): semicolon between page and pincite still extracts year+court (#525)

### DIFF
--- a/.changeset/fix-semicolon-pincite.md
+++ b/.changeset/fix-semicolon-pincite.md
@@ -1,0 +1,23 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): semicolon between page and pincite still extracts year+court (#525)
+
+Resolves the semicolon-pincite sub-issue of #525. OCR'd older
+opinions sometimes use a semicolon between page and pincite
+(`256 F.Supp. 572; 573-574 (S.D.N.Y. 1966)`). The comma-only
+separator in both `LOOKAHEAD_PINCITE_REGEX` and `LOOKAHEAD_PAREN_REGEX`
+dropped both the pincite AND the trailing year/court paren.
+
+| input | before | after |
+|---|---|---|
+| `256 F.Supp. 572; 573-574 (S.D.N.Y. 1966)` | pincite/year/court=undefined | pincite=573, year=1966, court=`S.D.N.Y.` ✓ |
+| `Smith, 100 F.2d 1; 5-7 (9th Cir. 1990)` | pincite/year=undefined | pincite=5, year=1990 ✓ |
+| `256 F.Supp. 572, 573 (S.D.N.Y. 1966)` (canonical comma) | unchanged | unchanged ✓ |
+| `256 F.Supp. 572 at 573 (S.D.N.Y. 1966)` (at form) | unchanged | unchanged ✓ |
+
+Both lookahead regexes now accept `[,;]` as the page-to-pincite
+separator.
+
+4 regression tests in `tests/extract/issueSemicolonPincite.test.ts`.

--- a/src/extract/extractCase.ts
+++ b/src/extract/extractCase.ts
@@ -548,8 +548,12 @@ const PAREN_REGEX = /\(([^)]+)\)/
  *  the leading ` at 638` could not be consumed and the regex failed.
  *  The at-form is repeatable too (rare in practice, but the comma form
  *  already was), so the entire prefix is wrapped in `(?:...)*`. */
+// Pincite separator admits `;` alongside `,` (#525). OCR'd older
+// opinions sometimes use semicolon between page and pincite
+// (`256 F.Supp. 572; 573-574 (court year)`); the existing comma-only
+// alternation blocked year+court extraction entirely.
 const LOOKAHEAD_PAREN_REGEX =
-  /^(?:(?:,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?|\s+at\s+(?:(?:pp?\.|pages?)\s*)?)\*?\d+(?:-\d+)?)*(?:\s+(?:n|note)\s*\.?\s*\d+)?\s*\(([^)]+)\)/
+  /^(?:(?:[,;]\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?|\s+at\s+(?:(?:pp?\.|pages?)\s*)?)\*?\d+(?:-\d+)?)*(?:\s+(?:n|note)\s*\.?\s*\d+)?\s*\(([^)]+)\)/
 
 /** Extracts pincite from look-ahead text.
  *  Accepts five prefix forms:
@@ -594,8 +598,12 @@ const LOOKAHEAD_PAREN_REGEX =
 // the trailing alternation. `parsePincite` surfaces this as
 // `pinciteInfo.footnote` with `page=undefined`. The leading `at` prefix is
 // allowed for symmetry with the page-bearing forms.
+// Leading separator accepts both comma and semicolon (#525). OCR'd
+// older opinions sometimes write `256 F.Supp. 572; 573-574 (court year)`
+// — the semicolon between page and pincite would otherwise block
+// pincite + year-paren extraction entirely.
 const LOOKAHEAD_PINCITE_REGEX =
-  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|,\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:\s*[-–—~]\s*\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:\s*[-–—~]\s*\d+)?)?|¶¶?\s*\d+(?:\s*[-–—~]\s*\d+)?|paras?\.?\s*\d+(?:\s*[-–—~]\s*\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:\s*[-–—~]\s*\d+)?)(?=$|[.,:;)([\]»"'“”‘’†‡§¶©°]|\s(?![A-Z]))/d
+  /^(?:\s+at\s+(?:(?:pp?\.|pages?)\s*)?|[,;]\s*(?:at\s+(?:(?:pp?\.|pages?)\s*)?)?)(\*?\d+(?:\s*[-–—~]\s*\*?\d+)?(?:(?:\s+|,\s+)(?:nn?|fns?|note)\s*\.?\s*\d+(?:\s*[-–—~]\s*\d+)?)?|¶¶?\s*\d+(?:\s*[-–—~]\s*\d+)?|paras?\.?\s*\d+(?:\s*[-–—~]\s*\d+)?|(?:nn?|fns?|note)\s*\.?\s*\d+(?:\s*[-–—~]\s*\d+)?)(?=$|[.,:;)([\]»"'“”‘’†‡§¶©°]|\s(?![A-Z]))/d
 
 /** Citation boundary pattern (digit-period-space) */
 const CITATION_BOUNDARY_REGEX = /\d\.\s+/g

--- a/tests/extract/issueSemicolonPincite.test.ts
+++ b/tests/extract/issueSemicolonPincite.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #525 (semicolon-pincite sub-issue) — OCR'd older opinions
+ * sometimes use a semicolon between page and pincite
+ * (`256 F.Supp. 572; 573-574 (court year)`). The comma-only
+ * separator in LOOKAHEAD_PINCITE_REGEX + LOOKAHEAD_PAREN_REGEX
+ * dropped both the pincite AND the trailing year/court paren.
+ */
+describe("Issue #525 - semicolon between page and pincite", () => {
+  it("`256 F.Supp. 572; 573-574 (S.D.N.Y. 1966)` extracts pincite + year + court", () => {
+    const cs = extractCitations(`256 F.Supp. 572; 573-574 (S.D.N.Y. 1966)`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { pincite?: number; year?: number; court?: string }
+    expect(c.pincite).toBe(573)
+    expect(c.year).toBe(1966)
+    expect(c.court).toBe("S.D.N.Y.")
+  })
+
+  it("`Smith, 100 F.2d 1; 5-7 (9th Cir. 1990)` works with case name", () => {
+    const cs = extractCitations(
+      `Smith v. Jones, 100 F.2d 1; 5-7 (9th Cir. 1990)`,
+    ).filter((c) => c.type === "case")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { pincite?: number; year?: number; court?: string }
+    expect(c.pincite).toBe(5)
+    expect(c.year).toBe(1990)
+  })
+
+  it("canonical `, 573` form still works (regression)", () => {
+    const cs = extractCitations(`256 F.Supp. 572, 573 (S.D.N.Y. 1966)`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { pincite?: number; year?: number }
+    expect(c.pincite).toBe(573)
+    expect(c.year).toBe(1966)
+  })
+
+  it("` at 573` form still works (regression)", () => {
+    const cs = extractCitations(`256 F.Supp. 572 at 573 (S.D.N.Y. 1966)`).filter(
+      (c) => c.type === "case",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { pincite?: number; year?: number }
+    expect(c.pincite).toBe(573)
+    expect(c.year).toBe(1966)
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the semicolon-pincite sub-issue of #525. OCR'd older opinions use \`256 F.Supp. 572; 573-574 (court year)\`; the comma-only separator dropped pincite + year + court.
- Both LOOKAHEAD_PINCITE_REGEX and LOOKAHEAD_PAREN_REGEX now accept \`[,;]\`.
- 4 regression tests.

## Test plan
- [x] Full suite: 4271 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)