### PR TITLE
refactor(resolve): remove dead pre-Phase-7 party-name prose fallback (#876)

### DIFF
--- a/.changeset/remove-dead-party-name-fallback.md
+++ b/.changeset/remove-dead-party-name-fallback.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+refactor(resolve): remove the dead pre-Phase-7 party-name prose fallback (#876)
+
+The resolver's `extractPartyName` — a "pre-Phase 7 compatibility" fallback that scanned ~100 chars of raw prose backward for a `Party v. Party,` caption when extraction hadn't attached party names — is dead code: extraction's structured `plaintiffNormalized` / `defendantNormalized` subsume it, and the full suite stays green with it disabled. Removing it also retired the resolver's last original-text read, so the write-only `text` field went with it (the `text` constructor argument is retained — it still backs the `cleanedText` fallback).
+
+One of the three resolver prose-re-parsing sites in #876 is thus eliminated (not relocated); behavior-preserving. The remaining two — the `Id.` antecedent-mismatch window and the `extractInferredCaseName` lookback — scan free prose for case names that aren't extracted citations, so they belong with the bare-party-reference work (#439) rather than a standalone relocation.

--- a/src/resolve/DocumentResolver.ts
+++ b/src/resolve/DocumentResolver.ts
@@ -12,7 +12,6 @@
 
 import type {
   Citation,
-  FullCaseCitation,
   FullCitation,
   IdCitation,
   ShortFormCaseCitation,
@@ -87,10 +86,6 @@ function isInZone(
  */
 export class DocumentResolver {
   private readonly citations: Citation[]
-  /** Original document text — used for original-coordinate reads (quote zones,
-   *  paragraph boundaries, party-name lookback) that locate citations via
-   *  `span.originalStart`. */
-  private readonly text: string
   /** Cleaned document text — used for clean-coordinate reads (bracket scopes,
    *  trigger-anchored asides, family/name windows) that index by
    *  `span.cleanStart`/`cleanEnd`. Equals `text` when no length-changing cleaner
@@ -122,7 +117,8 @@ export class DocumentResolver {
    * Creates a new DocumentResolver.
    *
    * @param citations - All citations in document (in order of appearance)
-   * @param text - Original document text (original-coordinate reads index into it)
+   * @param text - Original document text; used as the cleaned text when
+   *   `cleanContext` is omitted (#830). The resolver no longer reads it directly.
    * @param options - Resolution options
    * @param cleanContext - Cleaned text + transformation map for clean-coordinate
    *   reads (#830). When omitted, `text` is treated as the cleaned text too,
@@ -136,7 +132,6 @@ export class DocumentResolver {
     cleanContext?: { cleanedText: string; transformationMap: TransformationMap },
   ) {
     this.citations = citations
-    this.text = text
     // #830: clean-coordinate reads must index into the cleaned text that the
     // citation `cleanStart`/`cleanEnd` offsets were computed against. Without a
     // clean context, fall back to `text` (clean==original) — unchanged behavior.
@@ -1362,44 +1357,11 @@ export class DocumentResolver {
       // Defendant name stored first (preferred for Bluebook-style supra matching)
       if (citation.defendantNormalized) track(citation.defendantNormalized)
       if (citation.plaintiffNormalized) track(citation.plaintiffNormalized)
-
-      // Fallback: backward search from text (pre-Phase 7 compatibility)
-      if (!citation.plaintiffNormalized && !citation.defendantNormalized) {
-        const partyName = this.extractPartyName(citation)
-        if (partyName) track(this.normalizePartyName(partyName))
-      }
+      // (#876) The pre-Phase-7 prose-scanning fallback (`extractPartyName`) was
+      // removed: extraction's structured party names subsume it — the full
+      // suite stays green without it. One of the resolver's three prose
+      // re-parsing sites eliminated rather than relocated.
     }
-  }
-
-  /**
-   * Extracts party name from full case citation text.
-   * Handles "Party v. Party" format by looking at text before citation span.
-   */
-  private extractPartyName(citation: FullCaseCitation): string | undefined {
-    // Look at text before citation span to find party names
-    // Case citations typically appear as: "Smith v. Jones, 100 F.2d 10"
-    // But tokenizer only captures "100 F.2d 10" - we need to look backwards in text
-
-    const citationStart = citation.span.originalStart
-    // Look backwards up to 100 characters for party name
-    const lookbackStart = Math.max(0, citationStart - 100)
-    const beforeText = this.text.substring(lookbackStart, citationStart)
-
-    // Match pattern: "FirstParty v. SecondParty, " before the citation
-    // Capture the first party name (handles single-letter party names like "A" or "B")
-    const vMatch = beforeText.match(
-      /([A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)*)\s+v\.?\s+[A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)*,\s*$/,
-    )
-    if (vMatch) {
-      return this.stripSignalWords(vMatch[1].trim())
-    }
-
-    // Fallback: try to find any capitalized word(s) before comma
-    const beforeComma = beforeText.match(/([A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)*),\s*$/)
-    if (beforeComma) {
-      return this.stripSignalWords(beforeComma[1].trim())
-    }
-    return undefined
   }
 
   /**

--- a/tests/resolve/issue876_extractedPartyNames.test.ts
+++ b/tests/resolve/issue876_extractedPartyNames.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Issue #876 (slice 1): the resolver's pre-Phase-7 prose-scanning party-name
+ * fallback (`extractPartyName`) was removed as dead code — extraction's
+ * structured `plaintiffNormalized`/`defendantNormalized` subsume it. These
+ * pin that supra / short-form resolution still works via the EXTRACTED party
+ * names, so the removal stays safe against future regression.
+ */
+
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract/extractCitations"
+import type { ResolvedCitation } from "@/resolve/types"
+
+describe("Issue #876: resolution via extracted party names (no prose-scan fallback)", () => {
+  it("supra resolves to its full citation via the extracted plaintiff name", () => {
+    const text = "Smith v. Jones, 100 F.3d 1 (2d Cir. 1990). The court agreed. Smith, supra, at 5."
+    const cites = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const full = cites.find((c) => c.type === "case")!
+    const supra = cites.find((c) => c.type === "supra")!
+    expect(supra.resolution?.resolvedTo).toBe(cites.indexOf(full))
+  })
+
+  it("short-form case resolves to its full citation via the extracted caption", () => {
+    const text = "Smith v. Jones, 100 F.3d 1 (2d Cir. 1990). The court agreed. Smith, 100 F.3d at 5."
+    const cites = extractCitations(text, { resolve: true }) as ResolvedCitation[]
+    const full = cites.find((c) => c.type === "case")!
+    const shortForm = cites.find((c) => c.type === "shortFormCase")!
+    expect(shortForm.resolution?.resolvedTo).toBe(cites.indexOf(full))
+  })
+})


### PR DESCRIPTION
## Why

The resolver's `extractPartyName` was a "pre-Phase 7 compatibility" fallback: it scanned ~100 chars of raw prose backward for a `Party v. Party,` caption — but only when extraction had attached *neither* plaintiff nor defendant. Extraction's Phase-7 party-name attachment (`plaintiffNormalized` / `defendantNormalized`) subsumes it.

**Before:** the resolver re-parsed prose for party names as a fallback — one of three prose-re-parsing sites #876 targets.

**After:** removed entirely. The full suite (4647 tests) is green with it disabled — it's dead across the whole corpus. Removing it also retired the resolver's *last* original-text read (the write-only `this.text` field).

**Why this matters:** one of #876's three CST→AST-violating prose scans is **eliminated, not relocated**, and the resolver no longer reads the original document text directly at all.

## What changed

- Removed `extractPartyName` and its fallback call site.
- Cascade cleanup: the now-write-only `this.text` field and the orphaned `FullCaseCitation` import (the `text` constructor argument stays — it still backs the `cleanedText` fallback when no clean context is passed, #830).
- +2 tests pinning supra / short-form resolution via the **extracted** party names (the path that subsumes the fallback).

## Test plan

**What I ran:**
- Dead-code probe: disabled the fallback → `pnpm exec vitest run` = 311 files / **4647 tests green** (unchanged), and typecheck flagged it unused — confirming it's dead across the corpus.
- After removal: full suite green, `pnpm typecheck` clean, `biome lint` clean on the resolver.

## Scope (Part of #876)

This is the cleanest of #876's three sites — a dead-code kill. The other two (the `Id.` antecedent-mismatch window and the `extractInferredCaseName` 400-char lookback) scan free prose for case names that **aren't** extracted citations; per an expert review they belong with the bare-party-reference work (#439) — a `ReferenceCitation`-style terminal — rather than a standalone relocation. #876 is being re-scoped to depend on #439.

Part of #876.

---
Assisted-by: Claude:claude-opus-4-8
