### PR TITLE
feat(extract): capture-group threading substrate + Node >=22 floor

### DIFF
--- a/.changeset/capture-group-threading-substrate.md
+++ b/.changeset/capture-group-threading-substrate.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": minor
+---
+
+Thread regex capture groups from tokenize→extract, and raise the Node floor to >=22.
+
+**BREAKING (runtime floor):** the minimum supported Node is now 22 (was 18); the CI matrix is 22/24/26. This unlocks ES2025 duplicate named capturing groups, which the extraction refactor relies on.
+
+Internally, `Token` now carries optional `groups`/`groupSpans` (the named capture groups of the matching pattern) so extractors can read structured terminals instead of re-running a second regex. This PR is the additive substrate; it changes no extraction output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "sideEffects": false,
   "packageManager": "pnpm@10.6.5",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsdown",

--- a/src/data/caBareCodes.ts
+++ b/src/data/caBareCodes.ts
@@ -101,7 +101,7 @@ export function buildCaBareCodeRegex(): RegExp {
   // symmetric to the abbreviated-code and USC patterns.
   return new RegExp(
     `\\b(${alternation})\\s*,?\\s*§§?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9]))*(?:\\([^)]*\\))*(?:,?\\s+(?:subd\\.|subdivision|paragraph|par\\.)\\s+(?:\\([^)]*\\)|\\[[^\\]]*\\])(?:\\s*(?:\\([^)]*\\)|\\[[^\\]]*\\]))*)?(?:\\s*[-–—]+\\s*\\([A-Za-z0-9]+\\))?(?:\\s*et\\s+seq\\.?)?)`,
-    "g",
+    "gd",
   )
 }
 

--- a/src/data/stateStatutes.ts
+++ b/src/data/stateStatutes.ts
@@ -109,7 +109,7 @@ export function buildAbbreviatedCodeRegex(): RegExp {
     // field. Dash class accepts multi-hyphen `---` (post `normalizeDashes`
     // rewrite of em-dash). #591
     `\\b(?:(\\d+)\\s+)?(${alternation})\\s*,?\\s*(?:§§?|[Ss]ections?|[Ss]ec\\.?)?\\s*(\\d+(?:[A-Za-z0-9:/-]|\\.(?=[A-Za-z0-9])|,(?=\\d))*(?:\\s*\\((?![^)]*\\d{4})[A-Za-z0-9.-]+\\)|\\s*\\[[A-Za-z0-9.-]+\\])*(?:\\s*[-–—]+\\s*\\([A-Za-z0-9]+\\))?(?:\\s*et\\s+seq\\.?)?)`,
-    "g",
+    "gd",
   )
 }
 

--- a/src/extract/groupAccessor.ts
+++ b/src/extract/groupAccessor.ts
@@ -1,0 +1,31 @@
+/**
+ * Typed access to a Token's threaded named groups (#844). Extractors read
+ * groups through these helpers instead of touching the raw record, so a
+ * missing required group declines via CitationParseError (the #881 path) in
+ * one audited place. Per-extractor `GroupName` unions narrow the `name` arg
+ * to compile-time-checked literals at the call site.
+ *
+ * @module extract/groupAccessor
+ */
+
+import type { Token } from "@/tokenize"
+import { CitationParseError } from "./errors"
+
+/** Returns the named group's value, or declines (the tokenizer admitted a token the extractor can't parse). */
+export function requireGroup<N extends string>(token: Token, name: N): string {
+  const value = token.groups?.[name]
+  if (value === undefined) {
+    throw new CitationParseError(`Missing required capture group "${name}" in token: ${token.text}`)
+  }
+  return value
+}
+
+/** Returns the named group's value, or undefined if it did not participate. */
+export function optionalGroup<N extends string>(token: Token, name: N): string | undefined {
+  return token.groups?.[name]
+}
+
+/** Returns the named group's token-relative [start, end] span, or undefined. */
+export function groupSpan<N extends string>(token: Token, name: N): [number, number] | undefined {
+  return token.groupSpans?.[name]
+}

