### PR TITLE
feat(clean): add stripMarkdownEmphasis cleaner + additionalCleaners option (#835)

### DIFF
--- a/.changeset/feat-835-markdown-cleaner.md
+++ b/.changeset/feat-835-markdown-cleaner.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": minor
+---
+
+Add a built-in `stripMarkdownEmphasis` cleaner and an `additionalCleaners` option (#835). Markdown legal text — e.g. LLM-drafted briefs with emphasized case names like `*Leon v. Martinez*` — now has a ready-made, opt-in cleaner that strips `*`/`**`/`***` emphasis while preserving star-pagination pincites (`at *3`) and underscores (blank locators like `[____]`). The new `additionalCleaners` option appends cleaners to the default chain, so adding one no longer silently disables the defaults — unlike `cleaners`, which replaces them.

--- a/src/clean/cleanText.ts
+++ b/src/clean/cleanText.ts
@@ -37,7 +37,8 @@ export interface CleanTextResult {
  * cleaned text while reporting positions in the original text.
  *
  * @param original - Original input text
- * @param cleaners - Array of cleaner functions to apply (default: stripHtmlTags, decodeHtmlEntities, normalizeWhitespace, normalizeUnicode, normalizeDashes, fixSmartQuotes, normalizeTypography, normalizeReporterSpacing)
+ * @param cleaners - Array of cleaner functions to apply (default: stripHtmlTags, decodeHtmlEntities, normalizeWhitespace, normalizeUnicode, normalizeDashes, fixSmartQuotes, normalizeTypography, normalizeReporterSpacing). Passing a custom array REPLACES the defaults.
+ * @param additionalCleaners - Cleaners appended AFTER the effective base chain (the defaults, or a custom `cleaners` array). Use this to add a cleaner — e.g. `stripMarkdownEmphasis` — without dropping the defaults (#835).
  * @returns Cleaned text with position mappings and warnings
  *
  * @example
@@ -60,6 +61,7 @@ export function cleanText(
     normalizeTypography,
     normalizeReporterSpacing,
   ],
+  additionalCleaners: Array<(text: string) => string> = [],
 ): CleanTextResult {
   // Initialize 1:1 position mapping
   let currentText = original
@@ -72,8 +74,9 @@ export function cleanText(
     originalToClean.set(i, i)
   }
 
-  // Apply each cleaner sequentially, rebuilding position maps
-  for (const cleaner of cleaners) {
+  // Apply each cleaner sequentially, rebuilding position maps. Additional
+  // cleaners run after the base chain so adding one keeps the defaults (#835).
+  for (const cleaner of [...cleaners, ...additionalCleaners]) {
     const beforeText = currentText
     const afterText = cleaner(currentText)
 

--- a/src/clean/cleaners.ts
+++ b/src/clean/cleaners.ts
@@ -502,3 +502,32 @@ export function normalizeTypography(text: string): string {
 export function stripDiacritics(text: string): string {
   return text.normalize("NFD").replace(/[\u0300-\u036F]/g, "")
 }
+
+/**
+ * Strip markdown emphasis markers (`*italic*`, `**bold**`, `***both***`) while
+ * keeping the emphasized text. For markdown legal text (e.g. LLM-drafted briefs
+ * where case names are emphasized: `*Leon v. Martinez*`), whose asterisks
+ * otherwise break case-name capture / `fullSpan`.
+ *
+ * Deliberately conservative so it never corrupts citations:
+ * - Star-pagination pincites are preserved (`at *3` \u2014 an asterisk followed by a
+ *   digit, or with no closing `*`, never matches).
+ * - Underscores are never touched (`_x_`, and blank locators like `[____]`).
+ * - Lone or space-flanked asterisks (`a * b`) and backslash-escaped pairs
+ *   (`\*x\*`) are left alone.
+ *
+ * NOT in the default pipeline \u2014 pass it via `additionalCleaners` (recommended;
+ * keeps the defaults) or `cleaners`. It changes length; position tracking is
+ * handled by `cleanText`'s TransformationMap. Each pattern uses a single bounded
+ * quantifier (ReDoS-safe). (#835)
+ *
+ * @example
+ * stripMarkdownEmphasis("see *Leon v. Martinez*, 84 N.Y.2d 83")
+ * // => "see Leon v. Martinez, 84 N.Y.2d 83"
+ */
+export function stripMarkdownEmphasis(text: string): string {
+  return text
+    .replace(/\*\*\*([^*\n]+?)\*\*\*/g, "$1")
+    .replace(/\*\*([^*\n]+?)\*\*/g, "$1")
+    .replace(/(?<![\\*])\*([^\s*][^*\n]*?[^\s*]|[^\s*])\*(?![*\d])/g, "$1")
+}

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -95,6 +95,22 @@ export interface ExtractOptions {
   cleaners?: Array<(text: string) => string>
 
   /**
+   * Extra cleaners appended AFTER the effective base chain (the defaults, or a
+   * custom `cleaners` array). Unlike `cleaners` — which REPLACES the defaults —
+   * `additionalCleaners` keeps them, so you can add e.g. `stripMarkdownEmphasis`
+   * without silently dropping HTML stripping, whitespace/Unicode normalization,
+   * smart-quote fixing, reporter spacing, etc. (#835)
+   *
+   * @example
+   * ```typescript
+   * import { extractCitations, stripMarkdownEmphasis } from "eyecite-ts"
+   * // markdown legal text: keep all defaults, also strip *emphasis*
+   * extractCitations(markdownText, { additionalCleaners: [stripMarkdownEmphasis] })
+   * ```
+   */
+  additionalCleaners?: Array<(text: string) => string>
+
+  /**
    * Custom regex patterns (overrides defaults).
    *
    * If provided, these patterns replace the default pattern set:
@@ -233,7 +249,11 @@ export function extractCitations(
   const startTime = performance.now()
 
   // Step 1: Clean text
-  const { cleaned, transformationMap, warnings } = cleanText(text, options?.cleaners)
+  const { cleaned, transformationMap, warnings } = cleanText(
+    text,
+    options?.cleaners,
+    options?.additionalCleaners,
+  )
 
   // Step 1.5: Detect footnote zones (opt-in)
   let cleanFootnoteMap: FootnoteMap | undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ export { applyFalsePositiveFilters } from "./extract/filterFalsePositives"
 // ============================================================================
 
 // Text Cleaning Layer
-export { cleanText } from "./clean"
+export { cleanText, stripMarkdownEmphasis } from "./clean"
 export type { CleanTextResult } from "./clean/cleanText"
 // Extraction Functions (for advanced use cases)
 export {

--- a/tests/clean/issue835MarkdownCleaner.test.ts
+++ b/tests/clean/issue835MarkdownCleaner.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Issue #835: ship a built-in, opt-in markdown-emphasis cleaner and an
+ * `additionalCleaners` option that augments (rather than replaces) the default
+ * cleaner chain.
+ */
+
+import { describe, expect, it } from "vitest"
+import { cleanText, extractCitations, stripMarkdownEmphasis } from "@/index"
+
+interface MaybeCaseName {
+  caseName?: string
+}
+
+describe("#835 stripMarkdownEmphasis cleaner", () => {
+  it("strips single-asterisk emphasis", () => {
+    expect(stripMarkdownEmphasis("*Singh v. T-Mobile*")).toBe("Singh v. T-Mobile")
+  })
+
+  it("strips double-asterisk (bold) emphasis", () => {
+    expect(stripMarkdownEmphasis("**Leon v. Martinez**")).toBe("Leon v. Martinez")
+  })
+
+  it("strips triple-asterisk (bold italic) emphasis", () => {
+    expect(stripMarkdownEmphasis("***Roe v. Wade***")).toBe("Roe v. Wade")
+  })
+
+  it("strips emphasis inline within prose, leaving the rest intact", () => {
+    expect(stripMarkdownEmphasis("see *Leon v. Martinez*, 84 N.Y.2d 83")).toBe(
+      "see Leon v. Martinez, 84 N.Y.2d 83",
+    )
+  })
+
+  it("preserves star-pagination pincites (asterisk followed by a digit)", () => {
+    expect(stripMarkdownEmphasis("Foo, 2024 NY Slip Op 04063, at *3")).toBe(
+      "Foo, 2024 NY Slip Op 04063, at *3",
+    )
+  })
+
+  it("leaves underscores untouched (blank locators and underscore emphasis)", () => {
+    expect(stripMarkdownEmphasis("2021 N.Y. Slip Op. [____] (2021)")).toBe(
+      "2021 N.Y. Slip Op. [____] (2021)",
+    )
+    expect(stripMarkdownEmphasis("_untouched_")).toBe("_untouched_")
+  })
+
+  it("does not strip lone or space-flanked asterisks", () => {
+    expect(stripMarkdownEmphasis("a * b")).toBe("a * b")
+    expect(stripMarkdownEmphasis("3 * 4 = 12")).toBe("3 * 4 = 12")
+  })
+
+  it("does not strip a backslash-escaped asterisk pair", () => {
+    expect(stripMarkdownEmphasis("\\*literal\\*")).toBe("\\*literal\\*")
+  })
+
+  it("completes quickly on a long unterminated emphasis run (ReDoS-safe)", () => {
+    // One opening asterisk + a long no-close body: exercises the lazy quantifier's
+    // backtracking. A single bounded quantifier stays linear.
+    const evil = `*${"a".repeat(100000)}`
+    const start = performance.now()
+    const out = stripMarkdownEmphasis(evil)
+    expect(performance.now() - start).toBeLessThan(100)
+    expect(out).toBe(evil) // no closing asterisk → nothing stripped
+  })
+})
+
+describe("#835 additionalCleaners option (cleanText)", () => {
+  it("is opt-in: the default chain does NOT strip markdown emphasis", () => {
+    expect(cleanText("*Leon v. Martinez*").cleaned).toContain("*")
+  })
+
+  it("runs additionalCleaners ALONGSIDE the default chain (defaults + markdown both apply)", () => {
+    const { cleaned } = cleanText("<b>*Leon v. Martinez*</b>", undefined, [stripMarkdownEmphasis])
+    expect(cleaned).not.toContain("<b>") // default stripHtmlTags ran
+    expect(cleaned).not.toContain("*") // markdown cleaner ran
+    expect(cleaned).toContain("Leon v. Martinez")
+  })
+
+  it("appends additionalCleaners after a custom `cleaners` base (defaults replaced, not the additions)", () => {
+    const base = (t: string) => t.replace(/FOO/g, "BAR")
+    const { cleaned } = cleanText("<b>FOO *x*</b>", [base], [stripMarkdownEmphasis])
+    expect(cleaned).toContain("<b>") // defaults were replaced by [base], so HTML survives
+    expect(cleaned).toContain("BAR") // custom base ran
+    expect(cleaned).not.toContain("*") // additionalCleaners still ran
+  })
+
+  it("leaves the existing `cleaners` (replace) behavior unchanged when no additionalCleaners given", () => {
+    const base = (t: string) => t.replace(/FOO/g, "BAR")
+    expect(cleanText("<b>FOO</b>", [base]).cleaned).toBe("<b>BAR</b>")
+  })
+})
+
+describe("#835 additionalCleaners via extractCitations", () => {
+  it("captures an emphasized case name and still applies the default chain", () => {
+    const text = "see <b>*Leon v. Martinez*</b>, 84 N.Y.2d 83, 87 (1994)."
+    const cites = extractCitations(text, { additionalCleaners: [stripMarkdownEmphasis] })
+    const c = cites.find((x) => x.type === "case") as unknown as MaybeCaseName | undefined
+    expect(c?.caseName).toBe("Leon v. Martinez")
+  })
+
+  it("keeps result positions mapped to the ORIGINAL (emphasized) text", () => {
+    const text = "see *Leon v. Martinez*, 84 N.Y.2d 83, 87 (1994)."
+    const cites = extractCitations(text, { additionalCleaners: [stripMarkdownEmphasis] })
+    const core = cites.find((x) => x.type === "case")
+    expect(core).toBeDefined()
+    if (core) {
+      expect(text.slice(core.span.originalStart, core.span.originalEnd)).toContain("84 N.Y.2d 83")
+    }
+  })
+})


### PR DESCRIPTION
## Why

Markdown legal text — LLM-drafted briefs especially — emphasizes case names (`*Leon v. Martinez*`). Those asterisks break case-name capture, and the only workaround was passing a custom cleaner via `cleaners` — which **silently replaces the entire default chain** (HTML stripping, whitespace/Unicode normalization, smart-quote fixing, reporter spacing, …). So consumers either got mangled case names or accidentally disabled every default normalizer.

**Today:** to strip markdown you hand-write a cleaner and pass `cleaners: [yourCleaner]`, losing all 11 default cleaners unless you re-list them. **After this PR:** `additionalCleaners: [stripMarkdownEmphasis]` adds the markdown cleaner *on top of* the defaults, and the cleaner ships built-in.

This also completes the markdown story started in #830 (PR #841), which made the resolver survive a text-shrinking cleaner — now consumers have the cleaner itself.

## What changed

- **`stripMarkdownEmphasis`** (new; exported from `eyecite-ts`): an opt-in cleaner that strips `*` / `**` / `***` emphasis while **preserving star-pagination pincites** (`at *3`) and **leaving underscores untouched** (so blank locators like `[____]` and `_x_` survive). ReDoS-safe (single bounded quantifiers). Not in the default chain.
- **`additionalCleaners` option** (on `extractCitations` and `cleanText`): cleaners appended *after* the effective base chain (the defaults, or a custom `cleaners` array). The existing `cleaners` (replace) behavior is unchanged; precedence is documented on both.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — 4601 pass, 0 fail (full suite, on current `main`).
- `pnpm typecheck` — clean.
- `pnpm lint` (Biome) on the changed files — no findings.
- 15 new tests, written test-first: emphasis stripping (`*`/`**`/`***`, inline in prose); the safety constraints (star-pagination preserved, underscores untouched, lone / space-flanked / backslash-escaped asterisks ignored); `cleanText` chain behavior (opt-in by default, append-after-defaults, append-after-custom-base, `cleaners`-replace unchanged); end-to-end via `extractCitations` (emphasized case name captured **and** defaults still applied); original-text position fidelity; and a ReDoS guard (100k-char unterminated run completes < 100ms).

## What this PR does NOT ship

- Underscore/`_`-style emphasis (ambiguous with blank locators) — intentionally excluded.
- Full markdown parsing (links, headings, lists) — emphasis only.
- Making the cleaner a default-chain member — it's opt-in by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
