### PR TITLE
fix(resolve): trigger-anchored parenthetical-aside detection (#798)

### DIFF
--- a/.changeset/fix-id-trigger-anchored-paren-798.md
+++ b/.changeset/fix-id-trigger-anchored-paren-798.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): recognise `(quoting …)` / `(citing …)` asides even when the opening parenthesis is dropped (#798)
+
+The `Id.` parenthetical-child guard (#214) relied solely on a running `(`/`)` depth counter, so OCR/PDF text with an unbalanced or dropped opening paren caused `Id.` to resolve to the quoted-within authority instead of the citing one. A new shared, trigger-anchored signal (`triggerAnchoredAsideOwner`, with a named `PARENTHETICAL_TRIGGER_WORDS` vocabulary) now recognises the aside from its trigger word, bounded to the same clause, so the relationship survives a missing paren. The signal feeds both `Id.` and `supra` (via `isParentheticalAside`) and is exported for reuse by the citation graph (#801).

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -22,6 +22,7 @@ import { isFullCitation } from "../types/guards"
 import type { Span } from "../types/span"
 import { detectQuoteZones } from "../utils/detectQuoteZones"
 import { computeParenDepths } from "../utils/parenDepths"
+import { triggerAnchoredAsideOwner } from "../utils/parentheticalScope"
 import { BKTree } from "./bkTree"
 import { levenshteinDistance } from "./levenshtein"
 import { buildFootnoteScopes, detectParagraphBoundaries, isWithinBoundary } from "./scopeBoundary"
@@ -521,7 +522,10 @@ export class DocumentResolver {
    * with trigger-word anchoring so dropped/unbalanced parentheses still count.
    */
   private isParentheticalAside(index: number): boolean {
-    return this.parenDepths[index] > 0
+    if (this.parenDepths[index] > 0) return true
+    // #798: trigger-anchored — recognise a `quoting`/`citing` aside even when
+    // the opening `(` was dropped (OCR/PDF), where the depth scan misses it.
+    return triggerAnchoredAsideOwner(this.text, this.citations, index) !== undefined
   }
 
   /**

--- a/src/utils/parentheticalScope.ts
+++ b/src/utils/parentheticalScope.ts
@@ -1,0 +1,71 @@
+/**
+ * Trigger-anchored parenthetical-aside detection.
+ *
+ * The running `(`/`)` depth counter in `computeParenDepths` is the primary
+ * signal for "this citation sits inside another cite's explanatory
+ * parenthetical" (`(quoting X)` / `(citing Y)`). But dropped or unbalanced
+ * parentheses — common in OCR'd / PDF-extracted opinions — defeat it: with a
+ * missing opening `(`, the nested cite has depth 0 and looks top-level.
+ *
+ * This module recognises the aside from its *trigger word* instead, so the
+ * relationship survives a missing paren. It is shared between the resolver
+ * (`Id.`/`supra` antecedent selection, #214/#798/#799) and the citation graph's
+ * `in-parenthetical-of` edges (#801).
+ */
+
+import type { Citation } from "../types/citation"
+
+/**
+ * Explanatory-parenthetical signal words that *introduce* a nested citation.
+ * Kept small and named so both the resolver and the citation graph share one
+ * vocabulary. (End-of-parenthetical markers like "emphasis added" are not here:
+ * they do not introduce a citation.)
+ */
+export const PARENTHETICAL_TRIGGER_WORDS = ["quoting", "citing", "quoted in", "cited in"] as const
+
+/** Matches a trigger word at the very end of a region (optionally `… from`/`… to`). */
+const TRIGGER_AT_END_RE = /\b(?:quoting|citing|quoted in|cited in)(?:\s+(?:from|to))?[\s,]*$/i
+
+/** A sentence terminator (`. ` / `; ` / newline) — bounds an aside to its clause. */
+const SENTENCE_TERMINATOR_RE = /[.;]\s|[\n\r]/
+
+/**
+ * The start offset of a citation's lead-in: for `case`/`docket` citations the
+ * `fullSpan` start (covering the case name `Bar v. Baz`), otherwise the core
+ * span start. The trigger word sits immediately before this point.
+ */
+function leadStart(c: Citation): number {
+  if ((c.type === "case" || c.type === "docket") && c.fullSpan) {
+    return c.fullSpan.cleanStart
+  }
+  return c.span.cleanStart
+}
+
+/**
+ * If an explanatory-parenthetical trigger word directly introduces the citation
+ * at `index` — even with no opening `(` — return the index of the citation that
+ * owns the aside (the citing authority immediately before the trigger). Returns
+ * `undefined` when the citation is not trigger-introduced.
+ *
+ * Positions are clean-text offsets, so callers must pass the same cleaned text
+ * the citation spans were computed against.
+ */
+export function triggerAnchoredAsideOwner(
+  text: string,
+  citations: Citation[],
+  index: number,
+): number | undefined {
+  if (index <= 0) return undefined
+  const prev = citations[index - 1]
+  const cur = citations[index]
+  const from = prev.span.cleanEnd
+  const to = leadStart(cur)
+  if (to <= from) return undefined
+
+  const region = text.slice(from, to)
+  // The trigger must directly introduce THIS citation as an aside of `prev`: a
+  // sentence terminator anywhere in the gap means it does not.
+  if (SENTENCE_TERMINATOR_RE.test(region)) return undefined
+  if (!TRIGGER_AT_END_RE.test(region)) return undefined
+  return index - 1
+}

--- a/tests/resolve/issue798_idUnbalancedParenChild.test.ts
+++ b/tests/resolve/issue798_idUnbalancedParenChild.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Issue #798: `Id.` misresolves to a citation nested inside another cite's
+ * explanatory parenthetical when the source text has a dropped/unbalanced
+ * parenthesis (common in OCR/PDF). The #214 paren-child guard relies on a
+ * running `(`/`)` depth counter; with a missing opening paren the nested cite
+ * has depth 0 and is no longer flagged, so `Id.` resolves to the quoted-within
+ * authority instead of the citing one.
+ *
+ * Fix: recognise the aside from its trigger word (`quoting`/`citing`/…) even
+ * when the opening `(` is absent.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+const idResolvedTo = (text: string): number | undefined => {
+  const cites = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+  const id = cites.find((c) => c.type === "id")
+  return id?.resolution?.resolvedTo
+}
+
+describe("Issue #798: Id. trigger-anchored parenthetical-child detection", () => {
+  it("regression: balanced aside still resolves Id. to the citing authority", () => {
+    // Foo (neutral, idx 0) cites Bar v. Baz (idx 1) inside a balanced (quoting …)
+    expect(idResolvedTo("Foo, 2020 IL 12345 (quoting Bar v. Baz, 100 N.E.3d 200). Id.")).toBe(0)
+  })
+
+  it("unbalanced neutral container: dropped opening paren still resolves Id. to Foo", () => {
+    expect(idResolvedTo("Foo, 2020 IL 12345 quoting Bar v. Baz, 100 N.E.3d 200). Id.")).toBe(0)
+  })
+
+  it("unbalanced case container: dropped opening paren still resolves Id. to Foo v. Goo", () => {
+    expect(idResolvedTo("Foo v. Goo, 500 U.S. 100 quoting Bar v. Baz, 200 U.S. 50). Id.")).toBe(0)
+  })
+
+  it("guard: a trigger word not directly introducing a cite must not mis-flag the later cite", () => {
+    // `quoting from the record.` ends the sentence before Bar; Bar is a normal
+    // top-level cite, so Id. must resolve to Bar (idx 1), not Foo (idx 0).
+    expect(idResolvedTo("Foo, 100 U.S. 1, quoting from the record. Bar, 200 U.S. 2. Id.")).toBe(1)
+  })
+})

--- a/tests/utils/parentheticalScope.test.ts
+++ b/tests/utils/parentheticalScope.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { Citation } from "@/types/citation"
+import { PARENTHETICAL_TRIGGER_WORDS, triggerAnchoredAsideOwner } from "@/utils/parentheticalScope"
+
+// Inputs below have no HTML/Unicode transformations, so clean-text offsets
+// equal the raw string offsets and the citation spans index into `text`.
+const cites = (t: string) => extractCitations(t) as Citation[]
+
+describe("triggerAnchoredAsideOwner", () => {
+  it("returns the citing authority for a trigger-introduced cite (dropped open paren)", () => {
+    const text = "Foo v. Goo, 500 U.S. 100 quoting Bar v. Baz, 200 U.S. 50)."
+    expect(triggerAnchoredAsideOwner(text, cites(text), 1)).toBe(0)
+  })
+
+  it("works for non-case containers (neutral)", () => {
+    const text = "Foo, 2020 IL 12345 quoting Bar v. Baz, 100 N.E.3d 200)."
+    expect(triggerAnchoredAsideOwner(text, cites(text), 1)).toBe(0)
+  })
+
+  it("returns undefined for a normal top-level cite", () => {
+    const text = "Foo v. Goo, 500 U.S. 100. Bar v. Baz, 200 U.S. 50."
+    expect(triggerAnchoredAsideOwner(text, cites(text), 1)).toBeUndefined()
+  })
+
+  it("returns undefined when a sentence terminator separates the trigger from the cite", () => {
+    const text = "Foo, 100 U.S. 1, quoting from the record. Bar, 200 U.S. 2."
+    expect(triggerAnchoredAsideOwner(text, cites(text), 1)).toBeUndefined()
+  })
+
+  it("returns undefined for the first citation", () => {
+    const text = "Foo v. Goo, 500 U.S. 100."
+    expect(triggerAnchoredAsideOwner(text, cites(text), 0)).toBeUndefined()
+  })
+
+  it("exposes a named, shared trigger vocabulary", () => {
+    expect(PARENTHETICAL_TRIGGER_WORDS).toContain("quoting")
+    expect(PARENTHETICAL_TRIGGER_WORDS).toContain("citing")
+  })
+})


### PR DESCRIPTION
Closes #798.

> **Stacked on #802 (#799).** Base is `fix/resolve-supra-paren-child`; review/merge that first. GitHub will retarget this to `main` once #802 lands.

## Before
The `Id.` parenthetical-child guard (#214) relied solely on a running `(`/`)` depth counter. OCR/PDF opinions routinely drop a parenthesis — and with a missing opening `(`, the nested cite has depth 0, is no longer flagged as an aside, and `Id.` resolves to the **quoted-within** authority instead of the citing one.

```
Foo v. Goo, 500 U.S. 100 quoting Bar v. Baz, 200 U.S. 50). Id.
                                  └─ Id. wrongly resolved here (Bar v. Baz)
```

## Now
A new **trigger-anchored** signal recognises the aside from its trigger word (`quoting`/`citing`/`quoted in`/`cited in`), bounded to the same clause, so the relationship survives a missing paren. `Id.` resolves to `Foo v. Goo` again.

**Why this matters:** `Id.` is the most common back-reference; misattributing it to a quoted-within case silently changes which authority a proposition is tied to, and dropped parens are a realistic input class rather than an exotic one.

### Shared, reusable mechanism
The logic lives in a new `src/utils/parentheticalScope.ts` (`triggerAnchoredAsideOwner` + a named `PARENTHETICAL_TRIGGER_WORDS` vocabulary) and feeds `isParentheticalAside`, so **both `Id.` and `supra`** benefit. It returns the aside *owner* (not just a boolean), which the citation-graph follow-up (#801) reuses for its `in-parenthetical-of` edges.

### Over-firing guard
The trigger must directly introduce the citation with no intervening sentence terminator, so a stray trigger word in prose (`… quoting from the record. Bar, 200 U.S. 2. Id.`) does **not** mis-flag the later top-level cite — covered by a test.

## Tests
- `tests/resolve/issue798_idUnbalancedParenChild.test.ts`: unbalanced neutral + case containers resolve `Id.` to the citing authority; balanced regression unchanged; over-firing guard.
- `tests/utils/parentheticalScope.test.ts`: direct unit tests for the shared util (owner return value, non-case containers, terminator boundary, index 0, vocabulary).
- Full suite: **4419 passing, 0 regressions**. Typecheck + `pnpm lint` clean.

## Out of scope
The global `computeParenDepths` counter and the citation graph's `in-parenthetical-of` edges (same fragility) — tracked in **#801**, which builds on the exported helper here. A generic sentence-boundary depth reset is intentionally not used (it does not fix a *missing-open* paren).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