--- a/src/patterns/canonPatterns.ts
+++ b/src/patterns/canonPatterns.ts
@@ -17,7 +17,7 @@ export const CANON_RE: RegExp = new RegExp(CANON_SRC)
 export const canonPatterns: Pattern[] = [
   {
     id: "canon",
-    regex: new RegExp(CANON_SRC, "g"),
+    regex: new RegExp(CANON_SRC, "gd"),
     description: 'Code of Judicial Conduct canons (e.g. "Canon 7(B)(1)")',
     type: "canon",
   },

--- a/src/patterns/casePatterns.ts
+++ b/src/patterns/casePatterns.ts
@@ -75,7 +75,7 @@ export const casePatterns: Pattern[] = [
     // from matching as `page=1-5` with stray `-7`.
     regex: new RegExp(
       String.raw`\b(\d+(?:-\d+)?)\s+(F\.\s?Supp\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?|F\.\s?App'x|F\.(?:\d+(?:st|nd|rd|th)|2d|3d)?)(?:\s+(\d+-\d+|\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>†‡§¶©°])|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
-      "g",
+      "gd",
     ),
     description:
       "Federal Reporter (F., F.2d, F.3d, F.Nth, F.Supp., F.App'x, etc.)",
@@ -90,7 +90,7 @@ export const casePatterns: Pattern[] = [
     // (#509).
     regex: new RegExp(
       String.raw`\b(\d+(?:-\d+)?)\s+(U\.\s?S\.|S\.\s?Ct\.|L\.\s?Ed\.(?:\s?(?:\d+(?:st|nd|rd|th)|2d|3d))?)(?:\s+(?:\(\d+\s+[A-Z][A-Za-z.]+\)\s+)?(\d+-\d+(?=\s+\(\d{4}\))|\d+|_{3,}|-{3,})(?=\s|$|[().,;!?–—'"“”*<>†‡§¶©°]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
-      "g",
+      "gd",
     ),
     description:
       "U.S. Supreme Court reporters (with optional nominative reporter parenthetical)",
@@ -152,7 +152,7 @@ export const casePatterns: Pattern[] = [
     // journal-abbreviation guards (#332, #549).
     regex: new RegExp(
       String.raw`\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)(?!(?:AND|OR)\s+\d)([A-Z][A-Za-z.\d&']*(?:(?! L\.[JQR\s])(?! R\.\s+\d)\s+[A-Z\d&][A-Za-z.\d&']*)*?)(?:\s+(\d+-\d+(?=\s+\(\d{4}\))|\d+|_{3,}|-{3,})(?=\s|$|[().,;!?\[\]–—'"“”*<>†‡§¶©°]|-\D)|\s*,\s+(\d+|_{3,}|-{3,})${COMMA_PAGE_TERMINATOR})`,
-      "g",
+      "gd",
     ),
     description:
       'State reporters (broad pattern allowing multi-word reporters with & and \', excludes journal patterns with " L.J/Q/Rev", phantom matches across " v. "/" vs. ", CSM " at " short-form boundaries, Illinois " R. N" rule-marker boundaries, and Id./Ibid. short-form markers (#549), validated against reporters-db in Phase 3)',

--- a/src/patterns/constitutionalPatterns.ts
+++ b/src/patterns/constitutionalPatterns.ts
@@ -101,7 +101,7 @@ export const constitutionalPatterns: Pattern[] = [
     // `gi`: lowercase prose forms (`former article …`) must match; the
     // `former` + `(now …)` adjacency is the false-positive guard.
     id: "constitutional-historical-reform",
-    regex: new RegExp(HISTORICAL_REFORM, "gi"),
+    regex: new RegExp(HISTORICAL_REFORM, "gid"),
     description:
       'Historical-reform constitutional citations: "former art. XX, § 21 (now art. XIV, § 4)" — #789',
     type: "constitutional",
@@ -110,7 +110,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "us-constitution",
     regex: new RegExp(
       String.raw`\b(?:United\s+States\s+Constitution|U\.?\s*S\.?\s+Const\.?),?\s+${BODY_TAIL}`,
-      "gi",
+      "gid",
     ),
     description:
       'U.S. Constitution citations (e.g., "U.S. Const. art. III, § 2", "U.S. Const. amend. XIV")',
@@ -125,7 +125,7 @@ export const constitutionalPatterns: Pattern[] = [
     // positives from words that happen to start with a state stem.
     regex: new RegExp(
       String.raw`\b(?:Ala|Alaska|Ariz|Ark|Cal(?:if)?|Colo|Conn|Del|Fla|Ga|Haw|Idaho|Ill|Ind|Iowa|Kan|Ky|La|Me|Md|Mass|Mich|Minn|Miss|Mo|Mont|Neb|Nev|N\.?\s*H|N\.?\s*J|N\.?\s*M|N\.?\s*Y|N\.?\s*C|N\.?\s*D|Ohio|Okla|Or(?:e)?|Pa|R\.?\s*I|S\.?\s*C|S\.?\s*D|Tenn|Tex|Utah|Vt|W\.?\s*Va|Va|Wash|Wis|Wyo)(?:\.\s*|\s+)Const\.?,?\s+${BODY_TAIL}`,
-      "gi",
+      "gid",
     ),
     description:
       'State constitution citations (e.g., "Cal. Const. art. I, § 7", "N.Y. Const. art. VI, § 20", "Pa.Const. art. VIII, § 4")',
@@ -138,7 +138,7 @@ export const constitutionalPatterns: Pattern[] = [
     // Consequence: all-caps preceding words like "THE Const." won't match due to [A-Z]\s lookbehind — rare, acceptable tradeoff.
     // Known limitation: multi-character state abbreviations ending in lowercase (Alaska, Idaho, etc.)
     // bypass the lookbehind and produce a second bare match — tokenizer span dedup handles this.
-    regex: new RegExp(String.raw`(?<!\.\s)(?<![A-Z]\s)\bConst\.?,?\s+${BODY_TAIL}`, "g"),
+    regex: new RegExp(String.raw`(?<!\.\s)(?<![A-Z]\s)\bConst\.?,?\s+${BODY_TAIL}`, "gd"),
     description:
       'Bare constitutional citations without jurisdiction prefix (e.g., "Const. art. I, § 8, cl. 3")',
     type: "constitutional",
@@ -154,7 +154,7 @@ export const constitutionalPatterns: Pattern[] = [
     // Confidence set to 0.5 in extractor.
     regex: new RegExp(
       String.raw`(?<!Const\.?,?\s)\bArt\.?\s+([IVX]+|\d+)[,;]\s*§\s*[\w-]+(?:[,;]\s*cl\.?\s*\d+)?`,
-      "g",
+      "gd",
     ),
     description:
       'Bare article references without "Const." prefix (e.g., "Art. I, §8, cl. 3", "Art. 1, § 10")',
@@ -177,7 +177,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "bare-article-section",
     regex: new RegExp(
       String.raw`(?<!Const\.?,?\s)\b(?:Article|Art\.?)\s+([IVX]+|\d+)\s*[,;]\s*(?:Section|§)\s*([\w()-]+)`,
-      "g",
+      "gd",
     ),
     description:
       'Bare spelled-out article+section prose: "Article I, Section 8", "Art. 1, Section 6" — #321',
@@ -215,7 +215,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "state-const-prose-declaration",
     regex: new RegExp(
       String.raw`\b(?:art(?:icle)?\.?)\s+(\d+)\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey)\s+(?:Declaration\s+of\s+Rights|Constitution)\b`,
-      "gi",
+      "gid",
     ),
     description:
       'Prose-form state constitutional citations: "art. 14 of the Massachusetts Declaration of Rights" — #656',
@@ -225,7 +225,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "state-const-prose-section-article",
     regex: new RegExp(
       String.raw`\bSection\s+([\w()-]+)\s*,\s*Article\s+([IVX]+|\d+)\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey|Ohio|California|Texas|Florida|Illinois|Michigan|New\s+York|Georgia|Virginia|Washington|Arizona|Colorado|Wisconsin|Minnesota|Indiana|Louisiana|Oregon|Tennessee|South\s+Carolina|Alabama|Missouri|Kentucky|Connecticut|Iowa|Mississippi|Arkansas|Kansas|Nevada|Utah|Hawaii|Alaska|Idaho|Maine|Montana|Nebraska|New\s+Mexico|North\s+Dakota|Oklahoma|Rhode\s+Island|South\s+Dakota|West\s+Virginia|Wyoming|Florida)\s+Constitution\b`,
-      "g",
+      "gd",
     ),
     description:
       'Prose-form state constitutional citations: "Section 5(B), Article IV of the Ohio Constitution" — #656',
@@ -243,7 +243,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "state-const-prose-article-first",
     regex: new RegExp(
       String.raw`\b(?:article|art\.?)\s+([IVX]+|\d+)[,\s]+section\s+([\w()-]+),?\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey|Ohio|California|Texas|Florida|Illinois|Michigan|New\s+York|Georgia|Virginia|Washington|Arizona|Colorado|Wisconsin|Minnesota|Indiana|Louisiana|Oregon|Tennessee|South\s+Carolina|Alabama|Missouri|Kentucky|Connecticut|Iowa|Mississippi|Arkansas|Kansas|Nevada|Utah|Hawaii|Alaska|Idaho|Maine|Montana|Nebraska|New\s+Mexico|North\s+Dakota|Oklahoma|Rhode\s+Island|South\s+Dakota|West\s+Virginia|Wyoming)\s+Constitution\b`,
-      "gi",
+      "gid",
     ),
     description:
       'Prose-form state constitutional citations, article-first: "article XII, section 5 of the California Constitution" — #321',
@@ -264,7 +264,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "state-const-prose-plural-section",
     regex: new RegExp(
       String.raw`\bSections\s+(\d+(?:[\s,]+(?:and\s+)?\d+)+)\s+of\s+Article\s+([IVX]+|\d+)\s+of\s+the\s+(Massachusetts|Pennsylvania|Vermont|New\s+Hampshire|Maryland|North\s+Carolina|Delaware|New\s+Jersey|Ohio|California|Texas|Florida|Illinois|Michigan|New\s+York|Georgia|Virginia|Washington|Arizona|Colorado|Wisconsin|Minnesota|Indiana|Louisiana|Oregon|Tennessee|South\s+Carolina|Alabama|Missouri|Kentucky|Connecticut|Iowa|Mississippi|Arkansas|Kansas|Nevada|Utah|Hawaii|Alaska|Idaho|Maine|Montana|Nebraska|New\s+Mexico|North\s+Dakota|Oklahoma|Rhode\s+Island|South\s+Dakota|West\s+Virginia|Wyoming)\s+Constitution\b`,
-      "g",
+      "gd",
     ),
     description:
       'Plural-section prose: "Sections 5 and 10 of Article I of the Ohio Constitution" — #321',
@@ -274,7 +274,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "bare-amendment-word",
     regex: new RegExp(
       `(?<!Const\\.?,?\\s)\\b(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+(?:[Aa]mend(?:ment)?\\.?|[Aa]mdt\\.?)`,
-      "g",
+      "gd",
     ),
     description:
       'Bare word-form amendment references without "Const." prefix (e.g., "the Fifth Amendment", "the Fourteenth Amendment") — #534',
@@ -304,7 +304,7 @@ export const constitutionalPatterns: Pattern[] = [
     id: "bare-amendment-coord",
     regex: new RegExp(
       `(?<!Const\\.?,?\\s)\\b(${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})(?=,\\s+(?:(?:${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS}),?\\s+)*(?:and\\s+)?(?:${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+[Aa]mendments?|\\s+and\\s+(?:${AMEND_ORDINAL_ABBREV}|${AMEND_WORD_ORDINALS})\\s+[Aa]mendments?)`,
-      "g",
+      "gd",
     ),
     description:
       'Leading ordinals in coordinated amendment lists ("Fifth and Sixth Amendment" → Fifth + Sixth) — #657',

--- a/src/patterns/docketPatterns.ts
+++ b/src/patterns/docketPatterns.ts
@@ -33,7 +33,7 @@ export const docketPatterns: Pattern[] = [
     // The `\bNo\.` anchor + space-separated paren keep this narrow without a
     // case-name lookbehind — case-name validation lives in the extractor.
     regex:
-      /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?::?[A-Za-z\d]+)?(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+\s(\d{4}))\)/g,
+      /\b(?:(?:C\.A\.|Civ\.|Civil(?:\s+Action)?|Case|Adv\.|Docket)\s+)?No\.\s+([A-Za-z\d]+(?::?[A-Za-z\d]+)?(?:[-\s][A-Za-z\d]+)*)\s+\(([^)]+\s(\d{4}))\)/gd,
     description:
       'Docket-number citation: "Party v. Party, [C.A./Civ./Civil/Case/Adv./Docket] No. <docket> (<court> <year>)"',
     type: "docket",

--- a/src/patterns/federalRulePatterns.ts
+++ b/src/patterns/federalRulePatterns.ts
@@ -38,7 +38,7 @@ export const federalRulePatterns: Pattern[] = [
     // alongside the canonical abbreviations (#295).
     id: "fed-rule-abbreviated",
     regex:
-      /\bFed\.\s?(?:R\.|Rules?)\s?(Civ\.\s?(?:P\.|Proc\.)|Crim\.\s?(?:P\.|Proc\.)|Evid\.|App\.\s?(?:P\.|Proc\.)|Bankr\.\s?(?:P\.|Proc\.))\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+      /\bFed\.\s?(?:R\.|Rules?)\s?(Civ\.\s?(?:P\.|Proc\.)|Crim\.\s?(?:P\.|Proc\.)|Evid\.|App\.\s?(?:P\.|Proc\.)|Bankr\.\s?(?:P\.|Proc\.))\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description:
       'Abbreviated federal rules: "Fed. R. Civ. P. 56", "Fed. Rule Crim. Proc. 46(b)", "Fed.R.Bankr.P. 7001" — #576, #295',
     type: "federalRule",
@@ -52,7 +52,7 @@ export const federalRulePatterns: Pattern[] = [
     // never collides with prose; no negative lookbehind needed.
     id: "fed-rule-spelled",
     regex:
-      /\bFederal\s+Rules?\s+of\s+(?:the\s+)?(Civil\s+Procedure|Criminal\s+Procedure|Evidence|Appellate\s+Procedure|Bankruptcy\s+Procedure)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gi,
+      /\bFederal\s+Rules?\s+of\s+(?:the\s+)?(Civil\s+Procedure|Criminal\s+Procedure|Evidence|Appellate\s+Procedure|Bankruptcy\s+Procedure)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gid,
     description:
       'Spelled-out federal rules: "Federal Rule of Civil Procedure 56", "Federal Rules of Evidence 401" — #576',
     type: "federalRule",
@@ -63,7 +63,7 @@ export const federalRulePatterns: Pattern[] = [
     // Common in casual writing, court orders, and briefs. #696.
     id: "fed-rule-acronym",
     regex:
-      /\b(FRCP|FRE|FRAP|FRCrP|FRBP|F\.\s?R\.\s?C\.\s?P\.|F\.\s?R\.\s?E\.|F\.\s?R\.\s?A\.\s?P\.|F\.\s?R\.\s?Cr\.\s?P\.|F\.\s?R\.\s?B\.\s?P\.)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+      /\b(FRCP|FRE|FRAP|FRCrP|FRBP|F\.\s?R\.\s?C\.\s?P\.|F\.\s?R\.\s?E\.|F\.\s?R\.\s?A\.\s?P\.|F\.\s?R\.\s?Cr\.\s?P\.|F\.\s?R\.\s?B\.\s?P\.)\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description:
       'Acronym federal rules: "FRCP 12(b)(6)", "FRE 401", "F.R.C.P. 12" — #696',
     type: "federalRule",

--- a/src/patterns/journalPatterns.ts
+++ b/src/patterns/journalPatterns.ts
@@ -29,7 +29,7 @@ export const journalPatterns: Pattern[] = [
     // Real journal abbreviations (`Harv. L. Rev.`, `Yale L.J.`) and
     // single-word forms (`Neurology`) still match.
     regex:
-      /\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)([A-Z][A-Za-z.&']*(?:\s+[A-Z\d&][A-Za-z.&']*)*?)\s+(\d+)\b/g,
+      /\b(\d+(?:-\d+)?)\s+(?!(?:Ibid|Id)\.?\s+\d)([A-Z][A-Za-z.&']*(?:\s+[A-Z\d&][A-Za-z.&']*)*?)\s+(\d+)\b/gd,
     description:
       'Law review citations (e.g., "120 Harv. L. Rev. 500"), validated against journals-db in Phase 3. Each post-space token must start with uppercase/digit/& to reject prose phantoms.',
     type: "journal",

--- a/src/patterns/legislativeMaterialPatterns.ts
+++ b/src/patterns/legislativeMaterialPatterns.ts
@@ -27,13 +27,13 @@ export const LEGMAT_CONG_REC_RE: RegExp = new RegExp(CONG_REC_SRC)
 export const legislativeMaterialPatterns: Pattern[] = [
   {
     id: "legmat-report",
-    regex: new RegExp(REPORT_SRC, "g"),
+    regex: new RegExp(REPORT_SRC, "gd"),
     description: 'Committee reports (e.g. "H.R. Rep. No. 94-1487, p. 16 (1976)", "S. Rep. No. 861, at 2")',
     type: "legislativeMaterial",
   },
   {
     id: "legmat-cong-rec",
-    regex: new RegExp(CONG_REC_SRC, "g"),
+    regex: new RegExp(CONG_REC_SRC, "gd"),
     description: 'Congressional Record citations (e.g. "112 Cong. Rec. 1234")',
     type: "legislativeMaterial",
   },

--- a/src/patterns/localOrdinancePatterns.ts
+++ b/src/patterns/localOrdinancePatterns.ts
@@ -17,7 +17,7 @@ export const CCCO_ORDINANCE_RE: RegExp = new RegExp(CCCO_SRC)
 export const localOrdinancePatterns: Pattern[] = [
   {
     id: "ccco-ordinance",
-    regex: new RegExp(CCCO_SRC, "g"),
+    regex: new RegExp(CCCO_SRC, "gd"),
     description: 'Clark County ordinances (e.g. "CCCO § 2.12.010(1)")',
     type: "localOrdinance",
   },

--- a/src/patterns/neutralPatterns.ts
+++ b/src/patterns/neutralPatterns.ts
@@ -45,7 +45,7 @@ export const neutralPatterns: Pattern[] = [
     id: "state-vendor-neutral-hyphenated-ms",
     regex: new RegExp(
       `${NOT_AFTER_DOCKET_PREFIX}\\b(${PLAUSIBLE_YEAR})-([A-Z]+)-(\\d+)-([A-Z]+)\\b`,
-      "g",
+      "gd",
     ),
     description:
       'Mississippi 4-segment vendor-neutral (e.g., "2010-CT-01234-SCT", "2015-CA-00567-COA")',
@@ -59,7 +59,7 @@ export const neutralPatterns: Pattern[] = [
     id: "state-vendor-neutral-hyphenated",
     regex: new RegExp(
       `${NOT_AFTER_DOCKET_PREFIX}\\b(${PLAUSIBLE_YEAR})-([A-Z][A-Za-z]+)-(\\d+)\\b`,
-      "g",
+      "gd",
     ),
     description:
       'Hyphenated vendor-neutral (e.g., "2010-NMSC-007", "2024-Ohio-764", "2020-NCSC-118")',
@@ -78,7 +78,7 @@ export const neutralPatterns: Pattern[] = [
     // `documentNumber`.
     id: "state-vendor-neutral",
     regex:
-      /\b(\d{4})\s+(IL\s+App\s+\(\d+(?:st|nd|rd|th|d)\)|OK\s+(?:CIV\s+APP|CR|AG)|[A-Z]{2}(?:\s+App\.?)?)\s+(\d+(?:-U)?)\b/g,
+      /\b(\d{4})\s+(IL\s+App\s+\(\d+(?:st|nd|rd|th|d)\)|OK\s+(?:CIV\s+APP|CR|AG)|[A-Z]{2}(?:\s+App\.?)?)\s+(\d+(?:-U)?)\b/gd,
     description:
       'State vendor-neutral citations (e.g., "2007 UT 49", "2017 WI 17", "2013 IL 112116", "2011 IL App (1st) 101234", "2020 OK CIV APP 67", "2020 IL App (2d) 190123-U")',
     type: "neutral",
@@ -96,7 +96,7 @@ export const neutralPatterns: Pattern[] = [
     id: "ny-slip-op",
     regex: new RegExp(
       `\\b(${PLAUSIBLE_YEAR})\\s+N\\.?Y\\.?\\s+Slip\\s+Op\\.?\\s+(\\d+|${BLANK_LOCATOR})(\\((?:U|UV)\\)|\\[U\\])?`,
-      "g",
+      "gd",
     ),
     description:
       'NY Slip Op vendor-neutral citations (e.g., "2024 NY Slip Op 51234", "2020 NY Slip Op 51234(U)", "2023 N.Y. Slip Op. 03165", "2021 N.Y. Slip Op. [____]" #831)',
@@ -108,7 +108,7 @@ export const neutralPatterns: Pattern[] = [
     // to digits. The trailing `\b` lives on the numeric branch only: a `]`
     // followed by whitespace/EOL is two non-word chars, so an outer `\b` would
     // reject the bracketed form. `BLANK_LOCATOR` is self-delimited by its `]`.
-    regex: new RegExp(`\\b(\\d{4})\\s+WL\\s+(\\d+\\b|${BLANK_LOCATOR})`, "g"),
+    regex: new RegExp(`\\b(\\d{4})\\s+WL\\s+(\\d+\\b|${BLANK_LOCATOR})`, "gd"),
     description: 'WestLaw citations (e.g., "2021 WL 123456", "2024 WL [____]" #831)',
     type: "neutral",
   },
@@ -118,7 +118,7 @@ export const neutralPatterns: Pattern[] = [
     // sequential decision number within that year. Treated as a neutral
     // citation because year acts as the volume identifier.
     id: "tc-memo",
-    regex: /\bT\.\s?C\.\s+Memo\.\s+(\d{4})-(\d+)\b/g,
+    regex: /\bT\.\s?C\.\s+Memo\.\s+(\d{4})-(\d+)\b/gd,
     description:
       'Tax Court Memorandum decisions (e.g., "T.C. Memo. 2002-89", "T.C. Memo. 1970-86") — #324',
     type: "neutral",
@@ -130,7 +130,7 @@ export const neutralPatterns: Pattern[] = [
     // The non-greedy `[A-Z][A-Za-z.\s]+?` is bounded by the literal `\s+LEXIS`
     // that follows it, so it can't run away.
     id: "lexis",
-    regex: /\b(\d{4})\s+[A-Z][A-Za-z.\s]+?\s+LEXIS\s+(\d+)\b/g,
+    regex: /\b(\d{4})\s+[A-Z][A-Za-z.\s]+?\s+LEXIS\s+(\d+)\b/gd,
     description:
       'LexisNexis citations (federal: "2021 U.S. LEXIS 5000", "2021 U.S. App. LEXIS 12345"; state: "2020 Cal. LEXIS 1000", "2020 Tex. App. LEXIS 5000")',
     type: "neutral",
@@ -140,7 +140,7 @@ export const neutralPatterns: Pattern[] = [
     // `Pub. L. 116-283`) and the spelled-out form (`Public Law 116-127`,
     // `Public Law No. 116-127`). #533
     id: "public-law",
-    regex: /\b(?:Pub\.\s?L\.|Public\s+Law)(?:\s?No\.)?\s?(\d+-\d+)\b/g,
+    regex: /\b(?:Pub\.\s?L\.|Public\s+Law)(?:\s?No\.)?\s?(\d+-\d+)\b/gd,
     description:
       'Public Law citations: "Pub. L. No. 117-58", "Pub. L. 116-283", "Public Law 116-127", "Public Law No. 116-127"',
     type: "publicLaw",
@@ -150,20 +150,20 @@ export const neutralPatterns: Pattern[] = [
     // Page accepts comma-grouped digits (`12,345` and `1,234,567`). The
     // Federal Register routinely surfaces pages above 10,000 so the
     // comma-grouped form is common. Bare-digit form remains supported.
-    regex: /\b(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d{1,3}(?:,\d{3})+|\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+Fed\.\s?Reg\.\s+(\d{1,3}(?:,\d{3})+|\d+)\b/gd,
     description: 'Federal Register citations (e.g., "86 Fed. Reg. 12,345" or "86 Fed. Reg. 12345")',
     type: "federalRegister",
   },
   {
     id: "statutes-at-large",
     // Page accepts comma-grouped digits to match the federal-register fix.
-    regex: /\b(\d+(?:-\d+)?)\s+Stat\.\s+(\d{1,3}(?:,\d{3})+|\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+Stat\.\s+(\d{1,3}(?:,\d{3})+|\d+)\b/gd,
     description: 'Statutes at Large citations (e.g., "124 Stat. 1,119" or "124 Stat. 119")',
     type: "statutesAtLarge",
   },
   {
     id: "compact-law-review",
-    regex: /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.]+L\.(?:Rev|J|Q)\.)\s+(\d+)\b/g,
+    regex: /\b(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.]+L\.(?:Rev|J|Q)\.)\s+(\d+)\b/gd,
     description: 'Compact law review citations without spaces (e.g., "93 Harv.L.Rev. 752")',
     type: "journal",
   },

--- a/src/patterns/secondaryAuthorityPatterns.ts
+++ b/src/patterns/secondaryAuthorityPatterns.ts
@@ -160,7 +160,7 @@ export const secondaryAuthorityPatterns: Pattern[] = [
     // immediately followed by another alphanumeric. This stops greedy
     // capture at the trailing sentence period (`187.`).
     regex:
-      /\bRestatement\s+\((First|Second|Third|Fourth|1st|2d|3d|4th)\)\s+(?:of\s+)?([A-Za-z][A-Za-z\s,.&'-]+?)\s+§§?\s*(\d+(?:[A-Za-z0-9-]|\.[A-Za-z0-9])*(?:\([^)]*\))*)/g,
+      /\bRestatement\s+\((First|Second|Third|Fourth|1st|2d|3d|4th)\)\s+(?:of\s+)?([A-Za-z][A-Za-z\s,.&'-]+?)\s+§§?\s*(\d+(?:[A-Za-z0-9-]|\.[A-Za-z0-9])*(?:\([^)]*\))*)/gd,
     description:
       'Restatement: "Restatement (Second) of Torts § 402A", "Restatement (Third) of the Law Governing Lawyers § 1" — #578',
     type: "restatement",
@@ -177,7 +177,7 @@ export const secondaryAuthorityPatterns: Pattern[] = [
     // Captures: (1) volume, (2) journal name, (3) page — matches
     // extractJournal's parsing shape exactly.
     id: "bare-journal",
-    regex: new RegExp(`\\b(\\d+)\\s+(${BARE_JOURNAL_ALTERNATION})\\s+(\\d+)\\b`, "g"),
+    regex: new RegExp(`\\b(\\d+)\\s+(${BARE_JOURNAL_ALTERNATION})\\s+(\\d+)\\b`, "gd"),
     description:
       'Bare-abbreviation journals (scientific journals + period-stripped law reviews): "53 Neurology 1107", "70 Brook L Rev 1045" — #638',
     type: "journal",
@@ -195,7 +195,7 @@ export const secondaryAuthorityPatterns: Pattern[] = [
     // fell through to the broad state-reporter regex and emitted as
     // `type: "case"`. #638
     regex:
-      /\b(\d+)\s+(A\.\s?L\.\s?R\.(?:\s?(?:Fed\.(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?|ALR(?:\s?(?:Fed(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?)\s+(\d+)\b/g,
+      /\b(\d+)\s+(A\.\s?L\.\s?R\.(?:\s?(?:Fed\.(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?|ALR(?:\s?(?:Fed(?:\s?\d(?:d|nd|rd|th))?|\d(?:d|nd|rd|th)))?)\s+(\d+)\b/gd,
     description:
       'A.L.R. annotation citations (periodized + bare): "100 A.L.R.2d 1234", "48 ALR 749", "23 A.L.R. Fed. 3d 456" — #581 #638',
     type: "annotation",
@@ -235,7 +235,7 @@ export const secondaryAuthorityPatterns: Pattern[] = [
         `(${TREATISE_ALTERNATION})` +
         `|(?:[A-Z][A-Za-z.]*(?:\\s+[A-Z][A-Za-z.]*)*(?:\\s*&\\s*[A-Z][A-Za-z.]*(?:\\s+[A-Z][A-Za-z.]*)*)?,\\s+)(${TREATISE_BARE_TITLE_ALTERNATION})` +
         `)(?:\\s+\\(([^)]+)\\))?\\s+§§?\\s*(\\d+(?:[.:][A-Za-z0-9]+)*(?:\\[[A-Za-z0-9]+\\])?(?:\\([^)]*\\))*)`,
-      "g",
+      "gd",
     ),
     description:
       'Treatise: "5 Wright & Miller, Federal Practice and Procedure § 1290", "5A Charles Alan Wright & Arthur R. Miller, Federal Practice and Procedure § 1357" (#643), "1 Nimmer on Copyright § 5.05[A]" — #579',

--- a/src/patterns/sessionLawPatterns.ts
+++ b/src/patterns/sessionLawPatterns.ts
@@ -29,13 +29,13 @@ export const NV_SESSION_LAW_RE: RegExp = new RegExp(NV_SRC)
 export const sessionLawPatterns: Pattern[] = [
   {
     id: "ca-session-law",
-    regex: new RegExp(CA_SRC, "g"),
+    regex: new RegExp(CA_SRC, "gd"),
     description: 'California session laws (e.g. "Stats. 1992, ch. 726, § 2, p. 3523")',
     type: "sessionLaw",
   },
   {
     id: "nv-session-law",
-    regex: new RegExp(NV_SRC, "g"),
+    regex: new RegExp(NV_SRC, "gd"),
     description: 'Nevada session laws (e.g. "2003 Nev. Stat., ch. 427, §§ 25-26, at 2590-95")',
     type: "sessionLaw",
   },

--- a/src/patterns/shortForm.ts
+++ b/src/patterns/shortForm.ts
@@ -36,13 +36,13 @@ import type { Pattern } from "./casePatterns"
  *  (`Id., 6.`) keeps working because its digits are not followed by a
  *  capital-letter reporter shape. */
 export const ID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d(?:\s*\.|\s*,(?=\s+at\s))(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]d(?:\s*\.|\s*,(?=\s+at\s))(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/gd
 
 /** Ibid. with optional pincite (less common variant). Paragraph forms (#204)
  *  follow the same convention as Id. Optional space before the period (#305).
  *  Comma-pincite guard (#549) mirrors ID_PATTERN — see comment there. */
 export const IBID_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\s*\.(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /(?:^|(?<=\s)|(?<=["'(\[—]))\b[Ii]bid\s*\.(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s*(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:\s*[-–]\s*\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/gd
 
 /**
  * Supra with party name and optional pincite.
@@ -85,7 +85,7 @@ export const IBID_PATTERN: RegExp =
  * overlapping core spans (~4-5% of CAP opinions).
  */
 export const SUPRA_PATTERN: RegExp =
-  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/g
+  /\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+supra(?:\s+note\s+(\d+))?(?:(?:,\s+(?!\d+\s+[A-Z])|,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b)))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?/gd
 
 /**
  * Standalone supra without party name (common in footnotes).
@@ -97,7 +97,7 @@ export const SUPRA_PATTERN: RegExp =
  * footnote suffix #202, and `¶`/`para.` paragraph markers #204).
  */
 export const STANDALONE_SUPRA_PATTERN: RegExp =
-  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)|\s+(?:§+|Part|p\.)\s*\S+)/g
+  /(?:^|(?<=\s)|(?<=[;.]))supra(?:\s+note\s+(\d+)(?:,?\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?))?|\s+(?:at\s+(?:pp?\.\s*)?|(?=¶|paras?\.?\b))(¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?|\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?)|\s+(?:§+|Part|p\.)\s*\S+)/gd
 
 /**
  * Bracketed supra forms (#306) — `[supra]`, `[supra, 705]`, `[supra at 78-82]`,
@@ -111,7 +111,7 @@ export const STANDALONE_SUPRA_PATTERN: RegExp =
  *   optional range `N-M`).
  */
 export const BRACKETED_SUPRA_PATTERN: RegExp =
-  /(?:\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+)?\[supra(?:(?:,\s+|\s+at\s+(?:pp?\.\s*)?)(\d+(?:[-–—]\d+)?))?\]/g
+  /(?:\b([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*)\s*,?\s+)?\[supra(?:(?:,\s+|\s+at\s+(?:pp?\.\s*)?)(\d+(?:[-–—]\d+)?))?\]/gd
 
 /**
  * Short-form case: [Party,] volume reporter [,] at page
@@ -140,7 +140,7 @@ export const BRACKETED_SUPRA_PATTERN: RegExp =
  * a later pattern.
  */
 export const SHORT_FORM_CASE_PATTERN: RegExp =
-  /\b(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*|pages?\s+)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/g
+  /\b(?:([A-Z][a-zA-Z''\-]+\.?(?:(?:\s+v\.?\s+|\s+&\s+|,\s+|\s+)[A-Z][a-zA-Z''\-]+\.?)*),\s+)?(\d+(?:-\d+)?)\s+([A-Z][A-Za-z.''\s]+?(?:\d[a-z]{1,2})?)\s*,?\s+at\s+(?:pp?\.\s*|pages?\s+)?(\*?\d+(?:[-–—]\*?\d+)?(?:\s+(?:nn?|note)\s*\.?\s*\d+(?:[-–—]\d+)?)?|¶¶?\s*\d+(?:[-–—]\d+)?|paras?\.?\s*\d+(?:[-–—]\d+)?)\b/gd
 
 /** All short-form patterns for tokenization */
 export const SHORT_FORM_PATTERNS: readonly RegExp[] = [

--- a/src/patterns/stateRulePatterns.ts
+++ b/src/patterns/stateRulePatterns.ts
@@ -28,14 +28,14 @@ export const stateRulePatterns: Pattern[] = [
   {
     // Idaho Rule of Civil Procedure — abbreviated I.R.C.P.
     id: "id-rcp",
-    regex: /\bI\.R\.C\.P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    regex: /\bI\.R\.C\.P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description: 'Idaho Rule of Civil Procedure: "I.R.C.P. 60(b)(6)" — #636',
     type: "stateRule",
   },
   {
     // Idaho Rule of Civil Procedure — spelled-out form.
     id: "id-rcp-spelled",
-    regex: /\bIdaho\s+Rules?\s+of\s+Civil\s+Procedure\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gi,
+    regex: /\bIdaho\s+Rules?\s+of\s+Civil\s+Procedure\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gid,
     description: 'Idaho Rule of Civil Procedure (spelled): "Idaho Rule of Civil Procedure 60(b)" — #636',
     type: "stateRule",
   },
@@ -44,14 +44,14 @@ export const stateRulePatterns: Pattern[] = [
     // N.C.R.App. P. (interior spaces are flexible). Both forms appear in
     // NC opinions.
     id: "nc-rap",
-    regex: /\bN\.\s?C\.\s?R\.\s?App\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    regex: /\bN\.\s?C\.\s?R\.\s?App\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description: 'NC Rules of Appellate Procedure: "N.C. R. App. P. 10(b)(1)", "N.C.R.App. P. 37" — #636',
     type: "stateRule",
   },
   {
     // North Carolina Rules of Civil Procedure — N.C. R. Civ. P.
     id: "nc-rcp",
-    regex: /\bN\.\s?C\.\s?R\.\s?Civ\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    regex: /\bN\.\s?C\.\s?R\.\s?Civ\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description: 'NC Rules of Civil Procedure: "N.C. R. Civ. P. 12(b)" — #636',
     type: "stateRule",
   },
@@ -64,14 +64,14 @@ export const stateRulePatterns: Pattern[] = [
     // is outside the capture group; extractor uses patternId to assign
     // jurisdiction + ruleSet).
     id: "sc-scacr-postfix",
-    regex: /\bRule\s+(\d+(?:\.\d+)?(?:\([^)]*\))*),\s*SCACR\b/g,
+    regex: /\bRule\s+(\d+(?:\.\d+)?(?:\([^)]*\))*),\s*SCACR\b/gd,
     description: 'SC Appellate Court Rule (postfix): "Rule 268(d)(2), SCACR" — #636',
     type: "stateRule",
   },
   {
     // U.S. Court of Federal Claims — RCFC.
     id: "rcfc",
-    regex: /\bRCFC\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    regex: /\bRCFC\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description: 'Court of Federal Claims rule: "RCFC 56(c)" — #636',
     type: "stateRule",
   },
@@ -80,7 +80,7 @@ export const stateRulePatterns: Pattern[] = [
     // Tribal court citations have distinctive jurisdiction prefixes that
     // follow the same shape as state-rule patterns. #658
     id: "hcn-rcp",
-    regex: /\bHCN\s+R\.\s?Civ\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    regex: /\bHCN\s+R\.\s?Civ\.\s?P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description: 'Ho-Chunk Nation Rules of Civil Procedure: "HCN R. Civ. P. 5(C)(1)" — #658',
     type: "stateRule",
   },
@@ -88,7 +88,7 @@ export const stateRulePatterns: Pattern[] = [
     // Territorial Courts Rules of Civil Procedure — `T.C.R.C.P. 19(a)`.
     // Used by territorial / tribal courts (US Virgin Islands among others).
     id: "tcrcp",
-    regex: /\bT\.C\.R\.C\.P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/g,
+    regex: /\bT\.C\.R\.C\.P\.\s+(\d+(?:\.\d+)?(?:\([^)]*\))*)/gd,
     description: 'Territorial Courts Rules of Civil Procedure: "T.C.R.C.P. 19(a)" — #658',
     type: "stateRule",
   },

--- a/src/patterns/statutePatterns.ts
+++ b/src/patterns/statutePatterns.ts
@@ -59,7 +59,7 @@ export const statutePatterns: Pattern[] = [
     // guard `(?![^)]*\d{4})` lives INSIDE the subsection body (after
     // the section digits) and is preserved intact by this fix. #587
     regex:
-      /\b(\d+)\s*,?\s+(?:U\.?S\.?C\.?[AS]?\.?|USC[AS]?|United\s+States\s+Code)\s*,?\s*(?:§§?|[Ss]ections?|[Ss]ec\.?)?\s*(\d+[A-Za-z0-9-]*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/g,
+      /\b(\d+)\s*,?\s+(?:U\.?S\.?C\.?[AS]?\.?|USC[AS]?|United\s+States\s+Code)\s*,?\s*(?:§§?|[Ss]ections?|[Ss]ec\.?)?\s*(\d+[A-Za-z0-9-]*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/gd,
     description:
       'U.S. Code citations (U.S.C., USC, USCA, USCS, "United States Code") with optional §/Section connector — #428 #584 #586 #587',
     type: "statute",
@@ -81,7 +81,7 @@ export const statutePatterns: Pattern[] = [
     // § 226`) — symmetric to the USC fix for #586. The trailing letter
     // alternation is USC-only.
     regex:
-      /\b(\d+)\s*,?\s+C\.?F\.?R\.?\s*,?\s*(?:(?:Part|pt\.)\s+|§§?\s*|[Ss]ections?\s+|[Ss]ec\.?\s+)?(\d+(?:\.\d+)?[A-Za-z0-9-]*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/g,
+      /\b(\d+)\s*,?\s+C\.?F\.?R\.?\s*,?\s*(?:(?:Part|pt\.)\s+|§§?\s*|[Ss]ections?\s+|[Ss]ec\.?\s+)?(\d+(?:\.\d+)?[A-Za-z0-9-]*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/gd,
     description:
       'Code of Federal Regulations with optional Part/§/Section connector — #428 #587',
     type: "statute",
@@ -99,7 +99,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "irc",
     regex:
-      /\b(?:I\.R\.C\.|IRC)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(?:I\.R\.C\.|IRC)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/gd,
     description: 'Internal Revenue Code: "I.R.C. § 1367", "IRC § 1341" — #376',
     type: "statute",
   },
@@ -114,7 +114,7 @@ export const statutePatterns: Pattern[] = [
     // excluded by the internal-`.` rule (dot only followed by alphanumeric).
     id: "ussg",
     regex:
-      /\b(?:U\.S\.S\.G\.|USSG)\s*§§?\s*(\d+(?:[A-Za-z0-9-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+      /\b(?:U\.S\.S\.G\.|USSG)\s*§§?\s*(\d+(?:[A-Za-z0-9-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/gd,
     description: 'U.S. Sentencing Guidelines: "U.S.S.G. § 2K2.4(b)", "USSG § 3E1.1" — #577',
     type: "statute",
   },
@@ -129,13 +129,13 @@ export const statutePatterns: Pattern[] = [
     // specificity (postfix form) is listed first so it wins overlap dedup.
     id: "bankruptcy-code-postfix",
     regex:
-      /§§?\s*(\d+(?:[A-Za-z0-9-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)\s+of\s+the\s+Bankruptcy\s+Code/g,
+      /§§?\s*(\d+(?:[A-Za-z0-9-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)\s+of\s+the\s+Bankruptcy\s+Code/gd,
     description: 'Bankruptcy Code postfix alias: "§ 547 of the Bankruptcy Code" → 11 U.S.C. — #585',
     type: "statute",
   },
   {
     id: "bankruptcy-code-prefix",
-    regex: /\bBankruptcy\s+Code\s*§§?\s*(\d+(?:[A-Za-z0-9-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+    regex: /\bBankruptcy\s+Code\s*§§?\s*(\d+(?:[A-Za-z0-9-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/gd,
     description:
       'Bankruptcy Code prefix alias: "Bankruptcy Code § 548(a)(1)(B)(i)" → 11 U.S.C. — #585',
     type: "statute",
@@ -152,7 +152,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) chapter body — digits + optional hyphen-letter suffix
     // (NH uses forms like `169-D`, `458-C`).
     id: "rsa-chapter",
-    regex: /\bRSA\s+(?:\[chapter\]|chapter|ch\.?)\s+(\d+(?:-[A-Z])?)/g,
+    regex: /\bRSA\s+(?:\[chapter\]|chapter|ch\.?)\s+(\d+(?:-[A-Z])?)/gd,
     description:
       'New Hampshire RSA chapter-only form: "RSA chapter 169-D" / "RSA ch. 458-C" — #378',
     type: "statute",
@@ -165,7 +165,7 @@ export const statutePatterns: Pattern[] = [
     //
     // Captures: (1) chapter number.
     id: "oh-chapter",
-    regex: /\bR\.?\s*C\.?\s+Chapter\s+(\d+)/g,
+    regex: /\bR\.?\s*C\.?\s+Chapter\s+(\d+)/gd,
     description:
       'Ohio Revised Code chapter-only form: "R.C. Chapter 4509" / "R. C. Chapter 1702" — #388',
     type: "statute",
@@ -178,13 +178,13 @@ export const statutePatterns: Pattern[] = [
     //
     // Captures: (1) chapter number.
     id: "ors-chapter",
-    regex: /\bORS\s+chapter\s+(\d+)/g,
+    regex: /\bORS\s+chapter\s+(\d+)/gd,
     description: 'Oregon Revised Statutes chapter-only form: "ORS chapter 34" — #387',
     type: "statute",
   },
   {
     id: "prose",
-    regex: /\b[Ss]ection\s+(\d+[A-Za-z0-9-]*(?:\([^)]*\))*)\s+of\s+title\s+(\d+)\b/g,
+    regex: /\b[Ss]ection\s+(\d+[A-Za-z0-9-]*(?:\([^)]*\))*)\s+of\s+title\s+(\d+)\b/gd,
     description:
       'Prose-form federal citations (e.g., "section 1983 of title 42"). Note: MD-style "section X of the Y Article" deferred to PR 3.',
     type: "statute",
@@ -211,7 +211,7 @@ export const statutePatterns: Pattern[] = [
     // (paren and/or bracket groups, possibly space-separated).
     id: "ny-cplr-bare",
     regex:
-      /\b(?:N\.\s*Y\.\s*)?C\.?\s*P\.?\s*L\.?\s*R\.?\s*(?:§§?\s*)?(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*)((?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)/g,
+      /\b(?:N\.\s*Y\.\s*)?C\.?\s*P\.?\s*L\.?\s*R\.?\s*(?:§§?\s*)?(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*)((?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)/gd,
     description:
       'New York CPLR bare/dotted/§ forms: "CPLR 3025 (b)", "C.P.L.R. § 3211", "N.Y. C.P.L.R. § 211" — #592',
     type: "statute",
@@ -234,7 +234,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) acronym, (2) section body, (3) optional subsection chain.
     id: "ny-acronym-bare",
     regex:
-      /\b(?:N\.\s*Y\.\s*)?(RPAPL|RPL|BCL|EPTL|SCPA|DRL|LLCL|VTL)\s*(?:§§?\s*)?(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*)((?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)/g,
+      /\b(?:N\.\s*Y\.\s*)?(RPAPL|RPL|BCL|EPTL|SCPA|DRL|LLCL|VTL)\s*(?:§§?\s*)?(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*)((?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)/gd,
     description:
       'New York acronymized codes (RPAPL/RPL/BCL/EPTL/SCPA/DRL/LLCL/VTL) with bracket-or-paren subdivisions: "RPAPL 711 [5]", "EPTL § 5-1.1" — #640',
     type: "statute",
@@ -250,7 +250,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) title, (2) code, (3) section body with subsection chain.
     id: "lpra",
     regex:
-      /\b(\d+)\s+(L\.P\.R\.A\.|LPRA)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+      /\b(\d+)\s+(L\.P\.R\.A\.|LPRA)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/gd,
     description:
       'Puerto Rico statutes (Leyes de Puerto Rico Anotadas): "23 LPRA § 72", "21 L.P.R.A. § 4615" — #635',
     type: "statute",
@@ -280,7 +280,7 @@ export const statutePatterns: Pattern[] = [
     // field — symmetric to the federal USC pattern and the bare
     // abbreviated-code patterns.
     regex:
-      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s?)Va\.?|Ala(?:bama)?\.?)\s+([A-Z][A-Za-z.&']*(?:(?:\s+|,\s+)(?:&|[A-Z][A-Za-z.&']*))*)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:,?\s+(?:subd\.|subdivision|paragraphs?|pars?\.)\s+(?:\([^)]*\)|\[[^\]]*\])(?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)?(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/g,
+      /\b(N\.?\s*Y\.?|Cal(?:ifornia)?\.?|Tex(?:as)?\.?|Md\.?|(?<!W\.?\s?)Va\.?|Ala(?:bama)?\.?)\s+([A-Z][A-Za-z.&']*(?:(?:\s+|,\s+)(?:&|[A-Z][A-Za-z.&']*))*)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:,?\s+(?:subd\.|subdivision|paragraphs?|pars?\.)\s+(?:\([^)]*\)|\[[^\]]*\])(?:\s*(?:\([^)]*\)|\[[^\]]*\]))*)?(?:\s*[-–—]+\s*\([A-Za-z0-9]+\))?(?:\s*et\s+seq\.?)?)/gd,
     description:
       "Named-code state citations (NY, CA, TX, MD, VA, AL) with jurisdiction prefix + code name + §",
     type: "statute",
@@ -302,7 +302,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) code name, (2) section body with bracket/paren chain.
     id: "ny-bare-named-code",
     regex:
-      /\b(Penal|Labor|Real Property|General Business|General Obligations|General Municipal|Municipal Home Rule|Criminal Procedure|Insurance|Executive|Judiciary|Civil Practice|Civil Rights|Education|Public Health|Banking|Domestic Relations|Environmental Conservation|Election|Social Services|Estates Powers and Trusts|Vehicle and Traffic|Surrogate's Court Procedure|Family Court|Court of Claims|Workers' Compensation|Highway|Tax|Personal Property)\s+Law\s+§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s+(?:\([^)]*\)|\[[^\]]*\]))*)/g,
+      /\b(Penal|Labor|Real Property|General Business|General Obligations|General Municipal|Municipal Home Rule|Criminal Procedure|Insurance|Executive|Judiciary|Civil Practice|Civil Rights|Education|Public Health|Banking|Domestic Relations|Environmental Conservation|Election|Social Services|Estates Powers and Trusts|Vehicle and Traffic|Surrogate's Court Procedure|Family Court|Court of Claims|Workers' Compensation|Highway|Tax|Personal Property)\s+Law\s+§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*(?:\s+(?:\([^)]*\)|\[[^\]]*\]))*)/gd,
     description:
       'New York bare named-code form: "Penal Law § 130.00 [3]", "Labor Law § 220 [3-a]" — #386',
     type: "statute",
@@ -323,7 +323,7 @@ export const statutePatterns: Pattern[] = [
     // section digits and subsection paren, with negative lookahead to
     // exclude year-of-edition parens (`(1976)`, `(West 2018)`).
     regex:
-      /\b(Mass\.?\s*Gen\.?\s*Laws|General\s+Laws|M\.?G\.?L\.?A?\.?|A\.?L\.?M\.?|G\.?\s*L\.?)\s*(?:ch\.?|c\.?)\s*(\w+)(?:,?\s*(?:§§?|[Ss]ec\.?|[Ss]ection)\s*(\w+(?:[\w/-]|\.(?=\w))*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*et\s+seq\.?)?))?/g,
+      /\b(Mass\.?\s*Gen\.?\s*Laws|General\s+Laws|M\.?G\.?L\.?A?\.?|A\.?L\.?M\.?|G\.?\s*L\.?)\s*(?:ch\.?|c\.?)\s*(\w+)(?:,?\s*(?:§§?|[Ss]ec\.?|[Ss]ection)\s*(\w+(?:[\w/-]|\.(?=\w))*(?:\s*\((?![^)]*\d{4})[^)]*\))*(?:\s*et\s+seq\.?)?))?/gd,
     description: 'Massachusetts chapter-based citations (e.g., "Mass. Gen. Laws ch. 93A, § 2")',
     type: "statute",
   },
@@ -338,7 +338,7 @@ export const statutePatterns: Pattern[] = [
     // the section field (`5 ILCS 100/1-1.` → section "1-1", not "1-1.";
     // #283 / #331).
     regex:
-      /\b(\d+)\s+(?:ILCS|Ill\.?\s*Comp\.?\s*Stat\.?)\s*(?:Ann\.?\s+)?(\d+)\/(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(\d+)\s+(?:ILCS|Ill\.?\s*Comp\.?\s*Stat\.?)\s*(?:Ann\.?\s+)?(\d+)\/(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/gd,
     description: 'Illinois Compiled Statutes chapter-act citations (e.g., "735 ILCS 5/2-1001")',
     type: "statute",
   },
@@ -356,7 +356,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) year-of-edition, (2) chapter (incl. letter suffix `110A`),
     //   (3) paragraph body (subparagraphs + et seq.).
     regex:
-      /\bIll\.?\s*Rev\.?\s*Stat\.?,?\s+(\d{4}),?\s+[Cc]h(?:ap)?\.\s+(\d+[A-Z]?),?\s+pars?\.\s+(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\bIll\.?\s*Rev\.?\s*Stat\.?,?\s+(\d{4}),?\s+[Cc]h(?:ap)?\.\s+(\d+[A-Z]?),?\s+pars?\.\s+(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/gd,
     description: "Illinois Revised Statutes (pre-1993): Ill. Rev. Stat. YYYY, ch. N, par. N",
     type: "statute",
   },
@@ -369,7 +369,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) edition year, (2) section body.
     id: "rlh",
     regex:
-      /\bRLH\s+(\d{4})\s+§\s+(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\bRLH\s+(\d{4})\s+§\s+(\d+(?:[A-Za-z0-9:-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/gd,
     description: 'Revised Laws of Hawaii (pre-1955): "RLH 1935 § 2545" — #359',
     type: "statute",
   },
@@ -389,7 +389,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body, (2) optional edition year (1963/1973).
     id: "colorado-prose",
     regex:
-      /\b[Ss]ection\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Colo(?:rado)?\.?\s+Rev(?:ised)?\.?\s+Stat(?:utes)?\.?(?:\s+Ann(?:otated)?\.?)?(?:\s+(19\d{2}))?/g,
+      /\b[Ss]ection\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Colo(?:rado)?\.?\s+Rev(?:ised)?\.?\s+Stat(?:utes)?\.?(?:\s+Ann(?:otated)?\.?)?(?:\s+(19\d{2}))?/gd,
     description:
       'Pre-1973 Colorado prose form: "Section 148-21-34, Colorado Revised Statutes 1963" — #352',
     type: "statute",
@@ -411,7 +411,7 @@ export const statutePatterns: Pattern[] = [
     // `\b` wouldn't anchor at end-of-string. The closed alternation
     // (`Florida Statutes | Fla. Stat.`) is specific enough on its own.
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+(?:Florida\s+Statutes|Fla\.\s*Stat\.)/gd,
     description:
       'Florida postfix statute form: "section 812.035(7), Florida Statutes" / "§83.15, Florida Statutes" — #356',
     type: "statute",
@@ -425,7 +425,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "florida-prefix-spelled",
     regex:
-      /\bFlorida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?)/g,
+      /\bFlorida\s+Statutes?\s*§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?)/gd,
     description:
       'Florida spelled-out prefix form: "Florida Statute 679.504(3)" / "Florida Statutes §73.071" — #356',
     type: "statute",
@@ -440,7 +440,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "idaho-postfix",
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+Idaho\s+Code(?:\s+Ann\.?)?/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+Idaho\s+Code(?:\s+Ann\.?)?/gd,
     description: 'Idaho postfix statute form: "Section 23-908(4), Idaho Code" — #360',
     type: "statute",
   },
@@ -454,7 +454,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "mca-postfix",
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+MCA/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+MCA/gd,
     description: 'Montana Code Annotated postfix form: "§ 77-6-205(2), MCA" — #372',
     type: "statute",
   },
@@ -467,7 +467,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "tca-postfix",
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+T\.?C\.?A\.?/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|[Ss]ec\.?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s+et\s+seq\.?)?),?\s+T\.?C\.?A\.?/gd,
     description: 'Tennessee Code Annotated postfix form: "§ 39-904, T.C.A." — #398',
     type: "statute",
   },
@@ -481,7 +481,7 @@ export const statutePatterns: Pattern[] = [
     //
     // Captures: (1) chapter body in NN.NN form.
     id: "rcw-chapter-postfix",
-    regex: /\b[Cc]hapter\s+(\d+\.\d+)\s+RCW/g,
+    regex: /\b[Cc]hapter\s+(\d+\.\d+)\s+RCW/gd,
     description: 'Washington RCW chapter postfix form: "chapter 49.60 RCW" — #408',
     type: "statute",
   },
@@ -500,7 +500,7 @@ export const statutePatterns: Pattern[] = [
     // pattern only fires for real admin-code references.
     id: "state-admin-code",
     regex:
-      /\b(?:(NMAC)\s+(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)|(?<=^|[^A-Za-z])(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)\s+(NMAC)|(OAR)\s+(\d+-\d+-\d+)|(COMAR)\s+(\d+\.\d+\.\d+\.\d+[A-Z]?)|(IDAPA)\s+(\d+\.\d+\.\d+\.\d+\.\d+)|(?<=^|[^A-Za-z])(\d+\.\d+\.\d+(?:\(\d+\))?),\s+(ARM)\b)/g,
+      /\b(?:(NMAC)\s+(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)|(?<=^|[^A-Za-z])(\d+\.\d+\.\d+\.\d+(?:\([A-Z]\))?)\s+(NMAC)|(OAR)\s+(\d+-\d+-\d+)|(COMAR)\s+(\d+\.\d+\.\d+\.\d+[A-Z]?)|(IDAPA)\s+(\d+\.\d+\.\d+\.\d+\.\d+)|(?<=^|[^A-Za-z])(\d+\.\d+\.\d+(?:\(\d+\))?),\s+(ARM)\b)/gd,
     description: "State admin codes NMAC/OAR/COMAR/IDAPA/ARM — #438",
     type: "statute",
   },
@@ -516,7 +516,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body.
     id: "wi-stats-postfix",
     regex:
-      /(?<![A-Za-z])(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*(?:\s+et\s+seq\.?)?),?\s+(?:Stats\.|STATS\.)/g,
+      /(?<![A-Za-z])(?:§§?|[Ss]ections?|[Ss]ec\.?)\s*(\d+\.\d+(?:[A-Za-z0-9])?(?:\s*\([^)]*\))*[A-Za-z0-9]*(?:\s+et\s+seq\.?)?),?\s+(?:Stats\.|STATS\.)/gd,
     description:
       'Wisconsin Statutes postfix form: "§ 76.09, Stats." / "sec. 805.13(3), Stats." — #414',
     type: "statute",
@@ -533,7 +533,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) section body, (2) optional Reissue year.
     id: "rrs-1943",
     regex:
-      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+R\.?\s*R\.?\s*S\.?\s+1943(?:,\s+Reissue\s+(\d{4}))?/g,
+      /(?<![A-Za-z])(?:[Ss]ections?|§§?)\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+R\.?\s*R\.?\s*S\.?\s+1943(?:,\s+Reissue\s+(\d{4}))?/gd,
     description:
       'Nebraska Reissue Revised Statutes 1943: "§ 30-2806, R.R.S. 1943, Reissue 1975" — #373',
     type: "statute",
@@ -549,7 +549,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) optional reenactment year, (2) section body.
     id: "rigl-1956",
     regex:
-      /\bG\.?\s*L\.?\s+1956\s*(?:\((\d{4})\s+Reenactment\))?\s*,?\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+      /\bG\.?\s*L\.?\s+1956\s*(?:\((\d{4})\s+Reenactment\))?\s*,?\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/gd,
     description: 'Rhode Island General Laws 1956: "G.L. 1956 (1969 Reenactment) §11-23-1" — #393',
     type: "statute",
   },
@@ -569,7 +569,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) code-letter prefix, (2) section body.
     id: "md-article-letter",
     regex:
-      /\b(AB|AG|BO|BR|CJ|CL|CP|CR|CS|EC|ED|EL|EN|ET|FI|FL|GP|HG|HO|HS|HU|IN|LE|LG|LU|NR|PS|PUC|R\.?P\.?|RP|SF|SG|TA|TG|TP|TR)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/g,
+      /\b(AB|AG|BO|BR|CJ|CL|CP|CR|CS|EC|ED|EL|EN|ET|FI|FL|GP|HG|HO|HS|HU|IN|LE|LG|LU|NR|PS|PUC|R\.?P\.?|RP|SF|SG|TA|TG|TP|TR)\s*§§?\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*(?:\s*et\s+seq\.?)?)/gd,
     description:
       'Maryland article-letter codes: "HG § 19-906", "CP § 10-105", "R.P. § 8-211" — #368',
     type: "statute",
@@ -585,7 +585,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) edition year, (2) section body.
     id: "minn-st-year-edition",
     regex:
-      /\bMinn\.?\s+(?:Stat|St)\.?\s+(19\d{2}),\s*§\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*)/g,
+      /\bMinn\.?\s+(?:Stat|St)\.?\s+(19\d{2}),\s*§\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\)|\[[^\]]*\])*)/gd,
     description: 'Minnesota Statutes year-edition form: "Minn. St. 1971, § 176.66" — #371',
     type: "statute",
   },
@@ -602,7 +602,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) edition year, (2) optional Supp. marker, (3) section.
     id: "ksa-year-edition",
     regex:
-      /\bK\.?\s*S\.?\s*A\.?\s+(\d{4})(?:\s+(Supp\.?))?\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9])|,(?=\d))*(?:\([^)]*\))*)/g,
+      /\bK\.?\s*S\.?\s*A\.?\s+(\d{4})(?:\s+(Supp\.?))?\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9])|,(?=\d))*(?:\([^)]*\))*)/gd,
     description: 'Kansas Statutes Annotated year-edition: "K.S.A. 2009 Supp. 44-501(d)(2)" — #367',
     type: "statute",
   },
@@ -616,7 +616,7 @@ export const statutePatterns: Pattern[] = [
     //
     // Captures: (1) edition year, (2) section body.
     id: "ic-year-edition",
-    regex: /\bIC\s+(\d{4}),\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+    regex: /\bIC\s+(\d{4}),\s*(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/gd,
     description: 'Indiana Code year-edition form: "IC 1971, 35-13-4-4" — #363',
     type: "statute",
   },
@@ -650,7 +650,7 @@ export const statutePatterns: Pattern[] = [
     //
     // Captures: (1) optional 1931 year, (2) section body.
     id: "wv-code-1931",
-    regex: /\bCode,?(?:\s+(1931))?,\s+(\d+-\d+[A-Z]?-\d+(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/g,
+    regex: /\bCode,?(?:\s+(1931))?,\s+(\d+-\d+[A-Z]?-\d+(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/gd,
     description:
       'West Virginia historical Code 1931: "Code 1931, 49-6-3, as amended" / "Code, 14-2-13" — #406',
     type: "statute",
@@ -674,7 +674,7 @@ export const statutePatterns: Pattern[] = [
     // to Georgia by the ga-pre-1983 fallback; this prefix-qualified
     // shape now wins span dedup. #594
     regex:
-      /\b(?:N\.\s*Y\.\s*C\.\s*Admin\.?\s+Code|NYC\s+Admin\.?\s+Code|New\s+York\s+City\s+Administrative\s+Code)\s+§§?\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?)((?:\([^)]*\))*)/g,
+      /\b(?:N\.\s*Y\.\s*C\.\s*Admin\.?\s+Code|NYC\s+Admin\.?\s+Code|New\s+York\s+City\s+Administrative\s+Code)\s+§§?\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?)((?:\([^)]*\))*)/gd,
     description:
       'New York City Administrative Code: "N.Y.C. Admin. Code § 8-107(1)(a)" / "New York City Administrative Code § 8-107(1)(a)" — #594',
     type: "statute",
@@ -682,7 +682,7 @@ export const statutePatterns: Pattern[] = [
   {
     id: "ga-pre-1983",
     regex:
-      /\b(Code(?:\s+Ann\.?)?)\s+§\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/g,
+      /\b(Code(?:\s+Ann\.?)?)\s+§\s*(\d+-\d+(?![\d-])(?!\.\d)(?:[A-Za-z0-9])?(?:\([A-Za-z0-9]+\))*)/gd,
     description:
       'Georgia pre-1983 Code: "Code Ann. § 26-2101" / "Code § 27-2501" — #358 (#405 tightened)',
     type: "statute",
@@ -702,7 +702,7 @@ export const statutePatterns: Pattern[] = [
     // Captures: (1) "Virginia Code" or "Code", (2) section body.
     id: "va-bare-code",
     regex:
-      /\b(Virginia\s+Code|Code)\s+§\s*((?:\d+\.\d+-\d+(?:\.\d+)?|\d+-\d+\.\d+)(?:\([A-Za-z0-9]+\))*)/g,
+      /\b(Virginia\s+Code|Code)\s+§\s*((?:\d+\.\d+-\d+(?:\.\d+)?|\d+-\d+\.\d+)(?:\([A-Za-z0-9]+\))*)/gd,
     description:
       'Virginia bare Code form: "Code § 18.2-308.2" / "Virginia Code § 8.01-581.17" — #405',
     type: "statute",
@@ -725,7 +725,7 @@ export const statutePatterns: Pattern[] = [
     // (`[3]`) so `§ N-N-N(A)(1.5)` is captured in full. The dot inside
     // parens was missing previously, dropping decimal subsections. (#565)
     regex:
-      /(?<![A-Za-z])(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9.]+\)|\[[A-Za-z0-9.]+\])*)/g,
+      /(?<![A-Za-z])(?:§\s*|[Ss]ection\s+)(\d+[A-Z]?-\d+[A-Z]?-\d+[A-Z]?(?:\([A-Za-z0-9.]+\)|\[[A-Za-z0-9.]+\])*)/gd,
     description:
       'New Mexico bare-section form: "Section 32A-2-7(A)" / "§ 41-2-2" — #382 (#565 decimal subsection)',
     type: "statute",
@@ -746,7 +746,7 @@ export const statutePatterns: Pattern[] = [
     // 1940 in the extractor (the prefix asserts 1940). #343
     id: "ala-code-prefix",
     regex:
-      /\bCode(?:\s+of\s+Alabama)?,?\s+1940,?\s+T(?:itle|it)?\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/g,
+      /\bCode(?:\s+of\s+Alabama)?,?\s+1940,?\s+T(?:itle|it)?\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)/gd,
     description:
       'Alabama Code 1940 (Code-prefix form, pre-1975): "Code 1940, T. 15, § 389" / "Code of Alabama 1940, T. NN, § NNN" — #343',
     type: "statute",
@@ -760,7 +760,7 @@ export const statutePatterns: Pattern[] = [
     // (4) optional recompilation year.
     id: "ala-title-trailer",
     regex:
-      /\bTitle\s+(\d+),?\s+(?:§|Sec(?:tion)?s?\.?)\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?/g,
+      /\bTitle\s+(\d+),?\s+(?:§|Sec(?:tion)?s?\.?)\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*),?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?/gd,
     description:
       'Alabama Code (Title-first with Code trailer): "Title 26, Section 214, Code of Alabama 1940, as Recompiled 1958" — #343',
     type: "statute",
@@ -773,7 +773,7 @@ export const statutePatterns: Pattern[] = [
     // (3) optional edition year, (4) optional recompilation year.
     id: "ala-tit-bare",
     regex:
-      /\bTit\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)(?:,?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?)?/g,
+      /\bTit\.\s+(\d+),?\s+§\s+(\d+(?:[A-Za-z0-9:/-]|\.(?=[A-Za-z0-9]))*(?:\([^)]*\))*)(?:,?\s+Code(?:\s+of\s+Alabama)?,?\s+(\d{4})(?:,?\s+(?:as\s+)?[Rr]ecompiled\s+(\d{4}))?)?/gd,
     description: 'Alabama Code (abbreviated `Tit.` form): "Tit. 52, § 361" — #343',
     type: "statute",
   },

--- a/src/patterns/treatyPatterns.ts
+++ b/src/patterns/treatyPatterns.ts
@@ -26,13 +26,13 @@ export const TREATY_VOL_PAGE_RE: RegExp = new RegExp(VOL_PAGE_SRC)
 export const treatyPatterns: Pattern[] = [
   {
     id: "treaty-series-no",
-    regex: new RegExp(SERIES_NO_SRC, "g"),
+    regex: new RegExp(SERIES_NO_SRC, "gd"),
     description: 'Treaty series citations (e.g. "T.I.A.S. No. 1502")',
     type: "treaty",
   },
   {
     id: "treaty-volume-page",
-    regex: new RegExp(VOL_PAGE_SRC, "g"),
+    regex: new RegExp(VOL_PAGE_SRC, "gd"),
     description: 'Treaty volume-series-page citations (e.g. "1155 U.N.T.S. 331", "123 U.S.T. 456")',
     type: "treaty",
   },

--- a/src/tokenize/tokenizer.ts
+++ b/src/tokenize/tokenizer.ts
@@ -36,6 +36,18 @@ export interface Token {
 
   /** Pattern ID that matched this token */
   patternId: string
+
+  /**
+   * Named capture groups of the matching pattern. Present only for patterns
+   * that declare named groups; non-participating groups are omitted. (#844)
+   */
+  groups?: Record<string, string>
+
+  /**
+   * Token-relative [start, end] offsets for each participating named group.
+   * Same key set as `groups`. (#844)
+   */
+  groupSpans?: Record<string, [number, number]>
 }
 
 /**

--- a/src/tokenize/tokenizer.ts
+++ b/src/tokenize/tokenizer.ts
@@ -102,7 +102,7 @@ export function tokenize(
 
       for (const match of matches) {
         // Create token from match
-        tokens.push({
+        const token: Token = {
           text: match[0],
           span: {
             cleanStart: match.index!,
@@ -110,7 +110,32 @@ export function tokenize(
           },
           type: pattern.type,
           patternId: pattern.id,
-        })
+        }
+
+        // Thread named groups (#844). Only patterns with named groups populate
+        // `match.groups`; positional patterns thread nothing.
+        if (match.groups) {
+          const groups: Record<string, string> = {}
+          const groupSpans: Record<string, [number, number]> = {}
+          // NOTE: lib types `indices.groups` as non-optional [number,number];
+          // at runtime a non-participating named group is `undefined`. Guard it.
+          const indices = match.indices?.groups as
+            | Record<string, [number, number] | undefined>
+            | undefined
+          for (const name of Object.keys(match.groups)) {
+            const value = match.groups[name]
+            if (value === undefined) continue
+            groups[name] = value
+            const gi = indices?.[name]
+            if (gi) groupSpans[name] = [gi[0] - match.index!, gi[1] - match.index!]
+          }
+          if (Object.keys(groups).length > 0) {
+            token.groups = groups
+            token.groupSpans = groupSpans
+          }
+        }
+
+        tokens.push(token)
       }
     } catch (error) {
       // Timeout protection: If pattern throws (ReDoS, etc.), skip it

--- a/tests/extract/groupAccessor.test.ts
+++ b/tests/extract/groupAccessor.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { CitationParseError } from "@/extract"
+import { groupSpan, optionalGroup, requireGroup } from "@/extract/groupAccessor"
+import type { Token } from "@/tokenize"
+
+const tok = (groups?: Record<string, string>, groupSpans?: Record<string, [number, number]>): Token => ({
+  text: "410 U.S. 113",
+  span: { cleanStart: 0, cleanEnd: 12 },
+  type: "case",
+  patternId: "t",
+  groups,
+  groupSpans,
+})
+
+describe("groupAccessor (#844)", () => {
+  it("requireGroup returns the value or declines via CitationParseError", () => {
+    expect(requireGroup(tok({ volume: "410" }), "volume")).toBe("410")
+    expect(() => requireGroup(tok({ volume: "410" }), "page")).toThrow(CitationParseError)
+    expect(() => requireGroup(tok(undefined), "volume")).toThrow(CitationParseError)
+  })
+
+  it("optionalGroup returns the value or undefined", () => {
+    expect(optionalGroup(tok({ volume: "410" }), "volume")).toBe("410")
+    expect(optionalGroup(tok({ volume: "410" }), "page")).toBeUndefined()
+    expect(optionalGroup(tok(undefined), "volume")).toBeUndefined()
+  })
+
+  it("groupSpan returns the token-relative span or undefined", () => {
+    expect(groupSpan(tok({ volume: "410" }, { volume: [0, 3] }), "volume")).toEqual([0, 3])
+    expect(groupSpan(tok({ volume: "410" }), "volume")).toBeUndefined()
+  })
+})

--- a/tests/patterns/grammarOrder.test.ts
+++ b/tests/patterns/grammarOrder.test.ts
@@ -68,3 +68,20 @@ describe("authoritative pattern grammar order (#844)", () => {
     expect(idx(journalPatterns[0].id)).toBeGreaterThan(caseIdx)
   })
 })
+
+describe("capture-group threading invariants (#844)", () => {
+  it("every pattern compiles on the minimum supported Node", () => {
+    for (const p of orderedPatterns) {
+      // Recompiling proves the source+flags are valid on THIS runtime (CI floor = Node 22),
+      // catching e.g. duplicate-named-group syntax that older engines reject.
+      expect(() => new RegExp(p.regex.source, p.regex.flags), p.id).not.toThrow()
+    }
+  })
+
+  it("every pattern carries the g and d flags", () => {
+    for (const p of orderedPatterns) {
+      expect(p.regex.flags, `${p.id} missing g`).toContain("g")
+      expect(p.regex.flags, `${p.id} missing d`).toContain("d")
+    }
+  })
+})

--- a/tests/tokenize/threading.test.ts
+++ b/tests/tokenize/threading.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { tokenize } from "@/tokenize"
+import type { Pattern } from "@/patterns"
+
+// A throwaway pattern with named groups + an optional (non-participating) group.
+const NAMED: Pattern = {
+  id: "test-named",
+  regex: /(?<vol>\d+)\s+(?<rep>U\.S\.)(?:\s+\((?<nom>\d+)\))?\s+(?<page>\d+)/gd,
+  description: "test",
+  type: "case",
+}
+
+describe("tokenize() threads named groups (#844)", () => {
+  it("threads groups + token-relative spans, omitting non-participating groups", () => {
+    const text = "see 410 U.S. 113 here"
+    const [tok] = tokenize(text, [NAMED])
+    expect(tok.groups).toEqual({ vol: "410", rep: "U.S.", page: "113" }) // no `nom`
+    // token starts at index 4 ("410..."); spans are token-relative.
+    expect(tok.groupSpans?.vol).toEqual([0, 3])
+    expect(tok.groupSpans?.page).toEqual([9, 12])
+    expect(tok.groupSpans?.nom).toBeUndefined()
+  })
+
+  it("threads nothing for a pattern without named groups", () => {
+    const positional: Pattern = { id: "pos", regex: /(\d+) U\.S\. (\d+)/gd, description: "x", type: "case" }
+    const [tok] = tokenize("410 U.S. 113", [positional])
+    expect(tok.groups).toBeUndefined()
+    expect(tok.groupSpans).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Why

Every extractor currently re-runs a *second* "twin" regex over `token.text` to recover the capture groups the tokenizer already matched — the twin-regex split-brain that was the root cause of the #881 crash class (when the two regexes drift, the extractor chokes on what the tokenizer admitted).

**Today:** the tokenizer keeps only `match[0]` and discards the capture groups; each extractor re-derives structure with its own regex.

**After this PR:** the tokenizer threads each pattern's *named* capture groups — plus token-relative offsets — onto the `Token`, and a typed accessor reads them. This is the **substrate only**: no extractor reads the threaded groups yet and no twin regex is removed, so **extraction output is unchanged**. Later PRs migrate extractors to read `token.groups.x` and delete the duplicate re-exec.

This is sub-project A of the "thread the CST forward" slice from `docs/superpowers/specs/2026-06-09-capture-group-threading-design.md` (panel-hardened), implemented per `docs/superpowers/plans/2026-06-10-capture-group-threading-pr1-and-caseCore.md`.

## What changed

- **Runtime floor → Node ≥ 22** (`engines.node`), CI matrix → **22 / 24 / 26**. This is a **breaking** floor bump (was ≥18); it unlocks ES2025 duplicate named capturing groups, which the case-pattern migration (next PR) relies on.
- **`d` flag added to every pattern regex** (101 across 15 modules + 2 data-layer builders) — exposes `match.indices` for group offsets. **Flags only — no regex source changed** (machine-verified: the 101 removed vs. added regex bodies are identical multisets).
- **Additive `Token.groups` / `Token.groupSpans`** (optional — every existing `Token` literal stays valid).
- **`tokenize()` threads named groups**: only for patterns that declare named groups; non-participating groups are omitted (not stored as `undefined`/`NaN`); offsets are token-relative (`abs − match.index`).
- **`src/extract/groupAccessor.ts`** — `requireGroup` (declines via `CitationParseError`), `optionalGroup`, `groupSpan`.
- **Grammar-invariant test** — every `orderedPatterns` regex compiles and carries `g` + `d`.

## Test plan

**What I ran (verified by an independent reviewer audit):**
- `pnpm exec vitest run` → **4802 passed**, 10 skipped/8 todo (all pre-existing); the real-opinion corpus test is green. The only test-count delta is the new tests added here.
- `pnpm typecheck` → clean; `pnpm lint` → exit 0 (pre-existing warnings only); `pnpm build` → ok.
- New tests exercise real behavior: `tokenize()` threading (omit non-participating, token-relative spans, positional-pattern-threads-nothing) and the accessor decline path.

## Scope boundary (what this PR does NOT do)

No extractor reads `token.groups` yet; no twin regex is deleted; extraction output is byte-for-byte unchanged. The first extractor migration (`caseCore`) is the next PR.

Relates to #844 (this is its unfinished capture-group-threading half); unblocks #846 / #852 (value objects) and #876 (resolver).

---
Assisted-by: Claude:claude-opus-4-8
