### PR TITLE
feat(extract): ParallelGroup aggregate (#850)

### DIFF
--- a/.changeset/parallel-group.md
+++ b/.changeset/parallel-group.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): ParallelGroup aggregate (#850)
+
+Parallel citations (the same case reported in multiple reporters) now expose a `parallelGroup` aggregate (new exported `ParallelGroup` type) listing every member — including itself — by stable `CitationId` in document order. Combined with `byId()`, this resolves the full sibling citations rather than the lossy `{ volume, reporter, page }` value-copies on `parallelCitations`. Built in the consolidated structuring pass (#860), so it survives a consumer `filter`/`sort`/`map`. Additive — the flat `groupId` label and `parallelCitations` array are unchanged.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ if (citations[0].type === "case") {
   citations[0].parallelCitations
   // [{ volume: 93, reporter: 'S. Ct.', page: 705 },
   //  { volume: 35, reporter: 'L. Ed. 2d', page: 147 }]
+
+  // Every member also carries the group by stable id (doc order, incl. self),
+  // so byId() resolves the full sibling citations (not lossy value-copies):
+  citations[0].parallelGroup // { memberIds: ['c0', 'c1', 'c2'] }
 }
 ```
 

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -58,7 +58,14 @@ import {
 } from "@/patterns"
 import { parseBody } from "./statutes/parseBody"
 import { tokenize } from "@/tokenize"
-import type { Citation, HistoryChain, HistoryLink, HistorySignal } from "@/types/citation"
+import type {
+  Citation,
+  CitationId,
+  HistoryChain,
+  HistoryLink,
+  HistorySignal,
+  ParallelGroup,
+} from "@/types/citation"
 import { resolveCitations } from "../resolve"
 import type { ResolutionOptions, ResolvedCitation } from "../resolve/types"
 import { detectParallelCitations } from "./detectParallel"
@@ -862,6 +869,8 @@ function runStructuringPass(citations: Citation[], cleaned: string): void {
   buildHistoryChains(citations)
   // Inherit the chain root's caption onto history children (#224).
   inheritSubsequentHistoryCaseName(citations)
+  // Build the ParallelGroup aggregate (#850), keyed by stable id.
+  buildParallelGroups(citations)
   // Propagate the primary's caption onto parallel-cite secondaries (#282).
   inheritParallelCaseName(citations)
   // Group semicolon-separated string citations (excludes history-chain members).
@@ -993,6 +1002,35 @@ function buildHistoryChains(citations: Citation[]): void {
     for (const m of memberIdxs) {
       const cit = citations[m]
       if (cit.type === "case") cit.historyChain = chain
+    }
+  }
+}
+
+/**
+ * Build the ParallelGroup aggregate (#850): group case citations by their
+ * content-derived `groupId` (set during extraction) and attach a shared
+ * `parallelGroup` listing all member ids in document order (including self).
+ */
+function buildParallelGroups(citations: Citation[]): void {
+  const groups = new Map<string, number[]>()
+  for (let i = 0; i < citations.length; i++) {
+    const c = citations[i]
+    if (c.type === "case" && c.groupId !== undefined) {
+      const arr = groups.get(c.groupId)
+      if (arr) arr.push(i)
+      else groups.set(c.groupId, [i])
+    }
+  }
+  for (const indices of groups.values()) {
+    if (indices.length < 2) continue
+    const memberIds = indices
+      .map((i) => citations[i].id)
+      .filter((id): id is CitationId => id !== undefined)
+    if (memberIds.length < 2) continue
+    const group: ParallelGroup = { memberIds }
+    for (const i of indices) {
+      const c = citations[i]
+      if (c.type === "case") c.parallelGroup = group
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export type {
   JournalComponentSpans,
   NeutralCitation,
   NeutralComponentSpans,
+  ParallelGroup,
   Parenthetical,
   ParentheticalType,
   PublicLawCitation,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -312,6 +312,16 @@ export interface HistoryChain {
   links: HistoryLink[]
 }
 
+/**
+ * A parallel-citation group (#850): the same case reported in multiple reporters.
+ * Every member references all members (including itself) by stable `CitationId`,
+ * in document order. Built in the structuring pass; the flat `groupId` label and
+ * `parallelCitations` array are retained alongside it.
+ */
+export interface ParallelGroup {
+  memberIds: CitationId[]
+}
+
 export interface FullCaseCitation extends CitationBase {
   type: "case"
   volume: number | string
@@ -343,6 +353,12 @@ export interface FullCaseCitation extends CitationBase {
    * @example "410-U.S.-113" for parallel group [410 U.S. 113, 93 S. Ct. 705]
    */
   groupId?: string
+
+  /**
+   * Parallel-citation group (#850): all members (incl. self) by stable id, in
+   * document order. Survives consumer `filter`/`sort`/`map`. See {@link ParallelGroup}.
+   */
+  parallelGroup?: ParallelGroup
 
   /** Parallel citations for same case in different reporters */
   parallelCitations?: Array<{

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,6 +21,7 @@ export type {
   IdCitation,
   JournalCitation,
   NeutralCitation,
+  ParallelGroup,
   Parenthetical,
   ParentheticalType,
   PublicLawCitation,

--- a/tests/extract/parallelGroup.test.ts
+++ b/tests/extract/parallelGroup.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { FullCaseCitation } from "@/types/citation"
+
+const PARALLEL_TEXT = "Roe v. Wade, 410 U.S. 113, 93 S. Ct. 705, 35 L. Ed. 2d 147 (1973)."
+
+describe("ParallelGroup (#850)", () => {
+  it("builds a parallelGroup with all member ids (doc order, incl. self), shared by members", () => {
+    const citations = extractCitations(PARALLEL_TEXT)
+    const group = citations.filter(
+      (c) => c.type === "case" && (c as FullCaseCitation).groupId !== undefined,
+    ) as FullCaseCitation[]
+    expect(group.length).toBeGreaterThanOrEqual(2)
+
+    const memberIds = group.map((c) => c.id)
+    for (const c of group) {
+      expect(c.parallelGroup).toBeDefined()
+      expect(c.parallelGroup!.memberIds).toEqual(memberIds)
+    }
+  })
+
+  it("parallelGroup survives a consumer reorder (id-keyed, not positional)", () => {
+    const citations = extractCitations(PARALLEL_TEXT)
+    const reordered = [...citations].reverse()
+    const member = reordered.find(
+      (c) => c.type === "case" && (c as FullCaseCitation).parallelGroup !== undefined,
+    ) as FullCaseCitation | undefined
+    expect(member).toBeDefined()
+    for (const id of member!.parallelGroup!.memberIds) {
+      expect(reordered.find((c) => c.id === id)).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The second inter-citation aggregate on the #860 structuring pass: **`ParallelGroup`**.

**Before:** parallel citations (the same case in multiple reporters) were linked by a shared `groupId` string, and the primary carried a lossy `parallelCitations` array of `{ volume, reporter, page }` value-copies — dropping the siblings' pincite/court/spans/ids.

**Now:** every member carries a shared **`parallelGroup`** (new exported `ParallelGroup` type) listing all members — including itself — by stable `CitationId` in document order. Combined with `byId()`, that resolves the **full** sibling citations, not lossy copies. Built in the consolidated structuring pass (#860), so it survives a consumer `filter`/`sort`/`map`.

Additive and non-breaking — the flat `groupId` label and `parallelCitations` array are unchanged.

## Verification

- TDD (red→green): `tests/extract/parallelGroup.test.ts` — `parallelGroup.memberIds` covers all members (doc order, incl. self) and is shared by every member; member ids still resolve after a reversed array (id-keyed).
- `pnpm typecheck` clean; full suite **green (4,618 passing, 0 regressions)**. README + changeset added.

## Deferred (transparent)

Like #849's caption loop, `inheritParallelCaseName` is retained as-is (correct; suite-confirmed). Reducing it to read from the group is a behavior-equivalent optimization left as a follow-up.

Closes #850.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
