### PR TITLE
fix(document): in-parenthetical-of edges tolerate unbalanced parens (#801)

### DIFF
--- a/.changeset/fix-citation-graph-paren-edges-801.md
+++ b/.changeset/fix-citation-graph-paren-edges-801.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+fix(document): `in-parenthetical-of` citation-graph edges tolerate unbalanced parentheses (#801)
+
+`buildCitationGraph` derived `in-parenthetical-of` edges from the raw `computeParenDepths` counter, so dropped/unbalanced parentheses (OCR/PDF) corrupted them — a dropped opening paren lost the aside edge, and a dropped closing paren leaked a spurious edge onto every following top-level citation. Edges are now computed via a balance-tolerant owner (`computeInParentheticalOwners`) that reuses #798's trigger-anchored signal for dropped opening parens and a sentence-boundary guard for dropped closing parens. Balanced input (including parallel-cite siblings inside an aside) is unchanged.

--- a/src/document/analyzer.ts
+++ b/src/document/analyzer.ts
@@ -27,7 +27,7 @@ export function analyzeDocument(
   const quoteZones = detectQuoteZones(text)
 
   const prose = computeProseOffsets(text, citations, opts?.transformationMap)
-  const citationGraph = buildCitationGraph(citations, parenDepths)
+  const citationGraph = buildCitationGraph(citations, parenDepths, text)
   const quoteAttributions = attributeQuotes(text, quoteZones, citations)
   const footnoteZones = extractFootnoteZones(citations)
 

--- a/src/document/citationGraph.ts
+++ b/src/document/citationGraph.ts
@@ -1,4 +1,5 @@
 import type { Citation, HistorySignal } from "../types/citation"
+import { computeInParentheticalOwners } from "../utils/parentheticalScope"
 import type { CitationGraph, Edge } from "./types"
 
 /**
@@ -12,7 +13,7 @@ import type { CitationGraph, Edge } from "./types"
  *   - citation.subsequentHistoryOf           → "history-of" edge
  *   - citation.pinciteInheritedFrom          → "pincite-inherit" edge
  *   - citation.stringCitationGroupId         → "string-cite" edges
- *   - parenDepths (from computeParenDepths)  → "in-parenthetical-of" edge
+ *   - parenDepths + text (balance-tolerant)  → "in-parenthetical-of" edge
  *
  * Invariants:
  *   - nodes.length === citations.length (isolated nodes included)
@@ -20,7 +21,11 @@ import type { CitationGraph, Edge } from "./types"
  *   - No duplicates of the same (type, from, to)
  *   - Edges sorted by (from, type, to) for deterministic iteration
  */
-export function buildCitationGraph(citations: Citation[], parenDepths: number[]): CitationGraph {
+export function buildCitationGraph(
+  citations: Citation[],
+  parenDepths: number[],
+  text?: string,
+): CitationGraph {
   const nodes = citations.map((_, i) => i)
   const edges: Edge[] = []
   const seen = new Set<string>()
@@ -120,15 +125,16 @@ export function buildCitationGraph(citations: Citation[], parenDepths: number[])
     }
   }
 
-  // in-parenthetical-of edges — for each citation with parenDepth > 0, find
-  // the most recent earlier citation with a lower depth.
+  // in-parenthetical-of edges — balance-tolerant owner per citation (#801):
+  // the `(`/`)` depth signal plus trigger-word anchoring (recovers a dropped
+  // opening paren) and a sentence-boundary guard (rejects a dropped closing
+  // paren leaking onto a following top-level cite). Falls back to raw depth
+  // when `text` is not supplied (pre-#801 behavior).
+  const parentheticalOwners = computeInParentheticalOwners(citations, parenDepths, text)
   for (let i = 0; i < citations.length; i++) {
-    if (parenDepths[i] <= 0) continue
-    for (let j = i - 1; j >= 0; j--) {
-      if (parenDepths[j] < parenDepths[i]) {
-        addEdge({ type: "in-parenthetical-of", from: i, to: j })
-        break
-      }
+    const owner = parentheticalOwners[i]
+    if (owner !== undefined) {
+      addEdge({ type: "in-parenthetical-of", from: i, to: owner })
     }
   }
 

--- a/src/utils/parentheticalScope.ts
+++ b/src/utils/parentheticalScope.ts
@@ -69,3 +69,57 @@ export function triggerAnchoredAsideOwner(
   if (!TRIGGER_AT_END_RE.test(region)) return undefined
   return index - 1
 }
+
+/**
+ * Whether a sentence terminator separates citation `index` from the citation
+ * before it. Used to bound an aside to its clause so a dropped *closing* paren
+ * cannot leak `in-parenthetical-of` membership onto a following top-level cite.
+ * Checks only the prose gap between consecutive citations, so cite-internal
+ * periods (`v.`, `U.S.`) are never mistaken for sentence boundaries.
+ */
+function hasSentenceBoundaryBefore(text: string, citations: Citation[], index: number): boolean {
+  if (index <= 0) return false
+  const from = citations[index - 1].span.cleanEnd
+  const to = leadStart(citations[index])
+  if (to <= from) return false
+  return SENTENCE_TERMINATOR_RE.test(text.slice(from, to))
+}
+
+/**
+ * For each citation, the index of the citation whose explanatory parenthetical
+ * it sits inside (its "aside owner"), or `undefined` if it stands on its own.
+ *
+ * Balance-tolerant (#801): combines the `(`/`)` depth signal with trigger-word
+ * anchoring (recovers a dropped *opening* paren) and a sentence-boundary guard
+ * (rejects a dropped *closing* paren that would otherwise leak onto a following
+ * top-level cite). When `text` is omitted, falls back to the raw depth signal
+ * only — the pre-#801 behavior.
+ */
+export function computeInParentheticalOwners(
+  citations: Citation[],
+  parenDepths: number[],
+  text?: string,
+): (number | undefined)[] {
+  const owners: (number | undefined)[] = new Array(citations.length).fill(undefined)
+  for (let i = 0; i < citations.length; i++) {
+    // Trigger-anchored first: handles a dropped opening paren (depth would be 0).
+    if (text !== undefined) {
+      const triggered = triggerAnchoredAsideOwner(text, citations, i)
+      if (triggered !== undefined) {
+        owners[i] = triggered
+        continue
+      }
+    }
+    if (parenDepths[i] <= 0) continue
+    // Depth says nested. With text available, reject a dropped-closing-paren
+    // leak: an aside does not continue across a sentence boundary.
+    if (text !== undefined && hasSentenceBoundaryBefore(text, citations, i)) continue
+    for (let j = i - 1; j >= 0; j--) {
+      if (parenDepths[j] < parenDepths[i]) {
+        owners[i] = j
+        break
+      }
+    }
+  }
+  return owners
+}

--- a/tests/document/issue801_unbalancedParenEdges.test.ts
+++ b/tests/document/issue801_unbalancedParenEdges.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Issue #801: the citation graph's `in-parenthetical-of` edges were derived
+ * purely from `computeParenDepths` (a global `(`/`)` counter), so dropped or
+ * unbalanced parentheses (OCR/PDF) corrupted them:
+ *   - dropped opening paren → nested cite had depth 0 → edge missing;
+ *   - dropped closing paren → depth never returned to 0 → every following
+ *     top-level cite got a spurious edge.
+ *
+ * Follow-up to #798; reuses the same trigger-anchored aside signal.
+ */
+
+import { describe, expect, it } from "vitest"
+import { analyzeDocument } from "@/document"
+import { extractCitations } from "@/extract"
+
+const ipEdges = (text: string) => {
+  const cites = extractCitations(text)
+  return analyzeDocument(text, cites).citationGraph.edges.filter(
+    (e) => e.type === "in-parenthetical-of",
+  )
+}
+
+describe("Issue #801: in-parenthetical-of edges tolerate unbalanced parens", () => {
+  it("regression: balanced aside keeps the edge", () => {
+    expect(ipEdges("Foo, 2020 IL 12345 (quoting Bar v. Baz, 100 N.E.3d 200).")).toEqual([
+      { type: "in-parenthetical-of", from: 1, to: 0 },
+    ])
+  })
+
+  it("dropped opening paren: edge still present (trigger-anchored)", () => {
+    expect(ipEdges("Foo, 2020 IL 12345 quoting Bar v. Baz, 100 N.E.3d 200).")).toEqual([
+      { type: "in-parenthetical-of", from: 1, to: 0 },
+    ])
+  })
+
+  it("dropped closing paren: following top-level cite is NOT in-parenthetical", () => {
+    const edges = ipEdges(
+      "Foo, 2020 IL 12345 (quoting Bar v. Baz, 100 N.E.3d 200. Qux v. Quux, 5 U.S. 5.",
+    )
+    // Bar (1) is inside Foo's aside; Qux (2) must NOT get a spurious edge.
+    expect(edges).toContainEqual({ type: "in-parenthetical-of", from: 1, to: 0 })
+    expect(edges.some((e) => e.from === 2)).toBe(false)
+  })
+})

--- a/tests/utils/parentheticalScope.test.ts
+++ b/tests/utils/parentheticalScope.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest"
 import { extractCitations } from "@/extract/extractCitations"
 import type { Citation } from "@/types/citation"
-import { PARENTHETICAL_TRIGGER_WORDS, triggerAnchoredAsideOwner } from "@/utils/parentheticalScope"
+import { computeParenDepths } from "@/utils/parenDepths"
+import {
+  computeInParentheticalOwners,
+  PARENTHETICAL_TRIGGER_WORDS,
+  triggerAnchoredAsideOwner,
+} from "@/utils/parentheticalScope"
 
 // Inputs below have no HTML/Unicode transformations, so clean-text offsets
 // equal the raw string offsets and the citation spans index into `text`.
@@ -36,5 +41,37 @@ describe("triggerAnchoredAsideOwner", () => {
   it("exposes a named, shared trigger vocabulary", () => {
     expect(PARENTHETICAL_TRIGGER_WORDS).toContain("quoting")
     expect(PARENTHETICAL_TRIGGER_WORDS).toContain("citing")
+  })
+})
+
+describe("computeInParentheticalOwners", () => {
+  const owners = (t: string, withText = true) => {
+    const c = cites(t)
+    const depths = computeParenDepths(t, c)
+    return computeInParentheticalOwners(c, depths, withText ? t : undefined)
+  }
+
+  it("trigger-anchored owner for a dropped opening paren", () => {
+    expect(owners("Foo, 2020 IL 12345 quoting Bar v. Baz, 100 N.E.3d 200).")).toEqual([
+      undefined,
+      0,
+    ])
+  })
+
+  it("suppresses a dropped-closing-paren leak across a sentence boundary", () => {
+    const o = owners("Foo, 2020 IL 12345 (quoting Bar v. Baz, 100 N.E.3d 200. Qux v. Quux, 5 U.S. 5.")
+    expect(o[1]).toBe(0) // Bar inside Foo's aside
+    expect(o[2]).toBeUndefined() // Qux not leaked past the sentence boundary
+  })
+
+  it("keeps parallel-cite siblings inside a balanced aside", () => {
+    // Both reporters of the inner parallel cite sit inside Foo's aside.
+    const o = owners("Foo, 1 U.S. 1 (quoting Bar v. Baz, 2 U.S. 2, 5 S. Ct. 3).")
+    expect(o[1]).toBe(0)
+    expect(o[2]).toBe(0)
+  })
+
+  it("without text, falls back to the raw depth signal (legacy)", () => {
+    expect(owners("Foo, 1 U.S. 1 (quoting Bar v. Baz, 2 U.S. 2).", false)).toEqual([undefined, 0])
   })
 })


### PR DESCRIPTION
Closes #801.

> **Stacked on #803 (#798) → #802 (#799).** Base is `fix/id-trigger-anchored-paren-child`; merge #802 then #803 first. GitHub retargets this to `main` as the stack lands.

## Before
`buildCitationGraph` derived `in-parenthetical-of` edges from the raw `computeParenDepths` counter — a single `(`/`)` tally over the whole document. Dropped/unbalanced parentheses (OCR/PDF) corrupted them two ways:

- **dropped opening paren** → the nested cite had depth 0 → **edge missing** (aside link lost)
- **dropped closing paren** → depth never returned to 0 → **spurious edge** on every following top-level cite

## Now
Edges come from a balance-tolerant owner, `computeInParentheticalOwners`, which:
- reuses **#798's** trigger-anchored signal to recover a dropped **opening** paren, and
- applies a **sentence-boundary guard** so a dropped **closing** paren can't leak membership onto a following top-level cite.

Balanced input is unchanged — including parallel-cite siblings inside an aside (`(quoting Bar v. Baz, 2 U.S. 2, 5 S. Ct. 3)`), which both keep their edge. `buildCitationGraph` keeps a depth-only fallback when called without `text`.

**Why this matters:** the `in-parenthetical-of` relation feeds consumers reasoning about which authority quoted which; corrupt edges silently misattribute quotes in exactly the messy OCR/PDF inputs where they're most needed.

## Tests
- `tests/document/issue801_unbalancedParenEdges.test.ts`: balanced (regression), dropped-open (edge restored), dropped-close (no spurious edge) — via the public `analyzeDocument`.
- Extended `tests/utils/parentheticalScope.test.ts` with direct `computeInParentheticalOwners` cases (trigger-anchored, leak suppression, parallel-in-aside, no-text fallback).
- Full suite: **4428 passing, 0 regressions**. Typecheck + `pnpm lint` clean.

## Scope
Only the `in-parenthetical-of` edge derivation becomes balance-tolerant; `computeParenDepths` itself is unchanged. Exotic multi-sentence parentheticals (a second cite after a `. ` *inside* the same balanced parens) may lose that secondary edge — an accepted trade for fixing the realistic dropped-paren case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
