### PR TITLE
fix(resolve): recognize history subordinators in the trigger lexicon (#821)

### DIFF
--- a/.changeset/fix-trigger-lexicon-history-821.md
+++ b/.changeset/fix-trigger-lexicon-history-821.md
@@ -1,0 +1,15 @@
+---
+"eyecite-ts": patch
+---
+
+fix(resolve): recognize prior-/subsequent-history subordinators in the trigger lexicon (#821)
+
+The resolver-shared parenthetical-aside detector recognized only `quoting` /
+`citing` / `quoted in` / `cited in`. Under a dropped or garbled opening paren
+(OCR/PDF), a citation introduced by a history subordinator (`overruled by`,
+`abrogated by`, `superseded by`, `cited with approval in`, `as recognized in`) was
+not seen as an aside, so the #214/#799 exclusion never fired and recency
+mis-resolved `Id.`/`supra` to the subordinated cite. These tokens are now in the
+lexicon. It is a **soft** signal: it only changes resolution on dropped/garbled-paren
+input (balanced asides are already caught by bracket depth), and the regex stays
+ReDoS-safe (flat alternation, `\s+`-joined multi-word tokens).

--- a/src/utils/parentheticalScope.ts
+++ b/src/utils/parentheticalScope.ts
@@ -21,10 +21,29 @@ import type { Citation } from "../types/citation"
  * vocabulary. (End-of-parenthetical markers like "emphasis added" are not here:
  * they do not introduce a citation.)
  */
-export const PARENTHETICAL_TRIGGER_WORDS = ["quoting", "citing", "quoted in", "cited in"] as const
+export const PARENTHETICAL_TRIGGER_WORDS = [
+  "quoting",
+  "citing",
+  "quoted in",
+  "cited in",
+  // #821: prior-/subsequent-history subordinators — the cite they introduce is a
+  // subordinate aside of the previous authority, not a new antecedent. Only
+  // changes resolution under a dropped/garbled paren (balanced asides are caught
+  // by bracket depth); a soft signal layered on the hard bracket-scope filter.
+  "overruled by",
+  "abrogated by",
+  "superseded by",
+  "cited with approval in",
+  "as recognized in",
+] as const
 
-/** Matches a trigger word at the very end of a region (optionally `… from`/`… to`). */
-const TRIGGER_AT_END_RE = /\b(?:quoting|citing|quoted in|cited in)(?:\s+(?:from|to))?[\s,]*$/i
+/**
+ * Matches a trigger word at the very end of a region (optionally `… from`/`… to`).
+ * Multi-word triggers use `\s+` to tolerate OCR spacing; the flat alternation
+ * (no nested quantifiers) keeps it ReDoS-safe.
+ */
+const TRIGGER_AT_END_RE =
+  /\b(?:quoting|citing|quoted in|cited in|overruled\s+by|abrogated\s+by|superseded\s+by|cited\s+with\s+approval\s+in|as\s+recognized\s+in)(?:\s+(?:from|to))?[\s,]*$/i
 
 /** A sentence terminator (`. ` / `; ` / newline) — bounds an aside to its clause. */
 const SENTENCE_TERMINATOR_RE = /[.;]\s|[\n\r]/

--- a/tests/resolve/issue821_triggerLexiconHistory.test.ts
+++ b/tests/resolve/issue821_triggerLexiconHistory.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Issue #821: the resolver-shared subordinating-trigger lexicon recognized only
+ * quoting / citing / quoted in / cited in. Under a dropped opening paren
+ * (OCR/PDF), a citation introduced by a prior-/subsequent-history subordinator
+ * (`overruled by`, `abrogated by`, `cited with approval in`, …) was NOT
+ * recognized as a parenthetical aside, so the #214/#799 exclusion never fired
+ * and recency mis-resolved `Id.` to the subordinated cite. The lexicon now
+ * covers these — a soft signal that only changes behavior when the paren is
+ * dropped/garbled (balanced asides are already handled by bracket depth).
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+const idResolvedTo = (text: string): number | undefined =>
+  (extractCitations(text, { resolve: true }) as ResolvedCitation[]).find((c) => c.type === "id")
+    ?.resolution?.resolvedTo
+
+// Outer authority Smith (idx 0); subordinated cite Jones (idx 1) introduced by a
+// history trigger with a DROPPED opening paren (the OCR failure mode).
+const dropped = (trigger: string) =>
+  `Smith v. Allen, 5 U.S. 5 (1990) ${trigger} Jones v. Doe, 6 F.3d 6. Id. at 7.`
+
+describe("Issue #821: resolver trigger lexicon covers history subordinators", () => {
+  it("excludes a dropped-paren `(overruled by …)` aside → Id. resolves to the outer cite", () => {
+    expect(idResolvedTo(dropped("overruled by"))).toBe(0) // Smith, not Jones
+  })
+
+  it("excludes a dropped-paren `(abrogated by …)` aside", () => {
+    expect(idResolvedTo(dropped("abrogated by"))).toBe(0)
+  })
+
+  it("excludes a multi-word `(cited with approval in …)` aside", () => {
+    expect(idResolvedTo(dropped("cited with approval in"))).toBe(0)
+  })
+
+  it("(regression) balanced `(overruled by …)` is still excluded via bracket depth", () => {
+    expect(
+      idResolvedTo("Smith v. Allen, 5 U.S. 5 (1990) (overruled by Jones v. Doe, 6 F.3d 6). Id. at 7."),
+    ).toBe(0)
+  })
+
+  it("(regression) existing `quoting` trigger still recognized on a dropped paren", () => {
+    expect(idResolvedTo(dropped("quoting"))).toBe(0)
+  })
+
+  it("does NOT over-trigger on a non-subordinating signal (`See also` is a new authority)", () => {
+    // `See also Jones …` introduces Jones as its own authority, not a subordinate
+    // aside of Smith — `Id.` correctly anchors to the immediate Jones (idx 1).
+    expect(
+      idResolvedTo("Smith v. Allen, 5 U.S. 5 (1990). See also Jones v. Doe, 6 F.3d 6. Id. at 7."),
+    ).toBe(1)
+  })
+})


### PR DESCRIPTION
## Before / Now

**Before:** the resolver-shared parenthetical-aside detector recognized only `quoting` / `citing` / `quoted in` / `cited in`. Under a dropped/garbled opening paren (OCR/PDF), a citation introduced by a prior-/subsequent-history subordinator — `overruled by`, `abrogated by`, `superseded by`, `cited with approval in`, `as recognized in` — was *not* recognized as a subordinate aside, so the #214/#799 exclusion never fired and recency mis-resolved `Id.`/`supra` to the subordinated cite (e.g. `Smith … (1990) overruled by Jones …. Id.` → Jones).

**Now:** those tokens are in the lexicon (`TRIGGER_AT_END_RE` + the documented `PARENTHETICAL_TRIGGER_WORDS`), so the subordinated cite is excluded and `Id.` anchors to the outer authority. A **soft** signal — it only changes resolution on dropped/garbled-paren input; balanced asides are already handled by bracket depth.

## Why this matters

The OCR/PDF-robustness item flagged by the #810 measurement (OCR yields ~3.5× fewer detectable triggers). Closes a recency mis-resolution that only surfaces on dirty input, with no change to the clean-text default path.

## Verification

Belt-and-suspenders — six tests in `issue821_triggerLexiconHistory.test.ts`:
- per-trigger: `(overruled by)`, `(abrogated by)`, multi-word `(cited with approval in)` → `Id.` resolves to the outer cite;
- regressions: balanced `(overruled by)` (depth handles it), existing `quoting` on a dropped paren;
- negative: `See also Jones` must NOT over-trigger (Jones is a new authority → `Id.` anchors to it).

Full suite **4470 passing, 0 regressions** (incl. the citation-graph path that shares the lexicon); `typecheck` + `lint` clean; regex remains ReDoS-safe (flat alternation, `\s+`-joined multi-word tokens).

Closes #821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
