### PR TITLE
fix(extract): spelled-out Article N, Section N constitutional prose (#321)

### DIFF
--- a/.changeset/fix-bare-article-section.md
+++ b/.changeset/fix-bare-article-section.md
@@ -1,0 +1,17 @@
+---
+"eyecite-ts": patch
+---
+
+Recognize spelled-out bare `Article N, Section N` constitutional prose (#321)
+
+`Article I, Section 8`, `Article 1, Section 10`, and the abbreviated-article +
+word-section mix `Art. 1, Section 6` now extract as `type: "constitutional"`
+(article + section). Previously only the `§`-symbol form (`Art. I, § 10`) and
+the `of the <State> Constitution` prose trailer matched, so the spelled-out
+form attorneys use most in argument prose fell through.
+
+The tight comma-separated `Article <num>, Section <num>` adjacency plus a
+case-sensitive `Article`/`Art.` token keep ordinary contract/bylaw prose from
+matching; confidence is 0.5 (no `Const.` anchor), matching the existing bare
+form. A `(?<!Const\.?,?\s)` lookbehind avoids duplicating the core of a full
+`U.S. Const., Art. I, §7` citation.

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -346,6 +346,35 @@ export function extractConstitutional(
     }
   }
 
+  // #321 — Bare spelled-out `Article N, Section N` prose with no `Const.`
+  // anchor and no state trailer (`Article I, Section 8`, `Art. 1, Section
+  // 6`). CONSTITUTIONAL_BODY_RE doesn't recognize the spelled-out
+  // "Article"/"Section" word forms, so parse the article numeral + section
+  // directly. Jurisdiction is undefined and confidence is 0.5 (matching
+  // `bare-article`); the tight comma-separated adjacency captured by the
+  // pattern is the false-positive guard.
+  if (token.patternId === "bare-article-section") {
+    const m =
+      /(?<!Const\.?,?\s)\b(?:Article|Art\.?)\s+([IVX]+|\d+)\s*[,;]\s*(?:Section|§)\s*([\w()-]+)/.exec(
+        text,
+      )
+    const article = m ? parseNumeral(m[1]) : undefined
+    const section = m ? m[2] : undefined
+    const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
+    return {
+      type: "constitutional",
+      text,
+      span: { cleanStart: span.cleanStart, cleanEnd: span.cleanEnd, originalStart, originalEnd },
+      confidence: article === undefined ? 0.1 : 0.5,
+      matchedText: text,
+      processTimeMs: 0,
+      patternsChecked: 1,
+      article,
+      section,
+      jurisdiction: undefined,
+    }
+  }
+
   const bodyMatch = CONSTITUTIONAL_BODY_RE.exec(text)
 
   let article: number | undefined

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -127,6 +127,29 @@ export const constitutionalPatterns: Pattern[] = [
     type: "constitutional",
   },
   {
+    // #321 — Spelled-out bare `Article N, Section N` prose with no `Const.`
+    // anchor and no `of the <State> Constitution` trailer:
+    // `Article I, Section 8`, `Article 1, Section 10`, `Art. 1, Section 6`.
+    // The `bare-article` pattern above only accepts the abbreviated `Art.`
+    // token plus a `§` section symbol, so the spelled-out forms attorneys
+    // use most in argument prose fell through entirely. The tight
+    // `Article <num>, Section <num>` adjacency (comma/semicolon separator)
+    // is the false-positive guard; "Article"/"Art." is case-sensitive so
+    // lowercase contract/bylaw prose ("article 7, section 3") does not
+    // match. Confidence set to 0.5 in the extractor (same as `bare-article`).
+    // The `(?<!Const\.?,?\s)` lookbehind (mirroring `bare-article`) keeps
+    // this from also matching the `Art. I, §7` core inside a full
+    // `U.S. Const., Art. I, §7` citation already captured upstream.
+    id: "bare-article-section",
+    regex: new RegExp(
+      String.raw`(?<!Const\.?,?\s)\b(?:Article|Art\.?)\s+([IVX]+|\d+)\s*[,;]\s*(?:Section|§)\s*([\w()-]+)`,
+      "g",
+    ),
+    description:
+      'Bare spelled-out article+section prose: "Article I, Section 8", "Art. 1, Section 6" — #321',
+    type: "constitutional",
+  },
+  {
     // #534 — Bare word-form amendment references without `Const.` prefix:
     // `the Fifth Amendment`, `the Fourteenth Amendment`. Use a leading
     // word-boundary plus negative-lookbehind for `Const.?,?\s` so this

--- a/tests/extract/issueBareArticleSection.test.ts
+++ b/tests/extract/issueBareArticleSection.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #321 (part: spelled-out `Article N, Section N` prose) — the
+ * `bare-article` pattern only accepted the abbreviated `Art.` token plus a
+ * `§` section symbol, so the spelled-out prose form attorneys use most in
+ * argument (`Article I, Section 8`) and the abbreviated-article + word-
+ * section mix (`Art. 1, Section 6`) extracted as NOTHING.
+ *
+ * These bare forms have no `Const.` anchor and no `of the <State>
+ * Constitution` trailer, so the tight `Article <num>, Section <num>`
+ * adjacency (comma-separated) is the false-positive guard and confidence
+ * is 0.5 — matching `bare-article`. "Article"/"Art." is case-sensitive so
+ * lowercase contract/bylaw prose ("article 7, section 3 of our bylaws")
+ * does not match.
+ */
+const constOf = (t: string) =>
+  extractCitations(t).filter((c) => c.type === "constitutional") as Array<{
+    article?: number
+    section?: string
+    jurisdiction?: string
+    confidence: number
+  }>
+
+describe("Issue #321 - spelled-out Article N, Section N", () => {
+  it("`Article I, Section 8` (spelled article, Roman) extracts", () => {
+    const cs = constOf("Article I, Section 8 grants Congress power.")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].article).toBe(1)
+    expect(cs[0].section).toBe("8")
+    expect(cs[0].jurisdiction).toBeUndefined()
+  })
+
+  it("`Article 1, Section 10` (spelled article, Arabic) extracts", () => {
+    const cs = constOf("Article 1, Section 10 prohibits states from coining money.")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].article).toBe(1)
+    expect(cs[0].section).toBe("10")
+  })
+
+  it("`Art. 1, Section 6` (abbreviated article, word section) extracts", () => {
+    const cs = constOf("Art. 1, Section 6 protects legislative speech.")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].article).toBe(1)
+    expect(cs[0].section).toBe("6")
+  })
+
+  it("`Article IV, Section 2.` (trailing period) extracts section without the period", () => {
+    const cs = constOf("It violates Article IV, Section 2.")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].article).toBe(4)
+    expect(cs[0].section).toBe("2")
+  })
+
+  it("confidence is 0.5 (bare, no Const. anchor)", () => {
+    const cs = constOf("Article I, Section 8 is the source.")
+    expect(cs[0].confidence).toBe(0.5)
+  })
+
+  // False-positive guards / regressions
+  it("does NOT match `Article 7 of the lease and Section 3 of the addendum`", () => {
+    const cs = constOf("Article 7 of the lease and Section 3 of the addendum control.")
+    expect(cs).toHaveLength(0)
+  })
+
+  it("does NOT match lowercase prose without a trailer (`article 7, section 3`)", () => {
+    const cs = constOf("The article 7, section 3 of our bylaws says so.")
+    expect(cs).toHaveLength(0)
+  })
+
+  it("abbreviated `Art. I, § 10` (existing bare-article) still works", () => {
+    const cs = constOf("under Art. I, § 10")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].article).toBe(1)
+    expect(cs[0].section).toBe("10")
+  })
+})


