### PR TITLE
feat(extract): state-const prose article-first form (#321 partial)

### DIFF
--- a/.changeset/feat-state-const-prose-article-first.md
+++ b/.changeset/feat-state-const-prose-article-first.md
@@ -1,0 +1,28 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): state-const prose article-first form (#321 partial)
+
+Resolves the article-first prose sub-issue of #321.
+`article XII, section 5 of the California Constitution` (article-first
+ordering) wasn't recognized. The pre-existing
+`state-const-prose-section-article` pattern handled only the
+section-first form (`Section 5, Article IV of the Ohio Constitution`).
+
+| input | before | after |
+|---|---|---|
+| `article XII, section 5 of the California Constitution` | 0 cites | article=12, section=5, CA ✓ |
+| `article VI, section 10, of the California Constitution` (extra comma) | 0 cites | article=6, section=10, CA ✓ |
+| `Section 5(B), Article IV of the Ohio Constitution` (section-first) | unchanged | unchanged ✓ |
+| `art. 14 of the Massachusetts Declaration of Rights` | unchanged | unchanged ✓ |
+
+Added `state-const-prose-article-first` pattern + matching extractor
+branch. Covers all 50 US states.
+
+4 regression tests in `tests/extract/issueStateConstProseArticleFirst.test.ts`.
+
+This completes the major sub-issues of #321 covered in this PR series.
+The original issue's `Sections 5 and 10 of Article I of the Ohio
+Constitution` plural-section form remains open (rare; would need
+another bare-numeral chain expansion analogous to PR #771).

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -279,7 +279,8 @@ export function extractConstitutional(
   // names map to 2-letter codes via FULL_STATE_NAME_TO_CODE.
   if (
     token.patternId === "state-const-prose-declaration" ||
-    token.patternId === "state-const-prose-section-article"
+    token.patternId === "state-const-prose-section-article" ||
+    token.patternId === "state-const-prose-article-first"
   ) {
     let article: number | undefined
     let section: string | undefined
@@ -290,11 +291,20 @@ export function extractConstitutional(
         article = Number.parseInt(m[1], 10)
         stateName = m[2].trim().toLowerCase()
       }
-    } else {
+    } else if (token.patternId === "state-const-prose-section-article") {
       const m = /\bSection\s+([\w()-]+)\s*,\s*Article\s+([IVX]+|\d+)\s+of\s+the\s+([A-Za-z\s]+?)\s+Constitution\b/i.exec(text)
       if (m) {
         section = m[1]
         article = parseNumeral(m[2])
+        stateName = m[3].trim().toLowerCase()
+      }
+    } else {
+      // state-const-prose-article-first (#321):
+      // `article XII, section 5 of the California Constitution`
+      const m = /\b(?:article|art\.?)\s+([IVX]+|\d+)[,\s]+section\s+([\w()-]+),?\s+of\s+the\s+([A-Za-z\s]+?)\s+Constitution\b/i.exec(text)
+      if (m) {
+        article = parseNumeral(m[1])
+        section = m[2]
         stateName = m[3].trim().toLowerCase()
       }
     }

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -175,6 +175,24 @@ export const constitutionalPatterns: Pattern[] = [
     type: "constitutional",
   },
   {
+    // #321 — Article-first prose form: `article XII, section 5 of the
+    // California Constitution`, `article VI, section 10, of the
+    // California Constitution`. Mirror of the section-first variant
+    // above. Same patternId because the extractor produces the same
+    // shape (article + section + jurisdiction). The extractor
+    // distinguishes the two variants by group layout.
+    //
+    // Shape: (1) article numeral, (2) section text, (3) state name.
+    id: "state-const-prose-article-first",
+    regex: new RegExp(
+      String.raw`\b(?:article|art\.?)\s+([IVX]+|\d+)[,\s]+section\s+([\w()-]+),?\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey|Ohio|California|Texas|Florida|Illinois|Michigan|New\s+York|Georgia|Virginia|Washington|Arizona|Colorado|Wisconsin|Minnesota|Indiana|Louisiana|Oregon|Tennessee|South\s+Carolina|Alabama|Missouri|Kentucky|Connecticut|Iowa|Mississippi|Arkansas|Kansas|Nevada|Utah|Hawaii|Alaska|Idaho|Maine|Montana|Nebraska|New\s+Mexico|North\s+Dakota|Oklahoma|Rhode\s+Island|South\s+Dakota|West\s+Virginia|Wyoming)\s+Constitution\b`,
+      "gi",
+    ),
+    description:
+      'Prose-form state constitutional citations, article-first: "article XII, section 5 of the California Constitution" — #321',
+    type: "constitutional",
+  },
+  {
     id: "bare-amendment-word",
     regex: new RegExp(
       `(?<!Const\\.?,?\\s)\\b(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+(?:[Aa]mend(?:ment)?\\.?|[Aa]mdt\\.?)`,

--- a/tests/extract/issueStateConstProseArticleFirst.test.ts
+++ b/tests/extract/issueStateConstProseArticleFirst.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #321 (article-first prose form) — `article XII, section 5
+ * of the California Constitution` (article-first ordering) wasn't
+ * recognized. The pre-existing `state-const-prose-section-article`
+ * pattern handled the section-first form (`Section 5, Article IV
+ * of the Ohio Constitution`) only.
+ *
+ * Added a new `state-const-prose-article-first` pattern + extractor
+ * branch covering 50 US states.
+ */
+describe("Issue #321 - state-const prose article-first form", () => {
+  it("`article XII, section 5 of the California Constitution`", () => {
+    const cs = extractCitations(
+      `article XII, section 5 of the California Constitution`,
+    ).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { article?: number; section?: string; jurisdiction?: string }
+    expect(c.article).toBe(12)
+    expect(c.section).toBe("5")
+    expect(c.jurisdiction).toBe("CA")
+  })
+
+  it("`article VI, section 10, of the California Constitution` (extra comma)", () => {
+    const cs = extractCitations(
+      `article VI, section 10, of the California Constitution`,
+    ).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { article?: number; section?: string; jurisdiction?: string }
+    expect(c.article).toBe(6)
+    expect(c.section).toBe("10")
+    expect(c.jurisdiction).toBe("CA")
+  })
+
+  it("regression: section-first `Section 5(B), Article IV of the Ohio Constitution` still works", () => {
+    const cs = extractCitations(
+      `Section 5(B), Article IV of the Ohio Constitution`,
+    ).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { article?: number; section?: string; jurisdiction?: string }
+    expect(c.article).toBe(4)
+    expect(c.section).toBe("5(B)")
+    expect(c.jurisdiction).toBe("OH")
+  })
+
+  it("regression: `art. 14 of the Massachusetts Declaration of Rights` still works", () => {
+    const cs = extractCitations(
+      `art. 14 of the Massachusetts Declaration of Rights`,
+    ).filter((c) => c.type === "constitutional")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { article?: number; jurisdiction?: string }
+    expect(c.article).toBe(14)
+    expect(c.jurisdiction).toBe("MA")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the article-first prose sub-issue of #321. \`article XII, section 5 of the California Constitution\` (article-first ordering) wasn't recognized; the pre-existing pattern handled only section-first form.
- Added \`state-const-prose-article-first\` pattern + matching extractor branch. Covers all 50 US states.
- 4 regression tests.

The original issue's \`Sections 5 and 10 of Article I of the Ohio Constitution\` plural-section form remains open (would need another bare-numeral chain expansion).

## Test plan
- [x] Full suite: 4290 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)