### PR TITLE
feat(extract): nest citations in explanatory parentheticals (#851)

### DIFF
--- a/.changeset/recursive-parenthetical-citations.md
+++ b/.changeset/recursive-parenthetical-citations.md
@@ -1,0 +1,11 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): nest citations inside explanatory parentheticals as child citations (#851)
+
+A citation nested inside an explanatory parenthetical — e.g. the `Doe v. City, 100 F.2d 1` in `Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1)` — is now linked onto its host parenthetical's new `Parenthetical.citations` array as a child citation, keyed by its own stable `CitationId` (the `in-parenthetical-of` edge). Per Bluebook Rule 1.5(b) such a cite is a subordinate component of the citing authority, not a separate authority.
+
+This is **additive and non-breaking by default**: the nested cite is also kept as a top-level result, so a later case short form can still resolve to a case first cited in a parenthetical (Bluebook Rule 10.9(a)). A new `excludeParentheticalChildren` option opts into the strict subordinate model — `extractCitations(text, { excludeParentheticalChildren: true })` removes the nested cite from the top-level array, leaving it reachable only via its host's `parentheticals[].citations`, and hidden from the cross-citation groupers and the resolver. Children land on the smallest enclosing parenthetical, so genuinely nested asides like `(citing B (quoting C))` build a correct tree.
+
+Either mode preserves the existing, doctrinally-correct resolver behavior: `Id.`/`supra` never bind to a parenthetical-nested citation (Bluebook Rule 4.1/4.2) — only the host authority.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,24 @@ if (cite.type === "case") {
 
 Classification types: `holding`, `finding`, `stating`, `noting`, `explaining`, `quoting`, `citing`, `discussing`, `describing`, `recognizing`, `applying`, `rejecting`, `adopting`, `requiring`, `other`.
 
+A citation nested inside an explanatory parenthetical — e.g. the `Doe v. City, 100 F.2d 1` in `(quoting Doe v. City, 100 F.2d 1)` — is linked onto its host parenthetical's `citations` array as a child citation (with its own stable `id`):
+
+```typescript
+const text = "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1)."
+const [smith] = extractCitations(text)
+smith.parentheticals?.[0].citations
+// [ FullCaseCitation { caseName: "Doe v. City", reporter: "F.2d", page: 1, … } ]
+```
+
+By default this is **additive and non-breaking**: the nested cite is also kept as a top-level result, so a later case short form can still resolve to a case first cited in a parenthetical (Bluebook Rule 10.9(a)). Pass `{ excludeParentheticalChildren: true }` for the strict subordinate model — the nested cite is removed from the top-level array and reachable only via its host's `parentheticals[].citations`:
+
+```typescript
+extractCitations(text).length                                          // 2 (Smith + Doe)
+extractCitations(text, { excludeParentheticalChildren: true }).length  // 1 (Smith; Doe is a child)
+```
+
+Either way, `Id.`/`supra` never resolve to a parenthetical-nested citation (Bluebook Rule 4.1/4.2) — only the host authority.
+
 ### Citation Annotation
 
 Mark up citations with HTML using template or callback modes:

--- a/docs/research/2026-06-07-nested-parenthetical-citation-rules.md
+++ b/docs/research/2026-06-07-nested-parenthetical-citation-rules.md
@@ -1,0 +1,91 @@
+# Nested-Parenthetical Citations: Doctrine vs. Implementation
+
+**Date:** 2026-06-07
+**Question:** How do legal citation authorities treat a citation nested inside another citation's explanatory parenthetical — e.g. `Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1)` — and should an extraction tool surface it as a top-level resolvable citation or a subordinate child? (Informs eyecite-ts #851.)
+**Depth:** deep (5 angles · 16 sources fetched · 62 claims → 25 verified → 19 confirmed / 6 killed · 98 agents)
+**Verdict:** Doctrine and the reference implementation point in **opposite** directions. The "correct" answer is the subordinate-child model — but with one doctrinal exception (Rule 10.9(a)) that makes blanket non-resolvability **overbroad**.
+
+> Research docs are gitignored by team convention (not committed).
+
+---
+
+## TL;DR
+
+1. **Doctrine: the nested cite is SUBORDINATE, not an independent authority.** `(quoting B)` / `(citing B)` are named *parenthetical types* that occupy fixed slots within the host citation's parenthetical sequence (Bluebook Rule 1.5(b)) — a structured component of authority A, not a separately-listed authority. (High confidence.)
+2. **`Id.` after `A (quoting B)` resolves to A, never B.** Rule 4.1: sources in explanatory parentheticals "are not counted as intervening authorities." Canonical example: *Tuten* (quoting *Ralston*) → later `id.` = *Tuten*. **`supra` likewise will not attach to B.** (High confidence.) — eyecite-ts already does this (#214/#799).
+3. **The one exception — Rule 10.9(a):** a case *first cited in a parenthetical* **can** still anchor a later **case short form** (e.g. `100 F.2d at 5`), within the five-footnote window — even though `Id.`/`supra` ignore it. So "non-resolvable child" is doctrinally sound for `Id.`/`supra` but **overbroad** for the case-short-form pathway. (Medium confidence.) — this is exactly eyecite-ts's deliberately-kept "short-form case resolves to a parenthetical-internal citation" behavior, which turns out to be **doctrinally correct**.
+4. **Peer tools do the OPPOSITE.** Python eyecite stores the parenthetical as an opaque flat string, never parses cites out of it, and `filter_citations` has an explicit branch that **keeps** a separately-tokenized nested cite as a co-equal, fully-resolvable top-level peer — so a following `Id.` empirically resolves to the buried inner cite (the Rule 4.1 violation #830/#831 exemplified). CourtListener inherits this (flat opinion→opinion edges, `depth` = frequency only, no nesting field). **Cite eyecite as the counter-example the design corrects, not as precedent.**
+
+**Bottom line for #851:** the *nesting model* is doctrinally right and a justified divergence from upstream. Excluding children from `Id.`/`supra` is right (already done). **Fully removing them from the top-level array by default is overbroad** (breaks Rule 10.9(a) case-short-forms; diverges from the ecosystem; breaking for consumers). → Favor **additive nesting by default + the strict top-level exclusion behind an opt-in flag.**
+
+---
+
+## Q1 — Subordinate or independent authority?
+
+**Subordinate.** A parenthetical is "an explanatory phrase included in parentheses at the end of a legal citation" (Georgetown Law writing-center handout, verified verbatim). Bluebook **Rule 1.5(b)** fixes the order of parenthetical *types* within a single host citation:
+
+> `… (citations omitted) (quoting another source) (internal quotation marks omitted) (citing another source) …`
+
+`(quoting …)` and `(citing …)` sit in that ordered sequence alongside `(emphasis added)`, `(citations omitted)`, etc. — i.e., they are **components of authority A's citation**, not separate entries in the authority list. (Corroborated by Temple Law Review Rule B.6.) Confidence: **high** (3-0 + 2-1 + 2-1 across independent guides).
+
+## Q2 — `Id.` / `supra` / short-form resolution
+
+**`Id.` → host A, never nested B.** Bluebook **Rule 4.1** (verbatim via Tarlton/UT, corroborated by 5+ law-school guides):
+
+> "Sources cited in explanatory parentheticals or phrases or as part of a case prior or subsequent history are **not counted as intervening authorities** preventing the use of Id."
+
+Hawaii LibGuide: "whatever explanatory information is contained in a preceding parenthetical is **ignored** in the Id. citation." Indigo Book (verbatim): "If there is an explanatory parenthetical or phrase in the preceding citation, it is **not incorporated** with the use of id." Canonical example: `Tuten v. United States, 460 U.S. 660, 663 (1983) (quoting Ralston v. Robinson, 454 U.S. 201, 206 (1981))` + `See id. at 664` → **Tuten**. Confidence: **high**; no contradicting source found.
+
+> The deep-research pass *killed* (0-3 / 1-2) several plausible-sounding claims that `Id.` is **barred outright** when `A (quoting B)` "presents two authorities." Verifiers rejected that framing: under Rule 4.1 the parenthetical case is *not counted* as a second authority, so `Id.` is permitted and cleanly resolves to A. Worth recording so we don't reintroduce that wrong intuition.
+
+**The exception — Rule 10.9(a) / Bluepages B10.2 (case short forms).** Short forms are permitted once a full citation exists and "(1) it is clear to the reader which authority is referenced; (2) the full citation falls in the same general discussion; and (3) the reader will have little trouble locating the full citation." The verifier caveat is decisive for us:
+
+> **Rule 10.9(a)'s five-footnote rule is a genuine narrowing exception: a case first appearing in a parenthetical CAN anchor a later CASE short form, even though `supra` cannot attach to it and `Id.` ignores it.** So "non-resolvable child by default" is doctrinally defensible but **not absolute** for the case-short-form pathway specifically.
+
+This maps **exactly** onto eyecite-ts's existing, deliberately-tuned resolver:
+
+| Reference | Doctrine | eyecite-ts today |
+|---|---|---|
+| `Id.` after `A (quoting B)` | → A (Rule 4.1) | → A (#214) ✓ |
+| `supra` for B | abstains (B not a proper antecedent) | abstains (#799) ✓ |
+| case short form `100 F.2d at 5` for B | **permitted** (Rule 10.9(a)) | resolves to B ✓ |
+
+The resolver is doctrinally precise. **Full top-level exclusion would break the third row.**
+
+## Q3 — What it implies for an extraction tool
+
+Model the nested cite as a **child/attachment of its host** and keep it **out of `Id.`/`supra` resolution** — the subordinate model. But because Rule 10.9(a) preserves the case-short-form pathway (and because removing cites from a flat list breaks ecosystem parity), the *child node should remain reachable/resolvable for case short forms*, not be deleted outright.
+
+## Peer tools — the doctrine-vs-implementation split
+
+- **Python eyecite (the upstream eyecite-ts ports):** parenthetical stored as `parenthetical: str | None` on `CitationBase.Metadata` — opaque text, never parsed into sub-citations (`process_parenthetical` only balances parens / drops year-only). Verified at commit `04d82c0` + current main; grep for nested/child/subordinate/recursive = 0 hits. **But** `filter_citations` deliberately **keeps** a separately-tokenized nested cite as a top-level peer:
+  > `# A citation in a paren would also overlap and should be kept. … if paren and citation.matched_text() in paren: filtered_citations.append(citation); continue`
+  Empirically (eyecite v2.7.6 on our example): a **flat list of 2 co-equal `FullCaseCitation`s**, and `resolve.py` is parenthetical-blind (grep `parenthetical` → no matches), so a following `Id.` resolves to the buried `100 F.2d 1`. The keep-branch is a **pure substring test with no signal-word check** — it keeps *any* tokenized cite inside the prior parenthetical, `quoting`/`citing` or not.
+- **CourtListener** (powered by eyecite): citation graph is a flat opinion→opinion edge model (`OpinionsCited`: `citing_opinion`, `cited_opinion`, `depth`, `unique_together`). `depth` = citation **frequency**, not nesting. No parent/child or parenthetical-containment field. (`quoted`/`treatment` exist only as commented-out code. The separate "Parenthetical" model is court-written summary blurbs, not nested cites.)
+
+**So eyecite-ts modeling subordination is a deliberate, doctrinally-justified DIVERGENCE from upstream — not alignment with it.** And eyecite-ts's signal-aware extraction (#851 §5) is *more precise* than eyecite's bare substring containment.
+
+## Recommendation for #851
+
+The research argues against the locked AC's "exclude from top-level by default" and for a more nuanced default:
+
+- **Default (non-breaking):** additively nest paren-cites as children on `Parenthetical.citations` / short-form `parentheticalNode` (the doctrinally-correct subordination model + the `in-parenthetical-of` graph edge), **and keep them in the top-level array** so the Rule 10.9(a) case-short-form pathway and ecosystem parity survive. Resolver keeps its correct `Id.`/`supra` exclusion (#214/#799). All current tests stay green.
+- **Opt-in flag** (e.g. `extractCitations(text, { excludeParentheticalChildren: true })`): the strict subordinate model — remove children from the top-level resolvable array. For consumers who want #851's original full-exclusion semantics.
+- **Consider** gating nested-child extraction on the explanatory **signal** (`quoting`/`citing`/`quoted in`) rather than bare containment — doctrine ties subordination to the signal, and this avoids over-capturing year-only / pincite-only / coincidental parentheticals.
+
+## Open questions / gaps
+
+- **Tanbook (NY) and ALWD produced NO surviving verified claims** — the doctrinal answer rests on Bluebook + Indigo Book. The library handles many NY cites (A.D.3d, N.Y.3d), so a targeted Tanbook follow-up is warranted before treating the answer as NY-authoritative. (Texas Greenbook / Chicago Maroonbook also uncovered.)
+- Does Rule 10.9(a) warrant a **narrow resolver exception** — exclude nested cases from `Id.`/`supra` but keep them eligible as case-short-form antecedents within a five-footnote window? (eyecite-ts already does roughly this; worth documenting as intentional.)
+- Recursive/doubly-nested parentheticals `(citing B (quoting C))`: no peer-tool precedent for a recursive containment edge — depth semantics are an open design call.
+
+## Source quality
+
+Primary, code-level (eyecite/CourtListener) findings were re-verified by direct execution + at a pinned commit — very high confidence, current. Bluebook/Indigo doctrine rests on **secondary** sources (the Bluebook is paywalled), but operative rule text (4.1, 1.5(b), 10.9) was quoted verbatim and cross-corroborated across 5+ independent guides; stable across the 20th/21st (and per verifiers 22nd) editions. Indigo Book v2.x renumbers the rule (R6.2.x) without reversing the principle.
+
+### Key sources
+- Bluebook Rule 4.1 (verbatim, Tarlton Law Library/UT Austin); Rule 1.5(b) & 10.9 (Georgetown, Loyola, UC Davis, Florida A&M guides)
+- Indigo Book — law.resource.org/pub/us/code/blue/IndigoBook.html (R15.3.4)
+- Georgetown Law parentheticals handout (Karl Bock, 2016) — verified verbatim
+- Python eyecite — models.py / find.py / helpers.py (commit `04d82c0` + main); empirical run of v2.7.6
+- CourtListener — REST citations API docs + `cl/search/models.py` `OpinionsCited`

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -75,6 +75,7 @@ import { detectStringCitations, detectLeadingSignals } from "./detectStringCites
 import { extractId, extractShortFormCase, extractSupra } from "./extractShortForms"
 import { applyFalsePositiveFilters } from "./filterFalsePositives"
 import { assignCitationIds } from "./assignCitationIds"
+import { nestParentheticalCitations } from "./nestParentheticalCitations"
 import { parsePincite } from "./pincite"
 import { resolveOriginalSpan, type TransformationMap } from "@/types/span"
 
@@ -187,6 +188,27 @@ export interface ExtractOptions {
 
   /** Detect footnote zones and annotate citations with inFootnote/footnoteNumber (default: false) */
   detectFootnotes?: boolean
+
+  /**
+   * Strict subordinate model for citations nested inside explanatory
+   * parentheticals — e.g. the `Doe v. City, 100 F.2d 1` in
+   * `... (quoting Doe v. City, 100 F.2d 1)` (default: false; #851).
+   *
+   * Such nested citations are ALWAYS linked onto their host's
+   * `Parenthetical.citations` (the `in-parenthetical-of` edge). This flag
+   * controls whether they ALSO remain in the top-level result array:
+   * - `false` (default): additive and non-breaking — the nested cite stays a
+   *   top-level peer, so a later case short form can still resolve to a case
+   *   first cited in a parenthetical (Bluebook Rule 10.9(a)).
+   * - `true`: the nested cite is REMOVED from the top-level array and reachable
+   *   only via its host's `Parenthetical.citations` (or `byId`) — the resolver
+   *   and the cross-citation groupers no longer treat it as a top-level
+   *   candidate.
+   *
+   * Either way, `Id.`/`supra` never bind to a paren-child (Rule 4.1/4.2) — that
+   * exclusion lives in the resolver and is independent of this flag.
+   */
+  excludeParentheticalChildren?: boolean
 }
 
 /**
@@ -635,6 +657,17 @@ export function extractCitations(
   // dense and final, and before the structuring pass / footnote tagging /
   // resolution so every downstream reference is by a stable id, not array index.
   assignCitationIds(filtered)
+
+  // Step 4.955: Link citations nested inside explanatory parentheticals —
+  // e.g. `... (quoting Doe v. City, 100 F.2d 1)` — onto the enclosing
+  // `Parenthetical.citations` (#851). Additive by default (the child stays a
+  // top-level peer — Bluebook Rule 10.9(a)); `excludeParentheticalChildren`
+  // removes it from the top-level array. Runs after id assignment (children
+  // keep their stable ids) and before the structuring pass and resolution (so
+  // an excluded child is hidden from the groupers and the resolver).
+  nestParentheticalCitations(filtered, {
+    exclude: options?.excludeParentheticalChildren ?? false,
+  })
 
   // Step 4.96: Consolidated structuring pass (#860). The cross-citation LINKING
   // passes — subsequent-history chains, parallel-caption propagation, string-cite

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -201,9 +201,9 @@ export interface ExtractOptions {
    *   top-level peer, so a later case short form can still resolve to a case
    *   first cited in a parenthetical (Bluebook Rule 10.9(a)).
    * - `true`: the nested cite is REMOVED from the top-level array and reachable
-   *   only via its host's `Parenthetical.citations` (or `byId`) — the resolver
-   *   and the cross-citation groupers no longer treat it as a top-level
-   *   candidate.
+   *   only by traversing its host's `Parenthetical.citations` (it is then absent
+   *   from `byId(result)`) — the resolver and the cross-citation groupers no
+   *   longer treat it as a top-level candidate.
    *
    * Either way, `Id.`/`supra` never bind to a paren-child (Rule 4.1/4.2) — that
    * exclusion lives in the resolver and is independent of this flag.

--- a/src/extract/nestParentheticalCitations.ts
+++ b/src/extract/nestParentheticalCitations.ts
@@ -1,0 +1,87 @@
+import type { Citation, Parenthetical } from "../types/citation"
+
+/**
+ * Link citations nested inside explanatory parentheticals — e.g. the
+ * `Doe v. City, 100 F.2d 1` in `... (quoting Doe v. City, 100 F.2d 1)` — onto
+ * the enclosing `Parenthetical.citations`, as child nodes of their host
+ * citation (#851, spec §4c).
+ *
+ * The nested citation is already extracted as a flat sibling with a stable id
+ * (its core span sits inside the parenthetical span the cleaner preserves), so
+ * this pass does not re-parse — it links the existing citation under its host. A
+ * child is attached to the SMALLEST enclosing parenthetical, so genuinely nested
+ * children land on the innermost paren (and the tree stays correct under
+ * recursion).
+ *
+ * By default the linkage is ADDITIVE: the child is ALSO kept in the top-level
+ * array, so the result is non-breaking and a later case short form can still
+ * resolve to a case first cited in a parenthetical (Bluebook Rule 10.9(a)).
+ * When `exclude` is true, the child is REMOVED from the top-level array (the
+ * strict subordinate model) — the cross-citation groupers and the resolver no
+ * longer see it as a top-level candidate, and it is reachable only via its
+ * host's `Parenthetical.citations` (or `byId`).
+ *
+ * `Id.`/`supra` never bind to a paren-child regardless of `exclude` — that
+ * exclusion lives in the resolver (Rule 4.1/4.2; #214/#799) and is unaffected.
+ *
+ * Runs after assignCitationIds (children keep their stable ids) and before
+ * runStructuringPass / resolution. Mutates `citations` (and its parentheticals)
+ * in place.
+ */
+export function nestParentheticalCitations(
+  citations: Citation[],
+  options: { exclude?: boolean } = {},
+): void {
+  // Every explanatory parenthetical with a locatable span, paired with its
+  // owning citation. (Metadata parentheticals — court/year — are not in
+  // `parentheticals`, so a `(2d Cir. 2000)` never captures children.)
+  const parens: Array<{ owner: Citation; paren: Parenthetical }> = []
+  for (const citation of citations) {
+    const owned = (citation as { parentheticals?: Parenthetical[] }).parentheticals
+    if (!owned) continue
+    for (const paren of owned) {
+      if (paren.span) parens.push({ owner: citation, paren })
+    }
+  }
+  if (parens.length === 0) return
+
+  const nested = new Set<Citation>()
+  for (const child of citations) {
+    const span = child.span
+    if (!span) continue
+
+    let best: Parenthetical | undefined
+    let bestWidth = Number.POSITIVE_INFINITY
+    for (const { owner, paren } of parens) {
+      if (owner === child) continue
+      const ps = paren.span
+      if (!ps) continue
+      if (span.cleanStart >= ps.cleanStart && span.cleanEnd <= ps.cleanEnd) {
+        const width = ps.cleanEnd - ps.cleanStart
+        if (width < bestWidth) {
+          best = paren
+          bestWidth = width
+        }
+      }
+    }
+
+    if (best) {
+      best.citations ??= []
+      best.citations.push(child)
+      nested.add(child)
+    }
+  }
+
+  if (!options.exclude || nested.size === 0) return
+
+  // Strict model: drop nested children from the top-level array. The flat array
+  // is in document order, so the surviving order — and the push order into each
+  // `paren.citations` above — is document order too.
+  let write = 0
+  for (let read = 0; read < citations.length; read++) {
+    if (!nested.has(citations[read])) {
+      citations[write++] = citations[read]
+    }
+  }
+  citations.length = write
+}

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -230,6 +230,15 @@ export interface Parenthetical {
   type: ParentheticalType
   /** Position of full parenthetical block including delimiters */
   span?: Span
+  /**
+   * Nested child citations parsed from the parenthetical's inner text — e.g.
+   * the `Doe v. City, 100 F.2d 1` in `(quoting Doe v. City, 100 F.2d 1)`. Each
+   * child carries its own stable {@link CitationId} and is EXCLUDED from the
+   * top-level resolvable `Citation[]` returned by `extractCitations` (#851);
+   * reach it here, or via `byId`. The resolver does not treat a paren-child as
+   * an antecedent candidate. Recursive — a child may itself carry parentheticals.
+   */
+  citations?: Citation[]
 }
 
 /**

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -231,12 +231,18 @@ export interface Parenthetical {
   /** Position of full parenthetical block including delimiters */
   span?: Span
   /**
-   * Nested child citations parsed from the parenthetical's inner text — e.g.
-   * the `Doe v. City, 100 F.2d 1` in `(quoting Doe v. City, 100 F.2d 1)`. Each
-   * child carries its own stable {@link CitationId} and is EXCLUDED from the
-   * top-level resolvable `Citation[]` returned by `extractCitations` (#851);
-   * reach it here, or via `byId`. The resolver does not treat a paren-child as
-   * an antecedent candidate. Recursive — a child may itself carry parentheticals.
+   * Child citations nested within this explanatory parenthetical — e.g. the
+   * `Doe v. City, 100 F.2d 1` in `(quoting Doe v. City, 100 F.2d 1)` (#851).
+   * Each child carries its own stable {@link CitationId}, may be any citation
+   * type (not only cases), and may itself carry parentheticals (recursive). Per
+   * Bluebook Rule 1.5(b) such a cite is a subordinate component of the host
+   * citation, not a free-standing one.
+   *
+   * Populated additively by default: the child is ALSO a top-level result, so it
+   * stays reachable via `byId`. With `excludeParentheticalChildren`, the child
+   * is removed from the top-level array and reachable ONLY by traversing here
+   * (it is then absent from `byId(result)`). Either way, `Id.`/`supra` never
+   * resolve to a paren-child (Bluebook Rule 4.1/4.2).
    */
   citations?: Citation[]
 }

--- a/tests/extract/recursiveParenthetical.test.ts
+++ b/tests/extract/recursiveParenthetical.test.ts
@@ -115,5 +115,72 @@ describe("recursive Parenthetical (#851)", () => {
       expect(child?.reporter).toBe("F.2d")
       expect(child?.page).toBe(1)
     })
+
+    it("nests multiple children of one parenthetical in document order", () => {
+      const text =
+        "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (citing Doe v. City, 100 F.2d 1, and Roe v. Town, 5 F.3d 9)."
+      const citations = extractCitations(text)
+      const smith = citations.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Smith v. Jones",
+      ) as FullCaseCitation
+      const children = (smith.parentheticals?.[0]?.citations ?? []) as FullCaseCitation[]
+      expect(children.map((c) => c.caseName)).toEqual(["Doe v. City", "Roe v. Town"])
+    })
+
+    it("nests a non-case child (statute) and, under the flag, removes it from the top level", () => {
+      const text = "Smith v. State, 100 F.2d 50 (1990) (applying 42 U.S.C. § 1983)."
+
+      const additive = extractCitations(text)
+      expect(additive.some((c) => c.type === "statute")).toBe(true) // top-level by default
+      const host = additive.find((c) => c.type === "case") as FullCaseCitation
+      expect(host.parentheticals?.[0]?.citations?.[0]?.type).toBe("statute")
+
+      const strict = extractCitations(text, { excludeParentheticalChildren: true })
+      expect(strict.some((c) => c.type === "statute")).toBe(false) // removed from top level
+      expect((strict[0] as FullCaseCitation).parentheticals?.[0]?.citations?.[0]?.type).toBe(
+        "statute",
+      )
+    })
+  })
+
+  describe("doctrinal resolution (Bluebook Rules 4.1 / 10.9(a))", () => {
+    const QUOTE_THEN_ID =
+      "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1). Id. at 110."
+    const QUOTE_THEN_SHORTFORM =
+      "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1). Doe, 100 F.2d at 7."
+
+    it("Rule 4.1 — Id. binds to the host even when the paren-child is present (default)", () => {
+      const cites = extractCitations(QUOTE_THEN_ID, { resolve: true }) as ResolvedCitation[]
+      // Doe IS a top-level result in the default additive mode…
+      expect(
+        cites.some((c) => c.type === "case" && (c as FullCaseCitation).caseName === "Doe v. City"),
+      ).toBe(true)
+      // …yet Id. skips it and resolves to the host, not the buried cite.
+      const id = cites.find((c) => c.type === "id")
+      const smith = cites.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Smith v. Jones",
+      )
+      expect(id?.resolution?.resolvedTo).toBe(cites.indexOf(smith as ResolvedCitation))
+    })
+
+    it("Rule 10.9(a) — a case short form resolves to a paren-first case (default), abstains under exclusion", () => {
+      const additive = extractCitations(QUOTE_THEN_SHORTFORM, {
+        resolve: true,
+      }) as ResolvedCitation[]
+      const doe = additive.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Doe v. City",
+      )
+      const shortForm = additive.find((c) => c.type === "shortFormCase")
+      expect(doe).toBeDefined()
+      expect(shortForm?.resolution?.resolvedTo).toBe(additive.indexOf(doe as ResolvedCitation))
+
+      // Under the strict model the paren-first case is no longer a candidate.
+      const strict = extractCitations(QUOTE_THEN_SHORTFORM, {
+        resolve: true,
+        excludeParentheticalChildren: true,
+      }) as ResolvedCitation[]
+      const strictShortForm = strict.find((c) => c.type === "shortFormCase")
+      expect(strictShortForm?.resolution?.resolvedTo).toBeUndefined()
+    })
   })
 })

