### PR TITLE
fix(clean): backscan survives zero-width-space + <br> artifacts (#693)

### DIFF
--- a/.changeset/fix-backscan-artifacts.md
+++ b/.changeset/fix-backscan-artifacts.md
@@ -1,0 +1,19 @@
+---
+"eyecite-ts": patch
+---
+
+Fix case-name backscan for zero-width-space and `<br>` artifacts (#693)
+
+Two PDF/HTML artifacts that dropped or fragmented case captions are now handled
+in the cleaner:
+
+- Zero-width space (U+200B) standing in for a separator (`Smith‹ZWSP›v. Jones`)
+  was stripped (joining `Smithv.`) and lost the plaintiff; it now normalizes to
+  a space.
+- `<br>` line breaks (`Smith<br>v.<br>Jones`) only became a space when word
+  chars flanked both sides, so `v.<br>Jones` fused to `v.Jones`; `<br>` now
+  always collapses to a space.
+
+Trademark/registered symbols were already handled (#744). Em-dash and ellipsis
+separators remain documented limitations — the punctuation marks an
+interruption/omission, not a continuous case name.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -94,6 +94,10 @@ export function stripHtmlTags(text: string): string {
     const before = offset > 0 ? stripped[offset - 1] : ""
     const afterIdx = offset + match.length
     const after = afterIdx < stripped.length ? stripped[afterIdx] : ""
+    // A `<br>` line break is a visual separation, so it collapses to a space
+    // even when flanked by non-word chars (`v.<br>Jones` → `v. Jones`),
+    // unlike inline tags which only space two fused word chars. (#693)
+    if (/<br\b/i.test(match)) return " "
     return /\w/.test(before) && /\w/.test(after) ? " " : ""
   })
 }
@@ -167,7 +171,7 @@ export function stripPageBreakMarkers(text: string): string {
  * // => "Smith v. Doe"
  */
 export function replaceWhitespace(text: string): string {
-  return text.replace(/[\t\n\r\u00A0\u2000-\u200A\u202F\u205F\u3000]/g, " ")
+  return text.replace(/[\t\n\r\u00A0\u2000-\u200B\u202F\u205F\u3000\uFEFF]/g, " ")
 }
 
 /**
@@ -190,7 +194,7 @@ export function collapseSpaces(text: string): string {
  * // => "Smith v. Doe, 500 F.2d 123"
  */
 export function normalizeWhitespace(text: string): string {
-  return text.replace(/[\t\n\r\u00A0\u2000-\u200A\u202F\u205F\u3000]+/g, " ").replace(/ {2,}/g, " ")
+  return text.replace(/[\t\n\r\u00A0\u2000-\u200B\u202F\u205F\u3000\uFEFF]+/g, " ").replace(/ {2,}/g, " ")
 }
 
 /**

--- a/tests/extract/issue693BackscanArtifacts.test.ts
+++ b/tests/extract/issue693BackscanArtifacts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #693 — case-name backscan vs. PDF/HTML artifacts. Trademark/registered
+ * symbols (™ ® ℠ ©) were already fixed in #744. This covers the two remaining
+ * actionable artifacts, both of which dropped or fragmented the caption:
+ *
+ *   - Zero-width space (U+200B) standing in for a word separator
+ *     (`Smith<U+200B>v. Jones`) — was stripped (joining `Smithv.`), losing the
+ *     plaintiff. Now normalized to a space.
+ *   - `<br>` line breaks (`Smith<br>v.<br>Jones`) — stripHtmlTags only spaced a
+ *     tag run when word chars flanked both sides, so `v.<br>Jones` fused to
+ *     `v.Jones`. `<br>` now always collapses to a space.
+ *
+ * Em-dash (`Smith — the leading case —`) and ellipsis (`Smith… see`) remain
+ * documented limitations — the punctuation marks an interruption / omission,
+ * not a continuous case name.
+ */
+const caseName = (t: string): string | undefined => {
+  const c = extractCitations(t).find((x) => x.type === "case") as { caseName?: string } | undefined
+  return c?.caseName
+}
+
+describe("Issue #693 - backscan artifacts", () => {
+  it("zero-width space separator keeps the full caption", () => {
+    expect(caseName("Smith\u200Bv. Jones, 100 F.2d 1")).toBe("Smith v. Jones")
+  })
+
+  it("`<br>` line breaks between caption parts keep the full caption", () => {
+    expect(caseName("Smith<br>v.<br>Jones, 100 F.2d 1")).toBe("Smith v. Jones")
+  })
+
+  it("`<br/>` self-closing variant also works", () => {
+    expect(caseName("Smith<br/>v.<br/>Jones, 100 F.2d 1")).toBe("Smith v. Jones")
+  })
+
+  it("trademark/registered symbols still resolved (#744 regression)", () => {
+    expect(caseName("Smith™ v. Jones®, 100 F.2d 1")).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
## Why

Case captions are recovered by scanning backward from a citation. Two PDF/HTML artifacts silently broke that scan, dropping or fragmenting the caption.

**Today:**
- `extractCitations("Smith​v. Jones, 100 F.2d 1")` (a zero-width space between `Smith` and `v.`) → `caseName: "Jones"` — the plaintiff is lost.
- `extractCitations("Smith<br>v.<br>Jones, 100 F.2d 1")` → `caseName: undefined` — the whole caption is lost.

**After this PR:** both yield `caseName: "Smith v. Jones"`.

**Why this matters:** copied-from-PDF and HTML-sourced opinions stop losing the party names that anchor every short-form back-reference.

## Root cause (each confirmed empirically)

- **Zero-width space (U+200B):** the cleaner *stripped* it, fusing `Smith​v.` → `Smithv.`, which the backscan can't parse as a plaintiff. It's semantically a space, so it now normalizes to one (added to the whitespace cleaners alongside U+FEFF).
- **`<br>`:** `stripHtmlTags` only turned a tag run into a space when word chars flanked **both** sides, so `v.<br>Jones` (a `.` precedes the tag) collapsed to `v.Jones`. A `<br>` is a line break — it now always collapses to a space, regardless of neighbors.

## What changed

- `src/clean/cleaners.ts`: U+200B (and U+FEFF) added to `replaceWhitespace` / `normalizeWhitespace`; `stripHtmlTags` special-cases `<br>` to always emit a space.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **4390 passed**, 0 failed (265 files). New `issue693BackscanArtifacts.test.ts`: ZWSP, `<br>`, `<br/>`, and a ™/® regression.
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0

## Scope

Closes **#693**. Of the originally-reported artifacts: ™/® was already fixed (#744); ZWSP and `<br>` are fixed here. Em-dash (`Smith — the leading case —`) and ellipsis (`Smith… see`) remain **documented limitations** — that punctuation marks a parenthetical interruption or an omission, not a continuous case name, so a null caption is the defensible result.

---
Assisted-by: Claude:claude-opus-4-8
