### PR TITLE
feat(extract): constitutional preamble citations (U.S. Const. pmbl.) (#321 partial)

### DIFF
--- a/.changeset/feat-constitution-preamble.md
+++ b/.changeset/feat-constitution-preamble.md
@@ -1,0 +1,29 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): constitutional preamble citations (`U.S. Const. pmbl.`) (#321 partial)
+
+Resolves the preamble sub-issue of #321. `U.S. Const. pmbl.` and
+`U.S. Const. preamble` references weren't extracted — the BODY_TAIL
+regex required `art.` / `amend.` + numeral.
+
+Added a `PREAMBLE` alternative (`pmbl.` / `preamble`) to BODY_TAIL.
+A new `preamble: boolean` field on `ConstitutionalCitation` is set
+to `true` when the preamble branch matches. The field is mutually
+exclusive with `article` and `amendment` (none of which apply to
+the preamble).
+
+| input | before | after |
+|---|---|---|
+| `U.S. Const. pmbl.` | 0 cites | preamble=true, jurisdiction=US ✓ |
+| `U.S. Const, pmbl.` (comma) | 0 cites | preamble=true ✓ |
+| `U.S. Const. preamble` (unabbreviated) | 0 cites | preamble=true ✓ |
+| `U.S. Const. art. III, § 2` (control) | unchanged | unchanged ✓ |
+| `U.S. Const. amend. XIV` (control) | unchanged | unchanged ✓ |
+
+5 regression tests in `tests/extract/issueConstitutionPreamble.test.ts`.
+
+Other #321 sub-issues (plural `amends.`, full prose form
+`article XII, section 5 of the California Constitution`) remain
+open.

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -342,27 +342,34 @@ export function extractConstitutional(
   let amendment: number | undefined
   let section: string | undefined
   let clause: number | undefined
+  let preamble: boolean | undefined
 
   // BODY_TAIL groups (#534 — added inverse-shape `5th Amend.` branch):
   //   1: numeral (canonical `art./amend. <numeral>` branch)
   //   2: ordinal (inverse `<ordinal> amend.` branch)
   //   3: section
   //   4: clause
-  // Exactly one of group 1 or group 2 is populated per match.
+  // Exactly one of group 1 or group 2 is populated per match. When ALL
+  // groups are undefined, the match came from the preamble alternative
+  // in BODY_TAIL (#321). Detect via raw match text.
   if (bodyMatch) {
     const numeralText = bodyMatch[1] ?? bodyMatch[2]
-    const numeral = parseNumeral(numeralText)
-    const isInverseShape = bodyMatch[2] !== undefined
-    const isAmendment = isInverseShape || IS_AMENDMENT_RE.test(bodyMatch[0])
+    if (numeralText) {
+      const numeral = parseNumeral(numeralText)
+      const isInverseShape = bodyMatch[2] !== undefined
+      const isAmendment = isInverseShape || IS_AMENDMENT_RE.test(bodyMatch[0])
 
-    if (isAmendment) {
-      amendment = numeral
-    } else {
-      article = numeral
+      if (isAmendment) {
+        amendment = numeral
+      } else {
+        article = numeral
+      }
+
+      section = bodyMatch[3] || undefined
+      clause = bodyMatch[4] ? Number.parseInt(bodyMatch[4], 10) : undefined
+    } else if (/\b(?:pmbl\.?|preamble)\b/i.test(bodyMatch[0])) {
+      preamble = true
     }
-
-    section = bodyMatch[3] || undefined
-    clause = bodyMatch[4] ? Number.parseInt(bodyMatch[4], 10) : undefined
   }
 
   let jurisdiction: string | undefined
@@ -470,6 +477,7 @@ export function extractConstitutional(
     jurisdiction,
     article,
     amendment,
+    preamble,
     section,
     clause,
     spans,

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -56,7 +56,13 @@ const ORDINAL_PREFIX_AMENDMENT = `(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS
 // the structured section/clause field.
 const OPTIONAL_SECTION = String.raw`(?:[,;]?\s*§\s*([\w-]+))?`
 const OPTIONAL_CLAUSE = String.raw`(?:[,;]?\s*cl\.?\s*(\d+))?`
-const BODY_TAIL = `(?:${ARTICLE_OR_AMENDMENT}|${ORDINAL_PREFIX_AMENDMENT})${OPTIONAL_SECTION}${OPTIONAL_CLAUSE}`
+// Preamble (#321): `pmbl.` (Bluebook abbreviation) or `preamble`.
+// No numeral, no section, no clause — preamble has none. Captured as
+// a non-capturing alternative in BODY_TAIL so the existing group
+// layout (article/amendment numerals in groups 1/2, section in 3,
+// clause in 4) is preserved.
+const PREAMBLE = String.raw`(?:[,;]?\s*(?:pmbl\.?|preamble)\b)`
+const BODY_TAIL = `(?:(?:${ARTICLE_OR_AMENDMENT}|${ORDINAL_PREFIX_AMENDMENT})${OPTIONAL_SECTION}${OPTIONAL_CLAUSE}|${PREAMBLE})`
 
 /** Compiled body regex shared with the extractor to avoid duplicate definitions. */
 export const CONSTITUTIONAL_BODY_RE: RegExp = new RegExp(BODY_TAIL, "id")

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -951,10 +951,14 @@ export interface ConstitutionalCitation extends CitationBase {
   type: "constitutional"
   /** Jurisdiction code: "US", 2-letter state code, or undefined for bare "Const." */
   jurisdiction?: string
-  /** Article number (parsed from Roman numerals) — mutually exclusive with amendment */
+  /** Article number (parsed from Roman numerals) — mutually exclusive with amendment / preamble */
   article?: number
-  /** Amendment number (parsed from Roman numerals) — mutually exclusive with article */
+  /** Amendment number (parsed from Roman numerals) — mutually exclusive with article / preamble */
   amendment?: number
+  /** True when the citation references the Preamble (`U.S. Const. pmbl.`,
+   *  `U.S. Const. preamble`). Mutually exclusive with article / amendment.
+   *  Section and clause are not applicable to preamble. #321 */
+  preamble?: boolean
   /** Section identifier (string to handle non-numeric like "3-a") */
   section?: string
   /** Clause number (always numeric) */

--- a/tests/extract/issueConstitutionPreamble.test.ts
+++ b/tests/extract/issueConstitutionPreamble.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #321 (preamble sub-issue) — `U.S. Const. pmbl.` and
+ * `U.S. Const. preamble` references weren't extracted. The BODY_TAIL
+ * regex required art./amend. + numeral.
+ *
+ * Fix: added a PREAMBLE alternative (`pmbl.` / `preamble`) to BODY_TAIL.
+ * The extractor sets a new `preamble: true` field on the returned
+ * ConstitutionalCitation when this branch matches.
+ */
+describe("Issue #321 - constitutional preamble", () => {
+  it("`U.S. Const. pmbl.` extracts with preamble=true", () => {
+    const cs = extractCitations(`U.S. Const. pmbl.`).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as {
+      preamble?: boolean
+      article?: number
+      amendment?: number
+      jurisdiction?: string
+    }
+    expect(c.preamble).toBe(true)
+    expect(c.article).toBeUndefined()
+    expect(c.amendment).toBeUndefined()
+    expect(c.jurisdiction).toBe("US")
+  })
+
+  it("`U.S. Const, pmbl.` (comma-after-Const) works", () => {
+    const cs = extractCitations(`U.S. Const, pmbl.`).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { preamble?: boolean }).preamble).toBe(true)
+  })
+
+  it("`U.S. Const. preamble` (unabbreviated) works", () => {
+    const cs = extractCitations(`U.S. Const. preamble`).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { preamble?: boolean }).preamble).toBe(true)
+  })
+
+  it("article citation does NOT get preamble flag", () => {
+    const cs = extractCitations(`U.S. Const. art. III, § 2`).filter(
+      (c) => c.type === "constitutional",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { preamble?: unknown; article?: number }
+    expect(c.article).toBe(3)
+    expect(c.preamble).toBeUndefined()
+  })
+
+  it("amendment citation does NOT get preamble flag", () => {
+    const cs = extractCitations(`U.S. Const. amend. XIV`).filter(
+      (c) => c.type === "constitutional",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { preamble?: unknown; amendment?: number }
+    expect(c.amendment).toBe(14)
+    expect(c.preamble).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the preamble sub-issue of #321. \`U.S. Const. pmbl.\` and \`U.S. Const. preamble\` references weren't extracted.
- Added PREAMBLE alternative to BODY_TAIL + new \`preamble: boolean\` field on \`ConstitutionalCitation\` (mutually exclusive with article/amendment).
- 5 regression tests.

Other #321 sub-issues (plural \`amends.\`, prose form) remain open.

## Test plan
- [x] Full suite: 4280 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)