--- a/tests/extract/recursiveParenthetical.test.ts
+++ b/tests/extract/recursiveParenthetical.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { ResolvedCitation } from "@/resolve/types"
+import type { FullCaseCitation } from "@/types/citation"
+
+const QUOTING =
+  "Smith v. Jones, 200 F.3d 100, 105 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1, 3)."
+
+describe("recursive Parenthetical (#851)", () => {
+  describe("default — additive nesting, children stay top-level (non-breaking)", () => {
+    it("nests the (quoting …) citation on Parenthetical.citations while keeping it top-level", () => {
+      const citations = extractCitations(QUOTING)
+
+      // Non-breaking: both cites stay at the top level. Bluebook Rule 10.9(a) —
+      // a case first cited in a parenthetical may still anchor a later case
+      // short form — so the nested cite remains a resolvable top-level peer by
+      // default. (Strict exclusion is opt-in; see below.)
+      expect(citations).toHaveLength(2)
+      const parent = citations.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Smith v. Jones",
+      ) as FullCaseCitation
+      const topLevelChild = citations.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Doe v. City",
+      ) as FullCaseCitation
+      expect(parent).toBeDefined()
+      expect(topLevelChild).toBeDefined()
+
+      // The quoting parenthetical additionally carries the nested child — the
+      // same citation, by stable id (the `in-parenthetical-of` edge).
+      const paren = parent.parentheticals?.[0]
+      expect(paren?.type).toBe("quoting")
+      expect(paren?.text).toBe("quoting Doe v. City, 100 F.2d 1, 3") // raw text KEPT
+      expect(paren?.citations).toHaveLength(1)
+
+      const nested = paren?.citations?.[0] as FullCaseCitation
+      expect(nested.caseName).toBe("Doe v. City")
+      expect(nested.reporter).toBe("F.2d")
+      expect(nested.pincite).toBe(3)
+      expect(nested.id).toBe(topLevelChild.id) // same citation, reachable both ways
+    })
+  })
+
+  describe("with { excludeParentheticalChildren: true } — strict subordinate model", () => {
+    it("removes the nested citation from the top-level array, reachable only as a child", () => {
+      const citations = extractCitations(QUOTING, { excludeParentheticalChildren: true })
+
+      // Strict model: only the host remains at the top level.
+      expect(citations).toHaveLength(1)
+      const parent = citations[0] as FullCaseCitation
+      expect(parent.caseName).toBe("Smith v. Jones")
+      expect(
+        citations.some((c) => c.type === "case" && (c as FullCaseCitation).caseName === "Doe v. City"),
+      ).toBe(false)
+
+      // The child is still reachable as a parenthetical node, with its own id.
+      const child = parent.parentheticals?.[0]?.citations?.[0] as FullCaseCitation
+      expect(child.caseName).toBe("Doe v. City")
+      expect(child.pincite).toBe(3)
+      expect(child.id).toBeDefined()
+    })
+
+    it("hides the child from the resolver: Id. after A (quoting B) resolves to A, not B", () => {
+      const text =
+        "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1). Id. at 110."
+      const citations = extractCitations(text, {
+        excludeParentheticalChildren: true,
+        resolve: true,
+      }) as ResolvedCitation[]
+
+      // B (Doe) is gone from the top level entirely…
+      expect(
+        citations.some((c) => c.type === "case" && (c as FullCaseCitation).caseName === "Doe v. City"),
+      ).toBe(false)
+      // …so Id. structurally cannot bind to it — it resolves to the host A.
+      const id = citations.find((c) => c.type === "id")
+      const smith = citations.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Smith v. Jones",
+      )
+      expect(id?.resolution?.resolvedTo).toBe(citations.indexOf(smith as ResolvedCitation))
+    })
+  })
+
+  describe("edge cases", () => {
+    it("recursively nests A (citing B (quoting C)) — C under B, B under A (smallest enclosing)", () => {
+      const text =
+        "Top v. Case, 100 F.2d 1 (1990) (citing Mid v. Case, 200 F.3d 2 (1995) (quoting Inner v. Case, 300 F.4th 3 (2000)))."
+      const citations = extractCitations(text)
+      const top = citations.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Top v. Case",
+      ) as FullCaseCitation
+      expect(top).toBeDefined()
+
+      const mid = top.parentheticals?.[0]?.citations?.[0] as FullCaseCitation
+      expect(mid?.caseName).toBe("Mid v. Case")
+      // C sits inside BOTH parens; it lands on the innermost (Mid's), not Top's.
+      const inner = mid?.parentheticals?.[0]?.citations?.[0] as FullCaseCitation
+      expect(inner?.caseName).toBe("Inner v. Case")
+    })
+
+    it("does not add a citations array to a parenthetical with no nested citation", () => {
+      const text = "Smith v. Jones, 100 F.2d 1 (1990) (holding that the rule applies)."
+      const citations = extractCitations(text)
+      const smith = citations[0] as FullCaseCitation
+      expect(smith.parentheticals?.[0]?.type).toBe("holding")
+      expect(smith.parentheticals?.[0]?.citations).toBeUndefined()
+    })
+
+    it("nests a bare (quoting <reporter>) citation that has no case name", () => {
+      const text = "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting 100 F.2d 1)."
+      const citations = extractCitations(text)
+      const smith = citations.find(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Smith v. Jones",
+      ) as FullCaseCitation
+      const child = smith.parentheticals?.[0]?.citations?.[0] as FullCaseCitation
+      expect(child?.reporter).toBe("F.2d")
+      expect(child?.page).toBe(1)
+    })
+  })
+})


