### PR TITLE
fix(resolve): degrade Id. paren-child exclusion to soft on balanceOk failure (#820)

### DIFF
--- a/.changeset/fix-degrade-soft-balanceok-820.md
+++ b/.changeset/fix-degrade-soft-balanceok-820.md
@@ -1,0 +1,15 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): degrade `Id.` parenthetical-child exclusion to soft on bracket-balance failure (#820)
+
+`resolveId` hard-dropped a candidate antecedent whenever its bracket depth said
+"nested", even when that depth came from a clause whose brackets did not balance
+(`balanceOk=false` — e.g. a dropped/garbled paren from OCR/PDF) — silently
+resolving to a farther cite at confidence 1.0. The #809 `balanceOk` signal is now
+consumed: a depth-only paren-child exclusion in a balance-failed clause is
+degraded to **soft** — the candidate is kept, confidence is capped, and a warning
+is emitted, so `idConfidenceFloor` (#800) can abstain. Trigger-anchored asides and
+`fullSpan`-contained cites stay hard exclusions (they don't depend on the fragile
+depth count), and balanced clauses are unchanged.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -21,8 +21,7 @@ import type {
 import { isFullCitation } from "../types/guards"
 import type { Span } from "../types/span"
 import { detectQuoteZones } from "../utils/detectQuoteZones"
-import { computeParenDepths } from "../utils/parenDepths"
-import { triggerAnchoredAsideOwner } from "../utils/parentheticalScope"
+import { computeBracketScopes, triggerAnchoredAsideOwner } from "../utils/parentheticalScope"
 import { BKTree } from "./bkTree"
 import { levenshteinDistance } from "./levenshtein"
 import { buildFootnoteScopes, detectParagraphBoundaries, isWithinBoundary } from "./scopeBoundary"
@@ -100,6 +99,8 @@ export class DocumentResolver {
   private readonly quoteZones: ReadonlyArray<{ start: number; end: number }>
   /** Parenthesis depth at each citation's start (filled lazily by resolve()). */
   private parenDepths: number[] = []
+  /** Per-citation bracket-balance trust (#809/#820); false = structure unreliable. */
+  private balanceOks: boolean[] = []
   /** Resolution results accumulated during the in-flight resolve() pass. */
   private resolutions: Array<ResolutionResult | undefined> = []
   /** Resolved citations accumulated during the in-flight resolve() pass; used
@@ -167,7 +168,9 @@ export class DocumentResolver {
     // Reset per-call state so a single DocumentResolver can be reused (the
     // public API currently constructs a fresh one per document, but the
     // per-instance fields make the algorithm easier to follow).
-    this.parenDepths = computeParenDepths(this.text, this.citations)
+    const scopes = computeBracketScopes(this.text, this.citations)
+    this.parenDepths = scopes.map((s) => s.depth)
+    this.balanceOks = scopes.map((s) => s.balanceOk)
     this.resolutions = new Array(this.citations.length).fill(undefined)
     this.resolvedSoFar = resolved
 
@@ -387,6 +390,9 @@ export class DocumentResolver {
     interface Candidate {
       index: number
       family: CitationFamily
+      /** #820: kept despite a paren-child match because the depth-based exclusion
+       *  was untrusted (balanceOk=false) — its confidence is degraded. */
+      soft?: boolean
     }
     const candidates: Candidate[] = []
     const seen = new Set<number>()
@@ -425,7 +431,15 @@ export class DocumentResolver {
 
       const cit = this.citations[primaryIdx]
       if (!isFullCitation(cit)) continue
-      if (this.isParentheticalChild(primaryIdx)) continue
+      // #820: a depth-only paren-child exclusion in a balance-failed clause is
+      // untrustworthy — keep the candidate but mark it `soft` (confidence is
+      // degraded below) rather than silently dropping a possibly-correct
+      // antecedent. Trigger- and fullSpan-based exclusions stay hard.
+      let soft = false
+      if (this.isParentheticalChild(primaryIdx)) {
+        if (!this.isUntrustworthyDepthAside(primaryIdx)) continue
+        soft = true
+      }
       if (!this.isWithinScope(primaryIdx, currentIndex)) continue
 
       // Quote-boundary respect: a citation inside a quote zone is not eligible
@@ -436,6 +450,7 @@ export class DocumentResolver {
       candidates.push({
         index: primaryIdx,
         family: citationFamily(cit),
+        soft,
       })
     }
 
@@ -480,7 +495,19 @@ export class DocumentResolver {
     // Case-name window check: if the prose immediately before Id. names a
     // case that doesn't match the picked antecedent, downgrade confidence and
     // flag ambiguity (without refusing to commit).
-    const { confidence, warnings } = this.applyCaseNameWindowCheck(best.index, citation)
+    const base = this.applyCaseNameWindowCheck(best.index, citation)
+    // #820: when the chosen antecedent survived only because its depth-based
+    // paren-child exclusion was untrusted (balanceOk=false), degrade to soft —
+    // cap confidence and warn so the structural uncertainty is visible (and
+    // `idConfidenceFloor` can abstain).
+    const SOFT_SCOPE_CAP = 0.5
+    const confidence = best.soft ? Math.min(base.confidence, SOFT_SCOPE_CAP) : base.confidence
+    const warnings = best.soft
+      ? [
+          ...(base.warnings ?? []),
+          "Id. antecedent scope unreliable: bracket balance failed near the antecedent; depth-based paren-child exclusion degraded to soft (#820)",
+        ]
+      : base.warnings
 
     // #800: opt-in abstention. When `idConfidenceFloor` is set and the computed
     // confidence falls below it, decline to commit (mirroring resolveSupra's
@@ -603,12 +630,20 @@ export class DocumentResolver {
    * supra antecedents.
    */
   private isParentheticalChild(index: number): boolean {
-    if (this.isParentheticalAside(index)) return true
+    return this.isParentheticalAside(index) || this.isFullSpanContained(index)
+  }
+
+  /**
+   * Whether the citation's clean span is wholly inside a previously-resolved
+   * citation's `fullSpan` (the #214 strategy-2 signal). Independent of the
+   * fragile bracket-depth count, so it stays a *hard* exclusion even when
+   * balance fails (#820).
+   */
+  private isFullSpanContained(index: number): boolean {
     const cit = this.citations[index]
     for (let i = 0; i < this.resolvedSoFar.length; i++) {
       if (i === index) continue // a citation cannot be a paren child of itself
-      const prior = this.resolvedSoFar[i]
-      const priorFullSpan = getFullSpan(prior)
+      const priorFullSpan = getFullSpan(this.resolvedSoFar[i])
       if (!priorFullSpan) continue
       if (
         priorFullSpan.cleanStart <= cit.span.cleanStart &&
@@ -618,6 +653,21 @@ export class DocumentResolver {
       }
     }
     return false
+  }
+
+  /**
+   * #820: the citation's paren-child status rests ONLY on the (possibly
+   * desynced) bracket depth, in a clause whose brackets did not balance — so the
+   * "nested" verdict is untrustworthy. Trigger-anchored asides and
+   * fullSpan-contained cites are reliable (independent of the depth count) and
+   * stay hard exclusions; only the depth-only case under balance failure is
+   * soft, which `resolveId` keeps as a degraded-confidence candidate.
+   */
+  private isUntrustworthyDepthAside(index: number): boolean {
+    if (this.balanceOks[index] !== false) return false
+    if (this.parenDepths[index] <= 0) return false
+    if (triggerAnchoredAsideOwner(this.text, this.citations, index) !== undefined) return false
+    return !this.isFullSpanContained(index)
   }
 
   /**

--- a/tests/resolve/issue820_degradeSoftBalanceOk.test.ts
+++ b/tests/resolve/issue820_degradeSoftBalanceOk.test.ts
@@ -49,4 +49,16 @@ describe("Issue #820: degrade-to-soft on balanceOk failure (Id. path)", () => {
     expect(r?.confidence).toBe(1)
     expect(r?.warnings ?? []).toHaveLength(0)
   })
+
+  it("a fullSpan-contained cite stays HARD-excluded even when balanceOk=false", () => {
+    // Bar sits inside Foo's `fullSpan` AND its clause failed balance (`(see ] Bar…`),
+    // with no trigger word. fullSpan-containment is independent of the fragile
+    // depth count, so it stays a HARD exclusion — Id. resolves to Foo at full
+    // confidence with no #820 warning. Without the fullSpan guard, Bar would be
+    // soft-kept (balanceOk=false + depth, no trigger) and win on recency.
+    const r = idResolution("Foo v. Goo, 1 U.S. 1 (see ] Bar v. Baz, 2 U.S. 2). Id. at 5.")
+    expect(r?.resolvedTo).toBe(0) // Foo — not the fullSpan-contained Bar (idx 1)
+    expect(r?.confidence).toBe(1)
+    expect(r?.warnings ?? []).toHaveLength(0)
+  })
 })

--- a/tests/resolve/issue820_degradeSoftBalanceOk.test.ts
+++ b/tests/resolve/issue820_degradeSoftBalanceOk.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Issue #820: degrade the depth-based parenthetical-child exclusion to *soft*
+ * when the antecedent's clause has a bracket-balance failure (#809 `balanceOk`).
+ *
+ * A candidate that looks nested only because of a (possibly desynced) bracket
+ * depth, in a clause whose brackets did not balance, is an untrustworthy
+ * exclusion. `resolveId` previously hard-dropped it and silently resolved to a
+ * farther cite at confidence 1.0. Now it keeps the candidate but caps confidence
+ * and warns, so `idConfidenceFloor` (#800) can abstain. Where balance is clean,
+ * the exclusion stays hard. Wires the #809 `balanceOk` signal per #810/#817.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+// Smith (idx 1) reads depth=1, balanceOk=false: a `) (` desync makes it look
+// nested, but the failed balance means that "nested" verdict is untrustworthy.
+const UNTRUSTED = "Foo v. Goo, 1 U.S. 1 ) ( Smith v. Jones, 2 U.S. 2. Id. at 5."
+// Balanced `(quoting …)`: Smith is a genuine, trustworthy aside (balanceOk=true).
+const BALANCED = "Foo v. Goo, 1 U.S. 1 (quoting Smith v. Jones, 2 U.S. 2). Id. at 5."
+
+const idResolution = (text: string, idConfidenceFloor?: number) =>
+  (
+    extractCitations(text, {
+      resolve: true,
+      resolutionOptions: idConfidenceFloor === undefined ? undefined : { idConfidenceFloor },
+    }) as ResolvedCitation[]
+  ).find((c) => c.type === "id")?.resolution
+
+describe("Issue #820: degrade-to-soft on balanceOk failure (Id. path)", () => {
+  it("keeps the untrusted-depth antecedent but caps confidence and warns", () => {
+    // Pre-fix: silently resolved to Foo (0) at confidence 1.0, no warning.
+    const r = idResolution(UNTRUSTED)
+    expect(r?.resolvedTo).toBe(1) // Smith — no longer hard-dropped
+    expect(r?.confidence).toBeLessThanOrEqual(0.5)
+    expect(r?.warnings?.some((w) => /balance|scope|#820/i.test(w))).toBe(true)
+  })
+
+  it("idConfidenceFloor above the soft cap abstains", () => {
+    const r = idResolution(UNTRUSTED, 0.7)
+    expect(r?.resolvedTo).toBeUndefined()
+    expect(r?.failureReason).toMatch(/idConfidenceFloor/)
+  })
+
+  it("(regression) a balanced aside stays a hard exclusion at full confidence", () => {
+    const r = idResolution(BALANCED)
+    expect(r?.resolvedTo).toBe(0) // Foo — Smith hard-excluded as before
+    expect(r?.confidence).toBe(1)
+    expect(r?.warnings ?? []).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Before / Now

**Before:** `resolveId` hard-dropped a candidate antecedent whenever its bracket *depth* said "nested" — even when that depth came from a clause whose brackets didn't balance (`balanceOk=false`, e.g. a dropped/garbled paren from OCR/PDF). It then silently resolved to a farther cite at confidence 1.0, no warning. The #809 `balanceOk` structure-trust signal was produced but consumed nowhere.

**Now:** a depth-only paren-child exclusion in a balance-failed clause is degraded to **soft** — the candidate is kept, confidence is capped (≤ 0.5), and a warning is emitted, so `idConfidenceFloor` (#800) can abstain. Trigger-anchored asides and `fullSpan`-contained cites stay **hard** exclusions (they don't depend on the fragile depth count); balanced clauses are unchanged.

## Why this matters

Wires the `balanceOk` signal the #810/#817 measurement recommended, completing the "degrade-to-soft on balance failure" half of the scope policy. It turns a silent-confident-wrong attribution — the exact failure class this series targets — into a low-confidence, warned, abstainable one, *precisely* where the bracket structure is untrustworthy. **#819 had to land first** so `balanceOk` reflects genuine structural failure rather than the string-cite `;` separator; this builds on that.

## Verification

- New `tests/resolve/issue820_degradeSoftBalanceOk.test.ts` — **red before, green after**:
  1. an untrusted-depth antecedent is kept with capped confidence + a balance warning instead of a silent full-confidence resolution;
  2. `idConfidenceFloor` above the cap abstains;
  3. a balanced aside stays a hard exclusion at full confidence (regression).
- Full suite: **279 files / 4458 tests pass**, 0 regressions.
- `pnpm typecheck` + `pnpm lint` clean.

Closes #820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
