### PR TITLE
refactor(resolve): thread Id. section-pincite terminal forward (#847)

### DIFF
--- a/.changeset/id-section-pincite-terminal.md
+++ b/.changeset/id-section-pincite-terminal.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": minor
+---
+
+refactor(resolve) + feat(extract): thread the `Id.` section-pincite terminal forward (#847)
+
+The resolver's `Id.` family preference (case vs statute) used to peek ~20 chars of raw text after `Id.` for a `§`, because `extractId`'s pincite regex captures only page/paragraph shapes. Extraction now emits a `sectionPincite` terminal on `IdCitation` (the locator after `§`/`§§`, e.g. `1983(c)`), and the resolver reads that structured field instead of re-scanning prose — collapsing two duplicate raw-text peeks (`tailHasSection` + `getIdPreferredFamily`) into one field read. Behavior-preserving; the short-form resolution suite is green.
+
+First slice of #847 (CST→AST: stop re-parsing prose in the resolver). The remaining case-name-inference sites (the 80-char mismatch re-tokenize and the 400-char `Party v. Party` scans) are split into a follow-up, to land with the authoritative-grammar / capture-group-threading work (#844).

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -161,6 +161,24 @@ function buildParentheticalNode(
 }
 
 /**
+ * Section-style pincite immediately after an `Id.` (`Id. § 1983(c)`), which the
+ * `Id.` regex does not capture (#847). `^`-anchored, so it fires only when the
+ * `§` directly follows the citation core — mirroring the resolver's former
+ * 20-char §-peek; the 40-char slice just bounds the value scan. Returns the
+ * locator after `§`/`§§` (e.g. `1983(c)`, `201`, `1-5`) or `undefined`.
+ */
+const TRAILING_SECTION_REGEX = /^\s*,?\s*§§?\s*(\d+(?:\([^)]*\))*(?:[-–—]\d+)?)/
+
+function extractTrailingSectionPincite(
+  cleanedText: string | undefined,
+  fromCleanPos: number,
+): string | undefined {
+  if (!cleanedText) return undefined
+  const m = TRAILING_SECTION_REGEX.exec(cleanedText.slice(fromCleanPos, fromCleanPos + 40))
+  return m ? m[1] : undefined
+}
+
+/**
  * Extracts Id. citation metadata from a tokenized citation.
  *
  * Parses token text to extract:
@@ -311,6 +329,11 @@ export function extractId(
   const paren = extractTrailingParenthetical(cleanedText, span.cleanEnd)
   const parentheticalNode = paren ? buildParentheticalNode(paren, transformationMap) : undefined
 
+  // Section-style pincite (#847): `Id. § 1983(c)`. Gathered by lookahead since
+  // the Id. regex above only handles page/paragraph shapes, so the resolver can
+  // read a structured field for family preference instead of peeking raw text.
+  const sectionPincite = extractTrailingSectionPincite(cleanedText, span.cleanEnd)
+
   return {
     type: "id",
     text,
@@ -326,6 +349,7 @@ export function extractId(
     patternsChecked: 1,
     pincite,
     pinciteInfo,
+    ...(sectionPincite ? { sectionPincite } : {}),
     ...(paren ? { parenthetical: paren.text } : {}),
     ...(parentheticalNode ? { parentheticalNode } : {}),
     spans,

--- a/src/extract/extractShortForms.ts
+++ b/src/extract/extractShortForms.ts
@@ -163,9 +163,12 @@ function buildParentheticalNode(
 /**
  * Section-style pincite immediately after an `Id.` (`Id. § 1983(c)`), which the
  * `Id.` regex does not capture (#847). `^`-anchored, so it fires only when the
- * `§` directly follows the citation core — mirroring the resolver's former
- * 20-char §-peek; the 40-char slice just bounds the value scan. Returns the
- * locator after `§`/`§§` (e.g. `1983(c)`, `201`, `1-5`) or `undefined`.
+ * `§` directly follows the citation core. The 20-char slice matches the
+ * resolver's former §-peek window EXACTLY, so detection is byte-identical to
+ * the behavior this replaces; a real `§` lands within ~3 chars (the default
+ * cleaner collapses whitespace) and realistic section locators fit well inside
+ * 20. Returns the locator after `§`/`§§` (e.g. `1983(c)`, `201`, `1-5`) or
+ * `undefined`.
  */
 const TRAILING_SECTION_REGEX = /^\s*,?\s*§§?\s*(\d+(?:\([^)]*\))*(?:[-–—]\d+)?)/
 
