### PR TITLE
feat(extract): HistoryChain aggregate + subsequentHistoryOf.priorId (#849)

### DIFF
--- a/.changeset/history-chain.md
+++ b/.changeset/history-chain.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): HistoryChain aggregate + id-based subsequent-history reference (#849)
+
+Subsequent-history chains now expose an ordered `historyChain` aggregate (root → latest), shared by every member of the chain and keyed by stable `CitationId` — with new exported types `HistoryChain` / `HistoryLink`. The `subsequentHistoryOf` back-reference additionally carries `priorId` (the parent's stable id) alongside the retained numeric `index`. Built in the consolidated structuring pass (#860), so these relationships survive a consumer `filter`/`sort`/`map` of the result array. Additive — the flat `subsequentHistoryEntries` and `subsequentHistoryOf.index` fields are unchanged.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ const [cite] = extractCitations(text)
 if (cite.type === "case") {
   cite.subsequentHistoryEntries
   // [{ signal: 'affirmed', rawSignal: "aff'd", signalSpan: { ... }, order: 0 }]
+
+  // Ordered chain (root → latest), shared by every member, keyed by stable id:
+  cite.historyChain
+  // { links: [{ citationId: 'c0' }, { citationId: 'c1', signal: 'affirmed' }] }
+  // The back-reference also carries the parent's id alongside the numeric index:
+  // cite.subsequentHistoryOf // { index, priorId, signal }
 }
 ```
 

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -58,7 +58,7 @@ import {
 } from "@/patterns"
 import { parseBody } from "./statutes/parseBody"
 import { tokenize } from "@/tokenize"
-import type { Citation, HistorySignal } from "@/types/citation"
+import type { Citation, HistoryChain, HistoryLink, HistorySignal } from "@/types/citation"
 import { resolveCitations } from "../resolve"
 import type { ResolutionOptions, ResolvedCitation } from "../resolve/types"
 import { detectParallelCitations } from "./detectParallel"
@@ -858,6 +858,8 @@ function parseChainNumeral(raw: string): number | undefined {
 function runStructuringPass(citations: Citation[], cleaned: string): void {
   // Subsequent-history chains (#527): match signals → link parent↔child.
   linkSubsequentHistory(citations)
+  // Build the ordered HistoryChain aggregate (#849), keyed by stable id.
+  buildHistoryChains(citations)
   // Inherit the chain root's caption onto history children (#224).
   inheritSubsequentHistoryCaseName(citations)
   // Propagate the primary's caption onto parallel-cite secondaries (#282).
@@ -932,7 +934,66 @@ function linkSubsequentHistory(citations: Citation[]): void {
   for (const [childIdx, { parentIdx, signal }] of bestParent) {
     const child = citations[childIdx]
     if (child.type !== "case") continue
-    child.subsequentHistoryOf = { index: parentIdx, signal }
+    // #849: priorId is the id-based parent reference (linking now runs after
+    // assignCitationIds, so the parent's id is available). Survives consumer
+    // filter/reorder, unlike `index`.
+    child.subsequentHistoryOf = { index: parentIdx, priorId: citations[parentIdx]?.id, signal }
+  }
+}
+
+/**
+ * Build the ordered subsequent-history chain aggregate (#849) and attach it
+ * (shared) to every member, keyed by stable `CitationId`. Runs after
+ * `linkSubsequentHistory` has set the `subsequentHistoryOf` back-pointers, so
+ * it can read each child's parent index and resolve member ids.
+ */
+function buildHistoryChains(citations: Citation[]): void {
+  // child index -> { parentIdx, signal } from the back-pointers.
+  const parentOf = new Map<number, { parentIdx: number; signal: HistorySignal }>()
+  for (let i = 0; i < citations.length; i++) {
+    const c = citations[i]
+    if (c.type === "case" && c.subsequentHistoryOf) {
+      parentOf.set(i, { parentIdx: c.subsequentHistoryOf.index, signal: c.subsequentHistoryOf.signal })
+    }
+  }
+  if (parentOf.size === 0) return
+
+  // parent index -> earliest child (linear chains: one parent per child).
+  const childOf = new Map<number, { childIdx: number; signal: HistorySignal }>()
+  for (const [childIdx, { parentIdx, signal }] of parentOf) {
+    const existing = childOf.get(parentIdx)
+    if (!existing || childIdx < existing.childIdx) childOf.set(parentIdx, { childIdx, signal })
+  }
+
+  // Members participating in any chain; roots are members that are not children.
+  const members = new Set<number>()
+  for (const [childIdx, { parentIdx }] of parentOf) {
+    members.add(childIdx)
+    members.add(parentIdx)
+  }
+  for (const rootIdx of members) {
+    if (parentOf.has(rootIdx)) continue // not a root
+    const links: HistoryLink[] = []
+    const memberIdxs: number[] = []
+    const seen = new Set<number>()
+    let idx: number | undefined = rootIdx
+    let inbound: HistorySignal | undefined
+    while (idx !== undefined && !seen.has(idx)) {
+      seen.add(idx)
+      const cit = citations[idx]
+      if (cit?.type !== "case" || cit.id === undefined) break
+      links.push(inbound ? { citationId: cit.id, signal: inbound } : { citationId: cit.id })
+      memberIdxs.push(idx)
+      const next = childOf.get(idx)
+      idx = next?.childIdx
+      inbound = next?.signal
+    }
+    if (links.length < 2) continue
+    const chain: HistoryChain = { links }
+    for (const m of memberIdxs) {
+      const cit = citations[m]
+      if (cit.type === "case") cit.historyChain = chain
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ export type {
   FullCaseCitation,
   FullCitation,
   FullCitationType,
+  HistoryChain,
+  HistoryLink,
   HistorySignal,
   IdCitation,
   JournalCitation,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -293,6 +293,25 @@ export interface SubsequentHistoryEntry {
  * @example "500 F.2d 123"
  * @example "410 U.S. 113, 115"
  */
+/**
+ * One link in a subsequent-history chain (#849): the case at this position, plus
+ * the disposition signal that led TO it. The chain root has no inbound `signal`.
+ */
+export interface HistoryLink {
+  citationId: CitationId
+  signal?: HistorySignal
+}
+
+/**
+ * A subsequent-history chain (#849), ordered root → latest. Built post-id-assignment
+ * in the structuring pass and attached (shared) to every member, so a consumer can
+ * read the whole chain from any link. References members by stable `CitationId`,
+ * so it survives `filter`/`sort`/`map` of the result array.
+ */
+export interface HistoryChain {
+  links: HistoryLink[]
+}
+
 export interface FullCaseCitation extends CitationBase {
   type: "case"
   volume: number | string
@@ -355,12 +374,20 @@ export interface FullCaseCitation extends CitationBase {
   subsequentHistoryEntries?: SubsequentHistoryEntry[]
 
   /**
+   * Ordered subsequent-history chain (root → latest), shared by every member of
+   * the chain (#849). Built in the structuring pass; references members by stable
+   * id. The flat `subsequentHistoryOf` / `subsequentHistoryEntries` fields are
+   * retained alongside it. See {@link HistoryChain}.
+   */
+  historyChain?: HistoryChain
+
+  /**
    * Back-pointer indicating this citation is a subsequent history citation.
    * `index` is the parent's position in the results array returned by
    * `extractCitations()` — it becomes invalid if the array is filtered or reordered.
    * @example { index: 0, signal: "affirmed" }
    */
-  subsequentHistoryOf?: { index: number; signal: HistorySignal }
+  subsequentHistoryOf?: { index: number; priorId?: CitationId; signal: HistorySignal }
 
   /**
    * Date information in multiple formats.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,8 @@ export type {
   FullCaseCitation,
   FullCitation,
   FullCitationType,
+  HistoryChain,
+  HistoryLink,
   HistorySignal,
   IdCitation,
   JournalCitation,

--- a/tests/extract/historyChain.test.ts
+++ b/tests/extract/historyChain.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { FullCaseCitation } from "@/types/citation"
+
+const CHAIN_TEXT =
+  "Smith v. Doe, 100 F.3d 200 (2d Cir. 2010), aff'd, 200 F.3d 300 (2d Cir. 2011)."
+
+describe("HistoryChain (#849)", () => {
+  it("sets subsequentHistoryOf.priorId to the parent's stable id", () => {
+    const citations = extractCitations(CHAIN_TEXT)
+    const child = citations.find(
+      (c) => c.type === "case" && (c as FullCaseCitation).subsequentHistoryOf !== undefined,
+    ) as FullCaseCitation | undefined
+    expect(child).toBeDefined()
+
+    const ref = child!.subsequentHistoryOf!
+    // id-based parent reference, alongside the retained numeric index
+    expect(ref.priorId).toBe(citations[ref.index].id)
+  })
+
+  it("builds an ordered historyChain (root → latest) shared by chain members", () => {
+    const citations = extractCitations(CHAIN_TEXT)
+    const cases = citations.filter((c) => c.type === "case") as FullCaseCitation[]
+    const root = cases.find((c) => c.volume === 100)
+    const affirmed = cases.find((c) => c.volume === 200)
+    expect(root).toBeDefined()
+    expect(affirmed).toBeDefined()
+
+    // Both members carry the same ordered chain.
+    expect(root!.historyChain).toBeDefined()
+    expect(affirmed!.historyChain).toBeDefined()
+
+    const chain = affirmed!.historyChain!
+    expect(chain.links.map((l) => l.citationId)).toEqual([root!.id, affirmed!.id])
+    expect(chain.links[0].signal).toBeUndefined() // root has no inbound signal
+    expect(chain.links[1].signal).toBe("affirmed")
+  })
+
+  it("history links survive a consumer filter/reorder (id-keyed)", () => {
+    const citations = extractCitations(CHAIN_TEXT)
+    const reordered = [...citations].reverse()
+    const child = reordered.find(
+      (c) => c.type === "case" && (c as FullCaseCitation).subsequentHistoryOf?.priorId,
+    ) as FullCaseCitation | undefined
+    expect(child).toBeDefined()
+    // priorId still resolves against the reordered array via id, not position.
+    const parent = reordered.find((c) => c.id === child!.subsequentHistoryOf!.priorId)
+    expect(parent).toBeDefined()
+    expect((parent as FullCaseCitation).volume).toBe(100)
+  })
+})

--- a/tests/integration/subsequentHistory.test.ts
+++ b/tests/integration/subsequentHistory.test.ts
@@ -13,8 +13,9 @@ describe("subsequent history linking (#73)", () => {
       // Parent has entries
       expect(citations[0].subsequentHistoryEntries).toHaveLength(1)
       expect(citations[0].subsequentHistoryEntries?.[0].signal).toBe("affirmed")
-      // Child points back to parent
-      expect(citations[1].subsequentHistoryOf).toEqual({ index: 0, signal: "affirmed" })
+      // Child points back to parent (index retained; #849 adds id-based priorId)
+      expect(citations[1].subsequentHistoryOf).toMatchObject({ index: 0, signal: "affirmed" })
+      expect(citations[1].subsequentHistoryOf?.priorId).toBe(citations[0].id)
     }
   })
 
@@ -39,7 +40,8 @@ describe("subsequent history linking (#73)", () => {
     // the downstream `cert. denied`.
     expect(citations[1].type).toBe("case")
     if (citations[1].type === "case") {
-      expect(citations[1].subsequentHistoryOf).toEqual({ index: 0, signal: "affirmed" })
+      expect(citations[1].subsequentHistoryOf).toMatchObject({ index: 0, signal: "affirmed" })
+      expect(citations[1].subsequentHistoryOf?.priorId).toBe(citations[0].id)
       expect(citations[1].subsequentHistoryEntries).toHaveLength(1)
       expect(citations[1].subsequentHistoryEntries?.[0].signal).toBe("cert_denied")
     }
@@ -47,7 +49,8 @@ describe("subsequent history linking (#73)", () => {
     // not the original root (0).
     expect(citations[2].type).toBe("case")
     if (citations[2].type === "case") {
-      expect(citations[2].subsequentHistoryOf).toEqual({ index: 1, signal: "cert_denied" })
+      expect(citations[2].subsequentHistoryOf).toMatchObject({ index: 1, signal: "cert_denied" })
+      expect(citations[2].subsequentHistoryOf?.priorId).toBe(citations[1].id)
     }
   })
 


### PR DESCRIPTION
## Summary

The first inter-citation aggregate built on the #860 structuring pass: **`HistoryChain`** + an id-based subsequent-history back-reference.

**Before:** subsequent history was only a flat per-citation `subsequentHistoryEntries[]` plus a `subsequentHistoryOf.index` back-pointer (a positional array index that broke under consumer `filter`/`sort`).

**Now:**
- Every member of a history chain carries a shared, ordered **`historyChain`** (root → latest), with each link referencing a member by stable `CitationId` and carrying the inbound disposition signal. New exported types: `HistoryChain` / `HistoryLink`.
- `subsequentHistoryOf` gains **`priorId`** (the parent's stable id) alongside the retained numeric `index`.
- Both are built in the consolidated structuring pass (#860), so they **survive a consumer `filter`/`sort`/`map`** of the result array.

Additive and non-breaking — the flat `subsequentHistoryEntries` / `subsequentHistoryOf.index` fields are unchanged.

## Verification

- TDD (red→green): `tests/extract/historyChain.test.ts` — `priorId` resolves to the parent's id; ordered `historyChain` shared by members; links survive a reversed array (id-keyed).
- Existing `subsequentHistory.test.ts` assertions updated to `toMatchObject({ index, signal })` **and** strengthened to verify `priorId` points at the parent — not loosened.
- `pnpm typecheck` clean; full suite **green (4,616 passing)**.

## Deferred (transparent)

The `inheritSubsequentHistoryCaseName` fixed-point loop is **retained as-is** — it's correct, and the suite confirms it. Converting it to a `historyChain` traversal (the one remaining item from the issue's AC) is a behavior-equivalent micro-optimization left as a follow-up; flag if you'd like it folded in before merge.

Closes #849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
