### PR TITLE
fix(extract): plural-section constitutional prose (#321)

### DIFF
--- a/.changeset/fix-plural-section-const.md
+++ b/.changeset/fix-plural-section-const.md
@@ -1,0 +1,14 @@
+---
+"eyecite-ts": patch
+---
+
+Extract plural-section constitutional prose (#321)
+
+`Sections 5 and 10 of Article I of the Ohio Constitution` (and Oxford-comma
+lists like `Sections 5, 7, and 10 of …`) now emit one `constitutional`
+citation per section, each sharing the article and jurisdiction. Previously
+the section-first prose pattern matched a single `Section N` only, so the
+coordinated plural form dropped every section. Mirrors the plural-section
+statute expansion (#453); the plural `Sections` keyword + `of Article`
+connector + closed `of the <State> Constitution` trailer keep false
+positives out.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -547,6 +547,11 @@ export function extractCitations(
   // share an implied jurisdiction with the preceding cite. (#707)
   expandChainedConstitutional(citations, cleaned, transformationMap)
 
+  // Step 4.32: Expand plural-section constitutional prose (`Sections 5 and
+  // 10 of Article I of the Ohio Constitution`) into one cite per section,
+  // sharing the head's article + jurisdiction. (#321)
+  expandPluralSectionConstitutional(citations, transformationMap)
+
   // Step 4.35: Detect bare-prefix `§§ N, N` lists that lack any code
   // identifier in front of the §§ marker. These never produce a head cite
   // through normal tokenization, so seed a head before expansion. (#563)
@@ -1487,6 +1492,69 @@ function expandPluralSectionList(
 
   if (newCitations.length === 0) return
   citations.push(...newCitations)
+  citations.sort((a, b) => a.span.cleanStart - b.span.cleanStart)
+}
+
+/**
+ * Issue #321 — Expand plural-section constitutional prose (`Sections 5 and
+ * 10 of Article I of the Ohio Constitution`) into one constitutional cite
+ * per section. The `state-const-prose-plural-section` pattern produces a
+ * head cite for the FIRST section; this pass parses the remaining section
+ * numbers out of the head's own text and emits a sibling for each, sharing
+ * the head's article + jurisdiction. Mirrors expandPluralSectionList (#453).
+ */
+function expandPluralSectionConstitutional(
+  citations: Citation[],
+  transformationMap: TransformationMap,
+): void {
+  const HEAD_RE = /^Sections\s+(\d+(?:[\s,]+(?:and\s+)?\d+)+)\s+of\s+Article\b/i
+  const added: Citation[] = []
+
+  for (const c of citations) {
+    if (c.type !== "constitutional") continue
+    const headMatch = HEAD_RE.exec(c.text)
+    if (!headMatch) continue
+
+    const listText = headMatch[1]
+    const listOffset = c.text.indexOf(listText)
+    if (listOffset < 0) continue
+
+    const article = (c as { article?: number }).article
+    const jurisdiction = (c as { jurisdiction?: string }).jurisdiction
+
+    // Collect every section number with its offset inside the list text.
+    const numRe = /\d+/g
+    let nm: RegExpExecArray | null
+    let first = true
+    while ((nm = numRe.exec(listText)) !== null) {
+      // The first number is the head cite — already emitted by the extractor.
+      if (first) {
+        first = false
+        continue
+      }
+      const cleanStart = c.span.cleanStart + listOffset + nm.index
+      const cleanEnd = cleanStart + nm[0].length
+      const { originalStart, originalEnd } = resolveOriginalSpan(
+        { cleanStart, cleanEnd },
+        transformationMap,
+      )
+      added.push({
+        type: "constitutional",
+        text: nm[0],
+        span: { cleanStart, cleanEnd, originalStart, originalEnd },
+        confidence: c.confidence,
+        matchedText: nm[0],
+        processTimeMs: 0,
+        patternsChecked: 1,
+        section: nm[0],
+        ...(article !== undefined ? { article } : {}),
+        ...(jurisdiction ? { jurisdiction } : {}),
+      } as Citation)
+    }
+  }
+
+  if (added.length === 0) return
+  citations.push(...added)
   citations.sort((a, b) => a.span.cleanStart - b.span.cleanStart)
 }
 

--- a/src/extract/extractConstitutional.ts
+++ b/src/extract/extractConstitutional.ts
@@ -280,12 +280,27 @@ export function extractConstitutional(
   if (
     token.patternId === "state-const-prose-declaration" ||
     token.patternId === "state-const-prose-section-article" ||
-    token.patternId === "state-const-prose-article-first"
+    token.patternId === "state-const-prose-article-first" ||
+    token.patternId === "state-const-prose-plural-section"
   ) {
     let article: number | undefined
     let section: string | undefined
     let stateName: string | undefined
-    if (token.patternId === "state-const-prose-declaration") {
+    if (token.patternId === "state-const-prose-plural-section") {
+      // #321 plural-section: `Sections 5 and 10 of Article I of the Ohio
+      // Constitution`. Head cite = FIRST section number; the remaining
+      // sections become siblings in expandPluralSectionConstitutional.
+      // Group layout: (1) section-number list, (2) article, (3) state.
+      const m =
+        /\bSections\s+(\d+(?:[\s,]+(?:and\s+)?\d+)+)\s+of\s+Article\s+([IVX]+|\d+)\s+of\s+the\s+([A-Za-z\s]+?)\s+Constitution\b/.exec(
+          text,
+        )
+      if (m) {
+        section = m[1].match(/\d+/)?.[0]
+        article = parseNumeral(m[2])
+        stateName = m[3].trim().toLowerCase()
+      }
+    } else if (token.patternId === "state-const-prose-declaration") {
       const m = /\b(?:art(?:icle)?\.?)\s+(\d+)\s+of\s+the\s+([A-Za-z\s]+?)\s+(?:Declaration\s+of\s+Rights|Constitution)\b/i.exec(text)
       if (m) {
         article = Number.parseInt(m[1], 10)

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -216,6 +216,27 @@ export const constitutionalPatterns: Pattern[] = [
     type: "constitutional",
   },
   {
+    // #321 — Plural-section prose: `Sections 5 and 10 of Article I of the
+    // Ohio Constitution`. The singular `state-const-prose-section-article`
+    // pattern matches one `Section N` only; this coordinated form emits one
+    // constitutional cite per section — the head (first section) here, the
+    // remaining siblings in `expandPluralSectionConstitutional` — all
+    // sharing the article + jurisdiction. The plural `Sections` keyword,
+    // the `of Article` connector (vs the singular `, Article`), and the
+    // closed `of the <State> Constitution` trailer keep false positives out
+    // (e.g. "Sections 5 and 10 of the lease" does not match).
+    //
+    // Group layout: (1) section-number list, (2) article numeral, (3) state.
+    id: "state-const-prose-plural-section",
+    regex: new RegExp(
+      String.raw`\bSections\s+(\d+(?:[\s,]+(?:and\s+)?\d+)+)\s+of\s+Article\s+([IVX]+|\d+)\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey|Ohio|California|Texas|Florida|Illinois|Michigan|New\s+York|Georgia|Virginia|Washington|Arizona|Colorado|Wisconsin|Minnesota|Indiana|Louisiana|Oregon|Tennessee|South\s+Carolina|Alabama|Missouri|Kentucky|Connecticut|Iowa|Mississippi|Arkansas|Kansas|Nevada|Utah|Hawaii|Alaska|Idaho|Maine|Montana|Nebraska|New\s+Mexico|North\s+Dakota|Oklahoma|Rhode\s+Island|South\s+Dakota|West\s+Virginia|Wyoming)\s+Constitution\b`,
+      "g",
+    ),
+    description:
+      'Plural-section prose: "Sections 5 and 10 of Article I of the Ohio Constitution" — #321',
+    type: "constitutional",
+  },
+  {
     id: "bare-amendment-word",
     regex: new RegExp(
       `(?<!Const\\.?,?\\s)\\b(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+(?:[Aa]mend(?:ment)?\\.?|[Aa]mdt\\.?)`,

--- a/tests/extract/issuePluralSectionConst.test.ts
+++ b/tests/extract/issuePluralSectionConst.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #321 (part: plural-section prose) — `Sections 5 and 10 of Article I
+ * of the Ohio Constitution`. The section-first prose pattern matches a
+ * single `Section N` only, so the coordinated plural form (`Sections N and
+ * M`) dropped every section. Each section number now emits its own
+ * `constitutional` citation sharing the article + jurisdiction, mirroring
+ * the plural-section statute expansion (#453) and bare-amendment-coord
+ * (#657).
+ */
+const consts = (t: string) =>
+  extractCitations(t).filter((c) => c.type === "constitutional") as Array<{
+    article?: number
+    section?: string
+    jurisdiction?: string
+  }>
+
+describe("Issue #321 - plural-section constitutional prose", () => {
+  it("`Sections 5 and 10 of Article I of the Ohio Constitution` → two cites", () => {
+    const cs = consts("violates Sections 5 and 10 of Article I of the Ohio Constitution")
+    expect(cs).toHaveLength(2)
+    expect(cs.map((c) => c.section)).toEqual(["5", "10"])
+    for (const c of cs) {
+      expect(c.article).toBe(1)
+      expect(c.jurisdiction).toBe("OH")
+    }
+  })
+
+  it("Oxford-comma list `Sections 5, 7, and 10 of Article I of the California Constitution` → three cites", () => {
+    const cs = consts("Sections 5, 7, and 10 of Article I of the California Constitution")
+    expect(cs.map((c) => c.section)).toEqual(["5", "7", "10"])
+    for (const c of cs) {
+      expect(c.article).toBe(1)
+      expect(c.jurisdiction).toBe("CA")
+    }
+  })
+
+  it("singular `Section 5(B), Article IV of the Ohio Constitution` unchanged (one cite)", () => {
+    const cs = consts("Section 5(B), Article IV of the Ohio Constitution")
+    expect(cs).toHaveLength(1)
+    expect(cs[0].section).toBe("5(B)")
+    expect(cs[0].article).toBe(4)
+    expect(cs[0].jurisdiction).toBe("OH")
+  })
+
+  it("FP guard: `Sections 5 and 10 of the lease agreement` (no Article/Constitution) → none", () => {
+    const cs = consts("See Sections 5 and 10 of the lease agreement.")
+    expect(cs).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Why

State constitutions are frequently cited by coordinated section lists — `Sections 5 and 10 of Article I of the Ohio Constitution` — but those dropped entirely.

**Today:** `extractCitations("Sections 5 and 10 of Article I of the Ohio Constitution")` returns `[]`. The section-first prose pattern only matches a single `Section N`, so the plural/coordinated form yields nothing.

**After this PR:** it returns **two** `constitutional` citations — section `5` and section `10`, each with `article: 1` and `jurisdiction: "OH"`. Oxford-comma lists (`Sections 5, 7, and 10 of …`) emit one per section too.

**Why this matters:** state-constitutional argument prose becomes navigable per-section instead of silently dropping multi-section references.

## What changed

- New `state-const-prose-plural-section` pattern matches the coordinated phrase; its **head** cite is the first section.
- New `expandPluralSectionConstitutional` post-processing pass re-parses the head's text and emits a sibling `constitutional` cite for each remaining section number, sharing the head's article + jurisdiction. This mirrors the existing plural-section **statute** expansion (`expandPluralSectionList`, #453).
- **False-positive guard:** the plural `Sections` keyword + the `of Article` connector (vs the singular `, Article`) + the closed `of the <State> Constitution` trailer. `Sections 5 and 10 of the lease agreement` does **not** match.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **4382 passed**, 0 failed (264 files). New `issuePluralSectionConst.test.ts`: two-section list, Oxford-comma three-section list, singular-form regression (unchanged → one cite), FP guard.
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0

## Scope boundary

Advances **#321**; does not close it. After this, the only remaining listed sub-form is historical-reform tracking (`former article XX, section 21 (now art. XIV, § 4)`), which needs a design decision (emit one cite vs. two + how to represent supersession) and is better split into its own issue. All other #321 sub-forms already work on `main`.

---
Assisted-by: Claude:claude-opus-4-8