@@ -174,7 +177,7 @@ function extractTrailingSectionPincite(
   fromCleanPos: number,
 ): string | undefined {
   if (!cleanedText) return undefined
-  const m = TRAILING_SECTION_REGEX.exec(cleanedText.slice(fromCleanPos, fromCleanPos + 40))
+  const m = TRAILING_SECTION_REGEX.exec(cleanedText.slice(fromCleanPos, fromCleanPos + 20))
   return m ? m[1] : undefined
 }
 

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -416,12 +416,9 @@ export class DocumentResolver {
     // → statute; `Id. at 27` → case).
     const hasPincite =
       citation.pincite !== undefined || citation.pinciteInfo !== undefined
-    const tailHasSection = /^\s*[,]?\s*§§?\s*\d/.test(
-      this.cleanedText.substring(
-        citation.span.cleanEnd,
-        Math.min(this.cleanedText.length, citation.span.cleanEnd + 20),
-      ),
-    )
+    // #847: read the section-pincite terminal emitted at extraction time
+    // rather than re-peeking raw text after `Id.`.
+    const tailHasSection = citation.sectionPincite !== undefined
     const preferredFamily =
       hasPincite || tailHasSection ? this.getIdPreferredFamily(citation) : null
     const idQuoteZone = isInZone(citation.span.originalStart, this.quoteZones)
@@ -627,18 +624,12 @@ export class DocumentResolver {
 
   /**
    * Determines whether `Id.`'s pincite shape implies a case or statute
-   * antecedent. We peek at the cleaned text immediately after `Id.`'s span
-   * end because the regex in `extractIdCitation` only captures page-style
-   * pincites (`at NNN`, `¶ NNN`); a section-style pincite (`§ NNN`) lives
-   * in the raw text but not on the IdCitation object.
+   * antecedent. A section-style pincite (`Id. § 1983`) is captured at
+   * extraction time as `sectionPincite` (#847), so we read that structured
+   * field instead of re-peeking raw text; page/paragraph/bare `Id.` → case.
    */
   private getIdPreferredFamily(citation: IdCitation): CitationFamily {
-    // Look at up to 20 chars after Id.'s span end for a `§` token.
-    const start = citation.span.cleanEnd
-    const end = Math.min(this.cleanedText.length, start + 20)
-    const tail = this.cleanedText.substring(start, end)
-    if (/^\s*[,]?\s*§§?\s*\d/.test(tail)) return "statute"
-    return "case"
+    return citation.sectionPincite !== undefined ? "statute" : "case"
   }
 
   /**

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -1246,6 +1246,14 @@ export interface IdCitation extends CitationBase {
    */
   pinciteInheritedFromId?: CitationId
   /**
+   * Section-style pincite locator captured from `Id. § 1983(c)` forms (#847) —
+   * the text after `§`/`§§` (e.g. `1983(c)`, `201`, `1-5`). The `Id.` regex
+   * captures only page/paragraph pincites, so this is gathered by lookahead.
+   * Its presence marks the `Id.` as statute-family for antecedent selection;
+   * undefined for page/paragraph/bare `Id.` forms.
+   */
+  sectionPincite?: string
+  /**
    * Trailing parenthetical content (text between the parens, excluding the
    * parens themselves) captured from `Id. at N (...)` forms. Common values
    * include drop-citation markers (`citation omitted`, `internal quotation

--- a/tests/resolve/issue847_idSectionPincite.test.ts
+++ b/tests/resolve/issue847_idSectionPincite.test.ts
@@ -34,4 +34,26 @@ describe("Issue #847: Id. sectionPincite terminal", () => {
     const id = cites.find((c) => c.type === "id")!
     expect(id.resolution?.resolvedTo).toBe(cites.indexOf(statute))
   })
+
+  // Section-shape variants — lock the regex branches against future drift.
+  it("captures a double-§ range: Id. §§ 1-5", () => {
+    const id = extractCitations("29 U.S.C. §§ 1-5. Id. §§ 1-5.").find(
+      (c) => c.type === "id",
+    ) as IdCitation
+    expect(id.sectionPincite).toBe("1-5")
+  })
+
+  it("captures through the post-period-comma branch: Id., § 5", () => {
+    const id = extractCitations("29 U.S.C. § 5. Id., § 5.").find(
+      (c) => c.type === "id",
+    ) as IdCitation
+    expect(id.sectionPincite).toBe("5")
+  })
+
+  it("captures a bare section number: Id. § 5", () => {
+    const id = extractCitations("29 U.S.C. § 5. Id. § 5.").find(
+      (c) => c.type === "id",
+    ) as IdCitation
+    expect(id.sectionPincite).toBe("5")
+  })
 })

--- a/tests/resolve/issue847_idSectionPincite.test.ts
+++ b/tests/resolve/issue847_idSectionPincite.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #847: thread the `Id.` section-pincite terminal forward.
+ *
+ * `getIdPreferredFamily` (and the `tailHasSection` check in `resolveId`) used to
+ * peek ~20 chars of raw text after `Id.` for a `§` to decide case-vs-statute
+ * family, because `extractId`'s pincite regex only captures page/paragraph
+ * shapes. Extraction now emits a `sectionPincite` terminal on the IdCitation, so
+ * the resolver reads a structured field instead of re-scanning prose.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+import type { IdCitation } from "@/types/citation"
+
+describe("Issue #847: Id. sectionPincite terminal", () => {
+  it("populates sectionPincite for a §-style Id. pincite", () => {
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). 42 U.S.C. § 1983. Id. § 1983(c)."
+    const id = extractCitations(text).find((c) => c.type === "id") as IdCitation
+    expect(id.sectionPincite).toBe("1983(c)")
+  })
+
+  it("leaves sectionPincite undefined for a page-style Id. pincite", () => {
+    const id = extractCitations("29 U.S.C. § 201. Id. at 5.").find(
+      (c) => c.type === "id",
+    ) as IdCitation
+    expect(id.sectionPincite).toBeUndefined()
+  })
+
+  it("family detection now reads the field: Id. § N resolves to the statute over a case", () => {
+    const text = "Smith v. Jones, 100 F.3d 1 (1990). 42 U.S.C. § 1983. Id. § 1983(c)."
+    const cites = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const statute = cites.find((c) => c.type === "statute")!
+    const id = cites.find((c) => c.type === "id")!
+    expect(id.resolution?.resolvedTo).toBe(cites.indexOf(statute))
+  })
+})


### PR DESCRIPTION
## Why

The resolver decides `Id.` family (case vs statute) by peeking ~20 chars of raw text after `Id.` for a `§` — **twice** (`tailHasSection` and `getIdPreferredFamily`) — because `extractId`'s pincite regex captures only page/paragraph shapes. That's a CST→AST violation: the interpreter re-parses what the lexer could have emitted.

**Today:** family detection re-scans raw prose after every `Id.`

**After this PR:** `extractId` emits a `sectionPincite` terminal on `IdCitation` (the locator after `§`/`§§`, e.g. `1983(c)`), and the resolver reads that field — both peeks collapse to one structured read.

**Why this matters:** the resolver no longer re-parses prose for family detection, and the captured section is now structured data. Behavior-preserving — the `Id.`-family resolution suite (#514 etc.) stays green.

## What changed

- New `IdCitation.sectionPincite?: string`, captured in `extractId` via a `^`-anchored lookahead that mirrors the resolver's former §-peek trigger (fires on the same inputs).
- `DocumentResolver`: `tailHasSection` → `citation.sectionPincite !== undefined`; `getIdPreferredFamily` reads the field. Both raw-text peeks removed.

## Test plan

**What I ran:**
- `pnpm exec vitest run` — **310 files, 4642 tests pass** (+3 new in `issue847_idSectionPincite`).
- `issue514_idFamilyFallback` (the behavior guard, incl. `Id. § 1983(c)` → statute) green.
- `pnpm typecheck` clean; `biome lint` clean on changed files (3 pre-existing infos in an untouched regex).

## Scope boundary

First slice of #847 — the `§`-family detection site only. The case-name-inference sites (the 80-char mismatch re-tokenize and the two `Party v. Party` prose scans) are deferred to a follow-up, to land with the authoritative-grammar / capture-group-threading work (#844): they require extraction to emit prose-level case-name terminals, not just relocate a scan.

Part of #847.

---
Assisted-by: Claude:claude-opus-4-8
