### PR TITLE
fix(clean): block-element boundaries stop case-name fusion (#701)

### DIFF
--- a/.changeset/fix-html-block-fusion.md
+++ b/.changeset/fix-html-block-fusion.md
@@ -1,0 +1,13 @@
+---
+"eyecite-ts": patch
+---
+
+Stop HTML block boundaries from fusing into case names (#701)
+
+`stripHtmlTags` turned a tag run between two block elements into a single space
+(or nothing, after a period), so a heading or table cell merged into the
+following paragraph's caption — `<h2>Case</h2><p>Smith v. Jones` extracted
+caseName `"Case Smith v. Jones"`. Block-level boundaries (`p`, `div`, `h1`-`h6`,
+`li`, `tr`/`td`, `section`, …) now collapse to a sentence boundary so the
+case-name backscan stops there. `<br>` stays a space (an in-flow line break,
+#693) and inline tags (`<b>`, `<a>`) keep their word-fusion-only behavior.

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -64,6 +64,15 @@
  * stripHtmlTags("<![CDATA[500 F.2d 123]]>")
  * // => "500 F.2d 123"          // CDATA markers stripped, body kept (#561)
  */
+/** Block-level / sectioning HTML tags whose boundaries separate logical text
+ *  units (heading vs paragraph, list items, table cells). When stripped, these
+ *  must leave a sentence boundary — not a bare space — so the case-name
+ *  backscan stops there instead of fusing across the boundary (#701). `<br>`
+ *  is intentionally excluded: it is an in-flow line break that should stay a
+ *  space so a caption split across it is preserved (#693). */
+const BLOCK_TAG_RE =
+  /<\/?(?:p|div|h[1-6]|li|ul|ol|dl|dd|dt|table|thead|tbody|tfoot|tr|td|th|caption|section|article|aside|header|footer|nav|main|blockquote|figure|figcaption|hr|pre|address|form|fieldset)\b/i
+
 export function stripHtmlTags(text: string): string {
   // Pre-pass 1+2: delete script/style bodies (tag + body + close tag).
   // Body matching is non-greedy across any character (including newlines)
@@ -94,6 +103,19 @@ export function stripHtmlTags(text: string): string {
     const before = offset > 0 ? stripped[offset - 1] : ""
     const afterIdx = offset + match.length
     const after = afterIdx < stripped.length ? stripped[afterIdx] : ""
+    // Block-level boundaries separate logical units → leave a sentence
+    // boundary so the case-name backscan stops here instead of fusing the
+    // heading/cell into the following caption (`<h2>Case</h2><p>Smith...` →
+    // `Case. Smith...`). If the preceding char already ends a sentence (or
+    // there is none), a plain space suffices — avoids a doubled terminator
+    // (`First para.` + `</p><p>` → `First para. Brown`, not `para.. Brown`). (#701)
+    if (BLOCK_TAG_RE.test(match)) {
+      // No separator at the document edges — nothing to separate from.
+      if (before === "" || after === "") return ""
+      // A plain space suffices when a sentence terminator already precedes
+      // (avoids `para.. Brown`); otherwise insert one so the backscan stops.
+      return /[.!?]/.test(before) ? " " : ". "
+    }
     // A `<br>` line break is a visual separation, so it collapses to a space
     // even when flanked by non-word chars (`v.<br>Jones` → `v. Jones`),
     // unlike inline tags which only space two fused word chars. (#693)

--- a/tests/clean/stripHtmlTagsBlockFusion.test.ts
+++ b/tests/clean/stripHtmlTagsBlockFusion.test.ts
@@ -29,13 +29,16 @@ describe("#558 — block-element fusion phantom citations", () => {
     expect(cites).toHaveLength(2)
   })
 
-  it("preserves the cleaned text (block-element separator stays a single space)", () => {
-    // The fix is at the dedup layer — cleaned text shape is unchanged.
-    // Pinning this so a future cleaner change doesn't silently regress
-    // the position map.
+  it("preserves the cleaned text (block-element separator is a sentence boundary)", () => {
+    // #701 changed block-element boundaries from a bare space to a sentence
+    // boundary (". ") so the case-name backscan stops at the boundary instead
+    // of fusing the two paragraphs. This also strengthens #558: the period
+    // prevents the phantom journal token (`123 Then citing 600`) at the
+    // source, not only at the dedup layer (the no-phantom + span-position
+    // tests above still pass).
     const input = "<p>500 F.2d 123</p><p>Then citing 600 F.2d 234</p>"
     const { cleaned } = cleanText(input)
-    expect(cleaned).toBe("500 F.2d 123 Then citing 600 F.2d 234")
+    expect(cleaned).toBe("500 F.2d 123. Then citing 600 F.2d 234")
   })
 
   it("end-to-end span positions of the two real cites are not disturbed", () => {

--- a/tests/extract/issue701HtmlBlockFusion.test.ts
+++ b/tests/extract/issue701HtmlBlockFusion.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #701 — stripHtmlTags fused words across block-element boundaries. A
+ * tag run between word chars became a single space, so a heading and the
+ * following paragraph merged into one string and the case-name backscan
+ * swallowed the heading (`<h2>Case</h2><p>Smith v. Jones` → "Case Smith v.
+ * Jones"). When the boundary followed a `.` the run became "" instead, fusing
+ * `para.Brown`.
+ *
+ * Block-level boundaries (`p`, `div`, `h1`-`h6`, `li`, `tr`/`td`, etc.) now
+ * collapse to a sentence boundary so the backscan stops there. `<br>` stays a
+ * space (an in-flow line break — #693) and inline tags (`<b>`, `<i>`, `<a>`)
+ * keep the word-fusion-only behavior.
+ */
+const caseName = (t: string): string | undefined => {
+  const c = extractCitations(t).find((x) => x.type === "case") as { caseName?: string } | undefined
+  return c?.caseName
+}
+
+describe("Issue #701 - HTML block-element word fusion", () => {
+  it("heading then paragraph does not fuse into the caption", () => {
+    expect(caseName("<div><h2>Case</h2><p>Smith v. Jones, 100 F.2d 1.</p></div>")).toBe(
+      "Smith v. Jones",
+    )
+  })
+
+  it("paragraph boundary after a period does not fuse (`para.Brown`)", () => {
+    expect(caseName("<p>First para.</p><p>Brown v. Board, 347 U.S. 483.</p>")).toBe(
+      "Brown v. Board",
+    )
+  })
+
+  it("table cells do not fuse across the boundary", () => {
+    expect(caseName("<tr><td>Foo</td><td>Smith v. Jones, 100 F.2d 1</td></tr>")).toBe(
+      "Smith v. Jones",
+    )
+  })
+
+  it("list items do not fuse across the boundary", () => {
+    expect(caseName("<ul><li>Heading</li><li>Smith v. Jones, 100 F.2d 1</li></ul>")).toBe(
+      "Smith v. Jones",
+    )
+  })
+
+  // Regression guards — these must keep their current correct behavior.
+  it("`<br>` line breaks still traverse the caption (#693)", () => {
+    expect(caseName("Smith<br>v.<br>Jones, 100 F.2d 1")).toBe("Smith v. Jones")
+  })
+
+  it("inline tags inside a caption do not break it", () => {
+    expect(caseName("<b>Smith</b> v. <i>Jones</i>, 100 F.2d 1")).toBe("Smith v. Jones")
+  })
+})


### PR DESCRIPTION
## Why

Legal opinions are often extracted from HTML, where a heading and the following paragraph are separate logical units. The cleaner erased that structure, fusing them into one string so the case-name backscan swallowed the heading.

**Today:** `extractCitations("<div><h2>Case</h2><p>Smith v. Jones, 100 F.2d 1.</p></div>")` → `caseName: "Case Smith v. Jones"` (the `<h2>` heading leaks into the caption). When the boundary follows a period it was worse — `<p>First para.</p><p>Brown…` fused to `para.Brown`.

**After this PR:** `caseName: "Smith v. Jones"` — the block boundary stops the backscan.

**Why this matters:** HTML-sourced opinions stop contaminating captions with headings, list labels, and table-cell text.

## What changed

`stripHtmlTags` previously turned any tag run between word chars into a single space. Now:
- **Block-level boundaries** (`p`, `div`, `h1`-`h6`, `li`, `ul`/`ol`, `tr`/`td`/`th`, `section`, `article`, `blockquote`, …) collapse to a **sentence boundary** (`. `) so the backscan stops there. A plain space is used when a terminator already precedes (no `para.. Brown`), and nothing is inserted at the document edges.
- **`<br>`** stays a space — it's an in-flow line break, so a caption split across it is preserved (#693).
- **Inline tags** (`<b>`, `<i>`, `<a>`, `<span>`) keep the word-fusion-only behavior.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **4402 passed**, 0 failed (267 files). New `issue701HtmlBlockFusion.test.ts`: heading/paragraph, period-boundary, table cells, list items, plus `<br>` (#693) and inline-tag regression guards.
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0
- The block-separator change shifts cleaned-text length, so I checked the position-mapping suites (#154 zero-length spans, combined-cleaners) — all pass after handling document edges. Updated the #558 cleaned-text pin to the new sentence-boundary value; #558's actual goals (no phantom journal cite, undisturbed span positions) still pass, and the period now prevents that phantom at the source.

Closes #701.

---
Assisted-by: Claude:claude-opus-4-8
