### PR TITLE
fix(resolve): supra no longer leaks into string-cite parenthetical members (#819)

### DIFF
--- a/.changeset/fix-supra-string-cite-leak-819.md
+++ b/.changeset/fix-supra-string-cite-leak-819.md
@@ -1,0 +1,15 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): `supra` no longer leaks into string-cite parenthetical members (#819)
+
+`computeBracketScopes` treated the `;` separator in a `(citing A; B; C)` string
+cite as a clause boundary even while the outer `(` was still open, resetting its
+bounded bracket stack so 2nd-and-later members read depth 0 (and
+`balanceOk=false`) and escaped the #799 parenthetical-aside filter — `resolveSupra`
+could then accept a string-cite-internal authority as a named antecedent. A `;`
+inside an open paren is now treated as a string-cite separator, not a clause
+boundary, so every member reads the enclosing paren depth and is excluded like the
+first. The `.`/newline reset that confines genuinely-dangling parens (#809) is
+unchanged. This also de-pollutes the `balanceOk` structure-trust signal.

--- a/src/utils/parentheticalScope.ts
+++ b/src/utils/parentheticalScope.ts
@@ -174,10 +174,16 @@ export function computeBracketScopes(text: string, citations: Citation[]): Brack
         ch === "\r" ||
         ((ch === "." || ch === ";") && /\s/.test(text[pos + 1] ?? " "))
       ) {
-        // Clause boundary: an aside cannot continue across it. A still-open
-        // bracket here is an unclosed-open anomaly; reset the bounded scope.
-        if (stack.length > 0) balanceOk = false
-        stack.length = 0
+        // A `;` inside an open paren is a string-cite separator
+        // (`(citing A; B; C)`), not a clause boundary — keep the bounded scope
+        // so every member reads the paren depth, not just the first (#819).
+        // Otherwise a `.`/`;`/newline bounds the aside to its clause; a still-open
+        // bracket here is an unclosed-open anomaly (#809), so flag it and reset.
+        const stringCiteSeparator = ch === ";" && stack[stack.length - 1] === "("
+        if (!stringCiteSeparator) {
+          if (stack.length > 0) balanceOk = false
+          stack.length = 0
+        }
       }
     }
     scopes[i] = { depth: stack.length, balanceOk }

--- a/tests/resolve/issue819_supraStringCiteScopeLeak.test.ts
+++ b/tests/resolve/issue819_supraStringCiteScopeLeak.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Issue #819: `supra` must not resolve to a case cited only as a *non-first
+ * member* of a string-cite parenthetical `(citing A; B; C)`.
+ *
+ * Root cause: `computeBracketScopes` reset its bounded bracket stack on the `;`
+ * separator *while the outer `(` was still open*, so 2nd-and-later members read
+ * depth 0 (and `balanceOk=false`) and escaped the #799 parenthetical-aside
+ * filter. The 1st member (depth 1) was correctly excluded; later members leaked.
+ * Fix: a `;` inside an open paren is a string-cite separator, not a clause
+ * boundary — every member must read depth ≥ 1 like the first.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { Citation } from "@/types/citation"
+import type { ResolvedCitation } from "@/resolve/types"
+import { computeBracketScopes } from "@/utils/parentheticalScope"
+
+const STRING_CITE =
+  "Smith v. Jones, 1 U.S. 1 (citing Alpha v. Beta, 2 F.2d 2; Gamma v. Delta, 3 F.3d 3)."
+
+const supraResolvedTo = (text: string): number | undefined =>
+  (extractCitations(text, { resolve: true }) as ResolvedCitation[]).find((c) => c.type === "supra")
+    ?.resolution?.resolvedTo
+
+describe("Issue #819: supra skips string-cite parenthetical members", () => {
+  it("does not resolve supra to a 2nd-and-later member of (citing A; B; C)", () => {
+    // Gamma is the 2nd member, inside the (citing …) aside → not a valid supra
+    // antecedent (#799). Pre-fix it resolved to index 2 at confidence 1.0.
+    expect(supraResolvedTo(`${STRING_CITE} Gamma, supra, at 9.`)).toBeUndefined()
+  })
+
+  it("(control) already excludes the 1st member", () => {
+    expect(supraResolvedTo(`${STRING_CITE} Alpha, supra, at 9.`)).toBeUndefined()
+  })
+
+  it("computeBracketScopes: every string-cite member reads depth ≥ 1, balanceOk", () => {
+    const cites = extractCitations(STRING_CITE) as Citation[]
+    expect(cites.length).toBe(3) // Smith (outer), Alpha + Gamma (inside (citing …))
+    const scopes = computeBracketScopes(STRING_CITE, cites)
+    expect(scopes[0].depth).toBe(0) // Smith — top level
+    expect(scopes[1].depth).toBeGreaterThanOrEqual(1) // Alpha — inside the paren
+    expect(scopes[2].depth).toBeGreaterThanOrEqual(1) // Gamma — pre-fix: 0 (the bug)
+    expect(scopes[2].balanceOk).toBe(true) // pre-fix: false (the balanceOk pollution)
+  })
+})


### PR DESCRIPTION
## Before / Now

**Before:** `resolveSupra` could resolve `Gamma, supra` to a case named only as a *non-first member* of a `(citing A; B; C)` string-cite parenthetical — a #799 violation. Root cause: `computeBracketScopes` treated the `;` separator as a clause boundary *while the outer `(` was still open*, resetting its bracket stack so 2nd-and-later members read depth 0 (and `balanceOk=false`) and slipped past the parenthetical-aside filter. The 1st member (depth 1) was correctly excluded; later members leaked.

**Now:** a `;` inside an open paren is recognized as a string-cite separator, not a clause boundary, so every member reads the enclosing paren depth and is excluded like the first. The `.`/newline reset that confines genuinely-dangling parens (#809) is unchanged.

## Why this matters

Two payoffs:
1. Closes the `supra` scope leak (#819) — a confident-wrong named-antecedent attribution, the exact failure class the scope-before-recency series is eliminating.
2. **De-pollutes the `balanceOk` structure-trust signal.** The string-cite reset was firing `balanceOk=false` on ~a third of citations even in clean native legal text (measured on a verified OCR/native corpus — see #810), which would have made #820's degrade-to-soft trigger fire on legitimate string cites. **This is the prerequisite for #820.**

## Verification

- New `tests/resolve/issue819_supraStringCiteScopeLeak.test.ts` (integration + a `computeBracketScopes` unit assertion) — **red before the fix, green after**.
- Full suite: **278 files / 4455 tests pass**, 0 regressions (including #809 dangling-paren confinement and #799 supra aside-skip).
- `pnpm typecheck` and `pnpm lint` clean.

Closes #819. Unblocks #820 (degrade-to-soft can now trust `balanceOk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
