### PR TITLE
fix(resolve): bounded-depth bracket scan replaces global paren counter (#809)

### DIFF
--- a/.changeset/fix-bracket-stack-substrate-809.md
+++ b/.changeset/fix-bracket-stack-substrate-809.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): bounded-depth bracket scan replaces the global paren-depth counter (#809)
+
+`computeParenDepths` was a single running `(`/`)` counter over the whole document, so one dropped or garbled bracket (common in OCR/PDF) desynced the depth for **every** subsequent citation — silently mis-scoping antecedents. It now delegates to a new `computeBracketScopes`: a bounded-depth bracket stack scanned over the prose gaps between citations, reset at clause boundaries, so corruption is confined to the offending clause. Because only prose gaps are scanned, cite-internal periods (`v.`, `U.S.`) never trip the reset and balanced year parens never inflate depth. This fixes the resolver path (where `isParentheticalAside` reads the raw depth — a stray `(` previously excluded a perfectly good top-level antecedent in a later sentence) at the root, generalizing the tactical #798/#801 workarounds. `computeBracketScopes` also exposes a per-citation `balanceOk` structure-trust signal for future abstain gates (#800/#810). Balanced input is unchanged.

--- a/src/utils/parenDepths.ts
+++ b/src/utils/parenDepths.ts
@@ -1,30 +1,21 @@
 import type { Citation } from "../types/citation"
+import { computeBracketScopes } from "./parentheticalScope"
 
 /**
- * Compute parenthesis depth at the start position of each citation.
- * Walks the raw text once, counting `(` and `)` and recording the
- * running depth at every citation's `span.cleanStart`. Depth > 0
- * indicates the citation is nested inside an open parenthetical
- * block (typically an explanatory `(quoting X)` / `(citing Y)`
- * following an earlier citation).
+ * Bracket-nesting depth at the start of each citation. Depth > 0 indicates the
+ * citation is nested inside an open parenthetical block (typically an
+ * explanatory `(quoting X)` / `(citing Y)` following an earlier citation).
+ *
+ * Delegates to {@link computeBracketScopes} (#809): a bounded-depth, clause-reset
+ * bracket-stack scan over the prose gaps between citations. This replaced the
+ * earlier global `(`/`)` counter, which desynced for *every* subsequent citation
+ * on a single dropped/garbled bracket (common in OCR/PDF). For balanced input the
+ * depths are identical; for unbalanced input corruption is now bounded to the
+ * offending clause. Use `computeBracketScopes` directly when you also need the
+ * per-citation `balanceOk` structure-trust signal.
  *
  * Citations must be sorted by `span.cleanStart`.
  */
 export function computeParenDepths(text: string, citations: Citation[]): number[] {
-  const depths: number[] = new Array(citations.length).fill(0)
-  if (citations.length === 0) return depths
-
-  let depth = 0
-  let pos = 0
-  for (let i = 0; i < citations.length; i++) {
-    const start = citations[i].span.cleanStart
-    while (pos < start && pos < text.length) {
-      const ch = text[pos]
-      if (ch === "(") depth++
-      else if (ch === ")" && depth > 0) depth--
-      pos++
-    }
-    depths[i] = depth
-  }
-  return depths
+  return computeBracketScopes(text, citations).map((s) => s.depth)
 }

--- a/src/utils/parentheticalScope.ts
+++ b/src/utils/parentheticalScope.ts
@@ -123,3 +123,65 @@ export function computeInParentheticalOwners(
   }
   return owners
 }
