### PR TITLE
test(packaging): verify Node 18 tarball + enforce coverage gate

### DIFF
--- a/.changeset/ci-tarball-node18-coverage.md
+++ b/.changeset/ci-tarball-node18-coverage.md
@@ -1,0 +1,4 @@
+---
+---
+
+CI/test only (no runtime or package changes): verify the published tarball loads on Node 18 by building + packing once (Node 20+) and consuming that artifact across a Node 18/20/22 matrix, and enforce the vitest coverage thresholds that were previously silently ignored (they sat at the wrong config level). Closes #776.

--- a/.changeset/ci-tarball-node18-coverage.md
+++ b/.changeset/ci-tarball-node18-coverage.md
@@ -1,4 +1,5 @@
 ---
+"eyecite-ts": patch
 ---
 
-CI/test only (no runtime or package changes): verify the published tarball loads on Node 18 by building + packing once (Node 20+) and consuming that artifact across a Node 18/20/22 matrix, and enforce the vitest coverage thresholds that were previously silently ignored (they sat at the wrong config level). Closes #776.
+Verify in CI that the published package loads on Node 18 — the tarball is now built once (Node 20+) and exercised by a real consumer on Node 18/20/22, closing a gap where Node 18 was never tested against the actual published artifact. Also enforce the vitest coverage thresholds, which previously sat at the wrong config level and were silently ignored. No public API or runtime behavior changes. Closes #776.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,14 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm data:generate
+      # The published-tarball integration test runs in the dedicated `tarball`
+      # job below (built once, consumed across the Node matrix), so it is
+      # excluded here to avoid a redundant per-leg build.
       - name: Run tests
-        run: pnpm exec vitest run
+        run: pnpm exec vitest run --exclude '**/publishedTarball.test.ts'
         if: matrix.node-version != 22
       - name: Run tests with coverage
-        run: pnpm exec vitest run --coverage
+        run: pnpm exec vitest run --coverage --exclude '**/publishedTarball.test.ts'
         if: matrix.node-version == 22
       - uses: actions/upload-artifact@v4
         if: matrix.node-version == 22
@@ -78,3 +81,42 @@ jobs:
           test -f dist/index.mjs
           test -f dist/data/index.mjs
           test -f dist/annotate/index.mjs
+      - name: Pack tarball
+        run: npm pack --pack-destination pack
+      - name: Upload tarball artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarball
+          path: pack/*.tgz
+          retention-days: 1
+
+  tarball:
+    name: Tarball consumer (Node ${{ matrix.node-version }})
+    needs: [build]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Download packed tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: tarball
+          path: pack
+      - name: Resolve tarball path
+        id: tarball
+        run: echo "path=$(ls "$PWD"/pack/*.tgz)" >> "$GITHUB_OUTPUT"
+      # Consume the once-built (Node 20+) artifact on every supported Node,
+      # including Node 18 — verifies the published package actually loads there.
+      - name: Verify published tarball loads
+        run: pnpm exec vitest run tests/integration/publishedTarball.test.ts
+        env:
+          EYECITE_TARBALL: ${{ steps.tarball.outputs.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,9 @@ jobs:
           test -f dist/data/index.mjs
           test -f dist/annotate/index.mjs
       - name: Pack tarball
-        run: npm pack --pack-destination pack
+        run: |
+          mkdir -p pack
+          npm pack --pack-destination pack
       - name: Upload tarball artifact
         uses: actions/upload-artifact@v4
         with:

--- a/tests/integration/publishedTarball.test.ts
+++ b/tests/integration/publishedTarball.test.ts
@@ -18,16 +18,21 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest"
  *  - orphan chunks / CJS path mismatch
  *  - any future packaging regression where dist/ + the import graph drift apart
  *
- * Skipped on Node < 20: the test invokes `pnpm build` (tsdown → Rolldown),
- * which requires Node 20+ (`util.styleText`). The published artifact itself
- * works on Node 18 — only the build toolchain needs the newer Node. Coverage
- * of Node 18 consumer behavior comes from the rest of the test suite.
+ * Build vs consume are decoupled: set EYECITE_TARBALL to a pre-packed `.tgz` and
+ * the test installs that artifact directly — no local build — so it runs on any
+ * Node version, including Node 18. CI builds + packs once (Node 20+) and feeds
+ * the artifact to a Node 18/20/22 matrix. Without EYECITE_TARBALL the test builds
+ * and packs itself, which needs Node 20+ (tsdown → Rolldown `util.styleText`); on
+ * older Node with no tarball provided it skips.
  */
+const providedTarball = process.env.EYECITE_TARBALL
 const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10)
 const buildSupported = nodeMajor >= 20
+const canRun = Boolean(providedTarball) || buildSupported
 
 const projectRoot = resolve(__dirname, "../..")
 let workDir: string
+let tarballPath: string
 let esmConsumer: string
 let cjsConsumer: string
 
@@ -37,11 +42,9 @@ function installTarball(consumerDir: string, type: "module" | "commonjs"): void 
     join(consumerDir, "package.json"),
     JSON.stringify({ name: `consumer-${type}`, version: "0.0.0", type, private: true }),
   )
-  const tarball = readdirSync(workDir).find((f) => f.endsWith(".tgz"))
-  if (!tarball) throw new Error(`no packed tarball (*.tgz) found in ${workDir}`)
   // Quote the path (TMPDIR may contain spaces); --no-audit/--no-fund keep the
   // install hermetic (no registry audit/funding requests — zero runtime deps).
