### PR TITLE
ci: bump checkout/setup-node/pnpm-action-setup to v5 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Lint & Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -33,9 +33,9 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
@@ -67,9 +67,9 @@ jobs:
     needs: [quality, test]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
@@ -101,9 +101,9 @@ jobs:
       matrix:
         node-version: [18, 20, 22]
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Why

GitHub force-migrates Node 20 actions to the Node 24 runner on **2026-06-16**. `actions/checkout@v4`, `actions/setup-node@v4`, and `pnpm/action-setup@v4` all run on Node 20 and were emitting deprecation warnings (surfaced on the `0.32.0` Release run). Bumping to **v5** — the first Node-24 major for each — clears the warnings and avoids the forced-runtime swap.

## What changed

- `actions/checkout@v4 → v5`, `actions/setup-node@v4 → v5`, `pnpm/action-setup@v4 → v5` across `ci.yml`, `release.yml`, `claude.yml`, `claude-code-review.yml` (17 refs).
- v5 confirmed Node-24 via each action's `action.yml` (`runs.using: node24`). `pnpm/action-setup@v5` keeps `version` optional and still reads the `packageManager` field (no `version:` input is used here), and its v5.0.0 is *solely* the Node 24 bump — no behavior change.

## Test plan

**What I ran:**
- All four workflows still parse as valid YAML (`yaml.safe_load`).
- Confirmed the diff touches only the three actions — `upload-artifact`/`download-artifact`/`changesets`/`codecov`/`claude-code-action` are unchanged.

**What needs human verification:**
- [ ] This PR's own CI run is the real test — it exercises `checkout`/`setup-node`/`pnpm-action-setup@v5` end-to-end (install, build, full test matrix, size check, tarball consumers). Confirm green before merge.

## What this PR does NOT ship (scope boundary)

- `actions/upload-artifact@v4` / `download-artifact@v4` are also Node 20, but left for a separate follow-up: their majors have moved to v7/v8 with breaking changes, and the upload↔download pair must be bumped together compatibly. Out of scope for this quick fix.

---
Assisted-by: Claude:claude-opus-4-8