### PR DESCRIPTION
## Why

Attorneys cite the U.S. Constitution in argument prose as `Article I, Section 8` far more than the Bluebook `U.S. Const. art. I, § 8` — the spelled-out form is the back-reference everyone actually writes.

**Today:** `extractCitations("Article I, Section 8 grants Congress power.")` returns `[]`. The `bare-article` pattern only accepts the abbreviated `Art.` token **and** a `§` symbol, so the spelled-out article + word-`Section` form (and the common `Art. 1, Section 6` mix) extracts as nothing.

**After this PR:** those forms extract as `type: "constitutional"` with `article` + `section` (jurisdiction undefined, confidence 0.5 — same as the existing bare-article form).

**Why this matters:** constitutional argument prose becomes navigable by citation analysis instead of silently dropping the single most common way the Constitution is referenced.

## What changed

- New `bare-article-section` pattern: `Article`/`Art.` + numeral, comma/semicolon, then `Section`/`§` + numeral.
- **False-positive guard** is the tight comma-separated adjacency plus a **case-sensitive** `Article`/`Art.` token — lowercase contract/bylaw prose like `article 7, section 3 of our bylaws` does **not** match, and `Article 7 of the lease and Section 3 …` does **not** match (no comma adjacency).
- A `(?<!Const\.?,?\s)` lookbehind (mirroring `bare-article`) stops it from also matching the `Art. I, §7` core inside a full `U.S. Const., Art. I, §7` citation already captured upstream.
- Routed through `extractConstitutional`; no new type, no API change.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **4377 passed**, 0 failed (263 files). New file `issueBareArticleSection.test.ts` (8 cases: 3 target forms, Roman/Arabic, trailing period, confidence, 2 FP guards, 1 bare-article regression).
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0
- One pattern-level test (`constitutionalPatterns.test.ts > matches comma after Const.`) initially went red on a contained duplicate match; root-caused to the missing lookbehind and fixed (not silenced).

## Scope boundary

Advances **#321** (an umbrella issue); does not close it. After this, two listed sub-forms still miss and remain for a follow-up: plural-section prose (`Sections 5 and 10 of Article I of the Ohio Constitution`) and historical-reform tracking (`former article XX, section 21 (now art. XIV, § 4)`). All other #321 sub-forms (bare amendment names, bare `Art. N, § N`, plural `amends.` lists, preamble, prose article/section-first) already work on `main`.

---
Assisted-by: Claude:claude-opus-4-8
