### PR TITLE
fix(resolve): supra abstains/degrades on non-unique party-name keys (#818)

### DIFF
--- a/.changeset/fix-supra-cardinality-abstain-818.md
+++ b/.changeset/fix-supra-cardinality-abstain-818.md
@@ -1,0 +1,16 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): `supra` abstains / degrades on non-unique party-name keys (#818)
+
+`resolveSupra` silently committed to one authority at confidence 1.0 when a
+`supra`'s party-name key matched **>1 distinct in-scope authority** (the
+name-keyed history collapsed them via last-write-wins, hiding the ambiguity).
+`fullCitationHistory` is now a `Map<string, number[]>`, and `resolveSupra` applies
+a hybrid policy: exactly one authority resolves as before; a **true tie** (same
+name + same year, indistinguishable by the key) **abstains**; otherwise it picks
+the most-recent-within-name but **caps confidence and warns**, with
+`idConfidenceFloor` able to fail it closed — mirroring the `Id.` path (#800/#820).
+Parallel-cite siblings and re-citations (shared `groupId`, or volume-reporter-page)
+collapse to a single authority, so they never trigger false ambiguity.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -797,14 +797,15 @@ export class DocumentResolver {
     const fullPartyName = this.normalizePartyName(citation.partyName)
     const vSplit = fullPartyName.split(/\s+vs?\.\s+/)
 
+    // A full caption (`Plaintiff v. Defendant, supra`) is self-disambiguating, so
+    // it takes precedence and never falls through to the looser per-name queries
+    // (which would falsely flag a shared surname as ambiguous). #818: the caption
+    // can still be non-unique (two identical `Smith v. Jones`), so route its match
+    // set through the cardinality policy.
     if (vSplit.length === 2) {
-      const captionMatch = this.queryFullCaptionSupra(
-        vSplit[0].trim(),
-        vSplit[1].trim(),
-        currentIndex,
-      )
-      if (captionMatch) {
-        return this.createSupraSuccess(captionMatch)
+      const caption = this.queryFullCaptionSupra(vSplit[0].trim(), vSplit[1].trim(), currentIndex)
+      if (caption) {
+        return this.selectSupraAntecedent([...new Set(caption.indices)], caption.similarity)
       }
     }
 
@@ -821,26 +822,91 @@ export class DocumentResolver {
       }
     }
 
-    let bestMatch: { index: number; similarity: number } | undefined
+    // Aggregate all distinct in-scope authorities at the best similarity tier
+    // across the queries (#818: cardinality must survive to the policy step).
+    let bestSim = -1
+    const bestIndices: number[] = []
     for (const query of queries) {
       const match = this.queryPartyNameTree(query, currentIndex)
       if (!match) continue
-      if (!bestMatch || match.similarity > bestMatch.similarity) {
-        bestMatch = match
+      if (match.similarity > bestSim) {
+        bestSim = match.similarity
+        bestIndices.length = 0
+        bestIndices.push(...match.indices)
+      } else if (match.similarity === bestSim) {
+        for (const i of match.indices) if (!bestIndices.includes(i)) bestIndices.push(i)
       }
     }
 
-    if (!bestMatch) {
+    if (bestIndices.length === 0) {
       return this.createFailureResult("No full citation found in scope")
     }
-
-    if (bestMatch.similarity < this.options.partyMatchThreshold) {
+    if (bestSim < this.options.partyMatchThreshold) {
       return this.createFailureResult(
-        `Party name similarity ${bestMatch.similarity.toFixed(2)} below threshold ${this.options.partyMatchThreshold}`,
+        `Party name similarity ${bestSim.toFixed(2)} below threshold ${this.options.partyMatchThreshold}`,
       )
     }
 
-    return this.createSupraSuccess(bestMatch)
+    return this.selectSupraAntecedent([...new Set(bestIndices)], bestSim)
+  }
+
+  /**
+   * Apply the #818 hybrid policy to the in-scope authorities a `supra` name key
+   * resolved to. Exactly one → commit at the matched similarity. More than one is
+   * a non-unique key: a *true tie* (same name + same year, indistinguishable by
+   * the key alone) abstains; otherwise pick the most-recent-within-name but cap
+   * confidence and warn, with `idConfidenceFloor` able to fail it closed. Mirrors
+   * the `Id.` path's downgrade-warn-then-floor-abstain shape (#800/#820).
+   */
+  private selectSupraAntecedent(
+    indices: number[],
+    similarity: number,
+  ): ResolutionResult | undefined {
+    // Collapse parallel-cite siblings / re-citations of the SAME authority into
+    // one: parallel cites share a `groupId`, and a re-cited reporter shares
+    // volume-reporter-page. #818 must only fire on genuinely *different*
+    // same-name authorities, not on a parallel-cite group. Representative = the
+    // group's primary (earliest-cited) index.
+    const primaryByAuthority = new Map<string, number>()
+    for (const i of indices) {
+      const c = this.citations[i] as {
+        groupId?: string
+        volume?: number | string
+        reporter?: string
+        page?: number | string
+      }
+      const key = c.groupId ?? `${c.volume}-${c.reporter}-${c.page}`
+      const prev = primaryByAuthority.get(key)
+      if (prev === undefined || i < prev) primaryByAuthority.set(key, i)
+    }
+    const reps = [...primaryByAuthority.values()]
+
+    if (reps.length === 1) {
+      return this.createSupraSuccess({ index: reps[0], similarity })
+    }
+    const years = new Set(reps.map((i) => (this.citations[i] as { year?: number }).year))
+    if (years.size === 1) {
+      return this.createFailureResult(
+        `Ambiguous supra: ${reps.length} in-scope authorities share this name key and year — indistinguishable (#818)`,
+      )
+    }
+    // Distinguishable: recency-within-name (most-recent authority), degraded.
+    const chosen = Math.max(...reps)
+    const confidence = Math.min(similarity, 0.5)
+    const warnings = [
+      `Ambiguous supra: ${reps.length} in-scope authorities match this name key; resolved to the most recent by recency — verify (#818)`,
+    ]
+    const idFloor = this.options.idConfidenceFloor
+    if (idFloor !== undefined && confidence < idFloor) {
+      if (!this.options.reportUnresolved) return undefined
+      return {
+        resolvedTo: undefined,
+        failureReason: `Ambiguous supra confidence ${confidence.toFixed(2)} below idConfidenceFloor ${idFloor}`,
+        warnings,
+        confidence,
+      }
+    }
+    return { resolvedTo: chosen, antecedentIndex: chosen, confidence, warnings }
   }
 
   private createSupraSuccess(match: { index: number; similarity: number }): ResolutionResult {
@@ -875,10 +941,11 @@ export class DocumentResolver {
     plaintiffQuery: string,
     defendantQuery: string,
     currentIndex: number,
-  ): { index: number; similarity: number } | undefined {
+  ): { indices: number[]; similarity: number } | undefined {
     if (!plaintiffQuery || !defendantQuery) return undefined
 
-    let best: { index: number; similarity: number } | undefined
+    let bestSim = -1
+    const bestIndices: number[] = []
     for (let i = currentIndex - 1; i >= 0; i--) {
       const candidate = this.citations[i]
       if (candidate.type !== "case") continue
@@ -900,13 +967,19 @@ export class DocumentResolver {
       if (plaintiffSimilarity < this.options.partyMatchThreshold) continue
       if (defendantSimilarity < this.options.partyMatchThreshold) continue
 
+      // #818: collect ALL authorities at the top similarity tier so the caller
+      // can detect a non-unique caption (e.g. two identical `Smith v. Jones`).
       const similarity = Math.min(plaintiffSimilarity, defendantSimilarity)
-      if (!best || similarity > best.similarity) {
-        best = { index: i, similarity }
+      if (similarity > bestSim) {
+        bestSim = similarity
+        bestIndices.length = 0
+        bestIndices.push(i)
+      } else if (similarity === bestSim) {
+        bestIndices.push(i)
       }
     }
 
-    return best
+    return bestIndices.length > 0 ? { indices: bestIndices, similarity: bestSim } : undefined
   }
 
   /**
@@ -918,7 +991,7 @@ export class DocumentResolver {
   private queryPartyNameTree(
     query: string,
     currentIndex: number,
-  ): { index: number; similarity: number } | undefined {
+  ): { indices: number[]; similarity: number } | undefined {
     const queryLen = query.length
     const threshold = this.options.partyMatchThreshold
     // Safe upper bound: guarantees no match with similarity >= threshold is missed
@@ -928,28 +1001,35 @@ export class DocumentResolver {
     // Sort by insertion order to match Map iteration behavior (first-inserted wins on ties)
     candidates.sort((a, b) => a.insertionOrder - b.insertionOrder)
 
-    let best: { index: number; similarity: number } | undefined
+    let bestSim = -1
+    const bestIndices: number[] = []
     for (const candidate of candidates) {
-      const citationIndex = this.context.fullCitationHistory.get(candidate.key)
-      if (citationIndex === undefined) continue
+      const indices = this.context.fullCitationHistory.get(candidate.key)
+      if (indices === undefined) continue
 
-      // Check scope boundary (supra allows cross-zone: footnote -> body)
-      if (!this.isWithinScope(citationIndex, currentIndex, true)) continue
-      // #799: skip antecedents cited only inside another cite's `(quoting …)`
-      // aside, matching `resolveId`'s #214 parenthetical-child exclusion. Uses
-      // the precise aside signal so parallel-cite siblings are not excluded.
-      if (this.isParentheticalAside(citationIndex)) continue
-
-      // Convert distance to normalized similarity
+      // Convert distance to normalized similarity (one per key, shared by its cites)
       const maxLen = Math.max(queryLen, candidate.key.length)
       const similarity = maxLen === 0 ? 1.0 : 1 - candidate.distance / maxLen
 
-      // Update best match if this is better (strict > preserves first-wins tie-breaking)
-      if (!best || similarity > best.similarity) {
-        best = { index: citationIndex, similarity }
+      for (const citationIndex of indices) {
+        // Check scope boundary (supra allows cross-zone: footnote -> body)
+        if (!this.isWithinScope(citationIndex, currentIndex, true)) continue
+        // #799: skip antecedents cited only inside another cite's `(quoting …)`
+        // aside, matching `resolveId`'s #214 parenthetical-child exclusion.
+        if (this.isParentheticalAside(citationIndex)) continue
+
+        // #818: keep ALL distinct authorities at the top similarity tier so a
+        // non-unique name key (e.g. two `Smith`s) is visible to the caller.
+        if (similarity > bestSim) {
+          bestSim = similarity
+          bestIndices.length = 0
+          bestIndices.push(citationIndex)
+        } else if (similarity === bestSim && !bestIndices.includes(citationIndex)) {
+          bestIndices.push(citationIndex)
+        }
       }
     }
-    return best
+    return bestIndices.length > 0 ? { indices: bestIndices, similarity: bestSim } : undefined
   }
 
   private partyNameSimilarity(query: string, candidate: string | undefined): number {
@@ -1231,25 +1311,27 @@ export class DocumentResolver {
   private trackFullCitation(citation: Citation, index: number): void {
     // Only case citations have party names for supra resolution
     if (citation.type === "case") {
+      // #818: append `index` to the name's history list — a single normalized
+      // name can map to several distinct authorities (e.g. two `Smith` cases).
+      const track = (name: string) => {
+        const existing = this.context.fullCitationHistory.get(name)
+        if (existing) {
+          if (!existing.includes(index)) existing.push(index)
+        } else {
+          this.context.fullCitationHistory.set(name, [index])
+        }
+        this.partyNameTree.insert(name)
+      }
+
       // Phase 7: Use extracted party names when available
       // Defendant name stored first (preferred for Bluebook-style supra matching)
-      if (citation.defendantNormalized) {
-        this.context.fullCitationHistory.set(citation.defendantNormalized, index)
-        this.partyNameTree.insert(citation.defendantNormalized)
-      }
-      if (citation.plaintiffNormalized) {
-        this.context.fullCitationHistory.set(citation.plaintiffNormalized, index)
-        this.partyNameTree.insert(citation.plaintiffNormalized)
-      }
+      if (citation.defendantNormalized) track(citation.defendantNormalized)
+      if (citation.plaintiffNormalized) track(citation.plaintiffNormalized)
 
       // Fallback: backward search from text (pre-Phase 7 compatibility)
       if (!citation.plaintiffNormalized && !citation.defendantNormalized) {
         const partyName = this.extractPartyName(citation)
-        if (partyName) {
-          const normalized = this.normalizePartyName(partyName)
-          this.context.fullCitationHistory.set(normalized, index)
-          this.partyNameTree.insert(normalized)
-        }
+        if (partyName) track(this.normalizePartyName(partyName))
       }
     }
   }

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -157,10 +157,11 @@ export interface ResolutionContext {
 
   /**
    * History of all full citations by party name.
-   * Maps normalized party name to citation index.
-   * Used for supra resolution.
+   * Maps a normalized party name to ALL citation indices that share it (in
+   * document order), so the supra resolver can detect a non-unique name key
+   * (#818). Used for supra resolution.
    */
-  fullCitationHistory: Map<string, number>
+  fullCitationHistory: Map<string, number[]>
 
   /**
    * Map of citation index to paragraph number.

--- a/tests/resolve/issue818_supraCardinalityAbstain.test.ts
+++ b/tests/resolve/issue818_supraCardinalityAbstain.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Issue #818: `resolveSupra` must not silently commit at full confidence when a
+ * party-name key matches >1 distinct in-scope authority. Hybrid policy
+ * (warn + tie-abstain):
+ *   - exactly 1 match → resolve as before (full confidence);
+ *   - >1, distinguishable (different years) → recency-within-name, but capped
+ *     confidence + ambiguity warning (idConfidenceFloor can fail it closed);
+ *   - >1, true tie (same name + same year) → abstain (failureReason).
+ * Root cause: `fullCitationHistory` collapsed same-name authorities (last-write-
+ * wins); it is now a `Map<string, number[]>` so the cardinality is visible.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+const DIFF_YEARS =
+  "Smith v. Jones, 100 F.2d 1 (2010). Smith v. Roe, 200 F.3d 2 (2012). Smith, supra, at 5."
+const SAME_YEAR =
+  "Smith v. Jones, 100 F.2d 1 (2010). Smith v. Roe, 200 F.3d 2 (2010). Smith, supra, at 5."
+const UNIQUE = "Smith v. Jones, 100 F.2d 1 (2010). Doe v. Roe, 200 F.3d 2 (2012). Smith, supra, at 5."
+const CAPTION_TIE =
+  "Smith v. Jones, 100 F.2d 1 (2010). Smith v. Jones, 200 F.3d 2 (2010). Smith v. Jones, supra, at 5."
+
+const supraResolution = (text: string, idConfidenceFloor?: number) =>
+  (
+    extractCitations(text, {
+      resolve: true,
+      resolutionOptions: idConfidenceFloor === undefined ? undefined : { idConfidenceFloor },
+    }) as ResolvedCitation[]
+  ).find((c) => c.type === "supra")?.resolution
+
+describe("Issue #818: supra abstains/degrades on non-unique party-name keys", () => {
+  it(">1 distinguishable match → recency-within-name, capped confidence + ambiguity warning", () => {
+    // Pre-fix: silently resolved to idx 1 at confidence 1.0, no warning.
+    const r = supraResolution(DIFF_YEARS)
+    expect(r?.resolvedTo).toBe(1) // most-recent Smith (recency-within-name)
+    expect(r?.confidence).toBeLessThanOrEqual(0.5)
+    expect(r?.warnings?.some((w: string) => /ambiguous|#818/i.test(w))).toBe(true)
+  })
+
+  it("true tie (same name + same year) → abstains", () => {
+    const r = supraResolution(SAME_YEAR)
+    expect(r?.resolvedTo).toBeUndefined()
+    expect(r?.failureReason).toMatch(/ambiguous|indistinguishable/i)
+  })
+
+  it("(control) unique name key still resolves at full confidence", () => {
+    const r = supraResolution(UNIQUE)
+    expect(r?.resolvedTo).toBe(0)
+    expect(r?.confidence).toBe(1)
+    expect(r?.warnings ?? []).toHaveLength(0)
+  })
+
+  it("idConfidenceFloor fails the distinguishable-ambiguous case closed", () => {
+    const r = supraResolution(DIFF_YEARS, 0.7)
+    expect(r?.resolvedTo).toBeUndefined()
+    expect(r?.failureReason).toBeDefined()
+  })
+
+  it("full-caption duplicate (same name + year) also abstains", () => {
+    const r = supraResolution(CAPTION_TIE)
+    expect(r?.resolvedTo).toBeUndefined()
+    expect(r?.failureReason).toMatch(/ambiguous|indistinguishable/i)
+  })
+})


### PR DESCRIPTION
## Before / Now

**Before:** `resolveSupra` silently committed to one authority at **confidence 1.0, no warning** when a `supra`'s party-name key matched **>1 distinct in-scope authority** (e.g. two different `Smith` cases). The name-keyed history `Map<string, number>` collapsed same-name authorities via last-write-wins, so the resolver structurally couldn't even *see* the ambiguity — even a same-name/same-year true tie committed silently.

**Now:** `fullCitationHistory` is a `Map<string, number[]>`, so cardinality survives to resolution. The hybrid policy:
- **exactly 1 authority** → resolves as before (full confidence);
- **>1, distinguishable** (different years) → recency-within-name, but **confidence capped + ambiguity warning** (and `idConfidenceFloor` fails it closed);
- **>1, true tie** (same name + same year, indistinguishable by the key) → **abstains** (`failureReason`).

Parallel-cite siblings and re-citations (shared `groupId`, or volume-reporter-page) collapse to a single authority, so they never trigger false ambiguity.

## Why this matters

Closes the last silent-confident-wrong attribution on the `supra` path — the exact failure class the scope-before-recency series targets — aligning `supra` with the `Id.` path's downgrade-warn-then-floor-abstain shape (#800/#820) and upstream eyecite's fail-closed `matches[0] if len==1 else None`.

## Verification

Belt-and-suspenders — five dedicated tests in `issue818_supraCardinalityAbstain.test.ts`:
1. >1 distinguishable → recency-within-name, capped confidence + warning;
2. true tie (same year) → abstains;
3. unique control → full confidence (no regression);
4. `idConfidenceFloor` fails the distinguishable-ambiguous case closed;
5. full-caption duplicate (same name + year) → abstains.

The TDD red→green pass also surfaced and fixed a parallel-cite regression (siblings were wrongly counted as distinct authorities) — `#504` and the adversarial "supra after parallel cite" tests pass. Full suite **4464 passing, 0 regressions**; `typecheck` + `lint` clean.

Closes #818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
