### PR TITLE
fix(resolve): supra skips parenthetical-internal antecedents (#799)

### DIFF
--- a/.changeset/fix-supra-paren-child-799.md
+++ b/.changeset/fix-supra-paren-child-799.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): `supra` no longer resolves to a case cited only inside another citation's parenthetical (#799)
+
+`resolveSupra` now excludes parenthetical-internal asides (`(quoting X)` / `(citing Y)`) as antecedents, matching `resolveId`'s #214 exclusion — so `X v. Y, supra` no longer attaches to a case named only inside another cite's aside. The exclusion uses a precise depth-based aside signal (`isParentheticalAside`) that, unlike the fullSpan-containment fallback, does **not** drop parallel-cite siblings (e.g. `Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705`), which remain valid supra antecedents.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -512,15 +512,31 @@ export class DocumentResolver {
   }
 
   /**
-   * `(citing X)` / `(quoting Y)` detection (#214). Two strategies in OR:
-   *   - paren depth > 0 at the citation's start (works for any prior
-   *     citation type — statute, journal, etc.);
+   * The precise "explanatory aside" signal: the citation sits inside a
+   * `(quoting X)` / `(citing Y)` parenthetical. Currently paren depth > 0 at
+   * the citation's start (works for any container type — case, statute,
+   * journal, etc.). Used directly by supra (#799), which must not anchor to a
+   * quoted-within authority but also must NOT be fooled by the fullSpan
+   * fallback below (which matches parallel-cite siblings). #798 extends this
+   * with trigger-word anchoring so dropped/unbalanced parentheses still count.
+   */
+  private isParentheticalAside(index: number): boolean {
+    return this.parenDepths[index] > 0
+  }
+
+  /**
+   * `(citing X)` / `(quoting Y)` detection for `Id.` antecedent selection
+   * (#214). Two strategies in OR:
+   *   - the precise aside signal (`isParentheticalAside` — paren depth);
    *   - the citation's clean-span is wholly inside a previously-resolved
    *     citation's `fullSpan` (case-name-prefixed citations sometimes have
    *     `(...)` ranges that close before the paren-depth scan catches up).
+   * Strategy 2 is intentionally NOT used by supra (#799): it also matches
+   * parallel-cite siblings, which share a caption `fullSpan` yet are valid
+   * supra antecedents.
    */
   private isParentheticalChild(index: number): boolean {
-    if (this.parenDepths[index] > 0) return true
+    if (this.isParentheticalAside(index)) return true
     const cit = this.citations[index]
     for (let i = 0; i < this.resolvedSoFar.length; i++) {
       if (i === index) continue // a citation cannot be a paren child of itself
@@ -750,6 +766,11 @@ export class DocumentResolver {
       const candidate = this.citations[i]
       if (candidate.type !== "case") continue
       if (!this.isWithinScope(i, currentIndex, true)) continue
+      // #799: a case cited only inside another cite's `(quoting …)` aside is
+      // not a valid supra antecedent, matching `resolveId`'s #214 exclusion.
+      // Uses the precise aside signal so parallel-cite siblings (which share a
+      // caption fullSpan) are NOT excluded.
+      if (this.isParentheticalAside(i)) continue
 
       const plaintiffSimilarity = this.partyNameSimilarity(
         plaintiffQuery,
@@ -797,6 +818,10 @@ export class DocumentResolver {
 
       // Check scope boundary (supra allows cross-zone: footnote -> body)
       if (!this.isWithinScope(citationIndex, currentIndex, true)) continue
+      // #799: skip antecedents cited only inside another cite's `(quoting …)`
+      // aside, matching `resolveId`'s #214 parenthetical-child exclusion. Uses
+      // the precise aside signal so parallel-cite siblings are not excluded.
+      if (this.isParentheticalAside(citationIndex)) continue
 
       // Convert distance to normalized similarity
       const maxLen = Math.max(queryLen, candidate.key.length)

--- a/tests/integration/resolution.test.ts
+++ b/tests/integration/resolution.test.ts
@@ -78,19 +78,21 @@ describe("Resolution Integration Tests", () => {
       expect(id.resolution?.resolvedTo).not.toBe(citations.indexOf(gall))
     })
 
-    it("supra still resolves to a parenthetical-internal citation", () => {
-      // Even though Gall doesn't become Id.'s default antecedent, it must
-      // still be tracked for supra/short-form lookups.
+    it("supra does NOT resolve to a parenthetical-internal citation (#799)", () => {
+      // #799 supersedes the prior #214 behavior: a case cited only inside
+      // another cite's `(citing …)` aside is not a valid supra antecedent,
+      // matching `resolveId`'s exclusion. The resolver abstains rather than
+      // committing to the quoted-within Gall. (Gall is still indexed in the
+      // BK-tree; it is excluded as an aside at resolution time.)
       const text =
         "Bd. v. FirstService, 193 A.D.3d 672 (2d Dep't 2021) " +
         "(citing Gall v. Colon-Sylvain, 151 A.D.3d 698 (2d Dep't 2016)). " +
         "Gall, supra, at 700."
 
       const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
-      const gall = citations.find((c) => c.type === "case" && c.volume === 151)!
       const supra = citations.find((c) => c.type === "supra")!
 
-      expect(supra.resolution?.resolvedTo).toBe(citations.indexOf(gall))
+      expect(supra.resolution?.resolvedTo).toBeUndefined()
     })
 
     it("short-form case still resolves to a parenthetical-internal citation", () => {

--- a/tests/resolve/issue799_supraSkipsParenChild.test.ts
+++ b/tests/resolve/issue799_supraSkipsParenChild.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Issue #799: `supra` must not resolve to a case cited only inside another
+ * citation's explanatory parenthetical (`(quoting X)`). `resolveId` already
+ * excludes parenthetical-internal antecedents (#214) via `isParentheticalChild`;
+ * `resolveSupra` applied no such filter, so `X v. Y, supra` could resolve to a
+ * case named only inside another cite's aside. The two back-reference resolvers
+ * should agree on whether a parenthetical-internal cite is a valid antecedent.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #799: supra skips parenthetical-internal antecedents", () => {
+  it("does not resolve supra to a case named only inside another cite's (quoting ...)", () => {
+    const text =
+      "Foo v. Goo, 500 U.S. 100 (quoting Bar v. Baz, 200 U.S. 50). " +
+      "Filler text. Bar v. Baz, supra, at 55."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const supra = citations.find((c) => c.type === "supra")
+    expect(supra, "supra should extract").toBeDefined()
+    // Bar v. Baz appears ONLY inside Foo v. Goo's parenthetical → not a valid
+    // supra antecedent. The resolver must abstain rather than commit to it.
+    expect(supra?.resolution?.resolvedTo).toBeUndefined()
+  })
+
+  it("regression: supra still resolves to a case cited in its own right", () => {
+    const text = "Bar v. Baz, 200 U.S. 50 (1990). Filler text. Bar v. Baz, supra, at 55."
+    const citations = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const full = citations.find((c) => c.type === "case")
+    const supra = citations.find((c) => c.type === "supra")
+    expect(full).toBeDefined()
+    expect(supra?.resolution?.resolvedTo).toBe(citations.indexOf(full as ResolvedCitation))
+  })
+
+  it("supra and Id. agree: both skip the parenthetical-internal cite", () => {
+    const supraText =
+      "Foo v. Goo, 500 U.S. 100 (quoting Bar v. Baz, 200 U.S. 50). Filler. Bar v. Baz, supra."
+    const supraCites = extractCitations(supraText, { resolve: true }) as ResolvedCitation[]
+    const supra = supraCites.find((c) => c.type === "supra")
+    // index 1 is the paren-internal Bar v. Baz
+    expect(supra?.resolution?.resolvedTo).not.toBe(1)
+
+    // For comparison, `Id.` in the same layout already skips Bar v. Baz (#214)
+    // and resolves to the citing authority Foo v. Goo (index 0).
+    const idText = "Foo v. Goo, 500 U.S. 100 (quoting Bar v. Baz, 200 U.S. 50). Id."
+    const idCites = extractCitations(idText, { resolve: true }) as ResolvedCitation[]
+    const id = idCites.find((c) => c.type === "id")
+    expect(id?.resolution?.resolvedTo).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #799.

## Before
`resolveSupra` matched a supra's party name against all prior full citations, filtered only by scope. A case named **only** inside another cite's `(quoting …)` / `(citing …)` aside was a valid supra antecedent — so `X v. Y, supra` could attach a pinpoint to an authority the writer never independently cited. `resolveId` already excluded these (#214), so the two back-reference resolvers disagreed.

## Now
`resolveSupra` skips parenthetical-internal asides, matching `resolveId`. When a supra's only party-name match sits inside an aside, the resolver falls through to the next valid candidate or abstains.

**Why this matters:** a `supra` is meant to point back to an authority cited in its own right; resolving it to a quoted-within case silently changes which case a proposition is tied to.

### Precise aside signal (avoids a parallel-cite trap)
The exclusion uses a new depth-based `isParentheticalAside` rather than the broader `isParentheticalChild`. The latter also flags **parallel-cite siblings** (e.g. the `93 S. Ct. 705` half of `Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705`) because they share a caption `fullSpan` — those are valid supra antecedents and must not be dropped. `Id.` keeps using `isParentheticalChild` (behavior unchanged).

## Tests
- New `tests/resolve/issue799_supraSkipsParenChild.test.ts`: supra abstains on a paren-internal-only antecedent; regression still resolves a case cited in its own right; supra and `Id.` agree.
- Updated the #214 integration test that pinned the old behavior (supra → paren-internal) to the new #799 policy.
- Full suite: **4415 passing, 0 regressions**. Typecheck + `pnpm lint` clean.

## Scope / follow-up
Short-form-case resolution (`151 A.D.3d at 700`) still resolves to paren-internal cites — out of scope for #799 (supra-only); candidate for a follow-up if the same consistency is wanted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
