### PR TITLE
docs(research): mark #818–#821 shipped in the shortform-resolution ledger + analysis

### DIFF
--- a/docs/research/2026-06-03-shortform-resolution-811-scorer-seam-analysis.md
+++ b/docs/research/2026-06-03-shortform-resolution-811-scorer-seam-analysis.md
@@ -78,30 +78,32 @@ Then #810/#817 closed the loop: the measurement found recovery is already 100% o
 
 ## The honest gaps (what "no behavior change" quietly leaves on the floor)
 
-These are not defects — PR #816 did exactly what it advertised — but they are the real state of play for anyone picking this up:
+> **Update (2026-06-03):** these were the gaps right after #811. The do-now slate has since shipped — gap 3 (`balanceOk` unconsumed) is **resolved by #820**; supra cardinality/abstain landed in **#818**; history-subordinator triggers in **#821**. Each gap is annotated with its current status.
 
-1. **The seam is 1/3 wired.** Only `resolveId` routes through `selectAntecedent` (it is the sole call site). `resolveSupra` still ranks by BK-tree Levenshtein similarity (`src/resolve/DocumentResolver.ts:868`), and `resolveShortFormCase` still does its own party-overlap + recency loop (`src/resolve/DocumentResolver.ts:1009`). The PR acknowledges this ("supra/short-form route through the seam in a follow-up"), but note *why* it is non-trivial: those paths weight **different features** (similarity, party overlap) than family+recency, so unifying them means generalizing the feature vector, not just moving code.
+These were not defects — PR #816 did exactly what it advertised — but they were the real state of play right after the seam:
 
-2. **The literature's "dummy/null candidate" abstain mechanism isn't actually realized.** Docs #05/#08 lean hard on Lee et al.'s null candidate (scored 0) as the *native* abstain signal. In code, `selectAntecedent` returns `undefined` only on an **empty list** — but the sole caller already pre-guards emptiness at `src/resolve/DocumentResolver.ts:442` (returns before reaching line 478). So `selectAntecedent`'s `undefined` return and the `?? candidates[0]` fallback are **both dead from the only caller today**. Abstention is done entirely downstream by `idConfidenceFloor` (#800) at `src/resolve/DocumentResolver.ts:489`, not by a scored null candidate inside the scorer. The seam is forward-compatible with that mechanism; it just doesn't implement it yet.
+1. **The seam is 1/3 wired.** Only `resolveId` routes through `selectAntecedent` (it is the sole call site). `resolveSupra` still ranks by BK-tree Levenshtein similarity (`src/resolve/DocumentResolver.ts:868`), and `resolveShortFormCase` still does its own party-overlap + recency loop (`src/resolve/DocumentResolver.ts:1009`). The PR acknowledges this ("supra/short-form route through the seam in a follow-up"), but note *why* it is non-trivial: those paths weight **different features** (similarity, party overlap) than family+recency, so unifying them means generalizing the feature vector, not just moving code. **(Still open as of 2026-06-03):** #818 added supra cardinality / tie-abstain, but on its own path — `resolveSupra` still does not route through the `selectAntecedent` scorer.
 
-3. **`balanceOk` is produced but consumed nowhere.** #809's stack emits the per-clause structure-trust signal (`src/utils/parentheticalScope.ts:183`), but `src/utils/parenDepths.ts:20` maps it straight to `.depth` and **drops `balanceOk` on the floor** — there are zero consumers in `src/`. So #817's headline recommendation — *degrade scope to soft when `balanceOk = false`* — is a recommendation **awaiting implementation**, not shipped behavior. The signal is dangling, ready for a consumer.
+2. **The literature's "dummy/null candidate" abstain mechanism isn't actually realized.** Docs #05/#08 lean hard on Lee et al.'s null candidate (scored 0) as the *native* abstain signal. In code, `selectAntecedent` returns `undefined` only on an **empty list** — but the sole caller already pre-guards emptiness at `src/resolve/DocumentResolver.ts:442` (returns before reaching line 478). So `selectAntecedent`'s `undefined` return and the `?? candidates[0]` fallback are **both dead from the only caller today**. Abstention is done entirely downstream by `idConfidenceFloor` (#800) at `src/resolve/DocumentResolver.ts:489`, not by a scored null candidate inside the scorer (and, on the supra path, by the #818 tie-abstain). The seam is forward-compatible with a scored null candidate; it just doesn't implement one yet.
 
