### PR TITLE
feat(extract): StringCitationGroup aggregate (#857)

### DIFF
--- a/.changeset/string-citation-group.md
+++ b/.changeset/string-citation-group.md
@@ -1,0 +1,7 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): StringCitationGroup aggregate (#857)
+
+String citations (citations chained for one proposition, `See A; B; C`) now expose a `stringCitationGroup` aggregate (new exported `StringCitationGroup` type) listing every member — including itself — by stable `CitationId` in document order, plus the group's leading signal. Built in the consolidated structuring pass (#860), so it survives a consumer `filter`/`sort`/`map`. Additive — the flat `stringCitationGroupId` / `stringCitationIndex` / `stringCitationGroupSize` fields are unchanged. Completes the inter-citation aggregates alongside HistoryChain (#849) and ParallelGroup (#850).

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ cite.signal // "see also"
 
 Recognized signals: `see`, `see also`, `see generally`, `cf`, `but see`, `but cf`, `compare`, `accord`, `contra`, `e.g.`, and combined forms (`see, e.g.`, `see also, e.g.`, `but see, e.g.`, `cf., e.g.`, `but cf., e.g.`).
 
+Citations chained for one proposition (`See A; B; C`) form a **string-citation group** — each member carries `stringCitationGroup` (all member ids in document order, incl. self, keyed by stable id) plus the group's leading signal.
+
 ### Court Inference
 
 Case citations carry a `inferredCourt` field derived from the reporter series:

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -61,10 +61,12 @@ import { tokenize } from "@/tokenize"
 import type {
   Citation,
   CitationId,
+  CitationSignal,
   HistoryChain,
   HistoryLink,
   HistorySignal,
   ParallelGroup,
+  StringCitationGroup,
 } from "@/types/citation"
 import { resolveCitations } from "../resolve"
 import type { ResolutionOptions, ResolvedCitation } from "../resolve/types"
@@ -875,6 +877,8 @@ function runStructuringPass(citations: Citation[], cleaned: string): void {
   inheritParallelCaseName(citations)
   // Group semicolon-separated string citations (excludes history-chain members).
   detectStringCitations(citations, cleaned)
+  // Build the StringCitationGroup aggregate (#857), keyed by stable id.
+  buildStringCitationGroups(citations)
   // Backward-scan a leading signal for citations that still lack one.
   detectLeadingSignals(citations, cleaned)
   // Propagate the `compare A with B` signal across the `with` connector (#702).
@@ -1031,6 +1035,43 @@ function buildParallelGroups(citations: Citation[]): void {
     for (const i of indices) {
       const c = citations[i]
       if (c.type === "case") c.parallelGroup = group
+    }
+  }
+}
+
+/**
+ * Build the StringCitationGroup aggregate (#857): group citations by their
+ * `stringCitationGroupId` (set by detectStringCitations) and attach a shared
+ * `stringCitationGroup` listing all member ids in document order (incl. self),
+ * plus the group's leading signal.
+ */
+function buildStringCitationGroups(citations: Citation[]): void {
+  const groups = new Map<string, number[]>()
+  for (let i = 0; i < citations.length; i++) {
+    const gid = citations[i].stringCitationGroupId
+    if (gid !== undefined) {
+      const arr = groups.get(gid)
+      if (arr) arr.push(i)
+      else groups.set(gid, [i])
+    }
+  }
+  for (const indices of groups.values()) {
+    if (indices.length < 2) continue
+    const memberIds = indices
+      .map((i) => citations[i].id)
+      .filter((id): id is CitationId => id !== undefined)
+    if (memberIds.length < 2) continue
+    let signal: CitationSignal | undefined
+    for (const i of indices) {
+      const s = citations[i].signal
+      if (s !== undefined) {
+        signal = s
+        break
+      }
+    }
+    const group: StringCitationGroup = signal ? { memberIds, signal } : { memberIds }
+    for (const i of indices) {
+      citations[i].stringCitationGroup = group
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export type {
   StatuteComponentSpans,
   StatutesAtLargeCitation,
   StatutesAtLargeComponentSpans,
+  StringCitationGroup,
   SubsequentHistoryEntry,
   SupraCitation,
   TransformationMap,

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -102,6 +102,18 @@ export type CitationSignal =
   | "but cf., e.g."
 
 /**
+ * A string-citation group (#857): citations chained for one proposition
+ * (`See A; B; C`). Members reference all members (including self) by stable
+ * `CitationId` in document order; `signal` is the group's leading signal. Built
+ * in the structuring pass; the flat `stringCitationGroupId` / `stringCitationIndex`
+ * / `stringCitationGroupSize` fields are retained alongside it.
+ */
+export interface StringCitationGroup {
+  memberIds: CitationId[]
+  signal?: CitationSignal
+}
+
+/**
  * Base fields shared by all citation types.
  */
 export interface CitationBase {
@@ -151,6 +163,13 @@ export interface CitationBase {
 
   /** Total number of citations in this string citation group */
   stringCitationGroupSize?: number
+
+  /**
+   * String-citation group (#857): all members (incl. self) by stable id, in
+   * document order, plus the group's leading signal. Survives consumer
+   * `filter`/`sort`/`map`. See {@link StringCitationGroup}.
+   */
+  stringCitationGroup?: StringCitationGroup
 
   /** Whether this citation appears in a footnote (only populated when detectFootnotes enabled) */
   inFootnote?: boolean

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export type {
   ShortFormCitationType,
   StatuteCitation,
   StatutesAtLargeCitation,
+  StringCitationGroup,
   SubsequentHistoryEntry,
   SupraCitation,
   TreatiseCitation,

--- a/tests/extract/stringCitationGroup.test.ts
+++ b/tests/extract/stringCitationGroup.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+
+const STRING_TEXT =
+  "See Smith v. Doe, 100 F.3d 1 (2010); Roe v. Poe, 200 F.3d 2 (2011); Ada v. Cho, 300 F.3d 3 (2012)."
+
+describe("StringCitationGroup (#857)", () => {
+  it("builds a stringCitationGroup with all member ids (doc order, incl. self), shared by members", () => {
+    const citations = extractCitations(STRING_TEXT)
+    const group = citations.filter((c) => c.stringCitationGroupId !== undefined)
+    expect(group.length).toBeGreaterThanOrEqual(2)
+
+    const memberIds = group.map((c) => c.id)
+    for (const c of group) {
+      expect(c.stringCitationGroup).toBeDefined()
+      expect(c.stringCitationGroup!.memberIds).toEqual(memberIds)
+    }
+  })
+
+  it("stringCitationGroup survives a consumer reorder (id-keyed, not positional)", () => {
+    const citations = extractCitations(STRING_TEXT)
+    const reordered = [...citations].reverse()
+    const member = reordered.find((c) => c.stringCitationGroup !== undefined)
+    expect(member).toBeDefined()
+    for (const id of member!.stringCitationGroup!.memberIds) {
+      expect(reordered.find((c) => c.id === id)).toBeDefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

The third (and final cross-citation) aggregate on the #860 structuring pass: **`StringCitationGroup`**.

**Before:** string citations (chained for one proposition, `See A; B; C`) were linked by `stringCitationGroupId` + per-member `stringCitationIndex`/`stringCitationGroupSize` positional scalars.

**Now:** every member carries a shared **`stringCitationGroup`** (new exported `StringCitationGroup` type) — all members (including self) by stable `CitationId` in document order, plus the group's leading signal. Built in the consolidated structuring pass (#860), so it survives a consumer `filter`/`sort`/`map`.

Additive and non-breaking — the flat `stringCitationGroupId` / `stringCitationIndex` / `stringCitationGroupSize` fields are unchanged.

## Verification

- TDD (red→green): `tests/extract/stringCitationGroup.test.ts` — `memberIds` covers all members (doc order, incl. self), shared by every member; survives a reversed array (id-keyed). I empirically confirmed the grouping (`{memberIds:["c0","c1","c2"], signal:"see"}`) and corrected the test input after the first text — bare vol-reporter-page cites — didn't form a group.
- `pnpm typecheck` clean; full suite **green (4,620 passing, 0 regressions)**. README + changeset added.

With this, the three cross-citation aggregates — `HistoryChain` (#849), `ParallelGroup` (#850), `StringCitationGroup` (#857) — all sit on the shared structuring pass and reference members by stable id. The remaining inter-citation work is the per-citation recursive `Parenthetical` (#851).

Closes #857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
