### PR TITLE
fix(types): derive isFullCitation from a compiler-welded type inventory (#843)

### DIFF
--- a/.changeset/fix-843-isfullcitation-guard.md
+++ b/.changeset/fix-843-isfullcitation-guard.md
@@ -1,0 +1,5 @@
+---
+"eyecite-ts": patch
+---
+
+Fix `isFullCitation` silently misclassifying `regulation` and `stateRule` (#843). The guard hand-listed only 18 of the 20 `FullCitationType` members, so any consumer routing on it (e.g. `groupByCase`, custom pipelines) dropped those two types. The guard now reads a runtime inventory (`FULL_CITATION_TYPES`) that the compiler proves is an exact bijection with `FullCitationType` — via a `Record<FullCitationType, true>` map whose keys must list every union member — so the guard can never again omit a full type. Adds an exhaustiveness test asserting `isFullCitation` accepts every `FullCitationType` literal and rejects every `ShortFormCitationType` literal.

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -1335,6 +1335,52 @@ export type FullCitationType =
 export type ShortFormCitationType = "id" | "supra" | "shortFormCase"
 
 /**
+ * Runtime inventories of the type discriminators — the single source the
+ * `isFullCitation` / `isShortFormCitation` guards read.
+ *
+ * Each is `Object.keys` of a `Record<…Type, true>` map: the compiler forces the
+ * map to have an entry for EVERY union member (a missing one is a compile error)
+ * and rejects extras, so the runtime list is a compiler-enforced bijection with
+ * the type and can never silently omit a member — the omission that caused #843.
+ * (The type aliases stay literal unions because `scripts/generate-llms.ts`
+ * AST-parses them; deriving the type from the array would defeat that.)
+ */
+const FULL_CITATION_TYPE_PRESENCE: Record<FullCitationType, true> = {
+  case: true,
+  docket: true,
+  statute: true,
+  regulation: true,
+  journal: true,
+  neutral: true,
+  publicLaw: true,
+  federalRegister: true,
+  statutesAtLarge: true,
+  sessionLaw: true,
+  treaty: true,
+  legislativeMaterial: true,
+  localOrdinance: true,
+  canon: true,
+  constitutional: true,
+  federalRule: true,
+  stateRule: true,
+  restatement: true,
+  treatise: true,
+  annotation: true,
+}
+const SHORT_FORM_CITATION_TYPE_PRESENCE: Record<ShortFormCitationType, true> = {
+  id: true,
+  supra: true,
+  shortFormCase: true,
+}
+
+export const FULL_CITATION_TYPES: readonly FullCitationType[] = Object.keys(
+  FULL_CITATION_TYPE_PRESENCE,
+) as FullCitationType[]
+export const SHORT_FORM_CITATION_TYPES: readonly ShortFormCitationType[] = Object.keys(
+  SHORT_FORM_CITATION_TYPE_PRESENCE,
+) as ShortFormCitationType[]
+
+/**
  * Union of all full citation types (not short-form references).
  */
 export type FullCitation =

--- a/src/types/guards.ts
+++ b/src/types/guards.ts
@@ -1,45 +1,37 @@
-import type {
-  Citation,
-  CitationOfType,
-  CitationType,
-  FullCaseCitation,
-  FullCitation,
-  ShortFormCitation,
+import {
+  type Citation,
+  type CitationOfType,
+  type CitationType,
+  FULL_CITATION_TYPES,
+  type FullCaseCitation,
+  type FullCitation,
+  SHORT_FORM_CITATION_TYPES,
+  type ShortFormCitation,
 } from "./citation"
 
 /**
- * Type guard: narrows Citation to a full citation (case, statute, journal,
- * neutral, publicLaw, federalRegister, statutesAtLarge, constitutional,
- * federalRule, restatement, treatise, annotation).
+ * O(1) membership sets derived from the single-source type inventories
+ * (`FULL_CITATION_TYPES` / `SHORT_FORM_CITATION_TYPES`), so the guards below
+ * cannot drift from `FullCitationType` / `ShortFormCitationType` (#843).
+ */
+const FULL_CITATION_TYPE_SET: ReadonlySet<string> = new Set(FULL_CITATION_TYPES)
+const SHORT_FORM_CITATION_TYPE_SET: ReadonlySet<string> = new Set(SHORT_FORM_CITATION_TYPES)
+
+/**
+ * Type guard: narrows Citation to a full citation — any member of
+ * `FullCitationType`. Membership derives from `FULL_CITATION_TYPES` (the single
+ * source), so it can never silently omit a full type the way it once dropped
+ * `regulation` / `stateRule` (#843).
  */
 export function isFullCitation(citation: Citation): citation is FullCitation {
-  return (
-    citation.type === "case" ||
-    citation.type === "docket" ||
-    citation.type === "statute" ||
-    citation.type === "journal" ||
-    citation.type === "neutral" ||
-    citation.type === "publicLaw" ||
-    citation.type === "federalRegister" ||
-    citation.type === "statutesAtLarge" ||
-    citation.type === "sessionLaw" ||
-    citation.type === "treaty" ||
-    citation.type === "legislativeMaterial" ||
-    citation.type === "localOrdinance" ||
-    citation.type === "canon" ||
-    citation.type === "constitutional" ||
-    citation.type === "federalRule" ||
-    citation.type === "restatement" ||
-    citation.type === "treatise" ||
-    citation.type === "annotation"
-  )
+  return FULL_CITATION_TYPE_SET.has(citation.type)
 }
 
 /**
  * Type guard: narrows Citation to a short-form citation (id, supra, shortFormCase).
  */
 export function isShortFormCitation(citation: Citation): citation is ShortFormCitation {
-  return citation.type === "id" || citation.type === "supra" || citation.type === "shortFormCase"
+  return SHORT_FORM_CITATION_TYPE_SET.has(citation.type)
 }
 
 /**

--- a/tests/types/issue843FullCitationGuard.test.ts
+++ b/tests/types/issue843FullCitationGuard.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Issue #843: `isFullCitation` omitted `regulation` and `stateRule` (18 of 20
+ * full types), silently misclassifying them. Fix derives the guard from a single
+ * runtime source (`FULL_CITATION_TYPES`) shared with `FullCitationType`, so the
+ * type and guard can never drift apart.
+ */
+
+import { describe, expect, it } from "vitest"
+import { FULL_CITATION_TYPES, SHORT_FORM_CITATION_TYPES } from "@/types/citation"
+import type { Citation } from "@/types/citation"
+import { isFullCitation, isShortFormCitation } from "@/types/guards"
+
+// The guards only read `.type`; a minimal object suffices.
+const minimal = (type: string): Citation => ({ type }) as unknown as Citation
+
+describe("#843 isFullCitation single-source guard", () => {
+  it("returns true for `regulation` (was silently false)", () => {
+    expect(isFullCitation(minimal("regulation"))).toBe(true)
+  })
+
+  it("returns true for `stateRule` (was silently false)", () => {
+    expect(isFullCitation(minimal("stateRule"))).toBe(true)
+  })
+
+  it("exhaustive: every FullCitationType literal is recognized as a full citation", () => {
+    for (const t of FULL_CITATION_TYPES) {
+      expect(isFullCitation(minimal(t)), `isFullCitation should accept "${t}"`).toBe(true)
+    }
+  })
+
+  it("exhaustive: no ShortFormCitationType literal is a full citation", () => {
+    for (const t of SHORT_FORM_CITATION_TYPES) {
+      expect(isFullCitation(minimal(t)), `isFullCitation should reject "${t}"`).toBe(false)
+    }
+  })
+
+  it("isShortFormCitation is the exact complement of isFullCitation", () => {
+    for (const t of SHORT_FORM_CITATION_TYPES) {
+      expect(isShortFormCitation(minimal(t)), `isShortFormCitation should accept "${t}"`).toBe(true)
+    }
+    for (const t of FULL_CITATION_TYPES) {
+      expect(isShortFormCitation(minimal(t)), `isShortFormCitation should reject "${t}"`).toBe(false)
+    }
+  })
+
+  it("the two type inventories are disjoint and cover the discriminator space", () => {
+    const full = new Set<string>(FULL_CITATION_TYPES)
+    for (const t of SHORT_FORM_CITATION_TYPES) expect(full.has(t)).toBe(false)
+    expect(FULL_CITATION_TYPES.length + SHORT_FORM_CITATION_TYPES.length).toBe(23)
+  })
+})


### PR DESCRIPTION
## Why

`isFullCitation` hand-listed only **18 of the 20** `FullCitationType` members — it omitted `regulation` and `stateRule`. So `isFullCitation(regulationCitation)` returned `false` even though `RegulationCitation` / `StateRuleCitation` are full citations, and any consumer routing on the guard (e.g. `groupByCase`, custom pipelines) silently dropped those two types.

**Before:** the guard's accepted set was a second hand-maintained list that had already drifted from `FullCitationType` by two members. **After:** the guard reads a runtime inventory the compiler proves is an exact bijection with `FullCitationType`, so it can never silently omit a full type again.

## What changed

- `isFullCitation` (and `isShortFormCitation`) now test membership in `FULL_CITATION_TYPES` / `SHORT_FORM_CITATION_TYPES`.
- Those inventories are `Object.keys` of a `Record<FullCitationType, true>` / `Record<ShortFormCitationType, true>` map. The `Record` type forces an entry for **every** union member (a missing one is a compile error) and rejects extras — a compiler-enforced bijection with the type.

## Note on approach (why not `type X = (typeof LIST)[number]`)

The tidiest "single source" would derive the type from the list. That breaks the build: `scripts/generate-llms.ts` AST-parses `CitationType` / `ShortFormCitationType` / `FullCitationType` as **literal unions** and throws `No string-literal members found` on a derived type. So the type aliases stay literal unions and the `Record<…, true>` bijection is the compile-time weld instead — same guarantee (drift = type error), with no build-script change. Further consolidating `CitationType` and `generate-llms` onto the inventory is a reasonable follow-up.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — 4607 pass, 0 fail.
- `pnpm typecheck` — clean (the `Record` bijection compiles under isolatedDeclarations).
- `pnpm build` — succeeds (`generate-llms` parses the literal-union aliases fine; the earlier failure was a red→green check during development).
- `pnpm lint` (Biome) on the changed files — no findings.
- New exhaustiveness test (red-first): every `FullCitationType` literal → `isFullCitation` true (incl. `regulation` / `stateRule`); every `ShortFormCitationType` literal → false; `isShortFormCitation` is the exact complement. A future full type added to the union but not the inventory map fails to compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
