### PR TITLE
fix(extract): drop multi-word period-less journal phantoms in prose (#615)

### DIFF
--- a/.changeset/fix-journal-prose-phantom.md
+++ b/.changeset/fix-journal-prose-phantom.md
@@ -1,0 +1,31 @@
+---
+"eyecite-ts": patch
+---
+
+fix(extract): filter journal phantom matches in standalone prose (#615)
+
+Resolves #615. The journal `law-review` regex is intentionally broad
+(no journals-db gate) so it can fire on any `[volume] [Capitalized Run]
+[page]` shape — including pure prose like `In 1974 Senator Smith Jones
+500 cases were filed.`. The post-#614 overlap-dedup pass catches phantoms
+that overlap higher-priority citations, but standalone-prose phantoms
+slipped through.
+
+The extractor now drops multi-word journal captures that lack BOTH a
+period AND a short (≤2 char) word. Real journal abbreviations satisfy
+at least one of:
+
+- single word (`Neurology`, `JAMA`, `Science`), OR
+- contains a period (`Harv. L. Rev.`, `Yale L.J.`), OR
+- contains a short token (`Brook L Rev`, `Yale L J` — `L`, `J`, `Rev`).
+
+| input | before | after |
+|---|---|---|
+| `In 1974 Senator Smith Jones 500 cases were filed.` | phantom journal `Senator Smith Jones` | dropped ✓ |
+| `70 Brook L Rev 1045` | journal `Brook L Rev` | unchanged ✓ |
+| `96 Yale L J 1234` | journal `Yale L J` | unchanged ✓ |
+| `53 Neurology 1107` | journal `Neurology` | unchanged ✓ |
+| `100 Harv. L. Rev. 500` | journal `Harv. L. Rev.` | unchanged ✓ |
+| `285 JAMA 2486` | journal `JAMA` | unchanged ✓ |
+
+7 regression tests in `tests/extract/issue615JournalPhantom.test.ts`.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -415,9 +415,25 @@ export function extractCitations(
       case "statute":
         citation = extractStatute(token, transformationMap)
         break
-      case "journal":
-        citation = extractJournal(token, transformationMap, cleaned)
+      case "journal": {
+        const journalCitation = extractJournal(token, transformationMap, cleaned)
+        // Phantom-prose filter (#615). Without a journals-db gate, the broad
+        // journal regex can fire on `[vol] [Capitalized Run] [page]` shapes
+        // where the capitalized run is just sentence prose (`1974 Senator
+        // Smith Jones 500`). Real journal abbreviations are either single
+        // words (`Neurology`, `JAMA`) or contain at least one period or
+        // short token (`Harv. L. Rev.`, `Brook L Rev`, `Yale L J` — `L`,
+        // `J`, `Rev` are short Bluebook abbreviations). Multi-word captures
+        // that lack both a period AND a short (≤2 char) word are almost
+        // always phantoms; drop them here.
+        const name = journalCitation.journal
+        const words = name.split(/\s+/)
+        const isPhantom =
+          words.length >= 2 && !name.includes(".") && !words.some((w) => w.length <= 2)
+        if (isPhantom) continue
+        citation = journalCitation
         break
+      }
       case "neutral":
         citation = extractNeutral(token, transformationMap, cleaned)
         break

--- a/tests/extract/issue615JournalPhantom.test.ts
+++ b/tests/extract/issue615JournalPhantom.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { JournalCitation } from "@/types/citation"
+
+const journals = (text: string): JournalCitation[] =>
+  extractCitations(text).filter((c): c is JournalCitation => c.type === "journal")
+
+/**
+ * Issue #615 — journalPatterns over-matches in standalone prose.
+ *
+ * The journal-name capture (`[A-Z][A-Za-z.&']*(?:\s+[A-Z\d&][A-Za-z.&']*)*?`)
+ * has no period requirement and no journals-db gate, so any
+ * `[volume] [Capitalized Run] [page]` shape will tokenize as a journal —
+ * including pure prose like `1974 Senator Smith Jones 500`.
+ *
+ * Real journal abbreviations are either:
+ *   - single words (`Neurology`, `JAMA`, `Science`), OR
+ *   - contain at least one period (`Harv. L. Rev.`), OR
+ *   - contain at least one short word ≤2 chars (`Brook L Rev`, `Yale L J`).
+ *
+ * Multi-word captures lacking BOTH a period AND a short word are dropped
+ * at extract time as phantoms.
+ */
+describe("Issue #615 — journal phantom-prose filter", () => {
+  it("`In 1974 Senator Smith Jones 500 cases` does not emit a phantom journal", () => {
+    const cs = journals("In 1974 Senator Smith Jones 500 cases were filed.")
+    expect(cs).toHaveLength(0)
+  })
+
+  it("`1974 Some Capitalized Words 500` does not emit a phantom journal", () => {
+    const cs = journals("Around 1974 Some Capitalized Words 500 of them existed.")
+    expect(cs).toHaveLength(0)
+  })
+
+  it("`70 Brook L Rev 1045` (multi-word no-period with short token) still extracts", () => {
+    const cs = journals("70 Brook L Rev 1045")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].abbreviation).toBe("Brook L Rev")
+  })
+
+  it("`96 Yale L J 1234` (multi-word no-period with short tokens) still extracts", () => {
+    const cs = journals("96 Yale L J 1234")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].abbreviation).toBe("Yale L J")
+  })
+
+  it("`53 Neurology 1107` (single-word) still extracts", () => {
+    const cs = journals("53 Neurology 1107")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].abbreviation).toBe("Neurology")
+  })
+
+  it("`100 Harv. L. Rev. 500` (canonical with periods) still extracts", () => {
+    const cs = journals("100 Harv. L. Rev. 500")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].abbreviation).toBe("Harv. L. Rev.")
+  })
+
+  it("`285 JAMA 2486` (single-word acronym) still extracts", () => {
+    const cs = journals("285 JAMA 2486")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].abbreviation).toBe("JAMA")
+  })
+})


### PR DESCRIPTION
## Summary

- The journal `law-review` regex is intentionally broad — no journals-db gate — so it can match any `[vol] [Capitalized Run] [page]` shape in standalone prose like `In 1974 Senator Smith Jones 500 cases were filed.`. Post-#614 overlap-dedup catches phantoms that overlap other citations, but standalone-prose phantoms slipped through.
- Extractor now drops multi-word journal captures that lack BOTH a period AND a short (≤2 char) word. Real journal abbreviations satisfy at least one (single word like `Neurology`, period like `Harv. L. Rev.`, or short token like `Brook L Rev`/`Yale L J`).

Closes #615.

## Test plan

- [x] `pnpm exec vitest run tests/extract/issue615JournalPhantom.test.ts` — 7/7 passing
- [x] `pnpm exec vitest run` — 4308/4308 passing
- [x] `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)