### PR TITLE
feat(resolve): opt-in idConfidenceFloor abstention for Id. (#800)

### DIFF
--- a/.changeset/feat-id-confidence-floor-800.md
+++ b/.changeset/feat-id-confidence-floor-800.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": minor
+---
+
+feat(resolve): opt-in `idConfidenceFloor` abstention threshold for `Id.` (#800)
+
+`resolveId` downgrades confidence and warns when the prose before `Id.` names a different case than the chosen antecedent, but always commits — unlike `resolveSupra`, which abstains below `partyMatchThreshold`. New resolution option `idConfidenceFloor` lets callers make `Id.` fail closed: when set and the computed confidence falls below it, `Id.` returns an unresolved result (carrying the existing ambiguity warning and a `failureReason`) instead of committing. Default is unset — behavior is unchanged and non-breaking.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -88,8 +88,11 @@ function isInZone(
 export class DocumentResolver {
   private readonly citations: Citation[]
   private readonly text: string
-  private readonly options: Required<Omit<ResolutionOptions, "footnoteMap">> & {
+  private readonly options: Required<
+    Omit<ResolutionOptions, "footnoteMap" | "idConfidenceFloor">
+  > & {
     footnoteMap: ResolutionOptions["footnoteMap"]
+    idConfidenceFloor: ResolutionOptions["idConfidenceFloor"]
   }
   private readonly context: ResolutionContext
   private readonly partyNameTree: BKTree
@@ -122,6 +125,7 @@ export class DocumentResolver {
       partyMatchThreshold: options.partyMatchThreshold ?? 0.8,
       reportUnresolved: options.reportUnresolved ?? true,
       footnoteMap: options.footnoteMap,
+      idConfidenceFloor: options.idConfidenceFloor,
     }
 
     this.partyNameTree = new BKTree(levenshteinDistance)
@@ -477,6 +481,21 @@ export class DocumentResolver {
     // case that doesn't match the picked antecedent, downgrade confidence and
     // flag ambiguity (without refusing to commit).
     const { confidence, warnings } = this.applyCaseNameWindowCheck(best.index, citation)
+
+    // #800: opt-in abstention. When `idConfidenceFloor` is set and the computed
+    // confidence falls below it, decline to commit (mirroring resolveSupra's
+    // `partyMatchThreshold`) while preserving the ambiguity warning. Default
+    // (unset) keeps the always-commit behavior.
+    const idFloor = this.options.idConfidenceFloor
+    if (idFloor !== undefined && confidence < idFloor) {
+      if (!this.options.reportUnresolved) return undefined
+      return {
+        resolvedTo: undefined,
+        failureReason: `Id. confidence ${confidence.toFixed(2)} below idConfidenceFloor ${idFloor}`,
+        warnings,
+        confidence,
+      }
+    }
 
     // #508: `antecedentIndex` mirrors `resolvedTo` on the success path so
     // consumers see one source of truth. The pre-fix code called

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -53,6 +53,16 @@ export interface ResolutionOptions {
   partyMatchThreshold?: number
 
   /**
+   * Optional confidence floor for `Id.` resolution (default: unset — always
+   * commit). When set, an `Id.` whose computed confidence falls below the floor
+   * abstains (returns an unresolved result that still carries the ambiguity
+   * warning) instead of committing — mirroring `resolveSupra`'s
+   * `partyMatchThreshold`. Range 0–1. Leave unset to preserve the default
+   * always-commit behavior (non-breaking).
+   */
+  idConfidenceFloor?: number
+
+  /**
    * Report unresolved citations with failure reasons (default: true)
    * If false: resolution field will be undefined for unresolved citations
    */

--- a/tests/resolve/issue800_idConfidenceFloor.test.ts
+++ b/tests/resolve/issue800_idConfidenceFloor.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Issue #800: opt-in abstention threshold for `Id.`. `resolveId` downgrades
+ * confidence and warns when the prose before `Id.` names a different case than
+ * the chosen antecedent, but always commits. `resolveSupra` abstains below
+ * `partyMatchThreshold`; `Id.` had no equivalent. `idConfidenceFloor` lets
+ * callers make `Id.` fail closed below a confidence floor. Default: unchanged.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+const AMBIGUOUS =
+  "Smith v. Jones, 100 U.S. 1. Brown v. Green, 200 U.S. 2. " +
+  "The Smith court held otherwise. Id. at 5."
+
+const idOf = (cites: ResolvedCitation[]) => cites.find((c) => c.type === "id")!
+
+describe("Issue #800: idConfidenceFloor opt-in abstention for Id.", () => {
+  it("default (no floor): commits the ambiguous antecedent at 0.75 with a warning", () => {
+    const id = idOf(extractCitations(AMBIGUOUS, { resolve: true }) as ResolvedCitation[])
+    expect(id.resolution?.resolvedTo).toBe(1) // Brown v. Green (Rule 4.1 immediate)
+    expect(id.resolution?.confidence).toBeCloseTo(0.75)
+    expect(id.resolution?.warnings?.[0]).toMatch(/Ambiguous Id\. antecedent/)
+  })
+
+  it("floor above the confidence: abstains (resolvedTo undefined) but keeps the warning", () => {
+    const id = idOf(
+      extractCitations(AMBIGUOUS, {
+        resolve: true,
+        resolutionOptions: { idConfidenceFloor: 0.8 },
+      }) as ResolvedCitation[],
+    )
+    expect(id.resolution?.resolvedTo).toBeUndefined()
+    expect(id.resolution?.failureReason).toMatch(/idConfidenceFloor/)
+    expect(id.resolution?.warnings?.[0]).toMatch(/Ambiguous Id\. antecedent/)
+  })
+
+  it("floor below the confidence: still commits", () => {
+    const id = idOf(
+      extractCitations(AMBIGUOUS, {
+        resolve: true,
+        resolutionOptions: { idConfidenceFloor: 0.5 },
+      }) as ResolvedCitation[],
+    )
+    expect(id.resolution?.resolvedTo).toBe(1)
+  })
+
+  it("floor does not affect an unambiguous Id. (confidence 1.0)", () => {
+    const id = idOf(
+      extractCitations("Smith v. Jones, 100 U.S. 1. Id. at 5.", {
+        resolve: true,
+        resolutionOptions: { idConfidenceFloor: 0.9 },
+      }) as ResolvedCitation[],
+    )
+    expect(id.resolution?.resolvedTo).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #800.

## Before
When the prose immediately before `Id.` names a different case than the chosen antecedent, `resolveId` lowered confidence (e.g. `0.75`) and emitted an "Ambiguous Id. antecedent" warning — but **always committed**. `resolveSupra`, by contrast, abstains below `partyMatchThreshold`. There was no fail-closed option for `Id.`; callers had to post-filter on `confidence`/`warnings` themselves.

## Now
New resolution option **`idConfidenceFloor`** (a number, default **unset**). When set and an `Id.` resolution's computed confidence falls below it, `resolveId` returns an **unresolved** result — carrying the existing ambiguity warning plus a `failureReason` — instead of committing. Mirrors `resolveSupra`'s abstention.

```ts
extractCitations(text, { resolve: true, resolutionOptions: { idConfidenceFloor: 0.8 } })
```

**Why this matters:** in high-stakes use, a wrong antecedent is worse than no antecedent. This gives callers a built-in, fail-closed switch instead of bespoke post-filtering.

**Non-breaking:** unset ⇒ the default always-commit behavior is byte-for-byte unchanged.

## Tests
`tests/resolve/issue800_idConfidenceFloor.test.ts`:
- default (no floor) commits the ambiguous antecedent at `0.75` with the warning;
- floor above the confidence → abstains (`resolvedTo` undefined) but keeps the warning + `failureReason`;
- floor below the confidence → still commits;
- floor does not affect an unambiguous `Id.` (confidence `1.0`).

Full suite: **4416 passing, 0 regressions**. Typecheck + `pnpm lint` clean.

## Scope
Dedicated `Id.` option (not a shared supra+Id. threshold), per the triage decision. Confidence computation and warning wording are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
