### PR TITLE
feat(extract): structured parentheticalNode on short-form citations (#869)

### DIFF
--- a/.changeset/shortform-parenthetical-node.md
+++ b/.changeset/shortform-parenthetical-node.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": minor
+---
+
+feat(extract): structured `parentheticalNode` on short-form citations (#869)
+
+Short-form citations (`Id.`, `supra`, short-form case) now expose a structured `parentheticalNode` alongside their flat `parenthetical` string — the same `Parenthetical` shape full-case citations carry, with a classified `type`, a `span`, and any nested child citations in `citations`. So `Id. at 5 (quoting Doe v. City, 100 F.2d 1)` links the nested `Doe v. City` onto `id.parentheticalNode.citations`, completing the parenthetical-nesting work started for full-case citations in #867.
+
+Additive and non-breaking: the nested cite stays a top-level result by default (Bluebook Rule 10.9(a)), and `excludeParentheticalChildren` removes it the same way it does for full-case parentheticals. `Id.`/`supra` resolution is unchanged — they still bind only to the host authority, never a paren-child (Rule 4.1/4.2). The flat `parenthetical` string is retained unchanged.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ extractCitations(text, { excludeParentheticalChildren: true }).length  // 1 (Smi
 
 Either way, `Id.`/`supra` never resolve to a parenthetical-nested citation (Bluebook Rule 4.1/4.2) — only the host authority.
 
+Short-form citations (`Id.`, `supra`, short-form case) expose the same structure on a `parentheticalNode` (the structured form of their flat `parenthetical` string), so `Id. at 5 (quoting Doe v. City, 100 F.2d 1)` carries the nested `Doe v. City` the same way — honoring `excludeParentheticalChildren` identically:
+
+```typescript
+const [, id] = extractCitations("Bd. v. FirstService, 193 A.D.3d 672 (2021). Id. at 673 (quoting Doe v. City, 100 F.2d 1).")
+id.parentheticalNode?.citations // [ FullCaseCitation { caseName: "Doe v. City", … } ]
+```
+
 ### Citation Annotation
 
 Mark up citations with HTML using template or callback modes:

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -8,13 +8,19 @@
  */
 
 import type { Token } from "@/tokenize"
-import type { IdCitation, ShortFormCaseCitation, SupraCitation } from "@/types/citation"
+import type {
+  IdCitation,
+  Parenthetical,
+  ShortFormCaseCitation,
+  SupraCitation,
+} from "@/types/citation"
 import type {
   IdComponentSpans,
   ShortFormCaseComponentSpans,
   SupraComponentSpans,
 } from "@/types/componentSpans"
 import { resolveOriginalSpan, spanFromGroupIndex, type TransformationMap } from "@/types/span"
+import { classifyCaseParenthetical } from "./caseParentheticals"
 import { COMMON_REPORTERS } from "./caseReporterSemantics"
 import { parsePincite, type PinciteInfo } from "./pincite"
 
@@ -50,7 +56,7 @@ function stripSupraPartyPrefix(raw: string): string {
  * parens. Suitable for `Id. at N (Marsh)`, `Id. (citation omitted)`,
  * `Smith, supra (holding that ...)`, `Smith, 500 F.2d at 125 (citations omitted)`.
  */
-const TRAILING_PAREN_REGEX = /^[\s,]*\(([^()]*)\)/
+const TRAILING_PAREN_REGEX = /^[\s,]*\(([^()]*)\)/d
 
 /**
  * Additional pincite continuation (`, NNN`) after the primary pincite has been
@@ -90,21 +96,68 @@ const SHORTFORM_ADDITIONAL_PINCITE_REGEX =
 const SIGNAL_AT_END_REGEX =
   /(?<![A-Za-z])(?:but\s+cf\.,\s+e\.\s*g\.,?|see\s*,?\s+also,\s+e\.\s*g\.,?|but\s+see,\s+e\.\s*g\.,?|cf\.,\s+e\.\s*g\.,?|see,\s+e\.\s*g\.,?|see\s+generally|see\s*,?\s+also|but\s+see|but\s+cf\.?|compare|accord|contra|see|cf\.?|e\.\s*g\.,?)\s*$/i
 
+interface TrailingParenthetical {
+  /** Inner text, parens excluded (the flat `parenthetical` value). */
+  text: string
+  /** Clean-text span of the full `(...)` block, delimiters included. */
+  cleanStart: number
+  cleanEnd: number
+}
+
 /**
  * Scan the cleaned text after a short-form citation's span end for an
- * immediately-trailing `(...)` parenthetical. Returns the inner text
- * (excluding the parens) or `undefined` if none found. #303
+ * immediately-trailing `(...)` parenthetical. Returns the inner text plus the
+ * clean-text span of the full block (so a `parentheticalNode` can be built and
+ * nested citations located), or `undefined` if none found. #303 / #869
  */
 function extractTrailingParenthetical(
   cleanedText: string | undefined,
-  cleanEnd: number,
-): string | undefined {
+  fromCleanPos: number,
+): TrailingParenthetical | undefined {
   if (!cleanedText) return undefined
-  const after = cleanedText.slice(cleanEnd)
+  const after = cleanedText.slice(fromCleanPos)
   const m = TRAILING_PAREN_REGEX.exec(after)
-  if (!m) return undefined
+  if (!m?.indices) return undefined
   const content = m[1].trim()
-  return content.length > 0 ? content : undefined
+  if (content.length === 0) return undefined
+  // Group 1 is the inner content; the delimiters sit one char outside it.
+  const [innerStart, innerEnd] = m.indices[1]
+  return {
+    text: content,
+    cleanStart: fromCleanPos + innerStart - 1, // the "("
+    cleanEnd: fromCleanPos + innerEnd + 1, // just past the ")"
+  }
+}
+
+/**
+ * Build the structured `parentheticalNode` for a short-form citation (#869):
+ * the captured `(...)` text, classified by leading signal word (reusing the
+ * case-parenthetical classifier), with the block span mapped to original
+ * coordinates. Nested child citations are attached later by
+ * `nestParentheticalCitations`.
+ */
+function buildParentheticalNode(
+  paren: TrailingParenthetical,
+  transformationMap: TransformationMap,
+): Parenthetical {
+  const { originalStart, originalEnd } = resolveOriginalSpan(
+    { cleanStart: paren.cleanStart, cleanEnd: paren.cleanEnd },
+    transformationMap,
+  )
+  const classified = classifyCaseParenthetical({
+    text: paren.text,
+    span: { start: 0, end: paren.text.length },
+  })
+  return {
+    text: paren.text,
+    type: classified.kind === "explanatory" ? classified.type : "other",
+    span: {
+      cleanStart: paren.cleanStart,
+      cleanEnd: paren.cleanEnd,
+      originalStart,
+      originalEnd,
+    },
+  }
 }
 
 /**
@@ -254,7 +307,9 @@ export function extractId(
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
   // Trailing parenthetical (#303): `Id. at 770 (Marsh)`, `Id. (citation omitted)`.
-  const parenthetical = extractTrailingParenthetical(cleanedText, span.cleanEnd)
+  // Structured node (#869) carries the classified type, span, and nested cites.
+  const paren = extractTrailingParenthetical(cleanedText, span.cleanEnd)
+  const parentheticalNode = paren ? buildParentheticalNode(paren, transformationMap) : undefined
 
   return {
     type: "id",
@@ -271,7 +326,8 @@ export function extractId(
     patternsChecked: 1,
     pincite,
     pinciteInfo,
-    ...(parenthetical ? { parenthetical } : {}),
+    ...(paren ? { parenthetical: paren.text } : {}),
+    ...(parentheticalNode ? { parentheticalNode } : {}),
     spans,
   }
 }
@@ -403,8 +459,10 @@ export function extractSupra(
   // Translate positions from clean → original
   const { originalStart, originalEnd } = resolveOriginalSpan(span, transformationMap)
 
-  // Trailing parenthetical (#303): `Smith, supra (holding ...)`.
-  const parenthetical = extractTrailingParenthetical(cleanedText, span.cleanEnd)
+  // Trailing parenthetical (#303): `Smith, supra (holding ...)`. Structured
+  // node (#869) carries the classified type, span, and nested cites.
+  const paren = extractTrailingParenthetical(cleanedText, span.cleanEnd)
+  const parentheticalNode = paren ? buildParentheticalNode(paren, transformationMap) : undefined
 
   return {
     type: "supra",
@@ -422,7 +480,8 @@ export function extractSupra(
     partyName,
     pincite,
     pinciteInfo,
-    ...(parenthetical ? { parenthetical } : {}),
+    ...(paren ? { parenthetical: paren.text } : {}),
+    ...(parentheticalNode ? { parentheticalNode } : {}),
     spans,
   }
 }
@@ -569,7 +628,8 @@ export function extractShortFormCase(
     }
     trailingParenStart = span.cleanEnd + scan
   }
-  const parenthetical = extractTrailingParenthetical(cleanedText, trailingParenStart)
+  const paren = extractTrailingParenthetical(cleanedText, trailingParenStart)
+  const parentheticalNode = paren ? buildParentheticalNode(paren, transformationMap) : undefined
 
   return {
     type: "shortFormCase",
@@ -590,7 +650,8 @@ export function extractShortFormCase(
     pinciteInfo,
     partyName,
     partyNameNormalized,
-    ...(parenthetical ? { parenthetical } : {}),
+    ...(paren ? { parenthetical: paren.text } : {}),
+    ...(parentheticalNode ? { parentheticalNode } : {}),
     spans,
   }
 }

--- a/src/extract/nestParentheticalCitations.ts
+++ b/src/extract/nestParentheticalCitations.ts
@@ -37,11 +37,17 @@ export function nestParentheticalCitations(
   // `parentheticals`, so a `(2d Cir. 2000)` never captures children.)
   const parens: Array<{ owner: Citation; paren: Parenthetical }> = []
   for (const citation of citations) {
+    // Full-case citations carry `parentheticals[]`…
     const owned = (citation as { parentheticals?: Parenthetical[] }).parentheticals
-    if (!owned) continue
-    for (const paren of owned) {
-      if (paren.span) parens.push({ owner: citation, paren })
+    if (owned) {
+      for (const paren of owned) {
+        if (paren.span) parens.push({ owner: citation, paren })
+      }
     }
+    // …short-form citations (Id./supra/shortFormCase) carry a single
+    // structured `parentheticalNode` instead (#869).
+    const node = (citation as { parentheticalNode?: Parenthetical }).parentheticalNode
+    if (node?.span) parens.push({ owner: citation, paren: node })
   }
   if (parens.length === 0) return
 

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -1255,6 +1255,14 @@ export interface IdCitation extends CitationBase {
    */
   parenthetical?: string
   /**
+   * Structured form of {@link parenthetical} (#869) — same content, classified
+   * `type` and a `span`, plus any nested child citations in `citations` (e.g.
+   * the `Doe v. City, 100 F.2d 1` in `Id. (quoting Doe v. City, 100 F.2d 1)`).
+   * By default a nested child is also a top-level result; with
+   * `excludeParentheticalChildren` it lives only here. See {@link Parenthetical}.
+   */
+  parentheticalNode?: Parenthetical
+  /**
    * Case name inherited from the antecedent (full citation that the `Id.`
    * resolves to). Populated by the resolver when `resolve: true` and the
    * antecedent is a `case`-type citation. Undefined otherwise. Consumers
@@ -1316,6 +1324,14 @@ export interface SupraCitation extends CitationBase {
    * and rationale. #303
    */
   parenthetical?: string
+  /**
+   * Structured form of {@link parenthetical} (#869) — same content, classified
+   * `type` and a `span`, plus any nested child citations in `citations` (e.g.
+   * the `Doe v. City, 100 F.2d 1` in `Id. (quoting Doe v. City, 100 F.2d 1)`).
+   * By default a nested child is also a top-level result; with
+   * `excludeParentheticalChildren` it lives only here. See {@link Parenthetical}.
+   */
+  parentheticalNode?: Parenthetical
   /** Component-level spans (currently just `pincite`; extend when needed). */
   spans?: import("./componentSpans").SupraComponentSpans
 }
@@ -1386,6 +1402,14 @@ export interface ShortFormCaseCitation extends CitationBase {
    * and rationale. #303
    */
   parenthetical?: string
+  /**
+   * Structured form of {@link parenthetical} (#869) — same content, classified
+   * `type` and a `span`, plus any nested child citations in `citations` (e.g.
+   * the `Doe v. City, 100 F.2d 1` in `Id. (quoting Doe v. City, 100 F.2d 1)`).
+   * By default a nested child is also a top-level result; with
+   * `excludeParentheticalChildren` it lives only here. See {@link Parenthetical}.
+   */
+  parentheticalNode?: Parenthetical
 }
 
 /**

--- a/tests/extract/shortFormParentheticalNode.test.ts
+++ b/tests/extract/shortFormParentheticalNode.test.ts
@@ -86,4 +86,39 @@ describe("short-form parentheticalNode (#869)", () => {
     // Rule 4.1: Id. binds to the host (Smith), never the paren-child.
     expect(id?.resolution?.resolvedTo).toBe(citations.indexOf(smith as ResolvedCitation))
   })
+
+  it("pins the node span to the `(...)` block (delimiters included, end-exclusive)", () => {
+    const id = extractCitations(ID_QUOTING).find((c) => c.type === "id") as IdCitation
+    const span = id.parentheticalNode?.span
+    expect(span).toBeDefined()
+    // No HTML/Unicode transform here, so original offsets index the input.
+    expect(ID_QUOTING.slice(span?.originalStart, span?.originalEnd)).toBe(
+      "(quoting Doe v. City, 100 F.2d 1)",
+    )
+  })
+
+  it("does not over-capture a citation that follows the parenthetical", () => {
+    const text =
+      "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000). Id. at 5 (quoting Doe v. City, 100 F.2d 1). Roe v. Town, 300 F.3d 5."
+    const citations = extractCitations(text)
+    const id = citations.find((c) => c.type === "id") as IdCitation
+    // Only Doe is nested — the following Roe (after the `)`) is NOT swept in.
+    expect(id.parentheticalNode?.citations).toHaveLength(1)
+    expect((id.parentheticalNode?.citations?.[0] as FullCaseCitation).caseName).toBe("Doe v. City")
+    expect(
+      citations.some((c) => c.type === "case" && (c as FullCaseCitation).caseName === "Roe v. Town"),
+    ).toBe(true)
+  })
+
+  it("nests across a short-form case's additional-pincite chain (trailingParenStart scan)", () => {
+    // `at 105, 107` consumes an extra pincite before the paren — the node span
+    // must start past it (the shortFormCase-only `trailingParenStart` path).
+    const text =
+      "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000). Smith, 200 F.3d at 105, 107 (quoting Doe v. City, 100 F.2d 1)."
+    const sf = extractCitations(text).find(
+      (c) => c.type === "shortFormCase",
+    ) as ShortFormCaseCitation
+    expect(sf?.parentheticalNode?.type).toBe("quoting")
+    expect((sf?.parentheticalNode?.citations?.[0] as FullCaseCitation)?.caseName).toBe("Doe v. City")
+  })
 })

--- a/tests/extract/shortFormParentheticalNode.test.ts
+++ b/tests/extract/shortFormParentheticalNode.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/index"
+import type { ResolvedCitation } from "@/resolve/types"
+import type {
+  FullCaseCitation,
+  IdCitation,
+  ShortFormCaseCitation,
+  SupraCitation,
+} from "@/types/citation"
+
+const ID_QUOTING =
+  "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000). Id. at 110 (quoting Doe v. City, 100 F.2d 1)."
+
+describe("short-form parentheticalNode (#869)", () => {
+  it("builds a structured parentheticalNode on Id. with the nested citation as a child (default additive)", () => {
+    const citations = extractCitations(ID_QUOTING)
+
+    const id = citations.find((c) => c.type === "id") as IdCitation
+    expect(id).toBeDefined()
+
+    // Flat string retained (additive).
+    expect(id.parenthetical).toBe("quoting Doe v. City, 100 F.2d 1")
+
+    // Structured node added, classified, carrying the nested child.
+    expect(id.parentheticalNode?.type).toBe("quoting")
+    expect(id.parentheticalNode?.text).toBe("quoting Doe v. City, 100 F.2d 1")
+    expect(id.parentheticalNode?.citations).toHaveLength(1)
+
+    const child = id.parentheticalNode?.citations?.[0] as FullCaseCitation
+    expect(child.caseName).toBe("Doe v. City")
+    expect(child.reporter).toBe("F.2d")
+    expect(child.id).toBeDefined()
+
+    // Default is additive: Doe is also still a top-level result.
+    expect(
+      citations.some(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Doe v. City",
+      ),
+    ).toBe(true)
+  })
+
+  it("under { excludeParentheticalChildren: true }, the child leaves the top level", () => {
+    const citations = extractCitations(ID_QUOTING, { excludeParentheticalChildren: true })
+    expect(
+      citations.some(
+        (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Doe v. City",
+      ),
+    ).toBe(false)
+    const id = citations.find((c) => c.type === "id") as IdCitation
+    expect((id.parentheticalNode?.citations?.[0] as FullCaseCitation)?.caseName).toBe("Doe v. City")
+  })
+
+  it("builds a parentheticalNode on a supra citation", () => {
+    const text =
+      "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000). Smith, supra, at 5 (quoting Doe v. City, 100 F.2d 1)."
+    const supra = extractCitations(text).find((c) => c.type === "supra") as SupraCitation
+    expect(supra?.parentheticalNode?.type).toBe("quoting")
+    expect((supra?.parentheticalNode?.citations?.[0] as FullCaseCitation)?.caseName).toBe(
+      "Doe v. City",
+    )
+  })
+
+  it("builds a parentheticalNode on a short-form case citation", () => {
+    const text =
+      "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000). Smith, 200 F.3d at 105 (quoting Doe v. City, 100 F.2d 1)."
+    const sf = extractCitations(text).find((c) => c.type === "shortFormCase") as ShortFormCaseCitation
+    expect(sf?.parentheticalNode?.type).toBe("quoting")
+    expect((sf?.parentheticalNode?.citations?.[0] as FullCaseCitation)?.caseName).toBe("Doe v. City")
+  })
+
+  it("builds a node without citations for a non-citation parenthetical", () => {
+    const text = "Smith v. Jones, 200 F.3d 100 (2d Cir. 2000). Id. at 5 (citation omitted)."
+    const id = extractCitations(text).find((c) => c.type === "id") as IdCitation
+    expect(id.parenthetical).toBe("citation omitted") // flat string retained
+    expect(id.parentheticalNode?.text).toBe("citation omitted")
+    expect(id.parentheticalNode?.type).toBe("other")
+    expect(id.parentheticalNode?.citations).toBeUndefined()
+  })
+
+  it("does not disturb short-form resolution: Id. still resolves to its antecedent", () => {
+    const citations = extractCitations(ID_QUOTING, { resolve: true }) as ResolvedCitation[]
+    const id = citations.find((c) => c.type === "id")
+    const smith = citations.find(
+      (c) => c.type === "case" && (c as FullCaseCitation).caseName === "Smith v. Jones",
+    )
+    // Rule 4.1: Id. binds to the host (Smith), never the paren-child.
+    expect(id?.resolution?.resolvedTo).toBe(citations.indexOf(smith as ResolvedCitation))
+  })
+})


### PR DESCRIPTION
## Why

#867 brought citation nesting to **full-case** parentheticals. Short-form citations (`Id.`, `supra`, short-form case) were left exposing only a flat `parenthetical` string, so a citation nested in `Id. at 5 (quoting Doe v. City, 100 F.2d 1)` had no structured home.

**Today:** the nested cite in a short-form's parenthetical is only loose top-level text — no link from the short-form to it.

**After this PR:** the short-form carries a `parentheticalNode` (the structured form of its flat `parenthetical`) with the nested cite on `parentheticalNode.citations` — the same shape and `in-parenthetical-of` edge full-case citations already have.

**Why this matters:** the parenthetical-nesting story is now uniform across every citation kind; graph consumers get the edge for short-forms too, with identical doctrine — `Id.`/`supra` stay bound to the host (Rule 4.1/4.2), and the additive default preserves Rule 10.9(a).

## What changed

- New `parentheticalNode?: Parenthetical` on `IdCitation` / `SupraCitation` / `ShortFormCaseCitation`.
- `extractTrailingParenthetical` (the shared #303 helper) now also returns the paren block's clean span; a shared `buildParentheticalNode` maps it to original coordinates and classifies `type` (reusing the case-paren classifier).
- `nestParentheticalCitations` collects `parentheticalNode` alongside full-case `parentheticals[]`, so the existing pass attaches children and honors `excludeParentheticalChildren` unchanged.
- Flat `parenthetical` string retained; `Id.`/`supra` resolution untouched.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **309 files, 4636 tests pass** (+6 new in `shortFormParentheticalNode.test.ts`).
- `pnpm typecheck` clean; `biome lint` clean on changed files (3 pre-existing infos in an untouched regex).

**Coverage added:** Id. nesting (default additive, same-id child) · opt-in exclusion · supra · shortFormCase · non-citation paren (`(citation omitted)` → node with no `citations`) · resolution unaffected (`Id.` → host, Rule 4.1).

Closes #869.

---
Assisted-by: Claude:claude-opus-4-8
