### PR TITLE
refactor(resolve): candidate-list scorer seam for Id. selection (#811)

### DIFF
--- a/.changeset/refactor-candidate-scorer-811.md
+++ b/.changeset/refactor-candidate-scorer-811.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": patch
+---
+
+refactor(resolve): route `Id.` antecedent selection through a candidate-list scorer seam (#811)
+
+`resolveId`'s inline `preferred ?? candidates[0]` (family-preference + recency) pick is now expressed as an explicit `scoreAntecedentCandidates` / `selectAntecedent` step — the deterministic seam for a future feature-based learning-to-rank model, swappable without changing callers. **No behavior change**: the scorer reproduces the prior selection exactly (all existing resolutions identical). `supra` (similarity-ranked) and short-form-case (party-name overlap) selection route through the same seam in a follow-up, since they weight different features.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -472,11 +472,10 @@ export class DocumentResolver {
     // When preferredFamily is null (bare Id. with no pincite — #721),
     // pick the most recent candidate regardless of family. Otherwise,
     // prefer family-match first, then fall back to recency.
-    const preferred =
-      preferredFamily === null
-        ? undefined
-        : candidates.find((c) => c.family === preferredFamily)
-    const best = preferred ?? candidates[0]
+    // #811: route the family-preference + recency pick through the candidate
+    // scorer (the seam for a future learning-to-rank model). `candidates` is
+    // non-empty here (empty was handled above) and in reverse document order.
+    const best = this.selectAntecedent(candidates, preferredFamily) ?? candidates[0]
 
     // Case-name window check: if the prose immediately before Id. names a
     // case that doesn't match the picked antecedent, downgrade confidence and
@@ -513,6 +512,51 @@ export class DocumentResolver {
       confidence,
       warnings,
     }
+  }
+
+  /**
+   * Score scope-filtered antecedent candidates (#811). Deterministic structural
+   * scorer — `FAMILY_PREFERENCE_WEIGHT · familyMatch + recency` — reproducing the
+   * Bluebook Rule 4.1 selection "the most-recent preferred-family match, else the
+   * most-recent candidate overall". Candidates arrive in reverse document order
+   * (index 0 = most recent), so the recency term decreases with index.
+   *
+   * Built as an explicit scorer so a feature-based learning-to-rank model (adding
+   * party-name overlap, scope-depth delta, reporter/jurisdiction match, …) is a
+   * later drop-in without changing callers. This is the *seam*, not a new accuracy
+   * lever — scope/candidate-set selection dominates ranking (#812).
+   */
+  private scoreAntecedentCandidates(
+    candidates: ReadonlyArray<{ index: number; family: CitationFamily }>,
+    preferredFamily: CitationFamily | null,
+  ): number[] {
+    // Any weight > 1 makes a family match dominate the recency term (∈ (0,1]);
+    // the exact magnitude does not affect the deterministic ordering.
+    const FAMILY_PREFERENCE_WEIGHT = 10
+    const n = candidates.length
+    return candidates.map((c, i) => {
+      const recency = (n - i) / n
+      const familyMatch = preferredFamily !== null && c.family === preferredFamily ? 1 : 0
+      return FAMILY_PREFERENCE_WEIGHT * familyMatch + recency
+    })
+  }
+
+  /**
+   * Select the highest-scoring antecedent from a scope-filtered candidate list,
+   * or `undefined` to abstain (the null-candidate signal — an empty list). Strict
+   * `>` preserves the recency-first tie-break (earliest index = most recent).
+   */
+  private selectAntecedent<T extends { index: number; family: CitationFamily }>(
+    candidates: ReadonlyArray<T>,
+    preferredFamily: CitationFamily | null,
+  ): T | undefined {
+    if (candidates.length === 0) return undefined
+    const scores = this.scoreAntecedentCandidates(candidates, preferredFamily)
+    let bestIndex = 0
+    for (let i = 1; i < scores.length; i++) {
+      if (scores[i] > scores[bestIndex]) bestIndex = i
+    }
+    return candidates[bestIndex]
   }
 
   /**

--- a/tests/resolve/issue811_candidateScorer.test.ts
+++ b/tests/resolve/issue811_candidateScorer.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #811: antecedent selection routes through an explicit candidate-list
+ * scorer (the seam for a future learning-to-rank model). This pins, via the
+ * public API, the deterministic behavior the scorer reproduces on the `Id.`
+ * path: preferred-family dominates, recency breaks ties. Behavior is unchanged
+ * from the prior inline `preferred ?? candidates[0]` logic.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+const idResolvedTo = (text: string): number | undefined =>
+  (extractCitations(text, { resolve: true }) as ResolvedCitation[]).find((c) => c.type === "id")
+    ?.resolution?.resolvedTo
+
+describe("Issue #811: candidate-list scorer (Id. path)", () => {
+  it("page-pincite Id. prefers the case family over a more-recent statute", () => {
+    // case (0), statute (1); `Id. at 5` is a page pincite ⇒ case family ⇒ case (0),
+    // even though the statute is more recent.
+    expect(idResolvedTo("Smith v. Jones, 100 F.2d 1. 42 U.S.C. § 1983. Id. at 5.")).toBe(0)
+  })
+
+  it("recency breaks ties within the preferred family", () => {
+    // two cases; `Id. at 5` ⇒ most-recent case (1).
+    expect(idResolvedTo("Smith v. Jones, 100 F.2d 1. Doe v. Roe, 200 F.3d 2. Id. at 5.")).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes #811.

## What
`resolveId`'s inline antecedent pick —
```ts
const preferred = preferredFamily === null ? undefined : candidates.find((c) => c.family === preferredFamily)
const best = preferred ?? candidates[0]
```
— is now an explicit **candidate-list scorer**: `scoreAntecedentCandidates` (deterministic `FAMILY_PREFERENCE_WEIGHT·familyMatch + recency`) + `selectAntecedent`. This is the **seam** the brief asks for: a feature-based learning-to-rank model becomes a drop-in later (adding party-name overlap, scope-depth delta, reporter/jurisdiction match, …) **without changing callers**.

**No behavior change.** The scorer reproduces "most-recent preferred-family match, else most-recent overall" exactly — verified by the full suite (**277 files / 4452 tests, 0 regressions**). An empty candidate list (`selectAntecedent → undefined`) is the null-candidate abstain signal.

**Why this matters:** it future-proofs antecedent selection behind a clean interface. Per the design research (#812), getting the candidate *set* right (scope — #798/#809) dominates ranking, so this is structural plumbing, not a near-term accuracy lever.

## Scope (increment 1 of #811)
This routes the **`Id.` path** — where the candidate list and family/recency signals map cleanly to the scorer. `supra` (similarity-ranked) and short-form-case (party-name overlap) weight *different* features, so routing them through the same seam behavior-preservingly is a focused follow-up rather than one all-resolver rewrite. The seam (`scoreAntecedentCandidates` / `selectAntecedent`) is in place for them to adopt.

## Tests
- `tests/resolve/issue811_candidateScorer.test.ts`: family-preference dominates a more-recent statute; recency breaks ties (via public API).
- Full suite green; typecheck + `pnpm lint` clean; size 50.46 KB < 52 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