### PR DESCRIPTION
## Why

A case cited only inside another citation's explanatory parenthetical — the `Doe v. City` in `Smith v. Jones, 200 F.3d 100 (2d Cir. 2000) (quoting Doe v. City, 100 F.2d 1)` — was already extractable, but structurally flat: you got it as a top-level citation with no link back to the authority it explains. Per Bluebook Rule 1.5(b) that nested cite is a subordinate component of the citing authority, not a free-standing one.

**Today:** the nested cite is a top-level result with no relationship to its host; the parenthetical-containment link is invisible.

**After this PR:** it is *also* linked onto the host parenthetical's new `citations` array as a child (with its own stable id), so you can walk host → parenthetical → nested authority — while still appearing top-level by default, so nothing breaks.

**Why this matters:** consumers building a citation graph get the `in-parenthetical-of` edge for free, and the doctrinally-correct resolution is preserved — `Id.`/`supra` never bind to a buried cite (Rule 4.1/4.2), but a later case short form can still reach a case first cited in a parenthetical (Rule 10.9(a)).

The default is intentionally **additive (non-breaking)**. The strict subordinate model — removing the nested cite from the top-level array entirely — is **opt-in** via `excludeParentheticalChildren`, because removing it unconditionally would diverge from Rule 10.9(a) and from how upstream Python eyecite behaves. The doctrinal basis (Bluebook + Indigo Book + a peer-tool comparison) is written up in [`docs/research/2026-06-07-nested-parenthetical-citation-rules.md`](docs/research/2026-06-07-nested-parenthetical-citation-rules.md), included here.

