### PR TITLE
ci: bump upload-artifact to v6, download-artifact to v7 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run tests with coverage
         run: pnpm exec vitest run --coverage --exclude '**/publishedTarball.test.ts'
         if: matrix.node-version == 22
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: matrix.node-version == 22
         with:
           name: coverage
@@ -86,7 +86,7 @@ jobs:
           mkdir -p pack
           npm pack --pack-destination pack
       - name: Upload tarball artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tarball
           path: pack/*.tgz
@@ -109,7 +109,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Download packed tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: tarball
           path: pack


### PR DESCRIPTION
## Why

Follow-up to #870. `actions/upload-artifact@v4` and `actions/download-artifact@v4` are the last Node-20 actions in CI, facing GitHub's **2026-06-16** forced migration to the Node 24 runner.

## What changed

- `upload-artifact@v4 → v6` (coverage upload + tarball upload), `download-artifact@v4 → v7` (tarball download) — all in `ci.yml`.
- **v6/v7 are the first Node-24 majors** (confirmed via each `action.yml`) and are pure runtime bumps. Note `v5` of *both* is still Node 20, so the easy v5 swap wouldn't fix it — hence the larger jump, deliberately split out of #870.
- The skipped majors' breaking changes don't apply here: download is **by name** (`name: tarball`), not by ID, so `download-artifact@v5.0.0`'s by-ID path fix is moot; upload uses vanilla `path`+`name` (no `archive`/direct-upload). Both sides share the `@actions/artifact` v4 backend, so **upload v6 ↔ download v7 interoperate**.

## Test plan

**What I ran:**
- `ci.yml` parses as valid YAML.
- Reviewed the v4→v6 (upload) and v4→v7 (download) release notes against this repo's exact usage — no impacting breaking change.

**What needs human verification:**
- [ ] This PR's own CI run is the real test — the `build` job uploads the tarball with v6 and the `tarball` consumer job downloads it with v7 in the same run, then loads it across the Node matrix. Confirm green.

Closes #871.

---
Assisted-by: Claude:claude-opus-4-8
