### PR TITLE
fix(extract): partial-decimal section ranges populate sectionRange (#694 pt 3)

### DIFF
--- a/.changeset/fix-partial-decimal-section-range.md
+++ b/.changeset/fix-partial-decimal-section-range.md
@@ -1,0 +1,31 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): partial-decimal section ranges populate sectionRange (#694 pt 3)
+
+Resolves part 3 of #694. Bluebook shorthand for state codes with
+decimal-suffixed sections (`Tex. Bus. & Com. Code Ann. §§ 17.50-.55`,
+where the trailing endpoint inherits the integer stem) and the full
+repeated form (`§§ 17.50-17.55`) weren't expanded into structured
+`sectionRange` data.
+
+| input | before | after |
+|---|---|---|
+| `Tex. Bus. & Com. Code Ann. §§ 17.50-.55` | section=`17.50-.55`, no range | section=`17.50` + range `(17.50, 17.55)` ✓ |
+| `Tex. Bus. & Com. Code Ann. §§ 17.50-17.55` | section=`17.50-17.55`, no range | section=`17.50` + range `(17.50, 17.55)` ✓ |
+| `Va. Code § 18.2-308.2` (regression: not a range) | unchanged | unchanged ✓ |
+| `Tex. Bus. & Com. Code Ann. § 17.50` (single) | unchanged | unchanged ✓ |
+
+`parseBody` recognizes both partial (`.NN`) and full (`X.NN-X.MM`)
+decimal-range shorthand. The full-repeated form requires the integer
+stem to match on both sides to avoid mis-parsing VA hyphenated
+section identifiers (`18.2-308.2`) as ranges.
+
+Wired sectionRangeEnd through `extractAbbreviated` and `extractNamedCode`
+so the new sectionRange field is surfaced on the returned
+StatuteCitation.
+
+4 regression tests in `tests/extract/issuePartialDecimalSectionRange.test.ts`.
+
+This completes all 3 sub-issues of #694 across PRs #742, #754, and this PR.

--- a/src/extract/statutes/extractAbbreviated.ts
+++ b/src/extract/statutes/extractAbbreviated.ts
@@ -68,7 +68,8 @@ export function extractAbbreviated(
       ? codeEntry.abbreviation
       : abbrevText
 
-  const { section, subsection, subsectionRangeEnd, hasEtSeq } = parseBody(rawBody)
+  const { section, subsection, sectionRangeEnd, subsectionRangeEnd, hasEtSeq } =
+    parseBody(rawBody)
 
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
@@ -127,6 +128,7 @@ export function extractAbbreviated(
     title,
     code,
     section,
+    sectionRange: section && sectionRangeEnd ? { start: section, end: sectionRangeEnd } : undefined,
     subsection,
     subsectionRange:
       subsection && subsectionRangeEnd ? { start: subsection, end: subsectionRangeEnd } : undefined,

--- a/src/extract/statutes/extractNamedCode.ts
+++ b/src/extract/statutes/extractNamedCode.ts
@@ -189,7 +189,8 @@ export function extractNamedCode(
     }
   }
 
-  const { section, subsection, subsectionRangeEnd, hasEtSeq } = parseBody(rawBody)
+  const { section, subsection, sectionRangeEnd, subsectionRangeEnd, hasEtSeq } =
+    parseBody(rawBody)
 
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
@@ -260,6 +261,10 @@ export function extractNamedCode(
     code,
     chapter,
     section: sectionOut,
+    sectionRange:
+      sectionOut && sectionRangeEnd
+        ? { start: sectionOut, end: sectionRangeEnd }
+        : undefined,
     subsection,
     subsectionRange:
       subsection && subsectionRangeEnd ? { start: subsection, end: subsectionRangeEnd } : undefined,

--- a/src/extract/statutes/parseBody.ts
+++ b/src/extract/statutes/parseBody.ts
@@ -147,7 +147,36 @@ export function parseBody(rawBody: string): ParsedBody {
   // Detect plain numeric range (e.g. `591-99`, `1330-1332`). Callers may use
   // this to populate `sectionRange` and reset `section` to the start. #564
   const rangeMatch = PLAIN_NUMERIC_RANGE_RE.exec(sectionBody)
-  const sectionRangeEnd = rangeMatch ? rangeMatch[2] : undefined
+  let sectionRangeEnd = rangeMatch ? rangeMatch[2] : undefined
+
+  // Decimal section range (#694 pt 3). Two forms:
+  //   - `17.50-.55` (Bluebook partial shorthand) — trailing endpoint
+  //     inherits the stem of the start endpoint.
+  //   - `17.50-17.55` (full repeated form).
+  // Common in Texas Business & Commerce Code and other state codes
+  // with decimal-suffixed sections. Section field is trimmed to just
+  // the start endpoint so downstream consumers see a clean section
+  // number.
+  let sectionStartOnly = sectionBody
+  if (!sectionRangeEnd) {
+    const partialMatch = /^(\d+)\.(\d+)-\.(\d+)$/.exec(sectionBody)
+    if (partialMatch) {
+      sectionRangeEnd = `${partialMatch[1]}.${partialMatch[3]}`
+      sectionStartOnly = `${partialMatch[1]}.${partialMatch[2]}`
+      sectionBody = sectionStartOnly
+    } else {
+      // Full repeated form `17.50-17.55` — only treat as a range when
+      // the integer stem matches on both sides. Without this constraint
+      // VA hyphenated section identifiers like `18.2-308.2` would be
+      // mis-parsed as range `18.2` to `308.2`.
+      const fullDecimalMatch = /^(\d+)\.(\d+)-(\d+)\.(\d+)$/.exec(sectionBody)
+      if (fullDecimalMatch && fullDecimalMatch[1] === fullDecimalMatch[3]) {
+        sectionStartOnly = `${fullDecimalMatch[1]}.${fullDecimalMatch[2]}`
+        sectionRangeEnd = `${fullDecimalMatch[3]}.${fullDecimalMatch[4]}`
+        sectionBody = sectionStartOnly
+      }
+    }
+  }
 
   if (subMatch !== null && subGroups) {
     return {

--- a/tests/extract/issuePartialDecimalSectionRange.test.ts
+++ b/tests/extract/issuePartialDecimalSectionRange.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #694 (part 3) — Partial-decimal section ranges
+ * (`Tex. Bus. & Com. Code Ann. §§ 17.50-.55`, Bluebook shorthand
+ * where the trailing endpoint inherits the integer stem) and the
+ * full repeated form (`§§ 17.50-17.55`) weren't expanded into
+ * structured `sectionRange` data.
+ *
+ * Fix: parseBody now recognizes both forms. The section field is
+ * trimmed to the start endpoint only; `sectionRange.start` and
+ * `sectionRange.end` carry the full expansion.
+ *
+ * The full-repeated form requires the integer stem to match on both
+ * sides (`17.50-17.55`) to avoid mis-parsing VA hyphenated section
+ * identifiers (`18.2-308.2`) as ranges.
+ */
+describe("Issue #694 - partial-decimal section ranges", () => {
+  it("`Tex. Bus. & Com. Code Ann. §§ 17.50-.55` expands range", () => {
+    const cs = extractCitations(`Tex. Bus. & Com. Code Ann. §§ 17.50-.55`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as {
+      section?: string
+      sectionRange?: { start: string; end: string }
+    }
+    expect(c.section).toBe("17.50")
+    expect(c.sectionRange).toEqual({ start: "17.50", end: "17.55" })
+  })
+
+  it("`§§ 17.50-17.55` (full repeated form) also expands", () => {
+    const cs = extractCitations(`Tex. Bus. & Com. Code Ann. §§ 17.50-17.55`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as {
+      section?: string
+      sectionRange?: { start: string; end: string }
+    }
+    expect(c.section).toBe("17.50")
+    expect(c.sectionRange).toEqual({ start: "17.50", end: "17.55" })
+  })
+
+  it("VA hyphenated section `18.2-308.2` is NOT mis-parsed as range (regression)", () => {
+    const cs = extractCitations(`Va. Code § 18.2-308.2`).filter((c) => c.type === "statute")
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { section?: string; sectionRange?: unknown }
+    expect(c.section).toBe("18.2-308.2")
+    expect(c.sectionRange).toBeUndefined()
+  })
+
+  it("single section `§ 17.50` unaffected", () => {
+    const cs = extractCitations(`Tex. Bus. & Com. Code Ann. § 17.50`).filter(
+      (c) => c.type === "statute",
+    )
+    expect(cs).toHaveLength(1)
+    const c = cs[0] as { section?: string; sectionRange?: unknown }
+    expect(c.section).toBe("17.50")
+    expect(c.sectionRange).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Resolves part 3 of #694. Partial-decimal (\`17.50-.55\`) and full-decimal (\`17.50-17.55\`) section ranges weren't expanded into structured \`sectionRange\` data.
- \`parseBody\` recognizes both forms; full-form requires matching integer stem to avoid VA \`18.2-308.2\` false positives.
- Wired \`sectionRangeEnd\` through \`extractAbbreviated\` and \`extractNamedCode\` so the new \`sectionRange\` field is surfaced.
- 4 regression tests.

Completes all 3 sub-issues of #694 across PRs #742, #754, and this one.

## Test plan
- [x] Full suite: 4297 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)