### PR TITLE
feat(extract): judicial-conduct canon citations (#310)

### DIFF
--- a/.changeset/feat-canon.md
+++ b/.changeset/feat-canon.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": minor
+---
+
+Add `canon` citation type for Code of Judicial Conduct canons (#310)
+
+`Canon 7(B)(1)`, `Canon 2(A) of the Code of Judicial Conduct`, and bare `Canon 1` now extract as `type: "canon"` with `canon`, optional `subsection`, and (when stated) `ruleSet`. Distinct from attorney disciplinary/model rules (#295). Requires a capital `Canon` + number so lowercase "canon of …" prose is not matched.

--- a/src/extract/extractCanon.ts
+++ b/src/extract/extractCanon.ts
@@ -1,0 +1,39 @@
+/**
+ * Judicial-Conduct Canon Citation Extractor (#310)
+ *
+ * Parses Code of Judicial Conduct canon citations (`Canon 7(B)(1)`) into the
+ * `canon` type.
+ *
+ * @module extract/extractCanon
+ */
+
+import { CANON_RE } from "@/patterns/canonPatterns"
+import type { Token } from "@/tokenize/tokenizer"
+import type { CanonCitation } from "@/types/citation"
+import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
+
+export function extractCanon(token: Token, transformationMap: TransformationMap): CanonCitation {
+  const { text, span } = token
+  const m = CANON_RE.exec(text)
+  if (!m) throw new Error(`Failed to parse canon citation: ${text}`)
+
+  const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+
+  return {
+    type: "canon",
+    text,
+    span: {
+      cleanStart: span.cleanStart,
+      cleanEnd: span.cleanEnd,
+      originalStart,
+      originalEnd,
+    },
+    confidence: 0.9,
+    matchedText: text,
+    processTimeMs: 0,
+    patternsChecked: 1,
+    canon: m[1]!,
+    ...(m[2] ? { subsection: m[2] } : {}),
+    ...(m[3] ? { ruleSet: "Code of Judicial Conduct" } : {}),
+  }
+}

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -19,6 +19,7 @@ import type { FootnoteMap } from "@/footnotes/types"
 import {
   computeCaseConfidence,
   extractAnnotation,
+  extractCanon,
   extractCase,
   extractConstitutional,
   extractDocket,
@@ -39,6 +40,7 @@ import {
 } from "@/extract"
 import type { Pattern } from "@/patterns"
 import {
+  canonPatterns,
   casePatterns,
   constitutionalPatterns,
   docketPatterns,
@@ -260,6 +262,7 @@ export function extractCitations(
     ...treatyPatterns, // Treaty series — anchored by "T.I.A.S."/"U.N.T.S."/"U.S.T." (#309)
     ...legislativeMaterialPatterns, // Committee reports + Cong. Rec. — anchored by "Rep. No."/"Cong. Rec." (#308)
     ...localOrdinancePatterns, // Municipal ordinances — anchored by "CCCO §" (#778)
+    ...canonPatterns, // Judicial-conduct canons — anchored by "Canon N" (#310)
     ...docketPatterns, // Docket-number citations (anchored by "No. ")
     ...shortFormPatterns, // Short-form (requires " at " keyword)
     ...federalRulePatterns, // Fed. R. Civ. P. etc. — before casePatterns (#576, #582)
@@ -469,6 +472,9 @@ export function extractCitations(
         break
       case "localOrdinance":
         citation = extractLocalOrdinance(token, transformationMap)
+        break
+      case "canon":
+        citation = extractCanon(token, transformationMap)
         break
       case "constitutional":
         citation = extractConstitutional(token, transformationMap)

--- a/src/extract/index.ts
+++ b/src/extract/index.ts
@@ -15,6 +15,7 @@
  */
 
 export * from "./extractAnnotation"
+export * from "./extractCanon"
 export * from "./extractCase"
 export * from "./extractCitations"
 export * from "./extractConstitutional"

--- a/src/patterns/canonPatterns.ts
+++ b/src/patterns/canonPatterns.ts
@@ -1,0 +1,24 @@
+/**
+ * Judicial-Conduct Canon Citation Patterns (#310)
+ *
+ * Code of Judicial Conduct canons: `Canon 7(B)(1)`, `Canon 2(A)`, optionally
+ * followed by `of the Code of Judicial Conduct`. Requires a capital `Canon` +
+ * number to avoid matching lowercase "canon of ..." prose. The subsection chain
+ * `(?:\([A-Za-z0-9]+\))*` is anchored by literal parens (ReDoS-safe).
+ */
+
+import type { Pattern } from "./casePatterns"
+
+const CANON_SRC = String.raw`\bCanon\s+(\d+)((?:\([A-Za-z0-9]+\))*)(\s+of\s+the\s+Code\s+of\s+Judicial\s+Conduct)?`
+
+/** Non-global regex for the extractor to re-exec on the matched token text. */
+export const CANON_RE: RegExp = new RegExp(CANON_SRC)
+
+export const canonPatterns: Pattern[] = [
+  {
+    id: "canon",
+    regex: new RegExp(CANON_SRC, "g"),
+    description: 'Code of Judicial Conduct canons (e.g. "Canon 7(B)(1)")',
+    type: "canon",
+  },
+]

--- a/src/patterns/index.ts
+++ b/src/patterns/index.ts
@@ -6,6 +6,7 @@
  * - Importing all patterns: `import { casePatterns, statutePatterns, ... } from '@/patterns'`
  */
 
+export * from "./canonPatterns"
 export * from "./casePatterns"
 export * from "./constitutionalPatterns"
 export * from "./docketPatterns"

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -32,6 +32,7 @@ export type CitationType =
   | "treaty"
   | "legislativeMaterial"
   | "localOrdinance"
+  | "canon"
   | "constitutional"
   | "federalRule"
   | "restatement"
@@ -861,6 +862,23 @@ export interface LocalOrdinanceCitation extends CitationBase {
 }
 
 /**
+ * Judicial-conduct canon citation (#310).
+ *
+ * Code of Judicial Conduct canons: `Canon 7(B)(1)`, `Canon 2(A) of the Code of
+ * Judicial Conduct`. Distinct from attorney disciplinary/model rules (#295) —
+ * this is judicial conduct.
+ */
+export interface CanonCitation extends CitationBase {
+  type: "canon"
+  /** Canon number, e.g. "7", "2" */
+  canon: string
+  /** Subsection chain, e.g. "(B)(1)", "(A)" */
+  subsection?: string
+  /** Rule set when stated explicitly, e.g. "Code of Judicial Conduct" */
+  ruleSet?: string
+}
+
+/**
  * Federal Rules of Procedure citation (#576).
  *
  * Covers the four primary federal rule sets (civil, criminal, evidence,
@@ -1271,6 +1289,7 @@ export type Citation =
   | TreatyCitation
   | LegislativeMaterialCitation
   | LocalOrdinanceCitation
+  | CanonCitation
   | IdCitation
   | SupraCitation
   | ShortFormCaseCitation
@@ -1291,6 +1310,7 @@ export type FullCitationType =
   | "treaty"
   | "legislativeMaterial"
   | "localOrdinance"
+  | "canon"
   | "constitutional"
   | "federalRule"
   | "stateRule"
@@ -1308,6 +1328,7 @@ export type FullCitation =
   | TreatyCitation
   | LegislativeMaterialCitation
   | LocalOrdinanceCitation
+  | CanonCitation
   | DocketCitation
   | StatuteCitation
   | JournalCitation

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -26,6 +26,7 @@ export function isFullCitation(citation: Citation): citation is FullCitation {
     citation.type === "treaty" ||
     citation.type === "legislativeMaterial" ||
     citation.type === "localOrdinance" ||
+    citation.type === "canon" ||
     citation.type === "constitutional" ||
     citation.type === "federalRule" ||
     citation.type === "restatement" ||

--- a/src/utils/bluebook.ts
+++ b/src/utils/bluebook.ts
@@ -184,6 +184,9 @@ export function toBluebook(citation: Citation): string {
     case "localOrdinance":
       return `${citation.code} § ${citation.section}`
 
+    case "canon":
+      return `Canon ${citation.canon}${citation.subsection ?? ""}`
+
     case "id":
       return citation.pincite !== undefined ? `Id. at ${citation.pincite}` : "Id."
 

--- a/tests/extract/canon.test.ts
+++ b/tests/extract/canon.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { CanonCitation } from "@/types/citation"
+
+/**
+ * Code of Judicial Conduct canon citations (#310) — `Canon 7(B)(1)`,
+ * `Canon 2(A) of the Code of Judicial Conduct`. Distinct from attorney
+ * disciplinary/model rules (#295) — this is judicial conduct.
+ */
+const canon = (t: string): CanonCitation | undefined =>
+  extractCitations(t).find((c): c is CanonCitation => c.type === "canon")
+
+describe("judicial-conduct canons (#310)", () => {
+  it("Canon 7(B)(1)", () => {
+    const c = canon("The judge violated Canon 7(B)(1).")
+    expect(c).toBeDefined()
+    expect(c?.canon).toBe("7")
+    expect(c?.subsection).toBe("(B)(1)")
+  })
+
+  it("Canon 2(A)", () => {
+    const c = canon("Canon 2(A) requires impartiality.")
+    expect(c).toBeDefined()
+    expect(c?.canon).toBe("2")
+    expect(c?.subsection).toBe("(A)")
+  })
+
+  it("Canon 7(B)(2)(c) of the Code of Judicial Conduct (explicit rule set)", () => {
+    const c = canon("Canon 7(B)(2)(c) of the Code of Judicial Conduct")
+    expect(c).toBeDefined()
+    expect(c?.canon).toBe("7")
+    expect(c?.subsection).toBe("(B)(2)(c)")
+    expect(c?.ruleSet).toBe("Code of Judicial Conduct")
+  })
+
+  it("Canon 1 (minimal, no subsection)", () => {
+    const c = canon("See Canon 1.")
+    expect(c).toBeDefined()
+    expect(c?.canon).toBe("1")
+    expect(c?.subsection).toBeUndefined()
+  })
+})
+
+describe("canon regression", () => {
+  it("does not false-positive on lowercase 'canon' prose", () => {
+    const cits = extractCitations("Under the canon of constitutional avoidance, the court declined.")
+    expect(cits.some((c) => c.type === "canon")).toBe(false)
+  })
+})

--- a/tests/utils/bluebook.test.ts
+++ b/tests/utils/bluebook.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { toBluebook } from "../../src/utils"
 import type {
   AnnotationCitation,
+  CanonCitation,
   ConstitutionalCitation,
   FederalRegisterCitation,
   FederalRuleCitation,
@@ -494,6 +495,23 @@ describe("toBluebook", () => {
         section: "2.12.010(1)",
       }
       expect(toBluebook(cite)).toBe("CCCO § 2.12.010(1)")
+    })
+  })
+
+  describe("CanonCitation (#310)", () => {
+    it("formats a judicial-conduct canon with subsection", () => {
+      const cite: CanonCitation = {
+        ...BASE,
+        type: "canon",
+        canon: "7",
+        subsection: "(B)(1)",
+      }
+      expect(toBluebook(cite)).toBe("Canon 7(B)(1)")
+    })
+
+    it("formats a bare canon", () => {
+      const cite: CanonCitation = { ...BASE, type: "canon", canon: "1" }
+      expect(toBluebook(cite)).toBe("Canon 1")
     })
   })
 


### PR DESCRIPTION
## Why

Code of Judicial Conduct canons are the dispositive authority in judicial-discipline and recusal opinions, but weren't extracted — leaving the citation graph for an ethics opinion essentially empty.

**Today:** `extractCitations("The judge violated Canon 7(B)(1).")` returns `[]`.

**After this PR:** it extracts as `type: "canon"` with `canon: "7"`, `subsection: "(B)(1)"` (and `ruleSet: "Code of Judicial Conduct"` when the phrase is stated).

**Why this matters:** judicial-ethics opinions become navigable by citation analysis instead of dropping their core authority into `other`.

## What changed

- New `canon` discriminated-union member + `CanonCitation` interface (`canon`, `subsection`, `ruleSet`).
- One pattern: `Canon N(subsection-chain)?` (+ optional `of the Code of Judicial Conduct`), requiring a **capital** `Canon` + number so lowercase "canon of …" prose isn't matched. Ahead of `casePatterns` in dedup.
- `toBluebook` formats it; resolver / formatter exhaustive switches updated.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **4368 passed**, 0 failed (262 files); 5 extraction + 2 `toBluebook` tests, incl. a lowercase-"canon" no-false-positive regression test
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0

**Boundary:** judicial-conduct canons only. Attorney disciplinary / model rules (`Model Rule 1.5`) belong to #295, not here.

Closes #310.

---
Assisted-by: Claude:claude-opus-4-8