+
+/** Result of the bounded-depth bracket scan for one citation (#809). */
+export interface BracketScope {
+  /** Bracket-nesting depth at the citation's start (0 = top-level). */
+  depth: number
+  /** False when a bracket-balance anomaly occurred in this citation's lead-in clause. */
+  balanceOk: boolean
+}
+
+const OPENER_FOR: Record<string, string> = { ")": "(", "]": "[", "}": "{" }
+
+/**
+ * Bounded-depth, sentence-reset bracket scan over the prose gaps between
+ * citations (#809). Replaces the global linear paren counter: brackets are
+ * tracked on a stack that resets at clause boundaries, so a single unbalanced
+ * bracket cannot desync scope for citations in *later* clauses. Only the prose
+ * gaps between citations are scanned (each citation's own lead + core is
+ * skipped), so cite-internal periods (`v.`, `U.S.`) never trip the clause reset
+ * and balanced year parens never inflate depth.
+ *
+ * Returns, per citation: the bracket `depth` at its start, and a `balanceOk`
+ * flag — false when an unmatched closing bracket, or an unclosed opening bracket
+ * carried into a clause boundary, was seen in its lead-in. `balanceOk` is the
+ * structure-trust signal an abstain gate (#800/#810) can read.
+ *
+ * Citations must be sorted by `span.cleanStart`.
+ */
+export function computeBracketScopes(text: string, citations: Citation[]): BracketScope[] {
+  const scopes: BracketScope[] = citations.map(() => ({ depth: 0, balanceOk: true }))
+  if (citations.length === 0) return scopes
+
+  const stack: string[] = []
+  let prevEnd = 0
+  for (let i = 0; i < citations.length; i++) {
+    const to = leadStart(citations[i])
+    let balanceOk = true
+    for (let pos = prevEnd; pos < to && pos < text.length; pos++) {
+      const ch = text[pos]
+      if (ch === "(" || ch === "[" || ch === "{") {
+        stack.push(ch)
+      } else if (ch === ")" || ch === "]" || ch === "}") {
+        if (stack.length > 0 && stack[stack.length - 1] === OPENER_FOR[ch]) {
+          stack.pop()
+        } else {
+          balanceOk = false // unmatched close
+        }
+      } else if (
+        ch === "\n" ||
+        ch === "\r" ||
+        ((ch === "." || ch === ";") && /\s/.test(text[pos + 1] ?? " "))
+      ) {
+        // Clause boundary: an aside cannot continue across it. A still-open
+        // bracket here is an unclosed-open anomaly; reset the bounded scope.
+        if (stack.length > 0) balanceOk = false
+        stack.length = 0
+      }
+    }
+    scopes[i] = { depth: stack.length, balanceOk }
+    prevEnd = Math.max(prevEnd, citations[i].span.cleanEnd)
+  }
+  return scopes
+}

--- a/tests/resolve/issue809_strayBracketScope.test.ts
+++ b/tests/resolve/issue809_strayBracketScope.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Issue #809: replace the global linear paren-depth counter with a bounded-depth,
+ * sentence-reset bracket scan, so one unbalanced bracket no longer desyncs scope
+ * for citations in *later* clauses.
+ *
+ * The resolver's `isParentheticalAside` reads the raw depth, so a stray unclosed
+ * `(` in an earlier sentence used to inflate the depth of a perfectly good
+ * top-level antecedent in a following sentence and wrongly exclude it. (#801's
+ * sentence-boundary guard lives in the graph path only, not the resolver.)
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+const idResolvedTo = (text: string): number | undefined =>
+  (extractCitations(text, { resolve: true }) as ResolvedCitation[]).find((c) => c.type === "id")
+    ?.resolution?.resolvedTo
+
+describe("Issue #809: stray bracket does not corrupt later-clause scope", () => {
+  it("a stray unclosed ( in an earlier sentence doesn't exclude a later top-level antecedent", () => {
+    // Foo (0) ... unclosed `(` ... NEW sentence: Smith (1) is a top-level cite and
+    // the immediately preceding authority for Id. → must resolve to Smith.
+    const text =
+      "Foo v. Goo, 1 U.S. 1 (see generally the discussion. Smith v. Jones, 2 U.S. 2. Id. at 5."
+    expect(idResolvedTo(text)).toBe(1)
+  })
+
+  it("regression: a balanced (quoting …) aside is still excluded as an antecedent", () => {
+    // Bar is inside Foo's balanced parenthetical → Id. resolves to Foo (0), not Bar (1).
+    const text = "Foo, 2020 IL 12345 (quoting Bar v. Baz, 100 N.E.3d 200). Id."
+    expect(idResolvedTo(text)).toBe(0)
+  })
+})