-  execSync(`npm install --no-audit --no-fund "${join(workDir, tarball)}"`, {
+  execSync(`npm install --no-audit --no-fund "${tarballPath}"`, {
     cwd: consumerDir,
     stdio: "pipe",
   })
@@ -56,16 +59,25 @@ function runScript(consumerDir: string, scriptName: string, source: string) {
   })
 }
 
-describe.skipIf(!buildSupported)("Published tarball (#642 regression)", () => {
+describe.skipIf(!canRun)("Published tarball (#642 regression)", () => {
   beforeAll(() => {
     workDir = mkdtempSync(join(tmpdir(), "eyecite-tarball-"))
     esmConsumer = join(workDir, "esm-consumer")
     cjsConsumer = join(workDir, "cjs-consumer")
 
-    // Build is required; `files: ["dist"]` only ships what's already on disk,
-    // and a stale dist would mask real bugs.
-    execSync("pnpm build", { cwd: projectRoot, stdio: "pipe" })
-    execSync(`npm pack --pack-destination "${workDir}"`, { cwd: projectRoot, stdio: "pipe" })
+    if (providedTarball) {
+      // Consume a pre-built artifact (CI builds once on Node 20+ and runs this
+      // across the Node matrix). No build step — works on Node 18.
+      tarballPath = resolve(providedTarball)
+    } else {
+      // Local mode: build + pack ourselves. `files: ["dist"]` only ships what's
+      // already on disk, and a stale dist would mask real bugs.
+      execSync("pnpm build", { cwd: projectRoot, stdio: "pipe" })
+      execSync(`npm pack --pack-destination "${workDir}"`, { cwd: projectRoot, stdio: "pipe" })
+      const packed = readdirSync(workDir).find((f) => f.endsWith(".tgz"))
+      if (!packed) throw new Error(`no packed tarball (*.tgz) found in ${workDir}`)
+      tarballPath = join(workDir, packed)
+    }
 
     installTarball(esmConsumer, "module")
     installTarball(cjsConsumer, "commonjs")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,10 +20,15 @@ export default defineConfig({
       reporter: ["text", "json", "html"],
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/types/**", "src/data/reporters.gen.ts"],
-      lines: 80,
-      functions: 80,
-      branches: 75,
-      statements: 80,
+      // vitest 4 reads thresholds from `coverage.thresholds`; top-level keys are
+      // silently ignored (the gate was previously a no-op). Current coverage sits
+      // well above these (~96 stmts / 87 branch / 99 funcs / 98 lines).
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 75,
+        statements: 80,
+      },
     },
     testTimeout: 10000,
   },


### PR DESCRIPTION
Two test/CI hygiene gaps surfaced by the review subagents on #731 (tracked in #776). Neither touches the published package — CI/test-config only — but both weaken the safety net around the reporters packaging fix.

## 1. The published tarball is now verified on Node 18

**Today:** the published-tarball integration test skips entirely on Node <20, because its in-test `pnpm build` needs Rolldown's `util.styleText` (Node 20+). So a Node-22-built tarball was never actually loaded by a Node-18 consumer in CI — exactly the class of mismatch #642 was, and Node 18 is in `engines`.

**After this PR:** build + pack happen once (Node 22) and the resulting `.tgz` is consumed across a Node 18/20/22 matrix. The test honors an `EYECITE_TARBALL` env var (install a pre-built tarball, no build — runs on any Node) and self-builds only when it's absent (local dev, Node 20+). The integration test is dropped from the regular per-leg `test` job, so the build runs once per CI run instead of on both the 20 and 22 legs.

**Why this matters:** if a future bundler/target change emits dist syntax a Node-18 consumer can't load, CI catches it instead of a user's install — and CI does less work, not more.

## 2. Coverage thresholds are actually enforced

**Today:** `vitest.config.ts` declares `lines/functions/branches/statements` at the top level of `coverage`, but vitest 4 reads them from `coverage.thresholds`. The misplaced keys are ignored, so the 80/80/75/80 gate is a silent no-op.

**After this PR:** the thresholds live under `coverage.thresholds` and are enforced. Current coverage (~96 stmts / 87 branch / 99 funcs / 98 lines) clears them comfortably.

**Why this matters:** the coverage gate the project thought it had now actually exists.

## Test plan

**Ran locally (Node 24):**
- Consume mode with `dist/` deleted + `EYECITE_TARBALL` set — integration 3/3 in 666ms, proving it installs the prebuilt tarball with no build (the Node-18 code path).
- Self-build mode (no env var) — 3/3 in 2.6s (local dev path unchanged).
- Coverage enforcement — temporarily raising `lines` to 99 fails with `Coverage for lines (97.97%) does not meet global threshold (99%)`; reverted to 80 passes. Confirms the gate is live.
- `--exclude` skips exactly the integration file (254 of 255 files run).
- `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm size` (47.4/50 KB, 2.04/3 KB) — clean.

**Verified only in CI (no local Node 18 / no version manager here):**
- [ ] The new `tarball` job loads the Node-22-built artifact on **Node 18**. This is the headline check — if tsdown's untargeted output uses syntax Node 18 can't parse, this leg fails and the fix is a `target: "node18"` in `tsdown.config.ts`.

Closes #776.

---
Assisted-by: Claude:claude-opus-4-8