### PR TITLE
fix(extract): link short-form-anchored parallel citations to their case (#884)

### DIFF
--- a/.changeset/parallel-shortform-resolution.md
+++ b/.changeset/parallel-shortform-resolution.md
@@ -1,0 +1,9 @@
+---
+"eyecite-ts": patch
+---
+
+Fix: parallel reporter citations trailing a short-form — or in any citation chain that omits the closing year-parenthetical — are now grouped with, and resolved to, the same case as their anchor, instead of being orphaned with a fresh group id and no resolution (#884).
+
+A run like `Smith, 230 Md. at 236, 146 A.3d at 1202.` or `Neitzke, 490 U.S. at 324, 109 S.Ct. 1827.` now forms one parallel group anchored on the short-form, and the trailing parallels inherit the short-form's antecedent. The root cause was in parallel-chain detection: a tight-linked run was validated link-by-link, so an intermediate cite in a no-paren chain (`A, B, C.`) broke the chain and orphaned the head. Chains are now validated by their last member, so 3+-cite runs without a trailing paren group correctly.
+
+Additive and non-breaking: short-form case citations may now carry `parallelGroup`/`parallelCitations`, and a full reporter citation that trails a short-form as a parallel reference may carry an inherited `resolution`.

--- a/src/extract/detectParallel.ts
+++ b/src/extract/detectParallel.ts
@@ -98,6 +98,19 @@ export function detectParallelCitations(tokens: Token[], cleanedText = ""): Map<
         break // Stop looking once we hit non-case citation
       }
 
+      // A parallel cite always leads with its volume number. A secondary that
+      // re-introduces a party name (e.g. `Smith, 79 N.Y.2d at 552`) is a NEW
+      // case reference — a second short-form, not a parallel of the current
+      // run — so stop here so it isn't absorbed and can anchor its own group.
+      // This keeps every parallel group anchored on a SINGLE short-form (#884):
+      // without it, `Doe, 100 F.3d at 7, 583 N.Y.S.2d 957, Smith, 79 N.Y.2d at
+      // 552` would pull the unrelated Smith reference into Doe's group and
+      // mis-resolve its members. Volume-first short-forms (`146 A.3d at 1202`)
+      // are genuine parallels and stay in the run.
+      if (!/^\s*\d/.test(secondary.text)) {
+        break
+      }
+
       // Check proximity: comma should be right after primary (or previous secondary in chain)
       const prevToken = j === i + 1 ? primary : tokens[j - 1]
       const gapStart = prevToken.span.cleanEnd

--- a/src/extract/detectParallel.ts
+++ b/src/extract/detectParallel.ts
@@ -82,6 +82,11 @@ export function detectParallelCitations(tokens: Token[], cleanedText = ""): Map<
     }
 
     const secondaryIndices: number[] = []
+    // A tight-linked run is a parallel group only once it CLOSES — its LAST
+    // member must be followed by a shared parenthetical or a sentence-end
+    // terminator. Validating per-link (the old behavior) orphaned the head of a
+    // no-trailing-paren chain `A, B, C.` because the `A→B` link saw `, C` (#884).
+    let closed = false
 
     // Look ahead for potential secondary citations
     // Chain detection: "A, B, C (year)" where A is primary, B and C are secondaries
@@ -116,7 +121,7 @@ export function detectParallelCitations(tokens: Token[], cleanedText = ""): Map<
         cleanedText[secondary.span.cleanEnd] === "]"
       if (inBracket) {
         secondaryIndices.push(j)
-        usedAsSecondary.add(j)
+        closed = true // CA bracket form is self-closing
         // CA brackets always close after a single parallel cite — chain ends here.
         break
       }
@@ -164,27 +169,28 @@ export function detectParallelCitations(tokens: Token[], cleanedText = ""): Map<
         break // Separate parentheticals = not parallel, stop looking
       }
 