-4. **The "silent recency fallback" the synthesis wanted *removed* is still there.** `findImmediatePredecessor` (the confidence-0.7 "chained by position only" guess) still fires at `src/resolve/DocumentResolver.ts:448` (`Id.`) and `:992` (shortForm). `…-08-synthesis.md` §6 stage 4 calls for replacing it with an explicit abstain; what shipped instead is the *opt-in* `idConfidenceFloor` (#800), leaving the recency guess as the default.
+3. **`balanceOk` is produced but consumed nowhere.** → **✅ Resolved (#820).** At the time of #811, #809's `balanceOk` was dropped at `parenDepths` and read by no resolver path. #820 now threads it into `resolveId` (degrade-to-soft on balance failure), and #819 first de-polluted it (the string-cite reset had made it fire on ~32% of citations in clean text). The signal is now load-bearing, not dangling.
+
+4. **The "silent recency fallback" the synthesis wanted *removed* is still there.** `findImmediatePredecessor` (the confidence-0.7 "chained by position only" guess) still fires at `src/resolve/DocumentResolver.ts:448` (`Id.`) and `:992` (shortForm). `…-08-synthesis.md` §6 stage 4 calls for replacing it with an explicit abstain; what shipped instead is the *opt-in* `idConfidenceFloor` (#800), leaving the recency guess as the default. **(Narrowed by #820):** the depth-based-exclusion case now degrades to soft, but `findImmediatePredecessor` remains the default for the *no-candidate* case.
 
 ## Roadmap status (5-stage pipeline)
 
 | Stage | Target | Reality |
 |---|---|---|
-| 1 PARSE (stack) | replace linear counter | ✅ **shipped** (#809) — but `balanceOk` not yet consumed |
-| 2 SCOPE (hard, fullSpan-independent) | delete paren-internal cites | 🟡 **partial** — #798 trigger-anchoring in; `isParentheticalChild` still uses the `fullSpan` strategy (`:605`) |
+| 1 PARSE (stack) | replace linear counter | ✅ #809; `balanceOk` now **consumed** (#820) |
+| 2 SCOPE (hard, fullSpan-independent) | delete paren-internal cites | ✅ #798 + #821 (history triggers) + #819 (string-cite fix); neutral-cite `fullSpan` hole remains (low priority) |
 | 3 SALIENCE (scorer) | candidate-list scorer | ✅ **seam shipped** (#811), `Id.`-only, deterministic |
-| 4 ABSTAIN | fail closed, no silent recency | 🟡 **opt-in only** (#800 floor); default still guesses via `findImmediatePredecessor` |
+| 4 ABSTAIN | fail closed, no silent recency | ✅ #800 floor + #818 supra tie-abstain + #820 degrade-to-soft; `findImmediatePredecessor` remains the no-candidate fallback |
 | 5 PROVENANCE | quoting-chain edges | ⏸️ out of core, deferred |
 | — Learned ranker | LambdaMART drop-in | ⏸️ **deferred by measurement** (#817) — correct call |
 
 ## Bottom line
 
-#811 is a clean, mathematically-faithful seam, and the surrounding research is unusually rigorous (45 years of anaphora resolution → "scope dominates ranking" → build the frame, defer the ML, then measure to confirm the deferral). The genuinely *open* threads aren't in #811 itself — they are the dangling `balanceOk` consumer (#817's degrade-to-soft) and the still-default silent recency fallback (#800/#812 stage 4).
+#811 is a clean, mathematically-faithful seam, and the surrounding research is unusually rigorous (45 years of anaphora resolution → "scope dominates ranking" → build the frame, defer the ML, then measure to confirm the deferral). As of 2026-06-03 the do-now slate around it has shipped (#818–#821): `balanceOk` is wired (#820), `supra` fails closed on ambiguity (#818), and the trigger lexicon is broadened (#821). What remains is correctly deferred — the learned ranker (pending a labeled corpus) and provenance (out of core).
 
 ## Natural next steps
 

--- a/docs/research/2026-06-03-shortform-resolution-readers-guide.md
+++ b/docs/research/2026-06-03-shortform-resolution-readers-guide.md
@@ -4,7 +4,7 @@
 **Type:** Navigation map / synthesis (point-in-time snapshot)
 **Subject:** The 9-part `docs/research/2026-06-02-shortform-resolution-*` series (#812 roadmap, landed by #813) — a one-page map so the ~1,200 lines are navigable without reading them all.
 **Companion:** `docs/research/2026-06-03-shortform-resolution-811-scorer-seam-analysis.md` (deep dive on the #811 seam).
-**Snapshot note:** "Status" and "answered vs. live" reflect the tree as of 2026-06-03 and will drift. Re-verify against source and the issue tracker before acting.
+**Snapshot note:** Reflects the tree as of 2026-06-03, **after the implementation PRs merged** — #809 (stack), #811 (scorer seam), #818–#821 (this slate), plus docs/measurement #813/#817/#822. Status will still drift; re-verify against source and the tracker before acting.
 
 ---
 
@@ -20,20 +20,20 @@
 | **02** scope-and-binding | Model "inner cite invisible to outer `Id.`" as **lexical scoping** (symbol table), not c-command. Scope is a **HARD** filter, not a soft penalty. | stage-2 design; partially #798 | mechanism set; not fully wired |
 | **03** bracket-parsing-error-recovery | A counter recovers *depth* but not *structure* (`([)]`); use a bounded-depth **stack** + **island reconstruction**; emit a per-region balance signal. | **#809 / #814** (tightest doc→PR link) | ✅ shipped |
 | **04** provenance-lineage | Typed PROV DAG yes, semiring overkill; the stack contents *are* the quoting chain. Explanation layer, not the fix. | out of core | ⏸️ deferred |
-| **05** ranking-abstention | 1-of-N selection = mention-ranking (Lee et al.); build a candidate-list scorer + null candidate now, LambdaMART later; abstain is a *present* primitive (Chow, conformal). | **#811 / #816** (seam) + **#800** (floor) | ✅ seam shipped; abstain opt-in |
+| **05** ranking-abstention | 1-of-N selection = mention-ranking (Lee et al.); build a candidate-list scorer + null candidate now, LambdaMART later; abstain is a *present* primitive (Chow, conformal). | **#811** (seam) + **#800** / **#818** / **#820** (abstain) | ✅ seam + abstain shipped |
 | **06** legal-citation-tooling | eyecite = recency-with-the-bug; **eyecite-ts is the SOTA** (already has partial stages 2–4). The bug is two holes: the counter + the neutral-cite `fullSpan` gap. | diagnostic framing → #809 | ✅ counter fixed; `fullSpan` hole open |
-| **07** supra-named-lookup | `supra` is a **named global lookup**, not positional; two mechanisms, one entry point; abstain on non-unique name key. | resolver `resolveSupra` (#799) | 🟡 partial; tie-abstain unshipped |
+| **07** supra-named-lookup | `supra` is a **named global lookup**, not positional; two mechanisms, one entry point; abstain on non-unique name key. | resolver `resolveSupra` (#799, #818) | ✅ tie-abstain shipped (#818) |
 | **08** synthesis | Integrates 01–07: five-stage pipeline, hard-vs-soft ordering, supra verdict, do-now vs deferred, codebase mapping. | **#812** roadmap | umbrella |
-| **09** bracket-survival-measurement | Raw OCR-survival unmeasurable in-repo, but the decision doesn't hinge on it: `balanceOk` flags 100% of dropped-bracket damage → **degrade-to-soft on balance failure**. | **#810 / #817** | ✅ measured; recommendation unwired |
+| **09** bracket-survival-measurement | Raw OCR-survival unmeasurable in-repo, but the decision doesn't hinge on it: `balanceOk` flags 100% of dropped-bracket damage → **degrade-to-soft on balance failure**. | **#810 / #817** | ✅ measured; degrade-to-soft wired (#820) |
 
 ## Pipeline status (5 stages)
 
 | Stage | Target | Reality | Source doc |
 |---|---|---|---|
-| 1 PARSE (stack) | replace linear counter | ✅ #809 — `balanceOk` produced but **not consumed** | 03 |
-| 2 SCOPE (hard, `fullSpan`-independent) | delete paren-internal cites | 🟡 #798 trigger-anchoring in; `fullSpan` strategy + neutral-cite hole remain | 02, 06 |
-| 3 SALIENCE (scorer) | candidate-list scorer | ✅ #811 seam, `Id.`-only, deterministic | 05 |
-| 4 ABSTAIN | fail closed, no silent recency | 🟡 #800 floor (opt-in); `findImmediatePredecessor` recency guess still default | 05, 06 |
+| 1 PARSE (stack) | replace linear counter | ✅ #809; `balanceOk` now **consumed** by the resolver (#820) | 03 |
+| 2 SCOPE (hard, `fullSpan`-independent) | delete paren-internal cites | ✅ #798 + #821 (history triggers) + #819 (string-cite fix); neutral-cite `fullSpan` hole remains (low priority, 0 in-repo) | 02, 06 |
+| 3 SALIENCE (scorer) | candidate-list scorer | ✅ #811 seam, `Id.`-only, deterministic; learned ranker deferred | 05 |
+| 4 ABSTAIN | fail closed, no silent recency | ✅ #800 floor + #818 supra tie-abstain + #820 degrade-to-soft; `findImmediatePredecessor` remains the no-candidate fallback | 05, 06 |
 | 5 PROVENANCE | quoting-chain edges | ⏸️ out of core | 04 |
 | — Learned ranker | LambdaMART drop-in | ⏸️ deferred — **confirmed correct by #817** | 01, 05, 09 |
 
@@ -41,35 +41,36 @@
 
 The 9 docs raise ~27 open questions between them. Tracked by current status:
 
-> **Update (2026-06-03):** a fan-out of 11 research + code-assessment agents closed most of these. Newly-answered items are marked ⟳; one new bug surfaced (the `resolveSupra` string-cite leak).
+> **Update (2026-06-03):** an 11-agent fan-out closed most of these; the code-actionable items then **shipped via TDD**. Merged: **#819** (string-cite leak), **#820** (degrade-to-soft on `balanceOk`), **#818** (supra cardinality), **#821** (history-subordinator triggers) — plus **#809** (stack) and **#811** (scorer seam) earlier.
 
-**✅ Answered / resolved**
-- *Does `supra` obey `Id.`'s scope rules?* (01·Q1) → No — named vs. positional (07).
-- *How robust must the parser be to dirty PDF? / bracket recovery rate?* (01·Q4, 02·Q1, 03·Q2) → **Now measured on real legal OCR** via the CourtListener replica ([[reference-courtlistener-replica]]): raw `plain_text`, 300 docs/arm — whole-doc paren balance **68% native → 37% OCR** (OCR ~halves it; per-10k damage only +11%, consistent with Lopresti's spurious-insertion-dominated finding). Corpus blocker dissolved. See #810.
-- *Where is the candidate-set/feature seam in code?* (05·Q5) → `scoreAntecedentCandidates`/`selectAntecedent` (#811).
+**✅ Shipped (merged to main)**
+- *`resolveSupra` string-cite scope leak* → **#819.** The `"; "` clause-reset zeroed the depth of 2nd+ `(citing A; B; C)` members, leaking them past the #799 aside filter; a `;` inside an open paren is now a string-cite separator, not a clause boundary. Also de-polluted `balanceOk` (it had fired on ~32% of citations in *clean* text) — the precondition for #820.
+- *Degrade-to-soft on `balanceOk`* → **#820.** `resolveId` now consumes the #809 signal: a depth-only paren-child exclusion in a balance-failed clause is kept-but-soft (capped confidence + warning; `idConfidenceFloor` abstains). `fullSpan`/trigger exclusions stay hard.
+- *`supra` cardinality / non-unique name key* (07·Q1) → **#818.** `fullCitationHistory` is now `Map<string, number[]>`; a non-unique key picks recency-within-name with capped confidence + warning, abstains on a true tie (same name + year), `idConfidenceFloor` fails it closed. Parallel-cite siblings collapse to one authority (by `groupId` / reporter).
+- *Trigger-lexicon completeness* (03·Q4) → **#821.** The resolver-shared lexicon now covers history subordinators (`overruled by`, `abrogated by`, `superseded by`, `cited with approval in`, `as recognized in`). Soft signal, dropped-paren only, ReDoS-safe.
+- *Bare `supra` / `Id.`-after-`supra`* (07·Q2, Q5) → verified and pinned with regression tests (#818).
 - *Is the Hogue/Corsello bug parse-layer?* (06·Q1) → Yes — counter desync, fixed by #809.
-- ⟳ *Empirical nesting depth + scope formation* (02·Q3, 03·Q1) → Shallow: per-citation depth is 0 for 768/778 cites, 1 for 10, **never ≥2**. `computeBracketScopes` is a flat clause-resetting counter (no sibling / scope-tree concept); **no depth cap exists or is needed.** Block-vs-inline changes no `Id.` outcome but does change a `supra` outcome (the string-cite leak below).
-- ⟳ *Trigger-lexicon completeness* (03·Q4) → Measured: the resolver-shared detector recognizes exactly 4 tokens (`quoting`/`citing`/`quoted in`/`cited in`); misses every history subordinator (`overruled by`, `abrogated by`, …). Single plug-in point (`parentheticalScope.ts` `TRIGGER_AT_END_RE`); ReDoS-safe to extend; vocabulary already exists unshared in `extractCase.ts`. **Filed as #821.**
-- ⟳ *Bare `supra` / `Id.`-after-`supra`* (07·Q2, Q5) → Verified by repro: bare `supra` abstains; `Id.` after a resolved `supra` chains to its target. (Pin with regression tests.)
-- ⟳ *Grammatical-role salience for citations* (01·Q2, 02·Q4, 06·Q5) → **Resolved negative:** effect is small (~3 pts, parser-dependent; Tetreault 2001) and lives in the *production* term (the writer's choice of "Id."), which the resolver gets free (Kehler/Rohde). No evidence subject-position predicts the holding cite. **Don't add a grammatical-role term**; the only defensible parser-free move is promoting the case-name-window check into the #811 scorer (gated behind the corpus split).
-- ⟳ *`supra` scope / alias / reach rules* (07·Q1, Q3, Q4) → **Codified, not judgment calls:** a source first cited inside a parenthetical *cannot* anchor a later `supra` (YLJ Style Sheet → **hard-mask**); `(hereinafter X)` is real but register-bound to scholarly writing, absent from opinions/briefs (defer); `supra` reach is **document-global, not section-bounded** (don't window recency-within-name).
+- *Where is the candidate-set/feature seam?* (05·Q5) → `scoreAntecedentCandidates`/`selectAntecedent` (#811).
+- *Raw legal-OCR bracket-survival* (01·Q4, 02·Q1, 03·Q2) → **measured** on the CourtListener replica ([[reference-courtlistener-replica]]): whole-doc paren balance **68% native → 37% OCR**; in-pipeline `balanceOk`-fail **32% / 42%**; md5-verified fixture + harness committed (#822). See #810.
 
-**🔴 New bug found (2026-06-03)**
-- *`resolveSupra` string-cite scope leak* — In `(citing A; B; C)`, the `"; "` clause-reset zeroes the bracket depth of the 2nd+ members while the outer `(` is still open, so they read depth=0 (`balanceOk=false`) and **escape the #799 aside filter** — `resolveSupra` accepts a string-cite-internal authority as a valid named antecedent. `resolveId` is shielded by its `fullSpan`-containment fallback; `resolveSupra` is not. Cheapest fix: have `resolveSupra` consume `balanceOk` (treat `false`-clause candidates as untrusted). **Filed as #819** (shares the `balanceOk`-consumption fix with #820). **Coupling found via the replica measurement** (md5-verified verbatim fixture): `balanceOk=false` fires on **32% of citations in clean native text, 42% in OCR** — the 32% native baseline proves it's dominated by *this* string-cite reset, not OCR — so **#819 must land before #820** can trust `balanceOk` as a degrade-to-soft trigger (else it fires on ~⅓ of citations with zero OCR). Sequencing posted to both issues.
+**✅ Answered (no code needed)**
+- *Does `supra` obey `Id.`'s scope rules?* (01·Q1) → No — named vs. positional (07).
+- *Empirical nesting depth + scope formation* (02·Q3, 03·Q1) → Shallow (per-citation depth 0 for 768/778, 1 for 10, never ≥2); **no depth cap needed.**
+- *Grammatical-role salience for citations* (01·Q2, 02·Q4, 06·Q5) → **Resolved negative** (small ~3-pt parser-dependent effect; lives in the *production* term — the writer's choice of "Id."). Don't add a grammatical-role term; the parser-free move is promoting the case-name-window check into the #811 scorer, gated behind the corpus split below.
+- *`supra` scope / alias / reach rules* (07·Q1, Q3, Q4) → **Codified:** parenthetical-only antecedents can't anchor a `supra` (YLJ → hard-mask); `(hereinafter X)` is register-bound (defer); `supra` reach is document-global (don't window recency-within-name).
 
-**🟡 Partial / narrowed**
-- *Abstain threshold / α* (01·Q3, 03·Q3, 05·Q1–Q3) → **Narrowed:** the current `Id.` scorer emits only {1.0, 0.75}, so `idConfidenceFloor` is a *binary fail-closed gate* — **no α to tune** until the #811 seam makes the score continuous. α is a cost decision (abstain readily); needs a 300–1000-case labeled set before any coverage claim. #818 is a *cardinality* bug a floor cannot fix.
-- *`Id.` vs `supra` different traversal* (02·Q2) → Recognized (07); `resolveSupra` exists but routes outside the #811 seam; the abstain/hard-mask rules above are unimplemented.
+**🟡 Partial**
+- *Abstain threshold / α* (01·Q3, 03·Q3, 05·Q1–Q3) → `idConfidenceFloor` is a binary gate on the `Id.` path (the scorer emits {1.0, 0.75}); a tunable α needs the #811 seam to yield a continuous score **and** a labeled calibration set.
+- *`supra` hard-mask of parenthetical-only antecedents* (07·Q1) → cardinality / tie-abstain shipped (#818); the YLJ hard-mask of paren-only antecedents in the BK-tree path is **not yet implemented** (follow-up).
 
 **🔴 Still live (blocked)**
-- *Scope-error vs. intra-scope-salience-error split* (02·Q5) — **blocked on data.** In-repo: 28 cases gave 0 scope / 2 (flagged) salience errors → scope solved, ranker unjustified; the real lever (rate of multi-sibling-in-scope ties) needs a real labeled corpus. Raw corpus is now sourceable (replica), but the true split still needs **ground-truth antecedent labels** (replica gives text, not labels); the structural proxy (multi-sibling rate) is measurable next. Gates the learned ranker *and* the salience-scorer extension.
-- *Raw legal-OCR bracket-survival number* (03·Q2) — **✅ measured** (CourtListener replica, raw `plain_text`, 300/arm): **68% native → 37% OCR** whole-doc paren balance; imbalance/10k 4.67→5.19; trigger density 0.57→0.16. Corpus dissolved (`ocr_status` 1=OCR ~2.9M / 2=native ~12.7M; `search_opinion.extracted_by_ocr` for case law). **md5-verified verbatim fixture** committed (`tests/fixtures/courtlistener-ocr-sample.json` + `scripts/measure-ocr-fixture.ts`, 12/12 byte-faithful): in-pipeline `balanceOk`-fail **32% native / 42% OCR**, citation recall robust (6.3 cites/doc both arms). See #810 + [[reference-courtlistener-replica]].
-- *Neutral-cite `fullSpan` hole* (06·Q2) — **downgraded:** not neutral-specific (a dropped-open-paren + non-trigger case), **0 in-repo occurrences**, closed by the same `balanceOk` wiring. (Was mislabeled "highest-value scope gap" — the real live scope leak is the `resolveSupra` string-cite case above.)
-- *Bluebook single-authority abstain* (06·Q3) — recoverable from resolver inputs (boundaries/zones) but **unimplemented.**
-- *`supra` ambiguity (#818)* (07·Q1, Q3, Q4) — **filed as #818, now sharpened:** a *cardinality* bug (both same-name candidates score 1.0, so no floor catches it) → fix = `Map<string, number[]>` + accept-singleton / abstain-on-≥2, **plus** hard-mask parenthetical-only antecedents (YLJ rule) and **no** section-windowing.
+- *Scope-error vs. intra-scope-salience-error split* (02·Q5) — **blocked on a labeled corpus** (the replica gives raw text, not antecedent labels). Gates the learned ranker + the salience-scorer extension; structural proxy (multi-sibling-in-scope rate) measurable next.
+- *Raw legal-OCR survival at scale* (03·Q2) — proxy + matched-arm path identified (#810); a real labeled OCR corpus is still worth getting but **not a blocker** (the degrade-to-soft policy is already justified).
+- *Neutral-cite `fullSpan` hole* (06·Q2) — low priority (0 in-repo; dropped-paren cases now covered by the #820 `balanceOk` wiring); a `fullSpan`-independent containment for neutral inner cites remains unbuilt.
+- *Bluebook single-authority `Id.` abstain* (06·Q3) — recoverable from resolver inputs but **unimplemented**.
 
-**⏸️ Deferred by design (provenance / out of core)**
-- Proposition-graph substrate, span hashing, chain depth/termination, multi-chain confidence aggregation (04·Q1–Q4; 06·Q4).
+**⏸️ Deferred by design**
+- Learned ranker (deferral confirmed correct by #817); provenance graph + span hashing + `(hereinafter)` aliases (04·Q1–Q4; 06·Q4; 07·Q3) — out of core / register-bound.
 
 ## Reading paths
 


### PR DESCRIPTION
## What

Reconciles the two analysis docs with the now-merged implementation slate (#818–#821) — both were point-in-time snapshots written before the code landed.

**Reader's guide** (`…-readers-guide.md`):
- The open-questions ledger now leads with a **✅ Shipped** section (#819 string-cite leak, #820 degrade-to-soft, #818 supra cardinality, #821 trigger lexicon).
- Pipeline-status + at-a-glance tables flipped to shipped (stage 1 `balanceOk` now consumed; stage 4 abstain via #800/#818/#820; etc.).
- Remaining work re-scoped: scope-vs-salience split is **blocked on a labeled corpus**; learned ranker + provenance + `(hereinafter)` aliases deferred; neutral-cite `fullSpan` hole + Bluebook single-authority abstain still live (low priority).

**#811 analysis** (`…-811-scorer-seam-analysis.md`):
- Gap 3 (“`balanceOk` produced but consumed nowhere”) marked **✅ resolved by #820**.
- Gaps 1/2/4 annotated with current status; roadmap table + bottom line updated.

Docs only — no `src` change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
