### PR TITLE
feat(types): add a stable CitationId to every citation + byId() (#856)

### DIFF
--- a/.changeset/citation-id-foundation.md
+++ b/.changeset/citation-id-foundation.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": minor
+---
+
+feat(types): add a stable `CitationId` to every citation (#856)
+
+`extractCitations()` now stamps each result citation with a stable `id` (`c0`, `c1`, … in document order) on `CitationBase`, and exports a `byId(citations)` helper mapping ids to citations. The id is stable **within a single result set** — it survives consumer `filter`/`sort`/`map`, unlike array position — and is the identity basis for the forthcoming inter-citation aggregates (parallel groups, history chains, short-form references). It is **not** durable across runs; use `toDurableLocator()` for cross-run identity. Additive and non-breaking: `id` is optional and is always populated by `extractCitations()`.

--- a/README.md
+++ b/README.md
@@ -344,6 +344,23 @@ const ctx = getSurroundingContext(
 )
 ```
 
+### Citation Identity (`id` + `byId`)
+
+Every citation returned by `extractCitations()` carries a stable `id` (`"c0"`, `"c1"`, … in document order). The id is stable **within one result set** — it survives `filter`/`sort`/`map`, unlike array position — so you can reference and look up citations by id rather than by index.
+
+```typescript
+import { byId, extractCitations } from "eyecite-ts"
+
+const citations = extractCitations(text)
+citations[0].id // "c0"
+
+// Build a lookup keyed by stable id:
+const map = byId(citations) // Map<CitationId, Citation>
+const cite = map.get(citations[0].id!)
+```
+
+Because the key is the id and not the array position, `byId(citations.filter(...))` still resolves correctly after you have filtered or reordered the array. `id` is **not** durable across runs (the same text re-extracts to fresh ids each call) — for cross-run / cross-document identity use `toDurableLocator()` from `eyecite-ts/utils`.
+
 ## Type System
 
 All citation types use a [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) on the `type` field:

--- a/src/extract/assignCitationIds.ts
+++ b/src/extract/assignCitationIds.ts
@@ -1,0 +1,34 @@
+import type { Citation, CitationId } from "../types/citation"
+
+/**
+ * Assign a stable, per-result identity (`c0`, `c1`, …) to each citation, in
+ * place, in document order.
+ *
+ * Call once from `extractCitations()` AFTER all synthesis, filtering, and
+ * sorting are complete (so the set is total and dense) and BEFORE resolution
+ * (which records references by id). The numeric suffix matches the citation's
+ * position in the returned array at extraction time, but callers must treat the
+ * id as opaque — it is stable across downstream `filter`/`sort`/`map`, whereas
+ * array position is not. See {@link CitationId}.
+ */
+export function assignCitationIds(citations: Citation[]): void {
+  for (let i = 0; i < citations.length; i++) {
+    citations[i].id = `c${i}` as CitationId
+  }
+}
+
+/**
+ * Build a lookup from {@link CitationId} to its citation. Citations without an
+ * id (e.g. produced by the granular per-type extractors rather than by
+ * `extractCitations()`) are skipped. The map keys by stable id, so it keeps
+ * working after the caller has `filter`/`sort`/`map`-ed the array.
+ */
+export function byId(citations: Citation[]): Map<CitationId, Citation> {
+  const map = new Map<CitationId, Citation>()
+  for (const citation of citations) {
+    if (citation.id !== undefined) {
+      map.set(citation.id, citation)
+    }
+  }
+  return map
+}

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -65,6 +65,7 @@ import { detectParallelCitations } from "./detectParallel"
 import { detectStringCitations, detectLeadingSignals } from "./detectStringCites"
 import { extractId, extractShortFormCase, extractSupra } from "./extractShortForms"
 import { applyFalsePositiveFilters } from "./filterFalsePositives"
+import { assignCitationIds } from "./assignCitationIds"
 import { parsePincite } from "./pincite"
 import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
 
@@ -651,7 +652,12 @@ export function extractCitations(
     text,
   )
 
-  // Step 4.95: Tag citations with footnote metadata
+  // Step 4.95: Assign stable, per-result citation identities (#856). Runs after
+  // false-positive filtering so ids are dense, and before footnote tagging and
+  // resolution so every downstream reference is by a stable id, not array index.
+  assignCitationIds(filtered)
+
+  // Step 4.96: Tag citations with footnote metadata
   if (cleanFootnoteMap) {
     tagCitationsWithFootnotes(filtered, cleanFootnoteMap)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
   CaseComponentSpans,
   Citation,
   CitationBase,
+  CitationId,
   CitationOfType,
   CitationSignal,
   CitationType,
@@ -89,6 +90,7 @@ export {
 
 export type { ExtractOptions } from "./extract/extractCitations"
 export { extractCitations, extractCitationsAsync } from "./extract/extractCitations"
+export { byId } from "./extract/assignCitationIds"
 export { applyFalsePositiveFilters } from "./extract/filterFalsePositives"
 
 // ============================================================================

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -15,6 +15,28 @@ import type {
 import type { Span } from "./span"
 
 /**
+ * Generic nominal-typing brand. Zero runtime cost — the value stays a plain `T`
+ * (so it survives `JSON.stringify`, `structuredClone`, and `{...spread}`); the
+ * brand only exists in the type system to prevent mixing unrelated string ids.
+ */
+export type Brand<T, B extends string> = T & { readonly __brand: B }
+
+/**
+ * Stable identity for a citation **within one `extractCitations()` result set**.
+ * Survives consumer `filter`/`sort`/`map` of the returned array, so aggregates
+ * (history chains, parallel groups, short-form references) reference members by
+ * id rather than by fragile positional array index.
+ *
+ * NOT durable across runs — the same logical citation re-extracts to a fresh id
+ * each call. For cross-run identity use `toDurableLocator()` (contentHash).
+ *
+ * Opaque token (currently `"c0"`, `"c1"`, …): compare it, key a `Map`/`Set` with
+ * it, store it as a reference — but never parse it or derive it from array
+ * position. See `docs/superpowers/specs/2026-06-06-inter-citation-grammar-design.md`.
+ */
+export type CitationId = Brand<string, "CitationId">
+
+/**
  * Citation type discriminator for type-safe pattern matching.
  */
 export type CitationType =
@@ -83,6 +105,14 @@ export type CitationSignal =
  * Base fields shared by all citation types.
  */
 export interface CitationBase {
+  /**
+   * Stable identity within one `extractCitations()` result set (see {@link CitationId}).
+   * Populated by `extractCitations()` for every citation in its output. Optional
+   * because the granular per-type extractors (`extractCase()`, etc.) do not assign
+   * one — it is targeted to become required in a future major (#858).
+   */
+  id?: CitationId
+
   /** Original matched text */
   text: string
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export type {
   AnnotationCitation,
   Citation,
   CitationBase,
+  CitationId,
   CitationOfType,
   CitationSignal,
   CitationType,

--- a/tests/extract/citationId.test.ts
+++ b/tests/extract/citationId.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { byId, extractCitations } from "@/index"
+
+describe("citation identity (#856)", () => {
+  it("assigns a unique, non-empty id to every extracted citation", () => {
+    const text = "500 F.2d 123. 42 U.S.C. § 1983. 100 Harv. L. Rev. 1234."
+    const citations = extractCitations(text)
+
+    expect(citations.length).toBeGreaterThan(1)
+
+    const ids = citations.map((c) => c.id)
+    // Every citation carries a non-empty string id.
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true)
+    // Ids are unique within the result set.
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it("assigns deterministic ids across repeated extractions of the same text", () => {
+    const text = "500 F.2d 123. 42 U.S.C. § 1983."
+    const a = extractCitations(text).map((c) => c.id)
+    const b = extractCitations(text).map((c) => c.id)
+
+    expect(a).toEqual(b)
+    expect(a[0]).toBe("c0")
+  })
+
+  it("byId() maps every result citation by its id, and works on a filtered subset", () => {
+    const text = "500 F.2d 123. 42 U.S.C. § 1983. 100 Harv. L. Rev. 1234."
+    const citations = extractCitations(text)
+
+    const map = byId(citations)
+    for (const c of citations) {
+      expect(map.get(c.id!)).toBe(c)
+    }
+
+    // Ids are stable handles — a filtered subset still keys correctly,
+    // unlike array position.
+    const subset = citations.filter((_, i) => i !== 0)
+    const subsetMap = byId(subset)
+    expect(subsetMap.size).toBe(subset.length)
+    expect(subsetMap.get(citations[1].id!)).toBe(citations[1])
+  })
+})


### PR DESCRIPTION
## Summary

Implements the **CitationId foundation** (#856) — the identity substrate the inter-citation aggregates reference.

**Before:** citations had no stable identity; the only handle was the array index, which breaks the moment a consumer `filter`s or `sort`s the result.

**Now:** every citation from `extractCitations()` carries a stable, branded `id` (`"c0"`, `"c1"`, … in document order), and `byId()` builds a `Map<CitationId, Citation>`. The id is stable **within one result set** (survives `filter`/`sort`/`map`); it is **not** durable across runs — `toDurableLocator()` covers that.

**Why it matters:** this is the keystone that unblocks the inter-citation aggregate slices (#849/#850/#851/#857) to reference members by stable id instead of fragile positional indices.

## In scope / deferred

- **In:** `Brand` + `CitationId`, optional `id` on `CitationBase`, `assignCitationIds` (after false-positive filtering, before resolution), exported `byId()`, README docs, changeset.
- **Deferred to #860** (coupled, riskier orchestrator refactor): the consolidated structuring pass + resolver-side ref dual-emit. The history/parallel/string dual-emit lives in the aggregate slices.

## Verification

- New `tests/extract/citationId.test.ts`: unique ids, determinism (`c0`), `byId()` + survives-filter.
- `pnpm typecheck` clean; full suite green (**4604 passing**, 0 regressions). Additive / non-breaking — `id` is optional and always populated by `extractCitations()`.

Closes #856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