-      // Check that there IS a parenthetical after the secondary citation
-      // OR that the chain ends at sentence end (`.` / `;` / EOF) (#653).
-      // Sentence-end terminator catches `Kauffman v. Griesemer, 26 Pa. 407,
-      // 67 Am. Dec. 437.` — common when courts omit the year-paren on
-      // older parallel reporters. The tight-gap and intervening-`)` checks
-      // above already prevent unrelated cites from being grouped.
-      if (
-        !hasSharedParenthetical(cleanedText, secondary.span.cleanEnd) &&
-        !isParallelChainTerminator(cleanedText, secondary.span.cleanEnd)
-      ) {
-        break
-      }
-
-      // All conditions met - this is a parallel citation
+      // Tight-linked candidate — collect it. Whether the run is a real parallel
+      // group is decided after the chain ends (the close-check below): an
+      // intermediate cite (`A→B` in `A, B, C.`) need not be a chain terminator
+      // itself — only the LAST member must close the run (#884).
       secondaryIndices.push(j)
-      usedAsSecondary.add(j)
     }
 
-    // If we found any secondary citations, record the group
+    // Record the run only if it CLOSED: the last collected member must be
+    // followed by a shared parenthetical or a sentence-end terminator (#653).
+    // (A CA bracket run already set `closed`.) An unterminated tight run is not
+    // a parallel group — its members stay available as their own primaries.
     if (secondaryIndices.length > 0) {
-      parallelGroups.set(i, secondaryIndices)
+      if (!closed) {
+        const last = tokens[secondaryIndices[secondaryIndices.length - 1]]
+        closed =
+          hasSharedParenthetical(cleanedText, last.span.cleanEnd) ||
+          isParallelChainTerminator(cleanedText, last.span.cleanEnd)
+      }
+      if (closed) {
+        parallelGroups.set(i, secondaryIndices)
+        for (const j of secondaryIndices) usedAsSecondary.add(j)
+      }
     }
   }
 

