### PR TITLE
feat(extract): plural amends./arts. with chained continuations (#321 partial)

### DIFF
--- a/.changeset/feat-plural-amends-chain.md
+++ b/.changeset/feat-plural-amends-chain.md
@@ -1,0 +1,30 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): plural `amends.` / `arts.` with chained continuations (#321 partial)
+
+Resolves the plural-amendments sub-issue of #321.
+`U.S. Const. amends. V, XIV` (plural `amends.` form) wasn't
+tokenized at all; even after enabling the plural form, only the
+first amendment was extracted.
+
+| input | before | after |
+|---|---|---|
+| `U.S. Const. amends. V, XIV` | 0 cites | 2 cites (amendment=5, 14) ✓ |
+| `U.S. Const. amends. V and XIV` | 0 cites | 2 cites ✓ |
+| `U.S. Const. arts. I, II, III` | 0 cites | 3 cites (article=1, 2, 3) ✓ |
+| `U.S. Const. amend. V` (singular) | unchanged | unchanged ✓ |
+
+Two coordinated changes:
+1. `ARTICLE_OR_AMENDMENT` regex now accepts `arts?` / `amends?` /
+   `amdts?` plural forms.
+2. `expandChainedConstitutional` accepts a bare-numeral continuation
+   (`, XIV` / ` and XIV`) inheriting the article-or-amendment type
+   from the head cite — alongside the existing `; art./amend. <numeral>`
+   continuation shape from #707.
+
+4 regression tests in `tests/extract/issuePluralAmendsChain.test.ts`.
+
+Other #321 sub-issues (full prose form `article XII, section 5 of
+the California Constitution`) remain open.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -670,47 +670,87 @@ function expandChainedConstitutional(
   transformationMap: TransformationMap,
 ): void {
   const added: Citation[] = []
+  // Two chain shapes:
+  //   1. `; art./amend. <numeral>` — full continuation with explicit
+  //      article/amendment keyword (#707).
+  //   2. `, <numeral>` — bare-numeral continuation inheriting the
+  //      article-or-amendment type from the head cite (#321 partial).
+  //      Only valid when head cite has article or amendment set —
+  //      we use that to decide which field the continuation populates.
   const chainRe =
     /^\s*;\s*((?:art(?:icle)?\.?|amend(?:ment)?\.?|amdt\.?)\s+([IVX]+|\d+))(?:[,;]?\s*§\s*([\w-]+))?(?:[,;]?\s*cl\.?\s*(\d+))?/i
+  const bareNumeralChainRe = /^\s*(?:,|and)\s+([IVX]+|\d+)\b/
 
   for (const c of citations) {
     if (c.type !== "constitutional") continue
     const jurisdiction = (c as { jurisdiction?: string }).jurisdiction
     if (!jurisdiction) continue
+    const headIsAmendment = (c as { amendment?: number }).amendment !== undefined
+    const headIsArticle = (c as { article?: number }).article !== undefined
     let cursor = c.span.cleanEnd
     while (cursor < cleaned.length) {
       const tail = cleaned.slice(cursor)
       const m = chainRe.exec(tail)
-      if (!m) break
-      const matchedText = m[0]
-      const article = m[1]
-      const numeralText = m[2]
-      const section = m[3]
-      const clauseText = m[4]
-      const isAmendment = /^amend|^amdt/i.test(article)
-      const numeral = parseChainNumeral(numeralText)
-      if (numeral === undefined) break
-      const matchStart = cursor + matchedText.indexOf(article)
-      const matchEnd = cursor + matchedText.length
-      const { originalStart, originalEnd } = resolveOriginalSpan(
-        { cleanStart: matchStart, cleanEnd: matchEnd },
-        transformationMap,
-      )
-      const cite: Citation = {
-        type: "constitutional",
-        text: cleaned.slice(matchStart, matchEnd),
-        span: { cleanStart: matchStart, cleanEnd: matchEnd, originalStart, originalEnd },
-        confidence: c.confidence,
-        matchedText: cleaned.slice(matchStart, matchEnd),
-        processTimeMs: 0,
-        patternsChecked: 1,
-        jurisdiction,
-        ...(isAmendment ? { amendment: numeral } : { article: numeral }),
-        ...(section ? { section } : {}),
-        ...(clauseText ? { clause: Number.parseInt(clauseText, 10) } : {}),
-      } as Citation
-      added.push(cite)
-      cursor = matchEnd
+      const bareMatch = !m && (headIsAmendment || headIsArticle)
+        ? bareNumeralChainRe.exec(tail)
+        : null
+      if (!m && !bareMatch) break
+
+      if (m) {
+        const matchedText = m[0]
+        const article = m[1]
+        const numeralText = m[2]
+        const section = m[3]
+        const clauseText = m[4]
+        const isAmendment = /^amend|^amdt/i.test(article)
+        const numeral = parseChainNumeral(numeralText)
+        if (numeral === undefined) break
+        const matchStart = cursor + matchedText.indexOf(article)
+        const matchEnd = cursor + matchedText.length
+        const { originalStart, originalEnd } = resolveOriginalSpan(
+          { cleanStart: matchStart, cleanEnd: matchEnd },
+          transformationMap,
+        )
+        const cite: Citation = {
+          type: "constitutional",
+          text: cleaned.slice(matchStart, matchEnd),
+          span: { cleanStart: matchStart, cleanEnd: matchEnd, originalStart, originalEnd },
+          confidence: c.confidence,
+          matchedText: cleaned.slice(matchStart, matchEnd),
+          processTimeMs: 0,
+          patternsChecked: 1,
+          jurisdiction,
+          ...(isAmendment ? { amendment: numeral } : { article: numeral }),
+          ...(section ? { section } : {}),
+          ...(clauseText ? { clause: Number.parseInt(clauseText, 10) } : {}),
+        } as Citation
+        added.push(cite)
+        cursor = matchEnd
+      } else if (bareMatch) {
+        const matchedText = bareMatch[0]
+        const numeralText = bareMatch[1]
+        const numeral = parseChainNumeral(numeralText)
+        if (numeral === undefined) break
+        const matchStart = cursor + matchedText.indexOf(numeralText)
+        const matchEnd = cursor + matchedText.length
+        const { originalStart, originalEnd } = resolveOriginalSpan(
+          { cleanStart: matchStart, cleanEnd: matchEnd },
+          transformationMap,
+        )
+        const cite: Citation = {
+          type: "constitutional",
+          text: cleaned.slice(matchStart, matchEnd),
+          span: { cleanStart: matchStart, cleanEnd: matchEnd, originalStart, originalEnd },
+          confidence: c.confidence,
+          matchedText: cleaned.slice(matchStart, matchEnd),
+          processTimeMs: 0,
+          patternsChecked: 1,
+          jurisdiction,
+          ...(headIsAmendment ? { amendment: numeral } : { article: numeral }),
+        } as Citation
+        added.push(cite)
+        cursor = matchEnd
+      }
     }
   }
   citations.push(...added)

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -42,8 +42,12 @@ const AMEND_ORDINAL_ABBREV = String.raw`(?:1st|2nd|3rd|4th|5th|6th|7th|8th|9th|1
 const NUMERAL_FORM = `(?:[IVX]+|\\d+|${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})`
 
 // Article-or-amendment word, including the unabbreviated `Amendment`
-// alternative (#534).
-const ARTICLE_OR_AMENDMENT = String.raw`(?:art(?:icle)?\.?|amend(?:ment)?\.?|amdt\.?|Amendment)\s+(${NUMERAL_FORM})`
+// alternative (#534). Plural forms (`arts.`, `amends.`, `amdts.`) are
+// accepted for chained citations (#321 partial) — the tokenizer only
+// captures the first numeral; chained continuations are out of scope
+// for this pattern (a separate post-extraction pass like
+// expandChainedConstitutional could handle them).
+const ARTICLE_OR_AMENDMENT = String.raw`(?:arts?(?:icle)?\.?|amends?(?:ment)?\.?|amdts?\.?|Amendment)\s+(${NUMERAL_FORM})`
 
 // Inverse shape: numeral BEFORE the amendment word (e.g., `5th Amend.`,
 // `Fifth Amendment`). Only matches the amendment family — articles are

--- a/tests/extract/issuePluralAmendsChain.test.ts
+++ b/tests/extract/issuePluralAmendsChain.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #321 (plural-amendments sub-issue) — `U.S. Const. amends. V, XIV`
+ * (plural `amends.` form) wasn't tokenized at all. Even after enabling
+ * the plural form, only the first amendment was extracted — the
+ * comma-separated continuation `, XIV` was dropped.
+ *
+ * Fix has two parts:
+ * 1. ARTICLE_OR_AMENDMENT regex accepts `arts?` / `amends?` / `amdts?`
+ *    plural forms.
+ * 2. expandChainedConstitutional accepts a bare-numeral continuation
+ *    (`, XIV` / ` and XIV`) inheriting the article-or-amendment type
+ *    from the head cite.
+ */
+describe("Issue #321 - plural amends/arts chain expansion", () => {
+  it("`U.S. Const. amends. V, XIV` extracts 2 amendments", () => {
+    const cs = extractCitations(`U.S. Const. amends. V, XIV`).filter(
+      (c) => c.type === "constitutional",
+    )
+    expect(cs).toHaveLength(2)
+    expect((cs[0] as { amendment?: number }).amendment).toBe(5)
+    expect((cs[1] as { amendment?: number }).amendment).toBe(14)
+  })
+
+  it("`U.S. Const. amends. V and XIV` extracts 2 amendments (and-form)", () => {
+    const cs = extractCitations(`U.S. Const. amends. V and XIV`).filter(
+      (c) => c.type === "constitutional",
+    )
+    expect(cs).toHaveLength(2)
+    expect((cs[0] as { amendment?: number }).amendment).toBe(5)
+    expect((cs[1] as { amendment?: number }).amendment).toBe(14)
+  })
+
+  it("`U.S. Const. arts. I, II, III` extracts 3 articles", () => {
+    const cs = extractCitations(`U.S. Const. arts. I, II, III`).filter(
+      (c) => c.type === "constitutional",
+    )
+    expect(cs).toHaveLength(3)
+    expect((cs[0] as { article?: number }).article).toBe(1)
+    expect((cs[1] as { article?: number }).article).toBe(2)
+    expect((cs[2] as { article?: number }).article).toBe(3)
+  })
+
+  it("singular `U.S. Const. amend. V` still works (regression)", () => {
+    const cs = extractCitations(`U.S. Const. amend. V`).filter(
+      (c) => c.type === "constitutional",
+    )
+    expect(cs).toHaveLength(1)
+    expect((cs[0] as { amendment?: number }).amendment).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the plural-amendments sub-issue of #321. \`U.S. Const. amends. V, XIV\` (plural \`amends.\` form) wasn't tokenized; even after enabling the plural form, only the first amendment was extracted.
- Two coordinated changes:
  1. \`ARTICLE_OR_AMENDMENT\` regex accepts \`arts?\` / \`amends?\` / \`amdts?\` plural forms.
  2. \`expandChainedConstitutional\` accepts a bare-numeral continuation (\`, XIV\` / \` and XIV\`) inheriting the article-or-amendment type from the head cite.
- 4 regression tests.

Other #321 sub-issues (full prose form) remain open.

## Test plan
- [x] Full suite: 4285 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)