### PR TITLE
fix(extract): long-form federal rule variants (#295)

### DIFF
--- a/.changeset/fix-federal-rule-longform.md
+++ b/.changeset/fix-federal-rule-longform.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": patch
+---
+
+Extract long-form federal rule citations (#295)
+
+`Fed. Rule Bankr. P. 3001` and `Fed. Rule Crim. Proc. 46(b)` — the older
+long-form spellings that use `Rule` for `R.` and `Proc.` for `P.` — now extract
+as `federalRule` alongside the canonical abbreviations (`Fed. R. Crim. Proc. 46`
+also works). Bare `Rule N`, state procedural rules, and disciplinary rules
+remain other slices of #295.

--- a/src/extract/extractFederalRule.ts
+++ b/src/extract/extractFederalRule.ts
@@ -24,14 +24,18 @@ import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from 
  */
 const RULE_SET_MAP: ReadonlyMap<string, FederalRuleCitation["ruleSet"]> = new Map([
   ["civp", "civil"],
+  ["civproc", "civil"],
   ["civilprocedure", "civil"],
   ["crimp", "criminal"],
+  ["crimproc", "criminal"],
   ["criminalprocedure", "criminal"],
   ["evid", "evidence"],
   ["evidence", "evidence"],
   ["appp", "appellate"],
+  ["appproc", "appellate"],
   ["appellateprocedure", "appellate"],
   ["bankrp", "bankruptcy"],
+  ["bankrproc", "bankruptcy"],
   ["bankruptcyprocedure", "bankruptcy"],
   // Acronym forms (#696). Both bare (`FRCP`) and dotted (`F.R.C.P.`)
   // normalize via the period-and-space strip to the same lowercase key.
@@ -90,7 +94,7 @@ export function extractFederalRule(
   // Try the abbreviated form first (more common), then spelled-out,
   // then acronym (#696).
   const abbreviatedRegex =
-    /\bFed\.\s?R\.\s?(Civ\.\s?P\.|Crim\.\s?P\.|Evid\.|App\.\s?P\.|Bankr\.\s?P\.)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/d
+    /\bFed\.\s?(?:R\.|Rules?)\s?(Civ\.\s?(?:P\.|Proc\.)|Crim\.\s?(?:P\.|Proc\.)|Evid\.|App\.\s?(?:P\.|Proc\.)|Bankr\.\s?(?:P\.|Proc\.))\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/d
   const spelledRegex =
     /\bFederal\s+Rules?\s+of\s+(?:the\s+)?(Civil\s+Procedure|Criminal\s+Procedure|Evidence|Appellate\s+Procedure|Bankruptcy\s+Procedure)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/di
   const acronymRegex =

--- a/src/patterns/federalRulePatterns.ts
+++ b/src/patterns/federalRulePatterns.ts
@@ -32,11 +32,15 @@ export const federalRulePatterns: Pattern[] = [
     //
     // Subsection chain `(a)(1)(B)(i)` is captured greedily after the rule
     // number; the extractor splits it from the bare rule.
+    // The `R.` token also accepts the older long-form `Rule`/`Rules`, and
+    // each `P.`-suffixed set also accepts the long-form `Proc.`, so
+    // `Fed. Rule Bankr. P. 3001` and `Fed. Rule Crim. Proc. 46(b)` tokenize
+    // alongside the canonical abbreviations (#295).
     id: "fed-rule-abbreviated",
     regex:
-      /\bFed\.\s?R\.\s?(Civ\.\s?P\.|Crim\.\s?P\.|Evid\.|App\.\s?P\.|Bankr\.\s?P\.)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+      /\bFed\.\s?(?:R\.|Rules?)\s?(Civ\.\s?(?:P\.|Proc\.)|Crim\.\s?(?:P\.|Proc\.)|Evid\.|App\.\s?(?:P\.|Proc\.)|Bankr\.\s?(?:P\.|Proc\.))\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
     description:
-      'Abbreviated federal rules: "Fed. R. Civ. P. 56", "Fed. R. Evid. 401", "Fed.R.Bankr.P. 7001" — #576',
+      'Abbreviated federal rules: "Fed. R. Civ. P. 56", "Fed. Rule Crim. Proc. 46(b)", "Fed.R.Bankr.P. 7001" — #576, #295',
     type: "federalRule",
   },
   {

--- a/tests/extract/issue295FederalRuleLongForm.test.ts
+++ b/tests/extract/issue295FederalRuleLongForm.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+/**
+ * Issue #295 (slice: long-form federal rule variants). The abbreviated
+ * pattern required `Fed. R.` + a `P.`-suffixed set, so the older long-form
+ * spellings — `Fed. Rule Bankr. P. 3001`, `Fed. Rule Crim. Proc. 46(b)` —
+ * extracted as nothing. The pattern now accepts `Rule`/`Rules` for `R.` and
+ * `Proc.` for `P.`. (Bare `Rule N`, state procedural rules, and disciplinary
+ * rules remain other slices of #295.)
+ */
+const fedRule = (t: string) =>
+  extractCitations(t).find((c) => c.type === "federalRule") as
+    | { ruleSet?: string; rule?: string; subsection?: string }
+    | undefined
+
+describe("Issue #295 - long-form federal rules", () => {
+  it("`Fed. Rule Bankr. P. 3001` (long-form Rule) extracts", () => {
+    const c = fedRule("Petitioner moved under Fed. Rule Bankr. P. 3001.")
+    expect(c?.ruleSet).toBe("bankruptcy")
+    expect(c?.rule).toBe("3001")
+  })
+
+  it("`Fed. Rule Crim. Proc. 46(b)` (long-form Rule + Proc.) extracts", () => {
+    const c = fedRule("See Fed. Rule Crim. Proc. 46(b).")
+    expect(c?.ruleSet).toBe("criminal")
+    expect(c?.rule).toBe("46")
+    expect(c?.subsection).toBe("(b)")
+  })
+
+  it("`Fed. R. Crim. Proc. 46` (abbreviated R. + spelled Proc.) extracts", () => {
+    const c = fedRule("Fed. R. Crim. Proc. 46 governs.")
+    expect(c?.ruleSet).toBe("criminal")
+    expect(c?.rule).toBe("46")
+  })
+
+  // Regression controls — canonical forms unchanged.
+  it("`Fed. R. Civ. P. 12(b)(6)` still extracts", () => {
+    const c = fedRule("Fed. R. Civ. P. 12(b)(6)")
+    expect(c?.ruleSet).toBe("civil")
+    expect(c?.rule).toBe("12")
+    expect(c?.subsection).toBe("(b)(6)")
+  })
+
+  it("`Fed. R. Bankr. P. 3001` (abbreviated) still extracts", () => {
+    const c = fedRule("Fed. R. Bankr. P. 3001")
+    expect(c?.ruleSet).toBe("bankruptcy")
+    expect(c?.rule).toBe("3001")
+  })
+})


### PR DESCRIPTION
## Why

`Fed. R. Civ. P. 12(b)(6)` works, but the older **long-form** spellings — which use `Rule` for `R.` and `Proc.` for `P.` — extracted as nothing.

**Today:** `extractCitations("Fed. Rule Crim. Proc. 46(b)")` and `extractCitations("Fed. Rule Bankr. P. 3001")` return `[]`.

**After this PR:** both extract as `federalRule` (criminal rule 46(b); bankruptcy rule 3001). `Fed. R. Crim. Proc. 46` (abbreviated `R.` + spelled `Proc.`) works too.

**Why this matters:** older opinions and briefs that use the long-form spelling stop dropping their rule citations.

## What changed

The abbreviated federal-rule recognition (pattern + the extractor's mirrored re-parse) now accepts `Rule`/`Rules` as an alternative to `R.`, and `Proc.` as an alternative to `P.` in each set. `RULE_SET_MAP` gains the `*proc` lookup keys (`crimproc` → criminal, etc.). No new FP surface — the `Fed.` prefix + rule-set + number anchor is unchanged.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **4401 passed**, 0 failed (267 files). New `issue295FederalRuleLongForm.test.ts`: 3 long-form variants + 2 canonical-form regression controls.
- `pnpm typecheck` — clean
- `pnpm lint` — exit 0

## Scope

Advances **#295** (does not close it). This handles the "long-form variants" bullet; bare `Rule 12(b)(6)`, state procedural rules (`Crim.R. 32.1`, `Tex. R. App. P.`), specialty-court rules (`RCFC`, `R.C.M.`), and disciplinary rules (`DR 1-102`, `Prof. Cond. R.`) remain separate slices.

---
Assisted-by: Claude:claude-opus-4-8