--- a/src/extract/extractCitations.ts
+++ b/src/extract/extractCitations.ts
@@ -533,8 +533,10 @@ export function extractCitations(
     // Update processing time
     citation.processTimeMs = performance.now() - startTime
 
-    // Populate parallel citation metadata (Phase 8)
-    if (citation.type === "case") {
+    // Populate parallel citation metadata (Phase 8). A shortFormCase can anchor
+    // a parallel-reporter run (`Smith, 79 N.Y.2d at 552, 583 N.Y.S.2d 957`), so
+    // it participates here too (#884).
+    if (citation.type === "case" || citation.type === "shortFormCase") {
       const isPrimary = parallelGroups.has(i)
       const isSecondary = secondaryToGroup.has(i)
 
@@ -666,10 +668,13 @@ export function extractCitations(
     // backs clean-coordinate reads (bracket scopes, trigger asides). Without
     // this, clean-offset reads index the original text and desync once a
     // length-changing cleaner shrinks it.
-    return resolveCitations(filtered, text, resolutionOpts, {
+    const resolved = resolveCitations(filtered, text, resolutionOpts, {
       cleanedText: cleaned,
       transformationMap,
     })
+    // #884: trailing parallels of a resolved short-form inherit its antecedent.
+    propagateParallelResolution(resolved)
+    return resolved
   }
 
   return filtered
@@ -1026,7 +1031,7 @@ function buildParallelGroups(citations: Citation[]): void {
   const groups = new Map<string, number[]>()
   for (let i = 0; i < citations.length; i++) {
     const c = citations[i]
-    if (c.type === "case" && c.groupId !== undefined) {
+    if ((c.type === "case" || c.type === "shortFormCase") && c.groupId !== undefined) {
       const arr = groups.get(c.groupId)
       if (arr) arr.push(i)
       else groups.set(c.groupId, [i])
@@ -1041,7 +1046,44 @@ function buildParallelGroups(citations: Citation[]): void {
     const group: ParallelGroup = { memberIds }
     for (const i of indices) {
       const c = citations[i]
-      if (c.type === "case") c.parallelGroup = group
+      if (c.type === "case" || c.type === "shortFormCase") c.parallelGroup = group
+    }
+  }
+}
+
+/**
+ * #884: a parallel-reporter run can be anchored by a short-form that resolves to
+ * an antecedent (`Smith, 79 N.Y.2d 540 (1992). … Smith, 79 N.Y.2d at 552, 583
+ * N.Y.S.2d 957, 593 N.E.2d 1365.`). The trailing full parallels are the same
+ * case in other reporters, so they inherit the resolved antecedent of whichever
+ * group member resolved — otherwise they carry no link back to the case. Runs
+ * after resolution, reading the parallelGroup built in the structuring pass.
+ */
+function propagateParallelResolution(citations: ResolvedCitation[]): void {
+  const byId = new Map<CitationId, ResolvedCitation>()
+  for (const c of citations) if (c.id !== undefined) byId.set(c.id, c)
+  for (const c of citations) {
+    if (c.type !== "case" && c.type !== "shortFormCase") continue
+    const group = c.parallelGroup
+    // Only fill members that don't already resolve on their own.
+    if (!group || c.resolution?.resolvedToId !== undefined) continue
+    for (const memberId of group.memberIds) {
+      if (memberId === c.id) continue
+      const src = byId.get(memberId)?.resolution
+      if (src?.resolvedToId !== undefined && src.resolvedToId !== c.id) {
+        c.resolution = {
+          resolvedTo: src.resolvedTo,
+          resolvedToId: src.resolvedToId,
+          antecedentIndex: src.antecedentIndex,
+          antecedentId: src.antecedentId,
+          confidence: src.confidence,
+          warnings: [
+            ...(c.resolution?.warnings ?? []),
+            "Inherited antecedent via parallel-citation grouping (#884)",
+          ],
+        }
+        break
+      }
     }
   }
 }

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -6,7 +6,12 @@
  */
 
 import type { FootnoteMap } from "../footnotes/types"
-import type { Citation, CitationId, ShortFormCitation } from "../types/citation"
+import type {
+  Citation,
+  CitationId,
+  FullCaseCitation,
+  ShortFormCitation,
+} from "../types/citation"
 
 /**
  * Scope boundary strategy for resolution.
@@ -136,12 +141,20 @@ export interface ResolutionResult {
  * Citation with resolution metadata.
  *
  * Uses a distributive conditional type so that `resolution` is only
- * meaningfully present on short-form citations (Id., supra, short-form case).
- * On full citations, `resolution` is typed as `undefined`.
+ * meaningfully present on citations that can reference an antecedent:
+ * - Short-form citations (Id., supra, short-form case) always carry the field
+ *   (possibly `undefined` when resolution failed).
+ * - Full case citations carry it *optionally*: normally a full cite is an
+ *   antecedent (no resolution), but a full reporter cite trailing a short-form
+ *   as a parallel reference inherits that short-form's antecedent (#884), so it
+ *   becomes reference-like and may carry a `resolution`.
+ * - All other full citations have `resolution` typed as `undefined`.
  */
 export type ResolvedCitation<C extends Citation = Citation> = C extends ShortFormCitation
   ? C & { resolution: ResolutionResult | undefined }
-  : C & { resolution?: undefined }
+  : C extends FullCaseCitation
+    ? C & { resolution?: ResolutionResult }
+    : C & { resolution?: undefined }
 
 /**
  * Internal context for resolution process.

--- a/src/types/citation.ts
+++ b/src/types/citation.ts
@@ -1405,6 +1405,20 @@ export interface ShortFormCaseCitation extends CitationBase {
    *  `FullCaseCitation`. */
   partyNameNormalized?: string
   /**
+   * Parallel-reporter grouping (#884): a short-form can anchor a parallel run
+   * (`Smith, 79 N.Y.2d at 552, 583 N.Y.S.2d 957, 593 N.E.2d 1365`). These mirror
+   * the same-named fields on {@link FullCaseCitation} — `groupId` is the shared
+   * group key; `parallelGroup` lists all members (incl. self) by id, in document
+   * order; `parallelCitations` is the legacy flat copy on the primary.
+   */
+  groupId?: string
+  parallelGroup?: ParallelGroup
+  parallelCitations?: Array<{
+    volume: number | string
+    reporter: string
+    page: number
+  }>
+  /**
    * Trailing parenthetical content (text between the parens, excluding the
    * parens themselves). See `IdCitation.parenthetical` for common shapes
    * and rationale. #303

--- a/tests/extract/issue884ParallelShortform.test.ts
+++ b/tests/extract/issue884ParallelShortform.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { extractCitations } from "@/extract"
+import type { Citation } from "@/types/citation"
+
+// #884: parallel reporters trailing a short-form (or any no-trailing-paren chain)
+// were orphaned from the case. Root cause: the parallel chain-continuation gate
+// was checked per-link, so an intermediate cite in a no-paren chain broke the
+// chain and the head orphaned. Fix: validate the run by its LAST member, so
+// no-paren chains of 3+ cites group; the short-form/head becomes the anchor and
+// trailing parallels inherit its antecedent resolution.
+
+const run = (text: string): Citation[] => extractCitations(text, { resolve: true })
+const find = (cs: Citation[], m: string) => {
+  const c = cs.find((x) => x.matchedText.includes(m))
+  if (!c) throw new Error(`no citation matching ${m}`)
+  return c
+}
+// parallelGroup / resolution are additive fields not on the base union; read loosely.
+const members = (c: Citation): string[] | undefined =>
+  (c as { parallelGroup?: { memberIds?: string[] } }).parallelGroup?.memberIds
+const resolvedTo = (c: Citation): string | undefined => c.resolution?.resolvedToId
+
+describe("#884 parallel reporters after a short-form / no-paren chain", () => {
+  it("groups a FULL-cite lead's parallels even without a trailing year-paren", () => {
+    const cs = run("Smith v. Jones, 79 N.Y.2d 540, 583 N.Y.S.2d 957, 593 N.E.2d 1365.")
+    const head = find(cs, "79 N.Y.2d 540")
+    const p1 = find(cs, "583 N.Y.S.2d 957")
+    const p2 = find(cs, "593 N.E.2d 1365")
+    expect(members(head)).toEqual(expect.arrayContaining([head.id, p1.id, p2.id]))
+    expect(members(p1)).toEqual(members(head))
+    expect(members(p2)).toEqual(members(head))
+  })
+
+  it("groups trailing parallels with a SHORT-FORM lead and resolves them to the antecedent", () => {
+    const cs = run(
+      "Smith v. Jones, 79 N.Y.2d 540 (1992). We reaffirmed in Smith, 79 N.Y.2d at 552, 583 N.Y.S.2d 957, 593 N.E.2d 1365.",
+    )
+    const antecedent = find(cs, "79 N.Y.2d 540")
+    const shortForm = cs.find((c) => c.type === "shortFormCase")
+    if (!shortForm) throw new Error("no short form")
+    const p1 = find(cs, "583 N.Y.S.2d 957")
+    const p2 = find(cs, "593 N.E.2d 1365")
+    // one group anchored on the short form
+    expect(members(shortForm)).toEqual(expect.arrayContaining([shortForm.id, p1.id, p2.id]))
+    expect(members(p1)).toContain(shortForm.id)
+    // trailing parallels are the same case as the short form's antecedent
+    expect(resolvedTo(p1)).toBe(antecedent.id)
+    expect(resolvedTo(p2)).toBe(antecedent.id)
+  })
+
+  it("groups a SHORT-FORM lead with no antecedent (grouped, no resolution)", () => {
+    const cs = run("See Smith, 79 N.Y.2d at 552, 583 N.Y.S.2d 957, 593 N.E.2d 1365.")
+    const shortForm = cs.find((c) => c.type === "shortFormCase")
+    if (!shortForm) throw new Error("no short form")
+    const p1 = find(cs, "583 N.Y.S.2d 957")
+    const p2 = find(cs, "593 N.E.2d 1365")
+    expect(members(shortForm)).toEqual(expect.arrayContaining([shortForm.id, p1.id, p2.id]))
+  })
+
+  it("control: full-cite lead WITH a trailing paren still groups all three", () => {
+    const cs = run("Smith v. Jones, 79 N.Y.2d 540, 583 N.Y.S.2d 957, 593 N.E.2d 1365 (1992).")
+    const head = find(cs, "79 N.Y.2d 540")
+    expect(members(head)?.length).toBe(3)
+  })
+})

--- a/tests/extract/issue884ParallelShortform.test.ts
+++ b/tests/extract/issue884ParallelShortform.test.ts
@@ -55,11 +55,39 @@ describe("#884 parallel reporters after a short-form / no-paren chain", () => {
     const p1 = find(cs, "583 N.Y.S.2d 957")
     const p2 = find(cs, "593 N.E.2d 1365")
     expect(members(shortForm)).toEqual(expect.arrayContaining([shortForm.id, p1.id, p2.id]))
+    // No antecedent exists, so nothing resolves — propagation must not invent one.
+    expect(resolvedTo(p1)).toBeUndefined()
+    expect(resolvedTo(p2)).toBeUndefined()
   })
 
   it("control: full-cite lead WITH a trailing paren still groups all three", () => {
     const cs = run("Smith v. Jones, 79 N.Y.2d 540, 583 N.Y.S.2d 957, 593 N.E.2d 1365 (1992).")
     const head = find(cs, "79 N.Y.2d 540")
     expect(members(head)?.length).toBe(3)
+  })
+
+  it("does NOT absorb a second short-form (different case) into the first's group", () => {
+    // A second party-named short-form starts a NEW reference, not a parallel of
+    // the first. The Smith reference must stay separate and resolve to its OWN
+    // antecedent (Smith), never to Doe — a parallel group has one anchor.
+    const cs = run(
+      "Smith v. Jones, 79 N.Y.2d 540 (1992). Doe v. Roe, 100 F.3d 5 (1995). See Doe, 100 F.3d at 7, 583 N.Y.S.2d 957, Smith, 79 N.Y.2d at 552.",
+    )
+    const smithFull = find(cs, "79 N.Y.2d 540")
+    const doeFull = find(cs, "100 F.3d 5")
+    const doeShort = cs.find((c) => c.type === "shortFormCase" && c.matchedText.includes("Doe"))
+    const smithShort = cs.find(
+      (c) => c.type === "shortFormCase" && c.matchedText.includes("Smith, 79"),
+    )
+    if (!doeShort || !smithShort) throw new Error("missing short forms")
+    // The Smith short-form resolves to the Smith full cite, never to Doe.
+    expect(resolvedTo(smithShort)).toBe(smithFull.id)
+    expect(resolvedTo(smithShort)).not.toBe(doeFull.id)
+    // ...and is not pulled into Doe's parallel group.
+    expect(members(doeShort) ?? []).not.toContain(smithShort.id)
+    // The intervening bare cite must never inherit the WRONG case (Doe); the
+    // ambiguous cross-case run is rejected rather than mis-grouped (#884 review).
+    const between = find(cs, "583 N.Y.S.2d 957")
+    expect(resolvedTo(between)).not.toBe(doeFull.id)
   })
 })

--- a/tests/fixtures/corpus/projections.json
+++ b/tests/fixtures/corpus/projections.json
@@ -11880,7 +11880,7 @@
           37255,
           37276
         ],
-        "resolvedTo": null
+        "resolvedTo": "146 A.3d 1189"
       },
       {
         "type": "shortFormCase",
@@ -28737,7 +28737,7 @@
           8308,
           8323
         ],
-        "resolvedTo": null
+        "resolvedTo": "490 U.S. 319"
       },
       {
         "type": "case",


### PR DESCRIPTION
## Why

A **parallel citation** is the same case reported in more than one reporter — `490 U.S. 319, 109 S. Ct. 1827` is one Supreme Court decision in two places. A **short-form** is an abbreviated later reference to an already-cited case — `Smith, 79 N.Y.2d at 552`.

**Today:** when parallel reporters trail a short-form — or any citation chain that omits the closing `(year)` parenthetical — the trailing cites are orphaned: a fresh group id, no resolution, no link back to the case. In a real opinion, `Neitzke, 490 U.S. at 324, 109 S. Ct. 1827.` left `109 S. Ct. 1827` floating, unconnected to Neitzke.

**After this PR:** the run forms one parallel group anchored on the short-form, and the trailing parallels inherit the short-form's antecedent. `109 S. Ct. 1827` now resolves to `490 U.S. 319`; `Smith, 230 Md. at 236, 146 A.3d at 1202.` links both cites to the *Smith* case.

**Why this matters:** anyone building a citation graph or a table of authorities gets every reporter of a case connected to that case, instead of dangling fragments. Two real opinions in the regression corpus improve from this change (see Test plan).

### Corrected root cause

The original triage hypothesis on #884 was that `detectParallel` only anchors a group on a *full-form* case token, so a short-form lead wasn't a valid anchor. Systematic debugging disconfirmed that: a **full-cite** lead without a trailing paren *also* orphaned its parallels. The real root cause was chain-continuation — a tight-linked run (`A, B, C.`) was validated link-by-link, so the `A→B` link saw `, C`, broke, and orphaned the head. Chains are now validated by their **last** member.

## What changed

1. **Chain detection** (`src/extract/detectParallel.ts`): collect the tight-linked run, then accept it iff its *last* member closes (shared parenthetical or sentence terminator), instead of requiring every link to close. A second party-named short-form (`…, Smith, 79 N.Y.2d at 552`) is a new reference and ends the run, so a parallel group keeps a single anchor.
2. **Grouping** (`src/types/citation.ts`, `src/extract/extractCitations.ts`): a short-form case citation can now anchor a parallel group — `groupId`/`parallelGroup`/`parallelCitations` added to `ShortFormCaseCitation`, and the grouping gates accept `shortFormCase`.
3. **Resolution** (`src/extract/extractCitations.ts`, `src/resolve/types.ts`): after resolution, trailing parallels of a resolved group member inherit its antecedent. **Public-type change worth a look:** `ResolvedCitation` is broadened so a full reporter cite that trails a short-form as a parallel reference may carry an inherited `resolution` (full cites were previously typed `resolution?: undefined`). Additive and non-breaking — short-forms unchanged, all other full-cite types still `undefined`.

## Test plan

**What I ran (all observed green):**
- `pnpm exec vitest run` — 321 files, **4814 passed**, 0 failed.
- `pnpm typecheck` — clean. `pnpm lint` — exit 0. `pnpm build` — succeeds.
- New dedicated suite `tests/extract/issue884ParallelShortform.test.ts` (5 cases): full-lead-no-paren, short-lead + antecedent → resolution, short-lead-no-antecedent (asserts *no* spurious resolution), control full + paren, and a negative case proving a second short-form for a *different* case is neither absorbed nor mis-resolved.
- **Corpus regen** — exactly 2 real-opinion projections change, both `resolvedTo: null → correct case`, verified against the source text: Neitzke (`490 U.S. 319` / `109 S. Ct. 1827`) and *Smith* (`230 Md.` / `146 A.3d 1189`). Zero correct→wrong flips.
- Independent reviewer pass + adversarial probes for false grouping (prose between cites, signaled string cites, separate parentheticals, two-different-case chains) — all correct.

Closes #884.

---
Assisted-by: Claude Code:claude-opus-4-8
