### PR TITLE
feat(extract): Nevada Administrative Code (NAC) recognized (#377 partial)

### DIFF
--- a/.changeset/feat-nevada-nac.md
+++ b/.changeset/feat-nevada-nac.md
@@ -1,0 +1,21 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): Nevada Administrative Code (`NAC`) recognized (#377 partial)
+
+Resolves the NAC sub-issue of #377. Nevada Administrative Code citations
+(`NAC 616.650`) weren't extracted. The NRS (Nevada Revised Statutes)
+entry was already supported; NAC needed its own entry because it's
+a separate regulation code.
+
+| input | before | after |
+|---|---|---|
+| `NAC 616.650` | 0 cites | code=`NAC`, jurisdiction=NV ✓ |
+| `Nev. Admin. Code 616.650` | 0 cites | code=`Nev. Admin. Code`, NV ✓ |
+| `NRS 174.295` (regression control) | unchanged | unchanged ✓ |
+
+Other #377 sub-issues (CCCO Clark County Ordinances, Nevada session
+laws `Nev. Stat., ch. NNN, § N`) remain open.
+
+3 regression tests in `tests/extract/issueNevadaNAC.test.ts`.

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -439,6 +439,14 @@ export const stateStatuteEntries: StateStatuteEntry[] = [
     abbreviations: ["Nev. Rev. Stat. Ann.", "Nev. Rev. Stat.", "NRS"],
     regexFragment: "Nev\\.?\\s+Rev\\.?\\s+Stat\\.?(?:\\s+Ann\\.?)?|NRS",
   },
+  // Nevada Administrative Code — `NAC 616.650` (#377). Separate entry
+  // because the canonical-code resolution treats it as a regulation
+  // code distinct from NRS.
+  {
+    jurisdiction: "NV",
+    abbreviations: ["Nev. Admin. Code", "NAC"],
+    regexFragment: "Nev\\.?\\s+Admin\\.?\\s+Code|NAC",
+  },
   // ── Oklahoma ──────────────────────────────────────────────────────────────
   {
     jurisdiction: "OK",

--- a/tests/extract/issueNevadaNAC.test.ts
+++ b/tests/extract/issueNevadaNAC.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #377 (NAC sub-issue) — Nevada Administrative Code (`NAC`)
+ * wasn't recognized as a statute code. The NRS (Nevada Revised
+ * Statutes) entry was already supported; NAC needed its own entry
+ * because it's a separate regulation code.
+ *
+ * Other #377 sub-issues (CCCO Clark County Ordinances, Nevada
+ * session laws `Nev. Stat., ch. NNN`) remain open.
+ */
+describe("Issue #377 - Nevada Administrative Code (NAC)", () => {
+  it("`NAC 616.650` extracts as NV statute", () => {
+    const cs = extractCitations(`NAC 616.650`).filter((c) => c.type === "statute")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { code?: string; section?: string; jurisdiction?: string }
+    expect(c.code).toBe("NAC")
+    expect(c.section).toBe("616.650")
+    expect(c.jurisdiction).toBe("NV")
+  })
+
+  it("`Nev. Admin. Code 616.650` (spelled-out) extracts as NV statute", () => {
+    const cs = extractCitations(`Nev. Admin. Code 616.650`).filter((c) => c.type === "statute")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { code?: string; jurisdiction?: string }
+    expect(c.code).toBe("Nev. Admin. Code")
+    expect(c.jurisdiction).toBe("NV")
+  })
+
+  it("regression: `NRS 174.295` still works", () => {
+    const cs = extractCitations(`NRS 174.295`).filter((c) => c.type === "statute")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { code?: string; jurisdiction?: string }
+    expect(c.code).toBe("NRS")
+    expect(c.jurisdiction).toBe("NV")
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves the NAC sub-issue of #377. \`NAC 616.650\` wasn't recognized; NRS was already supported but NAC needed its own state-statute entry.
- Added \`Nev. Admin. Code\` / \`NAC\` entry with NV jurisdiction.
- 3 regression tests.

Other #377 sub-issues (CCCO Clark County Ordinances, Nevada session laws) remain open.

## Test plan
- [x] Full suite: 4294 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)