### PR TITLE
fix(resolve): supra/shortForm antecedentIndex mirrors resolvedTo (#795)

### DIFF
--- a/.changeset/fix-795-supra-shortform-antecedent-agreement.md
+++ b/.changeset/fix-795-supra-shortform-antecedent-agreement.md
@@ -1,0 +1,25 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): supra/shortFormCase `antecedentIndex` agrees with `resolvedTo` on success path (#795)
+
+#508 established that a resolved short-form's `antecedentIndex` mirrors
+`resolvedTo` on the success path so consumers have one source of truth, but
+applied the fix only to the `Id.` resolver. The supra and short-form-case
+success paths still computed `antecedentIndex` from a position-only
+`findImmediatePredecessor` walk, so when an intervening citation of a
+different case sat between the resolved antecedent and the short form, the
+two pointers disagreed: `resolvedTo` pointed at the resolved antecedent
+while `antecedentIndex` pointed at the intervening cite.
+
+The three success paths now mirror `resolvedTo`:
+`createSupraSuccess`, the short-form-case party-name match, and the
+short-form-case recency fallback. `findImmediatePredecessor` remains the
+fallback only for the unresolved/positional path, where `resolvedTo` is
+undefined (e.g. the case name appears only in prose) and a subsequent `Id.`
+still needs to cluster with the short form.
+
+Example: `Brown ... Mapp ... Brown, supra` now reports
+`antecedentIndex = resolvedTo` (Brown) instead of pointing at the
+intervening Mapp.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -671,7 +671,7 @@ export class DocumentResolver {
         currentIndex,
       )
       if (captionMatch) {
-        return this.createSupraSuccess(citation, captionMatch)
+        return this.createSupraSuccess(captionMatch)
       }
     }
 
@@ -707,22 +707,26 @@ export class DocumentResolver {
       )
     }
 
-    return this.createSupraSuccess(citation, bestMatch)
+    return this.createSupraSuccess(bestMatch)
   }
 