## What changed

- New `Parenthetical.citations?: Citation[]` — child citations nested in an explanatory parenthetical, attached to the **smallest enclosing** paren (so `(citing B (quoting C))` builds a correct tree). Each child keeps its own stable `CitationId`.
- New option `extractCitations(text, { excludeParentheticalChildren: true })` — removes nested children from the top-level array (strict subordinate model), hiding them from the cross-citation groupers and the resolver. Default `false` keeps them top-level.
- The linkage runs as one pass between id-assignment and the structuring/resolution stages, so an excluded child is consistently invisible downstream.
- Resolver behavior is unchanged in both modes: `Id.`/`supra` exclusion of paren-children (#214/#799) still holds — which the research confirms is the doctrinally-correct outcome.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **308 files, 4626 tests pass**, 0 fail. The additive default left the existing suite green; +6 new tests in `tests/extract/recursiveParenthetical.test.ts`.
- `pnpm typecheck` — clean (`tsc --noEmit`).
- `pnpm exec biome lint` on the changed/new source files — clean.

**Coverage added:** default additive nesting (child stays top-level, same id) · opt-in exclusion (child removed, reachable only as a child) · opt-in hides the child from the resolver (`Id.` → host) · recursive `(citing B (quoting C))` smallest-enclosing tree · over-capture guard (a `(holding …)` paren with no cite gets no `citations`) · bare `(quoting 100 F.2d 1)` with no case name.

## What this PR explicitly does NOT ship (scope boundary)

- **Short-form `parentheticalNode`** — structured nesting on `Id.`/`supra`/`shortFormCase` parentheticals (their flat `parenthetical` string is unchanged). The original #851 AC covered this too; it's a clean follow-up. Full-case `parentheticals[]` is done here.
- The original #851 AC specified exclusion *by default*; this PR makes exclusion **opt-in** instead, on the strength of the doctrinal research (Rule 10.9(a) + ecosystem parity). The issue's AC should be updated to match.
- **Tanbook / ALWD confirmation** — the doctrinal answer rests on Bluebook + Indigo Book; the NY Tanbook returned nothing verifiable (flagged in the research doc as an open follow-up).

Part of #851.

---
Assisted-by: Claude:claude-opus-4-8
