### PR TITLE
fix(resolve): keep clean/original coordinates consistent under a cleaner (#830)

### DIFF
--- a/.changeset/fix-830-resolver-clean-coords.md
+++ b/.changeset/fix-830-resolver-clean-coords.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix short-form resolution binding to the wrong case when a length-changing `cleaner` is used (#830). The resolver assumed clean-text offsets equaled original-text offsets and read its bracket-scope / trigger-anchor / name-window analysis against the original text using clean offsets. A cleaner that shrinks the text (e.g. markdown-emphasis stripping) made those offsets diverge — accumulating drift with preceding removed content — so parenthetical-child detection misfired and a trailing `Id.` could bind to a `(quoting …)` child instead of the citation-sentence's main case. The resolver now reads clean-coordinate offsets against the cleaned text and maps derived spans back to original coordinates, so resolution via a cleaner matches resolution of pre-stripped text.

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -641,7 +641,15 @@ export function extractCitations(
     const resolutionOpts = cleanFootnoteMap
       ? { ...options.resolutionOptions, footnoteMap: cleanFootnoteMap }
       : options.resolutionOptions
-    return resolveCitations(filtered, text, resolutionOpts)
+    // #830: hand the resolver BOTH texts. `text` (original) backs original-
+    // coordinate reads (quote zones, paragraph scope, party lookback); `cleaned`
+    // backs clean-coordinate reads (bracket scopes, trigger asides). Without
+    // this, clean-offset reads index the original text and desync once a
+    // length-changing cleaner shrinks it.
+    return resolveCitations(filtered, text, resolutionOpts, {
+      cleanedText: cleaned,
+      transformationMap,
+    })
   }
 
   return filtered

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -19,7 +19,7 @@ import type {
   SupraCitation,
 } from "../types/citation"
 import { isFullCitation } from "../types/guards"
-import type { Span } from "../types/span"
+import { resolveOriginalSpan, type Span, type TransformationMap } from "../types/span"
 import { detectQuoteZones } from "../utils/detectQuoteZones"
 import { computeBracketScopes, triggerAnchoredAsideOwner } from "../utils/parentheticalScope"
 import { BKTree } from "./bkTree"
@@ -87,7 +87,18 @@ function isInZone(
  */
 export class DocumentResolver {
   private readonly citations: Citation[]
+  /** Original document text — used for original-coordinate reads (quote zones,
+   *  paragraph boundaries, party-name lookback) that locate citations via
+   *  `span.originalStart`. */
   private readonly text: string
+  /** Cleaned document text — used for clean-coordinate reads (bracket scopes,
+   *  trigger-anchored asides, family/name windows) that index by
+   *  `span.cleanStart`/`cleanEnd`. Equals `text` when no length-changing cleaner
+   *  ran; diverges from it otherwise, which is the #830 desync this fixes. */
+  private readonly cleanedText: string
+  /** Maps clean→original offsets so derived output spans carry correct original
+   *  coordinates even when a cleaner transformed the text (#830). */
+  private readonly transformationMap?: TransformationMap
   private readonly options: Required<
     Omit<ResolutionOptions, "footnoteMap" | "idConfidenceFloor">
   > & {
@@ -111,12 +122,26 @@ export class DocumentResolver {
    * Creates a new DocumentResolver.
    *
    * @param citations - All citations in document (in order of appearance)
-   * @param text - Original document text
+   * @param text - Original document text (original-coordinate reads index into it)
    * @param options - Resolution options
+   * @param cleanContext - Cleaned text + transformation map for clean-coordinate
+   *   reads (#830). When omitted, `text` is treated as the cleaned text too,
+   *   preserving the historical clean==original behavior for callers that pass
+   *   only one text (e.g. text untouched by a length-changing cleaner).
    */
-  constructor(citations: Citation[], text: string, options: ResolutionOptions = {}) {
+  constructor(
+    citations: Citation[],
+    text: string,
+    options: ResolutionOptions = {},
+    cleanContext?: { cleanedText: string; transformationMap: TransformationMap },
+  ) {
     this.citations = citations
     this.text = text
+    // #830: clean-coordinate reads must index into the cleaned text that the
+    // citation `cleanStart`/`cleanEnd` offsets were computed against. Without a
+    // clean context, fall back to `text` (clean==original) — unchanged behavior.
+    this.cleanedText = cleanContext?.cleanedText ?? text
+    this.transformationMap = cleanContext?.transformationMap
 
     // Apply defaults to options
     this.options = {
@@ -168,7 +193,7 @@ export class DocumentResolver {
     // Reset per-call state so a single DocumentResolver can be reused (the
     // public API currently constructs a fresh one per document, but the
     // per-instance fields make the algorithm easier to follow).
-    const scopes = computeBracketScopes(this.text, this.citations)
+    const scopes = computeBracketScopes(this.cleanedText, this.citations)
     this.parenDepths = scopes.map((s) => s.depth)
     this.balanceOks = scopes.map((s) => s.balanceOk)
     this.resolutions = new Array(this.citations.length).fill(undefined)
@@ -378,9 +403,9 @@ export class DocumentResolver {
     const hasPincite =
       citation.pincite !== undefined || citation.pinciteInfo !== undefined
     const tailHasSection = /^\s*[,]?\s*§§?\s*\d/.test(
-      this.text.substring(
+      this.cleanedText.substring(
         citation.span.cleanEnd,
-        Math.min(this.text.length, citation.span.cleanEnd + 20),
+        Math.min(this.cleanedText.length, citation.span.cleanEnd + 20),
       ),
     )
     const preferredFamily =
@@ -596,8 +621,8 @@ export class DocumentResolver {
   private getIdPreferredFamily(citation: IdCitation): CitationFamily {
     // Look at up to 20 chars after Id.'s span end for a `§` token.
     const start = citation.span.cleanEnd
-    const end = Math.min(this.text.length, start + 20)
-    const tail = this.text.substring(start, end)
+    const end = Math.min(this.cleanedText.length, start + 20)
+    const tail = this.cleanedText.substring(start, end)
     if (/^\s*[,]?\s*§§?\s*\d/.test(tail)) return "statute"
     return "case"
   }
@@ -615,7 +640,7 @@ export class DocumentResolver {
     if (this.parenDepths[index] > 0) return true
     // #798: trigger-anchored — recognise a `quoting`/`citing` aside even when
     // the opening `(` was dropped (OCR/PDF), where the depth scan misses it.
-    return triggerAnchoredAsideOwner(this.text, this.citations, index) !== undefined
+    return triggerAnchoredAsideOwner(this.cleanedText, this.citations, index) !== undefined
   }
 
   /**
@@ -666,7 +691,8 @@ export class DocumentResolver {
   private isUntrustworthyDepthAside(index: number): boolean {
     if (this.balanceOks[index] !== false) return false
     if (this.parenDepths[index] <= 0) return false
-    if (triggerAnchoredAsideOwner(this.text, this.citations, index) !== undefined) return false
+    if (triggerAnchoredAsideOwner(this.cleanedText, this.citations, index) !== undefined)
+      return false
     return !this.isFullSpanContained(index)
   }
 
@@ -700,7 +726,7 @@ export class DocumentResolver {
     }
     if (windowStart >= idStart) return DEFAULT
 
-    const window = this.text.substring(windowStart, idStart)
+    const window = this.cleanedText.substring(windowStart, idStart)
 
     // Match capitalized words that are case-name-like. Filter out common
     // English/legal prose words that happen to be capitalized.
@@ -1220,7 +1246,7 @@ export class DocumentResolver {
     if (!citation.partyName) return undefined
 
     const start = Math.max(0, citation.span.cleanStart - LOOKBACK)
-    const window = this.text.substring(start, citation.span.cleanStart)
+    const window = this.cleanedText.substring(start, citation.span.cleanStart)
     if (window.length === 0) return undefined
 
     // Lightweight "Party v. Party" matcher. Allows capitalized words
@@ -1287,18 +1313,22 @@ export class DocumentResolver {
 
     if (!best) return undefined
 
+    // `best.start`/`best.end` are clean-text offsets (the window scans the
+    // cleaned text). Map them back to original coordinates so the emitted span
+    // carries correct original positions even when a cleaner transformed the
+    // source (#830). Without a transformation map, fall back to clean==original.
+    const { originalStart, originalEnd } = this.transformationMap
+      ? resolveOriginalSpan({ cleanStart: best.start, cleanEnd: best.end }, this.transformationMap)
+      : { originalStart: best.start, originalEnd: best.end }
     return {
       caseName: best.caseName,
       plaintiff: best.plaintiff,
       defendant: best.defendant,
-      // Clean coordinates; consumers should treat these as offsets in
-      // the resolver's input `text`. When the cleaner did not transform
-      // the source, clean == original.
       span: {
         cleanStart: best.start,
         cleanEnd: best.end,
-        originalStart: best.start,
-        originalEnd: best.end,
+        originalStart,
+        originalEnd,
       },
     }
   }

--- a/src/resolve/index.ts
+++ b/src/resolve/index.ts
@@ -18,6 +18,7 @@
  */
 
 import type { Citation } from "../types/citation"
+import type { TransformationMap } from "../types/span"
 import { DocumentResolver } from "./DocumentResolver"
 import type { ResolutionOptions, ResolvedCitation } from "./types"
 
@@ -29,14 +30,19 @@ import type { ResolutionOptions, ResolvedCitation } from "./types"
  * @param citations - Extracted citations in order of appearance
  * @param text - Original document text
  * @param options - Resolution options
+ * @param cleanContext - Optional cleaned text + transformation map. Pass when a
+ *   length-changing cleaner was applied so clean-coordinate reads index the
+ *   cleaned text and derived spans map back to original coordinates (#830). When
+ *   omitted, `text` is treated as the cleaned text too (clean == original).
  * @returns Citations with resolution metadata
  */
 export function resolveCitations(
   citations: Citation[],
   text: string,
   options?: ResolutionOptions,
+  cleanContext?: { cleanedText: string; transformationMap: TransformationMap },
 ): ResolvedCitation[] {
-  const resolver = new DocumentResolver(citations, text, options)
+  const resolver = new DocumentResolver(citations, text, options, cleanContext)
   return resolver.resolve()
 }
 

--- a/tests/resolve/issue830CleanerCoordinateDesync.test.ts
+++ b/tests/resolve/issue830CleanerCoordinateDesync.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Issue #830: with a length-changing `cleaner` active, `Id.` resolves to a
+ * citation nested inside another cite's `(quoting …)` explanatory parenthetical
+ * instead of the citation-sentence's main case.
+ *
+ * Root cause: the resolution subsystem assumes clean-text offsets == original-
+ * text offsets and reads `this.text` (the ORIGINAL text) using citation
+ * `cleanStart`/`cleanEnd` offsets for its bracket-scope / trigger-anchor
+ * analysis. A cleaner that *shrinks* the text (e.g. markdown-emphasis stripping)
+ * makes those offsets diverge, and the divergence grows with the amount of
+ * removed preceding content — so the parenthetical-child detection reads the
+ * wrong region and the trailing `Id.` binds to the quoted child.
+ *
+ * The invariant: resolving text via a length-changing cleaner must produce the
+ * SAME antecedent as resolving the already-stripped (original == clean) text.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import { resolveCitations } from "@/resolve"
+import type { ResolvedCitation } from "@/resolve/types"
+
+/** A length-changing markdown-emphasis stripper (the reported trigger). */
+const stripMarkdownEmphasis = (t: string): string =>
+  t
+    .replace(/\*\*\*([\s\S]*?)\*\*\*/g, "$1")
+    .replace(/\*\*([\s\S]*?)\*\*/g, "$1")
+    .replace(/(?<![\\*])\*([^\s*][\s\S]*?[^\s*])\*(?![*\d])/g, "$1")
+
+interface MaybePincite {
+  pincite?: number | string
+}
+interface MaybeCaseName {
+  caseName?: string
+}
+interface MaybeInferred {
+  inferredCaseName?: string
+  inferredCaseNameSpan?: {
+    cleanStart: number
+    cleanEnd: number
+    originalStart: number
+    originalEnd: number
+  }
+}
+
+/**
+ * Resolve `text` and return the caseName the `Id.` whose pincite includes
+ * `pinciteNeedle` binds to. `viaCleaner` chooses the markdown-stripping cleaner
+ * path vs. feeding already-stripped (original == clean) text.
+ */
+const idAntecedentCaseName = (
+  text: string,
+  pinciteNeedle: string,
+  viaCleaner: boolean,
+): string | undefined => {
+  const cites = (
+    viaCleaner
+      ? extractCitations(text, { resolve: true, cleaners: [stripMarkdownEmphasis] })
+      : extractCitations(stripMarkdownEmphasis(text), { resolve: true })
+  ) as ResolvedCitation[]
+  const id = cites.find(
+    (c) =>
+      c.type === "id" &&
+      String((c as unknown as MaybePincite).pincite ?? "").includes(pinciteNeedle),
+  )
+  const to = id?.resolution?.resolvedTo
+  return to != null ? (cites[to] as unknown as MaybeCaseName).caseName : undefined
+}
+
+// The reported document (Section II accumulates the context that triggers the
+// drift; Section III holds the misbinding `Id. at 58–59`).
+const SECTION_II_III = `II. THE THIRD CAUSE OF ACTION FOR UNJUST ENRICHMENT MUST BE DISMISSED.
+
+"The existence of a valid and enforceable written contract governing a particular subject matter ordinarily precludes recovery in quasi contract for events arising out of the same subject matter." *Singh v. T-Mobile*, 232 A.D.3d 662, 662 (2d Dep't 2024) (quoting *Barker v. Time Warner Cable, Inc.*, 83 A.D.3d 750, 752); accord *Polaris Venture Partners VI L.P. v. AD-Venture Capital Partners L.P.*, 179 A.D.3d 548, 548 (1st Dep't 2020) ("the existence of an express contract governing the subject matter precludes plaintiffs claim for unjust enrichment") (citing *Clark-Fitzpatrick, Inc. v. Long Is. R.R. Co.*, 70 N.Y.2d 382, 388 (1987)); *DirecTV, LLC v. Nexstar Broadcasting, Inc.*, 2024 NY Slip Op 04225 (1st Dep't 2024) (unjust enrichment claim precluded and properly dismissed where parties executed a valid written contract governing the subject matter); *Bronx-Lebanon Hosp. Ctr. v. New York State Catholic Health Plan, Inc.*, 2025 NY Slip Op 01161 (1st Dep't 2025) (dismissing quasi-contract claims where "all aspects of the dispute" were governed by the written agreements at issue).
+
+III. THE FOURTH CAUSE OF ACTION MUST BE DISMISSED BECAUSE INJUNCTIVE RELIEF IS A REMEDY, NOT AN INDEPENDENT CAUSE OF ACTION.
+
+As the courts have repeatedly held, "[a]n injunction is a remedy, a form of relief that may be granted against a defendant when its proponent establishes the merits of its substantive cause of action against that defendant." *Weinreb v. 37 Apartments Corp.*, 97 A.D.3d 54, 59 (1st Dep't 2012). "Although it is permissible to plead a cause of action for a permanent injunction, . . . permanent injunctive relief is, at its core, a remedy that is dependent on the merits of the substantive claims asserted." *Id.* (quoting *Corsello v. Verizon N.Y., Inc.*, 77 A.D.3d 344, 368 (1st Dep't 2010)). Consequently, "injunctive relief is simply not available when the plaintiff does not have any remaining substantive cause of action." *Id.* at 58–59; accord *Klein v. Catholic Health Sys. of Long Is., Inc.*, 231 A.D.3d 797, 797 (2d Dep't 2024); *Pickard v. Campbell*, 207 A.D.3d 1105, 1110 (4th Dep't 2022) (request for an injunction dismissed "despite being styled as a separate cause of action"); *Fenton v. Floce Holdings, LLC*, 2024 NY Slip Op 04063, at *3 (2d Dep't 2024); *Hogue v. Village of Dering Harbor*, 199 A.D.3d 900, 903 (2d Dep't 2021).`
+
+// A reduced reproducer (~5 cites vs. the 14-cite report). Verified to FAIL on
+// the pre-fix resolver: three emphasis-wrapped prefix cites accumulate enough
+// cleaner drift that the trailing `Id. at 58` mis-binds to the quoted child
+// ("Child v. Quoted") instead of the citing authority ("Main Co. v. Lead Corp.").
+const SYNTH = `*Aaa Co. v. Bbb Inc.*, 100 N.E.3d 1, 5 (2020) (quoting *Ccc v. Ddd*, 10 N.E.2d 2, 3); *Eee Co. v. Fff LLC*, 200 N.E.3d 4, 8 (2021) (citing *Ggg v. Hhh*, 20 N.E.2d 5, 6); *Iii v. Jjj*, 2024 NY Slip Op 04225 (2024). *Main Co. v. Lead Corp.*, 97 A.D.3d 54, 59 (2012). *Id.* (quoting *Child v. Quoted*, 77 A.D.3d 344, 368 (2010)). *Id.* at 58.`
+
+describe("Issue #830: cleaner clean/original coordinate desync in Id. resolution", () => {
+  it("full doc: Id. at 58–59 resolves to the citing case (Weinreb), not the quoted child (Corsello)", () => {
+    expect(idAntecedentCaseName(SECTION_II_III, "58", true)).toBe("Weinreb v. 37 Apartments Corp.")
+  })
+
+  it("regression: the first Id. (pincite 59, before the quoting aside) still resolves to Weinreb via the cleaner", () => {
+    // This Id. resolved correctly even before the fix (it precedes the
+    // (quoting Corsello) aside); guard that the coordinate change didn't break it.
+    expect(idAntecedentCaseName(SECTION_II_III, "59", true)).toBe("Weinreb v. 37 Apartments Corp.")
+  })
+
+  it("invariant: resolving via a length-changing cleaner equals resolving pre-stripped text", () => {
+    const viaCleaner = idAntecedentCaseName(SECTION_II_III, "58", true)
+    const preStripped = idAntecedentCaseName(SECTION_II_III, "58", false)
+    expect(viaCleaner).toBe(preStripped)
+  })
+
+  it("regression: the pre-stripped (original == clean) path already resolves to Weinreb", () => {
+    expect(idAntecedentCaseName(SECTION_II_III, "58", false)).toBe("Weinreb v. 37 Apartments Corp.")
+  })
+
+  it("reduced reproducer: Id. at 58 binds to the citing authority (Main), not the quoted child", () => {
+    // Verified to fail on the pre-fix resolver (last Id. -> "Child v. Quoted" /
+    // an earlier prefix cite). With the fix it binds to the citing authority.
+    const viaCleaner = idAntecedentCaseName(SYNTH, "58", true)
+    const preStripped = idAntecedentCaseName(SYNTH, "58", false)
+    expect(viaCleaner).toBe("Main Co. v. Lead Corp.")
+    expect(viaCleaner).toBe(preStripped)
+  })
+
+  it("short-form prose inference under a cleaner: inferred name + its ORIGINAL-text span map correctly", () => {
+    // Exercises extractInferredCaseName's window read (now on cleaned text) and
+    // the clean->original span mapping. The cleaner strips emphasis, so the
+    // inferred-name span must map back to the ORIGINAL (emphasized) text — not
+    // the clean offset, which would land in the wrong place.
+    const original =
+      "*Smith v. Jones*, 100 F.2d 50, 55 (1990). In *Yellen v. Kassin*, the court held. Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(original, {
+      resolve: true,
+      cleaners: [stripMarkdownEmphasis],
+    }) as ResolvedCitation[]
+    const short = cites.find((c) => c.type === "shortFormCase") as unknown as MaybeInferred | undefined
+    expect(short?.inferredCaseName).toBe("Yellen v. Kassin")
+    const span = short?.inferredCaseNameSpan
+    expect(span).toBeDefined()
+    if (span) {
+      const cleaned = stripMarkdownEmphasis(original)
+      // cleanStart must land on the name in the CLEANED text. Before the fix the
+      // window was scanned against the original text, so cleanStart held an
+      // ORIGINAL offset — wrong against the cleaned text. (This is the assertion
+      // that fails on the pre-fix resolver.)
+      expect(cleaned.startsWith("Yellen v. Kassin", span.cleanStart)).toBe(true)
+      // originalStart must land on the name in the ORIGINAL (emphasized) text —
+      // the clean→original mapping. (The end maps just past the stripped closing
+      // `*`, so assert the start position rather than an exact slice.)
+      expect(original.startsWith("Yellen v. Kassin", span.originalStart)).toBe(true)
+    }
+  })
+
+  it("backward-compat: resolveCitations() with no clean context (clean == original) still infers prose names", () => {
+    // Calls the public resolver directly without the clean context, exercising
+    // the clean==original fallback (no cleaned text, no transformation map) —
+    // the path external callers hit, and the ternary's no-map branch.
+    const text =
+      "Smith v. Jones, 100 F.2d 50, 55 (1990). In Yellen v. Kassin, the court held. Yellen, 416 N.J. Super. at 590."
+    const cites = extractCitations(text)
+    const resolved: ResolvedCitation[] = resolveCitations(cites, text)
+    const short = resolved.find((c) => c.type === "shortFormCase") as unknown as
+      | MaybeInferred
+      | undefined
+    expect(short?.inferredCaseName).toBe("Yellen v. Kassin")
+    const span = short?.inferredCaseNameSpan
+    expect(span).toBeDefined()
+    if (span) {
+      // No transformation map → clean == original; the span still locates the name.
+      expect(text.startsWith("Yellen v. Kassin", span.originalStart)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Why

`extractCitations(text, { resolve: true })` could bind an `Id.` (or other short-form) to the **wrong case** whenever a custom `cleaner` removed characters from the text — e.g. a markdown-emphasis stripper applied to LLM-drafted briefs. The misbinding was silent (reported with `confidence: 1.0`), so a consumer trusting `resolution.resolvedTo` would attribute a quote or pincite to the wrong authority.

**Today:** with a length-changing cleaner, a trailing `Id.` after a `(quoting …)` parenthetical resolves to the *quoted child* instead of the citation-sentence's main case. **After this PR:** it resolves to the main case — the same result you'd get by pre-stripping the markup before extraction.

Root cause: the resolver assumed clean-text offsets equaled original-text offsets. Its parenthetical-aside detection (bracket scopes, trigger-anchored asides) and its family/name windows read the **original** text using citation **clean** offsets. A cleaner that shrinks the text makes those diverge — and the drift accumulates over preceding removed content — so the aside detection reads the wrong region. Pre-stripping the same markup (so clean == original) always resolved correctly, which pinpointed the desync.

## What changed

- The resolver reads its clean-offset analysis (bracket scopes, trigger-anchored asides, family/name windows) against the **cleaned** text, while original-offset reads (quote zones, paragraph scope, party-name lookback) stay on the original text.
- The short-form inferred-case-name span is mapped from clean back to original coordinates via the existing `resolveOriginalSpan`, so its `originalStart`/`originalEnd` stay correct under a cleaner.
- `resolveCitations` / `DocumentResolver` gain an optional clean-context parameter (cleaned text + transformation map). Omitting it preserves the prior `clean == original` behavior, so external callers and the public API are unaffected.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — 4560 pass, 0 fail (full suite, rebased on top of #839).
- `pnpm typecheck` — clean.
- `pnpm lint` (Biome) on the changed files — no findings.
- New regression suite (`tests/resolve/issue830CleanerCoordinateDesync.test.ts`, 6 tests). I verified 4 of them fail on the pre-fix resolver and pass with the fix: the reported 14-cite document, the cleaner-vs-pre-stripped invariant, a reduced ~5-cite reproducer, and short-form prose-inference span mapping. The other 2 guard the already-correct working paths (pre-stripped text; the first `Id.`).

## What this PR explicitly does NOT ship (scope boundary)

- `analyzeDocument`'s `in-parenthetical-of` edge under a cleaner. That layer uses a separate scope engine and is already correct when handed cleaned text; threading cleaned text into it belongs to the one-call facade (#836).
- The unbalanced / dropped-parenthesis variant of paren-child misbinding — a different root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