--- a/tests/utils/parentheticalScope.test.ts
+++ b/tests/utils/parentheticalScope.test.ts
@@ -3,6 +3,7 @@ import { extractCitations } from "@/extract/extractCitations"
 import type { Citation } from "@/types/citation"
 import { computeParenDepths } from "@/utils/parenDepths"
 import {
+  computeBracketScopes,
   computeInParentheticalOwners,
   PARENTHETICAL_TRIGGER_WORDS,
   triggerAnchoredAsideOwner,
@@ -73,5 +74,38 @@ describe("computeInParentheticalOwners", () => {
 
   it("without text, falls back to the raw depth signal (legacy)", () => {
     expect(owners("Foo, 1 U.S. 1 (quoting Bar v. Baz, 2 U.S. 2).", false)).toEqual([undefined, 0])
+  })
+})
+
+describe("computeBracketScopes (#809)", () => {
+  const scopes = (t: string) => computeBracketScopes(t, cites(t))
+
+  it("balanced aside: nested cite has depth 1, balanceOk true", () => {
+    const s = scopes("Foo, 2020 IL 12345 (quoting Bar v. Baz, 100 N.E.3d 200). Id.")
+    expect(s[0].depth).toBe(0)
+    expect(s[1].depth).toBe(1) // Bar inside the (quoting …)
+    expect(s.every((x) => x.balanceOk)).toBe(true)
+  })
+
+  it("a stray unclosed ( does not desync depth for a later-clause cite", () => {
+    const s = scopes("Foo v. Goo, 1 U.S. 1 (see generally the discussion. Smith v. Jones, 2 U.S. 2.")
+    expect(s[1].depth).toBe(0) // Smith is top-level despite the earlier stray `(`
+    expect(s[1].balanceOk).toBe(false) // …and the broken structure is flagged
+  })
+
+  it("an unmatched ) flags balanceOk false without going negative", () => {
+    const s = scopes("Foo, 1 U.S. 1) Bar v. Baz, 2 U.S. 2.")
+    expect(s[1].depth).toBe(0)
+    expect(s[1].balanceOk).toBe(false)
+  })
+
+  it("parallel-cite siblings inside a balanced aside both read depth 1", () => {
+    const s = scopes("Foo, 1 U.S. 1 (quoting Bar v. Baz, 2 U.S. 2, 5 S. Ct. 3).")
+    expect(s[1].depth).toBe(1)
+    expect(s[2].depth).toBe(1)
+  })
+
+  it("empty input returns an empty array", () => {
+    expect(computeBracketScopes("", [])).toEqual([])
   })
 })


### PR DESCRIPTION
Closes #809.

## Before
`computeParenDepths` was a single running `(`/`)` counter walked over the whole document. One dropped or garbled bracket (common in OCR/PDF) desynced the depth for **every** subsequent citation. The resolver's `isParentheticalAside` reads that raw depth, so a stray unclosed `(` in one sentence silently excluded a perfectly good top-level antecedent in a *later* sentence:

```ts
// stray unclosed `(` in sentence 1 ...
extractCitations("Foo v. Goo, 1 U.S. 1 (see generally the discussion. Smith v. Jones, 2 U.S. 2. Id. at 5.", { resolve: true })
// Id. -> Foo (0)   ✗  (Smith's depth was inflated to 1 by the never-closed `(`)
```
(The #801 sentence-boundary guard only protected the *graph* path, not the resolver.)

## Now
A new **`computeBracketScopes`** — a bounded-depth bracket **stack**, scanned over the **prose gaps between citations** and **reset at clause boundaries** — replaces the global counter, which `computeParenDepths` now delegates to. Corruption is confined to the offending clause, so `Id.` resolves to `Smith` again. Because only prose gaps are scanned, cite-internal periods (`v.`, `U.S.`) never trip the reset and balanced year parens never inflate depth.

It also returns a per-citation **`balanceOk`** structure-trust signal (false on an unmatched close / unclosed open) — the input a future abstain gate (#800/#810) needs.

**Why this matters:** this fixes the root cause behind #798/#801 — a single stray bracket no longer mis-scopes citations document-wide — and unifies the tactical trigger-anchored / sentence-boundary workarounds onto one robust substrate.

## Tests
- `tests/resolve/issue809_strayBracketScope.test.ts`: stray-bracket resolver case + balanced regression.
- `tests/utils/parentheticalScope.test.ts`: direct `computeBracketScopes` cases (balanced depth, stray-`(` confinement + `balanceOk=false`, unmatched `)`, parallel-in-aside, empty input).
- Full suite: **276 files / 4450 tests, 0 regressions.** ReDoS budget holds (linear scan), size **50.35 KB < 52 KB**, typecheck + `pnpm lint` clean.

## Scope
Substrate only. The **hard-vs-soft scope-filter policy** (consuming `balanceOk`) is deliberately deferred to **#810**'s measurement; balanced behavior is unchanged. Multi-bracket-type (`[]`/`{}`) is handled by the stack but no citation form depends on it yet. Roadmap: #812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