-  private createSupraSuccess(
-    citation: SupraCitation,
-    match: { index: number; similarity: number },
-  ): ResolutionResult {
+  private createSupraSuccess(match: { index: number; similarity: number }): ResolutionResult {
     // Return successful resolution with confidence based on similarity
     const warnings: string[] = []
     if (match.similarity < 1.0) {
       warnings.push(`Fuzzy match: similarity ${match.similarity.toFixed(2)}`)
     }
 
+    // #795: `antecedentIndex` mirrors `resolvedTo` on the success path so
+    // consumers see one source of truth, matching the #508 `Id.` fix. The
+    // pre-fix code called `findImmediatePredecessor` here, which walks the
+    // array by position and returns an intervening citation of a different
+    // case when one sits between the party-name antecedent and the supra.
+    // `findImmediatePredecessor` remains the fallback only for the
+    // unresolved/positional path where no `resolvedTo` is available.
     return {
       resolvedTo: match.index,
-      antecedentIndex: this.findImmediatePredecessor(citation),
+      antecedentIndex: match.index,
       confidence: match.similarity,
       warnings: warnings.length > 0 ? warnings : undefined,
     }
@@ -940,7 +944,8 @@ export class DocumentResolver {
       if (namedMatch !== undefined) {
         return {
           resolvedTo: namedMatch,
-          antecedentIndex: this.findImmediatePredecessor(citation),
+          // #795: mirror `resolvedTo` on the success path (see createSupraSuccess).
+          antecedentIndex: namedMatch,
           confidence: 0.98, // Higher than bare vol+reporter — party-name disambiguation tightens.
         }
       }
@@ -949,7 +954,8 @@ export class DocumentResolver {
     // No party name (or no name match): pick most recent candidate.
     return {
       resolvedTo: candidates[0],
-      antecedentIndex: this.findImmediatePredecessor(citation),
+      // #795: mirror `resolvedTo` on the success path (see createSupraSuccess).
+      antecedentIndex: candidates[0],
       confidence: 0.95,
     }
   }

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -77,15 +77,18 @@ export interface ResolutionResult {
   resolvedTo?: number
 
   /**
-   * Index of the immediately preceding cited authority in document order,
-   * regardless of whether *that* citation itself resolved to a full cite.
-   * Bluebook Rule 4.1 / Indigo Book R6.2.2: `Id.` anchors here.
+   * Index of this short-form's antecedent.
    *
-   * - When the predecessor is a full citation or successfully-resolved
-   *   short-form, this points one step back (may equal `resolvedTo`).
-   * - When the predecessor is an unresolved short-form (e.g. because the
-   *   case name appears only in prose), this still points at it; the
-   *   `resolvedTo` field stays undefined.
+   * - SUCCESS path (`resolvedTo` defined): mirrors `resolvedTo`, so consumers
+   *   have one source of truth for what the short-form points at — even when
+   *   an intervening citation of a different authority sits between the
+   *   resolved antecedent and the short-form (#508 for `Id.`, #795 for supra
+   *   and shortFormCase).
+   * - UNRESOLVED/fallback path (`resolvedTo` undefined, e.g. the case name
+   *   appears only in prose): points at the immediately preceding cited
+   *   authority in document order per Bluebook Rule 4.1 / Indigo Book
+   *   R6.2.2, so a subsequent `Id.` (or a consumer walking the chain) can
+   *   still cluster with the short-form.
    * - Records the immediate predecessor only; follow transitively via
    *   `resolutions[antecedentIndex].antecedentIndex` for the originator.
    *   Same idiom as `ShortFormCaseCitation.pinciteInheritedFrom`.

--- a/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
+++ b/tests/resolve/idWalksToUnresolvedAntecedent.test.ts
@@ -73,21 +73,23 @@ describe("antecedentIndex — Id. clusters with unresolved short-form (Bluebook 
   })
 })
 
-describe("supra success path also populates antecedentIndex", () => {
-  it("Smith → Brown → Smith, supra — supra resolves AND records antecedentIndex one step back", () => {
+describe("supra success path: antecedentIndex agrees with resolvedTo (#795)", () => {
+  it("Smith → Brown → Smith, supra — both pointers are the resolved case (Smith)", () => {
+    // Pre-#795 the supra success path used `findImmediatePredecessor` for
+    // `antecedentIndex`, which returned the intervening Brown (idx 1) while
+    // `resolvedTo` correctly pointed at Smith (idx 0). #795 mirrors
+    // `resolvedTo` on the success path so the two agree — matching the #508
+    // `Id.` invariant.
     const text =
       "Smith v. Jones, 100 F.2d 50 (1990). Brown v. Doe, 200 F.3d 100 (2000). Smith, supra."
     const cites = extractCitations(text, { resolve: true })
     expect(cites).toHaveLength(3)
     const supra = cites[2]
     expect(supra.type).toBe("supra")
-    expect(
-      (supra as { resolution?: { resolvedTo?: number; antecedentIndex?: number } }).resolution
-        ?.resolvedTo,
-    ).toBe(0) // resolves to Smith
-    expect(
-      (supra as { resolution?: { resolvedTo?: number; antecedentIndex?: number } }).resolution
-        ?.antecedentIndex,
-    ).toBe(1) // immediate predecessor is Brown (one step back)
+    const resolution = (
+      supra as { resolution?: { resolvedTo?: number; antecedentIndex?: number } }
+    ).resolution
+    expect(resolution?.resolvedTo).toBe(0) // resolves to Smith
+    expect(resolution?.antecedentIndex).toBe(0) // #795: mirrors resolvedTo (was 1, the intervening Brown)
   })
 })

--- a/tests/resolve/issue795_supraShortFormAntecedentAgreement.test.ts
+++ b/tests/resolve/issue795_supraShortFormAntecedentAgreement.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Issue #795: `antecedentIndex` disagrees with `resolvedTo` on the
+ * supra / shortFormCase **success** paths, breaking the #508 invariant.
+ *
+ * #508 established that a resolved short-form's `antecedentIndex` mirrors
+ * `resolvedTo` on the success path so consumers have one source of truth.
+ * That fix was applied only to the `Id.` resolver; the supra and
+ * shortFormCase success paths still computed `antecedentIndex` via
+ * `findImmediatePredecessor` — a position-only walk that returns the
+ * immediately preceding cite regardless of which authority actually
+ * resolved. When an intervening citation of a *different* case sits
+ * between the true antecedent and the short form, the two pointers
+ * disagree: `resolvedTo` points at the resolved antecedent while
+ * `antecedentIndex` points at the intervening cite.
+ *
+ * Fix (matching the #508 `Id.` shape): mirror `resolvedTo` on the three
+ * success paths. `findImmediatePredecessor` remains the fallback only for
+ * the unresolved/positional path, where `resolvedTo` is undefined.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #795: supra/shortFormCase antecedentIndex agrees with resolvedTo on the success path", () => {
+  it("supra named-match across an intervening case — both pointers are the resolved case", () => {
+    // Brown (#0) → Mapp (#1) → Brown, supra (#2). The supra resolves by
+    // party name to Brown; the positional predecessor is the intervening
+    // Mapp. Both pointers must be Brown.
+    const text =
+      "Brown v. Board of Education, 347 U.S. 483 (1954). " +
+      "The Court later decided Mapp v. Ohio, 367 U.S. 643 (1961). " +
+      "But Brown, supra, at 500, controls."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const brown = citations.find((c) => c.type === "case" && c.volume === 347)!
+    const supra = citations.find((c) => c.type === "supra")!
+    expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(brown))
+    expect(supra.resolution?.antecedentIndex).toBe(supra.resolution?.resolvedTo)
+  })
+
+  it("shortFormCase party-name match across an intervening case — both pointers are the named case", () => {
+    // Smith 100 F.3d (#0) → Doe 200 F.3d (#1) → Smith, 100 F.3d at 5 (#2).
+    // vol+reporter narrows to Smith and the party name confirms it; the
+    // positional predecessor is the intervening Doe. Both pointers = Smith.
+    const text =
+      "Smith v. Jones, 100 F.3d 1 (1990). " +
+      "Doe v. Roe, 200 F.3d 50 (2000). " +
+      "Smith, 100 F.3d at 5."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = citations.find((c) => c.type === "case" && c.volume === 100)!
+    const shortForm = citations.find((c) => c.type === "shortFormCase")!
+    expect(shortForm.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    expect(shortForm.resolution?.antecedentIndex).toBe(shortForm.resolution?.resolvedTo)
+  })
+
+  it("shortFormCase recency-fallback across an intervening case — both pointers are the resolved case", () => {
+    // Same shape with no back-reference party name, exercising the
+    // recency-fallback branch: `100 F.3d at 5` resolves to the only
+    // vol+reporter match (Smith), not the positional predecessor (Doe).
+    const text =
+      "Smith v. Jones, 100 F.3d 1 (1990). " +
+      "Doe v. Roe, 200 F.3d 50 (2000). " +
+      "100 F.3d at 5."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = citations.find((c) => c.type === "case" && c.volume === 100)!
+    const shortForm = citations.find((c) => c.type === "shortFormCase")!
+    expect(shortForm.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    expect(shortForm.resolution?.antecedentIndex).toBe(shortForm.resolution?.resolvedTo)
+  })
+
+  it("immediate antecedent (no intervening cite) — already agreed; lock it in", () => {
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). Smith, supra, at 5."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const smith = citations.find((c) => c.type === "case")!
+    const supra = citations.find((c) => c.type === "supra")!
+    expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(smith))
+    expect(supra.resolution?.antecedentIndex).toBe(citations.indexOf(smith))
+  })
+
+  it("carve-out: unresolved shortFormCase still records the positional predecessor", () => {
+    // vol+reporter lookup fails (400 F.3d ≠ 500 F.2d) → resolvedTo undefined.
+    // The fallback path keeps `findImmediatePredecessor` so a later `Id.` (or
+    // a consumer walking the chain) can still cluster with the short form.
+    const text = "Smith v. Jones, 500 F.2d 123. See 400 F.3d at 200."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const shortForm = citations.find((c) => c.type === "shortFormCase")!
+    expect(shortForm.resolution?.resolvedTo).toBeUndefined()
+    expect(shortForm.resolution?.antecedentIndex).toBe(0)
+  })
+})


### PR DESCRIPTION
## Why

A resolved short-form citation (`supra`, or a short-form case like `100 F.3d at 5`) carries two back-pointers: `resolvedTo` (the full citation it resolves to) and `antecedentIndex` (the citation it points one step back to). #508 established that on a successful resolution the two should agree — one source of truth — but wired that invariant into the `Id.` resolver only.

For `supra` and short-form-case, `antecedentIndex` was still computed by walking backward to the *immediately preceding citation by position*. So whenever a citation of a different case sat between the true antecedent and the short form, the two pointers disagreed — and anything consuming `antecedentIndex` (e.g. the citation graph's "antecedent" edge) drew a link to the wrong case.

**Before:** `Brown ... Mapp ... Brown, supra` → `resolvedTo` = Brown, but `antecedentIndex` = Mapp (the intervening case).

**Now:** both point at Brown.

**Why this matters:** consumers can trust `antecedentIndex` and `resolvedTo` to name the same authority on any successful resolution, across all three short-form types — not just `Id.`.

## What changed

- The three success paths now mirror `resolvedTo`: `createSupraSuccess`, the short-form-case party-name match, and the short-form-case recency fallback.
- The unresolved/positional fallback (where `resolvedTo` is `undefined`, e.g. the case name appears only in prose) is intentionally unchanged — it still records the immediate predecessor so a later `Id.` can cluster with the short form.
- Dropped the now-unused `citation` parameter from the private `createSupraSuccess`.
- Reconciled the stale `antecedentIndex` type doc with the post-#508/#795 invariant, and updated the one `supra` test that pinned the old "one step back" value.

## Test plan

**What I ran:**
- Added `issue795_supraShortFormAntecedentAgreement.test.ts` — 5 cases (supra named-match, short-form party match, short-form recency fallback, immediate-antecedent regression, and the unresolved carve-out). All pass.
- `pnpm exec vitest run` — 269 files, **4412 passed, 0 failed**.
- `pnpm typecheck` — clean.
- `pnpm lint` — exit 0.

Fixes #795.

---
Assisted-by: Claude:claude-opus-4-8
