### PR TITLE
fix(clean): strip soft hyphens + PDF page-break markers (#676)

### DIFF
--- a/.changeset/fix-pdf-ocr-artifacts.md
+++ b/.changeset/fix-pdf-ocr-artifacts.md
@@ -1,0 +1,17 @@
+---
+"eyecite-ts": patch
+---
+
+Handle PDF/OCR artifacts: soft hyphens and page-break markers (#676)
+
+- Soft hyphen (U+00AD) is now stripped during Unicode normalization, so a
+  reporter split across a PDF line break (`100 F.­2d 123`) extracts cleanly.
+- Page-break marker lines — a number fenced by dashes on its own line
+  (`100\n— 14 —\nF.2d 123`) — are removed by a new `stripPageBreakMarkers`
+  cleaner so the citation rejoins across the artifact. Conservative: the
+  number must be dash-fenced AND line-bounded, so ordinary dashed prose is
+  untouched.
+
+Paragraph pincites (`¶ 12`) were already captured in `pinciteInfo.paragraph`
+(#204); a URL-safety invariant (`https://…/100/U.S./123` extracts nothing) now
+has explicit regression coverage.

--- a/src/clean/cleanText.ts
+++ b/src/clean/cleanText.ts
@@ -12,6 +12,7 @@ import {
   rejoinHyphenatedWords,
   replaceWhitespace,
   stripHtmlTags,
+  stripPageBreakMarkers,
 } from "./cleaners"
 
 /**
@@ -50,6 +51,7 @@ export function cleanText(
     stripHtmlTags,
     decodeHtmlEntities,
     rejoinHyphenatedWords,
+    stripPageBreakMarkers,
     replaceWhitespace,
     collapseSpaces,
     normalizeUnicode,

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -137,6 +137,26 @@ export function rejoinHyphenatedWords(text: string): string {
 }
 
 /**
+ * Strip PDF page-break marker lines — a number fenced by dashes on its own
+ * line (`\n— 14 —\n`) — that PDF-to-text conversion inserts mid-citation,
+ * splitting a citation across the artifact (`100\n— 14 —\nF.2d 123`). The
+ * marker plus its surrounding line breaks collapse to a single space so the
+ * citation text on either side rejoins. (#676)
+ *
+ * Conservative: the number must be fenced by dashes (em/en/hyphen) AND
+ * bounded by line breaks on both sides, so ordinary dashed prose and
+ * horizontal rules without a number are untouched. Must run before
+ * replaceWhitespace, which would otherwise erase the line-break anchors.
+ *
+ * @example
+ * stripPageBreakMarkers("Smith, 100\n— 14 —\nF.2d 123")
+ * // => "Smith, 100 F.2d 123"
+ */
+export function stripPageBreakMarkers(text: string): string {
+  return text.replace(/[\r\n]+[^\S\r\n]*[—–-]+[^\S\r\n]*\d+[^\S\r\n]*[—–-]+[^\S\r\n]*[\r\n]+/g, " ")
+}
+
+/**
  * Replace each whitespace character (tab, newline, etc.) with a regular space.
  * Does NOT collapse consecutive spaces — that's a separate step so the position
  * mapper can handle each transformation type correctly (same-length replacement
@@ -196,6 +216,10 @@ export function normalizeUnicode(text: string): string {
   // cleaned text length is never increased by the normalize() call.
   const stripped = text
     .replace(/[™®℠©]/g, "")
+    // Soft hyphen (U+00AD): a zero-width discretionary hyphen PDFs insert at
+    // line breaks. Strip it (don't replace with "-") so a reporter split
+    // across a line break (`F.2d` split by the hyphen) extracts cleanly. (#676)
+    .replace(/\u00AD/g, "")
     // Vulgar fractions (½ ⅓ ¼ ¾ ⅕ ⅖ ⅗ ⅘ ⅙ ⅚ ⅛ ⅜ ⅝ ⅞ ⅐ ⅑ ⅒ ⅔)
     .replace(/[¼-¾⅐-⅞]/g, "")
     // Numero sign (№) — common in older dockets; the surrounding "Docket"

--- a/tests/extract/issueAdversarialInputs2.test.ts
+++ b/tests/extract/issueAdversarialInputs2.test.ts
@@ -9,14 +9,14 @@ const caseOf = (text: string) => extractCitations(text).filter((c) => c.type ===
 
 describe("adversarial input regression — round 2", () => {
   describe("PDF / OCR artifacts", () => {
-    it.todo("soft hyphen `­` (U+00AD) inside reporter should normalize", () => {
+    it("soft hyphen `­` (U+00AD) inside reporter should normalize", () => {
       // PDFs often insert U+00AD as a discretionary hyphen at line breaks.
       // `100 F.­2d 123` should normalize to `100 F.2d 123` and extract.
       const cs = caseOf("100 F.­2d 123")
       expect(cs).toHaveLength(1)
     })
 
-    it.todo("page-number artifact `100\\n— 14 —\\nF.2d 123` (PDF page break)", () => {
+    it("page-number artifact `100\\n— 14 —\\nF.2d 123` (PDF page break)", () => {
       // PDF-to-text conversion inserts page numbers mid-citation: the
       // volume `100` and the rest of the citation `F.2d 123` are
       // separated by a `— 14 —` page marker. A robust cleaner should
@@ -39,12 +39,14 @@ describe("adversarial input regression — round 2", () => {
   })
 
   describe("paragraph pincites (¶)", () => {
-    it.todo("`Smith, 100 F.2d 100, ¶ 12` captures ¶12 as pincite", () => {
+    it("`Smith, 100 F.2d 100, ¶ 12` captures ¶12 as pincite", () => {
       const cs = caseOf("Smith, 100 F.2d 100, ¶ 12")
       expect(cs).toHaveLength(1)
-      // Verify pincite is captured — paragraph mark + number
-      const c = cs[0] as Record<string, unknown>
-      expect(c.pincite).toBeDefined()
+      // Paragraph pincites are captured in `pinciteInfo.paragraph` (#204), not
+      // the numeric `pincite` field — by design `page` and `paragraph` are
+      // mutually exclusive, so the page-only `pincite` stays undefined here.
+      const c = cs[0] as { pincite?: number; pinciteInfo?: { paragraph?: number } }
+      expect(c.pinciteInfo?.paragraph).toBe(12)
     })
 
     it("`Smith, 100 F.2d 100` (no pincite) still extracts", () => {
@@ -172,7 +174,7 @@ describe("adversarial input regression — round 2", () => {
   })
 
   describe("citation in URL — should NOT extract", () => {
-    it.todo("`https://example.com/100/U.S./123` does not extract a phantom case", () => {
+    it("`https://example.com/100/U.S./123` does not extract a phantom case", () => {
       // URLs containing what looks like a citation should be rejected.
       // Currently the slash separators stop the regex from matching,
       // but document the invariant.


### PR DESCRIPTION
## Why

Court opinions extracted from PDFs carry layout artifacts that split a citation mid-string, so the citation silently fails to extract.

**Today:**
- `extractCitations("100 F.­2d 123")` returns `[]` — a soft hyphen (U+00AD, the invisible discretionary hyphen PDFs insert at line breaks) sits inside the reporter, breaking `F.2d`.
- `extractCitations("Smith, 100\n— 14 —\nF.2d 123")` returns `[]` — a page-number line (`— 14 —`) landed between the volume and the rest of the citation.

**After this PR:** both extract the intended `100 F.2d 123`.

**Why this matters:** PDF-sourced opinions (the majority of real-world input) stop dropping citations at every page break and line-wrapped reporter.

## What changed

- **Soft hyphen (U+00AD)** is stripped in `normalizeUnicode` (alongside the existing trademark/fraction stripping). It's a zero-width discretionary hyphen, so it's removed rather than replaced with `-`.
- **`stripPageBreakMarkers`** — a new cleaner that removes a number fenced by dashes on its own line (`\n— 14 —\n`) and rejoins the surrounding text. It runs before whitespace normalization (which would erase the line-break anchors). Conservative: the number must be **dash-fenced and line-bounded**, so ordinary dashed prose and numberless horizontal rules are untouched.

Two `it.todo`s in `issueAdversarialInputs2.test.ts` are also promoted to real tests:
- **Paragraph pincites (`¶ 12`)** are already captured — in `pinciteInfo.paragraph` (#204), not the page-only numeric `pincite` field (page and paragraph are mutually exclusive by design). The todo asserted the wrong field; it now asserts `pinciteInfo.paragraph`.
- **URL safety** — `https://example.com/100/U.S./123` extracts nothing; now an explicit invariant test so future regex changes can't regress it.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **4386 passed**, 0 failed (264 files); the 4 formerly-`todo` cases in `issueAdversarialInputs2.test.ts` now pass.
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0
- Verified empirically before/after with a scratch probe; the global cleaner-pipeline changes pass the full corpus (clean + position-mapping suites) with no regressions.

Closes #676.

---
Assisted-by: Claude:claude-opus-4-8
